### PR TITLE
docs: update README and add OpenAPI spec for v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agora CMS — Central Management System
 
-Agora CMS is the central control server for a fleet of [Agora](https://github.com/sslivins/agora) media playback devices (Raspberry Pi Zero 2 W). It manages device registration, content scheduling, and asset distribution across up to ~30 devices on a network.
+Agora CMS is the central control server for a fleet of [Agora](https://github.com/sslivins/agora) media playback devices (Raspberry Pi Zero 2 W). It manages device registration, content scheduling, asset transcoding, and distribution across up to ~30 devices on a network.
 
 ## How It Works
 
@@ -19,99 +19,270 @@ Agora CMS is the central control server for a fleet of [Agora](https://github.co
   └─────────┘
 ```
 
-### Device Communication
+## Quick Start
 
-- **Device-initiated WebSocket**: Each Pi connects outbound to the CMS on boot, solving NAT/firewall issues. Works whether the CMS is on the local network or in the cloud.
-- **On connect**: Device authenticates with its unique ID + token, pulls its current schedule and asset assignments.
-- **Live updates**: CMS pushes changes instantly over the open WebSocket — schedule updates, "play now" overrides, new asset notifications.
-- **On disconnect**: Device reconnects and re-syncs automatically. No local schedule persistence — the CMS is the single source of truth.
+```bash
+cp .env.example .env    # Edit credentials and secrets
+docker compose up -d    # Starts CMS + PostgreSQL
+```
 
-### Device Registration
+The web UI is available at `http://localhost:8080`. Default login: `admin` / `agora`.
 
-1. New device boots and connects to the CMS WebSocket endpoint
-2. CMS sees an unknown device ID → creates it as **pending**
-3. Admin approves the device in the CMS web UI, assigns it to a group/location
-4. Device receives its config (splash screen, schedule, settings)
+## Features
 
-### Flash-Aware Asset Management
+### Device Management
 
-Raspberry Pi devices have limited SD card storage. The CMS manages this:
+- **Auto-registration**: New devices connecting are created as **pending** for admin approval
+- **Device groups**: Organize devices by location or purpose for bulk scheduling
+- **Device profiles**: Hardware capability templates (codec, resolution, bitrate) for transcoding
+- **Live status**: See each device's playback state, uptime, and storage in real time
+- **Remote control**: Play, stop, reboot, set password, and push config updates to any device
+- **Reset Auth**: Clear auth credentials for re-flashed devices without database access
+- **API key rotation**: Device API keys are automatically rotated on a configurable interval
 
-- **At most 2 videos on a device at any time** — the currently playing asset and the next scheduled one
-- Schedules can be set far into the future (e.g., a Christmas video created in summer) but assets are only transferred to the device when needed
-- CMS pre-fetches the next asset before its start time
-- When an asset is no longer needed, CMS instructs the device to delete it
-- Supports devices with varying storage capacity (minimum: 1 video)
+### Content & Asset Library
+
+- **Upload**: Drag-and-drop media upload (up to 2 GB) with automatic format detection
+- **Image conversion**: HEIC, AVIF, WebP, BMP, TIFF, GIF are auto-converted to JPEG on upload
+- **Video transcoding**: Videos are automatically transcoded for each device profile using ffmpeg
+  - Hardware-friendly: H.264 Main profile, BT.709 color space (Pi V4L2 compatible)
+  - Scale-to-fit with aspect ratio preservation
+  - Progress tracking in the UI
+- **Media metadata**: Resolution, duration, codecs, bitrate, frame rate extracted via ffprobe
+- **Preview**: Stream source files directly from the library
 
 ### Scheduling
 
-- **One-time**: Play video X on device Y from 2pm–4pm on Dec 25
-- **Recurring**: Play video X every Mon/Wed/Fri 11am–2pm
-- **Default/fallback**: What to show when nothing is scheduled (splash screen or a default video)
-- **Priority**: Emergency content can override the regular schedule
-- Schedules are per-device or per-device-group
+- **Time-based**: Play asset X on device Y from 2pm–4pm
+- **Date ranges**: Start/end dates for seasonal content (e.g., holiday videos)
+- **Recurring**: Select days of the week (Mon/Wed/Fri, weekdays, etc.)
+- **Default/fallback**: What to show when nothing is scheduled (per-device or per-group)
+- **Priority**: Higher-priority schedules override lower ones
+- **End Now**: Skip the current occurrence of a schedule immediately
+- **Per-device or per-group**: Target individual devices or entire groups
 
-## Tech Stack
+### Flash-Aware Asset Distribution
 
-- **Python 3.11+**, **FastAPI**, **Pydantic v2**, **uvicorn**
-- **PostgreSQL** — devices, groups, schedules, asset metadata
-- **WebSocket** — real-time device communication (FastAPI native)
-- **Jinja2** — server-rendered admin web UI
-- **Docker Compose** — CMS + PostgreSQL
+- Devices have limited SD card storage — CMS manages this automatically
+- Assets are only transferred when needed for upcoming schedules
+- CMS pre-fetches the next asset before its start time
+- When an asset is no longer needed, CMS instructs the device to delete it
+- Budget-aware: respects each device's reported storage capacity
 
-## Project Structure
+## Web UI Pages
 
-```
-cms/
-  __init__.py          # version
-  main.py              # FastAPI app entry point
-  config.py            # Settings (Pydantic)
-  database.py          # SQLAlchemy / DB session
-  models/              # SQLAlchemy ORM models
-    device.py          # Device, DeviceGroup
-    asset.py           # Asset metadata
-    schedule.py        # Schedule, ScheduleRule
-  schemas/             # Pydantic request/response schemas
-    device.py
-    asset.py
-    schedule.py
-    protocol.py        # WebSocket message types (shared contract with device)
-  routers/
-    devices.py         # Device management API
-    assets.py          # Asset library API
-    schedules.py       # Schedule CRUD API
-    ws.py              # WebSocket endpoint for devices
-  services/
-    scheduler.py       # Schedule evaluation (what should play now/next)
-    asset_manager.py   # Asset distribution logic
-    device_manager.py  # Device state tracking, connection registry
-  static/              # CSS, JS
-  templates/           # Jinja2 admin UI templates
-```
+| Page | Description |
+|------|-------------|
+| Dashboard | Device status overview, now-playing, upcoming schedules |
+| Devices | Device list with inline editing, groups management, remote actions |
+| Assets | Upload, library browser, variant/transcoding status, preview |
+| Schedules | Schedule table with create/edit modals, end-now |
+| Profiles | Device profiles for transcoding (built-in Pi Zero 2 W + custom) |
+| Settings | Admin password, timezone configuration |
+
+## API Endpoints
+
+All `/api/` endpoints require session authentication unless noted.
+
+### Dashboard
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/dashboard` | Device states, now-playing, upcoming schedules |
+
+### Devices
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/devices` | List all devices |
+| `GET` | `/api/devices/{id}` | Get device details |
+| `PATCH` | `/api/devices/{id}` | Update name, status, group, default asset |
+| `DELETE` | `/api/devices/{id}` | Delete device |
+| `POST` | `/api/devices/{id}/password` | Set device web password |
+| `POST` | `/api/devices/{id}/reboot` | Reboot device |
+| `POST` | `/api/devices/{id}/reset-auth` | Clear auth tokens (for re-flashed devices) |
+
+### Device Groups
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/devices/groups/` | List groups with device counts |
+| `POST` | `/api/devices/groups/` | Create group |
+| `PATCH` | `/api/devices/groups/{id}` | Update group |
+| `DELETE` | `/api/devices/groups/{id}` | Delete group |
+
+### Assets
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/assets` | List all assets |
+| `GET` | `/api/assets/status` | Asset counts and variant stats |
+| `POST` | `/api/assets/upload` | Upload asset (up to 2 GB) |
+| `GET` | `/api/assets/{id}` | Get asset details with variants |
+| `GET` | `/api/assets/{id}/preview` | Download source file |
+| `DELETE` | `/api/assets/{id}` | Delete asset (blocked if in use by schedules) |
+| `GET` | `/api/assets/{id}/download` | Download source (no auth — device use) |
+| `GET` | `/api/assets/variants/{id}/download` | Download transcoded variant (no auth) |
+
+### Schedules
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/schedules` | List schedules |
+| `POST` | `/api/schedules` | Create schedule |
+| `GET` | `/api/schedules/{id}` | Get schedule |
+| `PATCH` | `/api/schedules/{id}` | Update schedule |
+| `DELETE` | `/api/schedules/{id}` | Delete schedule |
+| `POST` | `/api/schedules/{id}/end-now` | Skip current occurrence |
+
+### Device Profiles
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/profiles` | List profiles with variant stats |
+| `POST` | `/api/profiles` | Create profile (queues transcoding) |
+| `PUT` | `/api/profiles/{id}` | Update profile |
+| `DELETE` | `/api/profiles/{id}` | Delete profile |
+
+### Settings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/settings/password` | Change admin password |
+| `POST` | `/settings/timezone` | Set CMS timezone |
+
+### WebSocket
+
+| Path | Description |
+|------|-------------|
+| `GET` | `/ws/device` | Device WebSocket endpoint (protocol v1) |
 
 ## Protocol (CMS ↔ Device)
 
 Protocol version: **1**
 
-All WebSocket messages are JSON with a `type` field:
+All WebSocket messages are JSON with a `type` field.
 
 ### Device → CMS
+
 | Type | Description |
 |------|-------------|
-| `register` | Initial handshake: device ID, auth token, firmware version, storage capacity |
-| `status` | Periodic heartbeat: current playback state, disk usage, uptime |
-| `asset_ack` | Confirms asset downloaded successfully |
-| `asset_deleted` | Confirms asset removed from local storage |
+| `register` | Device ID, auth token, firmware version, storage capacity |
+| `status` | Heartbeat: playback state, disk usage, uptime (every 30s) |
+| `fetch_request` | Request an asset by filename |
+| `fetch_failed` | Download failed with reason and budget info |
+| `asset_ack` | Confirm asset downloaded with checksum |
+| `asset_deleted` | Confirm asset removed |
 
 ### CMS → Device
+
 | Type | Description |
 |------|-------------|
-| `sync` | Full state: current schedule window, assigned assets, config |
-| `play` | Immediate playback command (asset name, loop flag) |
-| `stop` | Stop playback, show splash |
-| `fetch_asset` | Download an asset from URL (pre-fetch for upcoming schedule) |
-| `delete_asset` | Remove an asset from local storage |
-| `config` | Updated device config (splash, settings) |
+| `auth_assigned` | Initial auth token (new device registration) |
+| `sync` | Full schedule window, timezone, default asset |
+| `play` | Immediate playback command |
+| `stop` | Stop playback |
+| `fetch_asset` | Download URL + checksum + size |
+| `delete_asset` | Remove local asset |
+| `config` | Update splash, password, API key, device name |
+| `reboot` | Reboot device |
+
+### Connection Flow
+
+1. Device sends `register` with ID + auth token (empty on first connect)
+2. CMS creates device as **pending** if new
+3. CMS sends `auth_assigned` with unique token (stored hashed)
+4. CMS sends `sync` with schedule window
+5. CMS sends `fetch_asset` + `play` for approved devices with default asset
+6. CMS sends `config` with rotated API key
+7. Ongoing: device `status` heartbeats, CMS pushes schedule changes
+
+## Tech Stack
+
+- **Python 3.11+**, **FastAPI**, **Pydantic v2**, **uvicorn**
+- **PostgreSQL 16** + **SQLAlchemy 2.0** (async with asyncpg)
+- **ffmpeg** / **ffprobe** for video transcoding and metadata
+- **libheif** for HEIC image conversion
+- **WebSocket** — real-time device communication (FastAPI native)
+- **Jinja2** — server-rendered admin web UI
+- **Docker Compose** — CMS + PostgreSQL
+
+## Configuration
+
+Environment variables (prefix `AGORA_CMS_`), set in `.env`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `postgresql+asyncpg://agora:agora@db:5432/agora_cms` | PostgreSQL connection |
+| `SECRET_KEY` | `change-me-in-production` | Session signing key |
+| `ADMIN_USERNAME` | `admin` | Initial admin username |
+| `ADMIN_PASSWORD` | `agora` | Initial admin password |
+| `ASSET_STORAGE_PATH` | `/opt/agora-cms/assets` | Asset storage root |
+| `DEFAULT_DEVICE_STORAGE_MB` | `500` | Default device flash budget |
+| `API_KEY_ROTATION_HOURS` | `24` | Device API key rotation interval |
+
+## Project Structure
+
+```
+cms/
+  __init__.py              # Version
+  main.py                  # FastAPI app entry point
+  config.py                # Pydantic settings
+  auth.py                  # Session auth, password hashing
+  database.py              # SQLAlchemy engine and session
+  ui.py                    # Web UI routes (Jinja2)
+  models/
+    device.py              # Device, DeviceGroup, DeviceProfile
+    asset.py               # Asset, AssetVariant
+    schedule.py            # Schedule
+    setting.py             # CMSSetting (admin credentials, timezone)
+  schemas/
+    device.py              # Device CRUD schemas
+    asset.py               # Asset response schemas
+    schedule.py            # Schedule CRUD schemas
+    profile.py             # Profile CRUD schemas
+    protocol.py            # WebSocket message types (shared contract)
+  routers/
+    devices.py             # Device management API
+    assets.py              # Asset library API
+    schedules.py           # Schedule CRUD API
+    profiles.py            # Device profile API
+    ws.py                  # WebSocket endpoint
+  services/
+    scheduler.py           # Schedule evaluation, sync pushing
+    transcoder.py          # Video transcoding, media probing
+    device_manager.py      # Connection registry, state tracking
+  static/                  # CSS, JS
+  templates/               # Jinja2 admin UI templates
+tests/                     # pytest + pytest-asyncio + httpx + aiosqlite
+```
+
+## Data Model
+
+| Table | Purpose |
+|-------|---------|
+| `devices` | Device registry (ID, name, status, group, profile, storage, auth hashes) |
+| `device_groups` | Groups for bulk scheduling |
+| `device_profiles` | Hardware capability templates for transcoding |
+| `assets` | Source media library with metadata |
+| `asset_variants` | Transcoded formats per device profile (status, progress) |
+| `device_assets` | Tracks which assets are on which device |
+| `schedules` | Schedule rules (target, asset, time window, recurrence, priority) |
+| `cms_settings` | Runtime settings (admin credentials, timezone) |
+
+## Development
+
+### Running Tests
+
+```bash
+docker exec agora-cms-cms-1 python -m pytest tests/ --tb=short -q
+```
+
+### Rebuilding
+
+```bash
+docker compose up -d --build
+```
 
 ## Related
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1215 @@
+openapi: 3.0.3
+info:
+  title: Agora CMS
+  description: >
+    Central management server for Agora media playback devices. Provides device
+    registration, content scheduling, asset transcoding, and fleet management
+    via a REST API, WebSocket endpoint, and admin web UI.
+  version: 0.5.0
+  license:
+    name: MIT
+
+servers:
+  - url: http://localhost:8080
+    description: Local Docker Compose
+
+security:
+  - sessionCookie: []
+
+tags:
+  - name: dashboard
+    description: Dashboard overview data
+  - name: devices
+    description: Device management
+  - name: groups
+    description: Device groups
+  - name: assets
+    description: Asset library and transcoding
+  - name: schedules
+    description: Content scheduling
+  - name: profiles
+    description: Device profiles for transcoding
+  - name: settings
+    description: CMS settings
+
+paths:
+  # ── Dashboard ──
+  /api/dashboard:
+    get:
+      tags: [dashboard]
+      summary: Dashboard data
+      description: Returns device states, now-playing info, pending/offline device lists, and upcoming schedules.
+      operationId: getDashboard
+      responses:
+        "200":
+          description: Dashboard data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DashboardResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  # ── Devices ──
+  /api/devices:
+    get:
+      tags: [devices]
+      summary: List devices
+      description: Returns all registered devices ordered by registration date.
+      operationId: listDevices
+      responses:
+        "200":
+          description: Device list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DeviceOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/devices/{device_id}:
+    get:
+      tags: [devices]
+      summary: Get device
+      operationId: getDevice
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      responses:
+        "200":
+          description: Device details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found.
+    patch:
+      tags: [devices]
+      summary: Update device
+      description: Update device name, status, group, or default asset.
+      operationId: updateDevice
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceUpdate"
+      responses:
+        "200":
+          description: Updated device.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found.
+    delete:
+      tags: [devices]
+      summary: Delete device
+      operationId: deleteDevice
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      responses:
+        "200":
+          description: Device deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found.
+
+  /api/devices/{device_id}/password:
+    post:
+      tags: [devices]
+      summary: Set device web password
+      description: Push a new web UI password to the device over WebSocket.
+      operationId: setDevicePassword
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [password]
+              properties:
+                password:
+                  type: string
+                  minLength: 4
+      responses:
+        "200":
+          description: Password set.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found or not connected.
+
+  /api/devices/{device_id}/reboot:
+    post:
+      tags: [devices]
+      summary: Reboot device
+      description: Send a reboot command to the device over WebSocket.
+      operationId: rebootDevice
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      responses:
+        "200":
+          description: Reboot command sent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found or not connected.
+
+  /api/devices/{device_id}/reset-auth:
+    post:
+      tags: [devices]
+      summary: Reset device authentication
+      description: >
+        Clear the device's stored auth token hash and API key hash. Use this
+        when a device has been re-flashed with a fresh SD card and needs to
+        re-register. The device will receive new credentials on next connect.
+      operationId: resetDeviceAuth
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      responses:
+        "200":
+          description: Auth credentials cleared.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Device not found.
+
+  # ── Device Groups ──
+  /api/devices/groups/:
+    get:
+      tags: [groups]
+      summary: List groups
+      description: Returns all device groups with device counts.
+      operationId: listGroups
+      responses:
+        "200":
+          description: Group list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DeviceGroupOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [groups]
+      summary: Create group
+      operationId: createGroup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceGroupCreate"
+      responses:
+        "201":
+          description: Group created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceGroupOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/devices/groups/{group_id}:
+    patch:
+      tags: [groups]
+      summary: Update group
+      operationId: updateGroup
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceGroupUpdate"
+      responses:
+        "200":
+          description: Updated group.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceGroupOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Group not found.
+    delete:
+      tags: [groups]
+      summary: Delete group
+      operationId: deleteGroup
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Group deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Group not found.
+
+  # ── Assets ──
+  /api/assets:
+    get:
+      tags: [assets]
+      summary: List assets
+      description: Returns all assets ordered by upload date.
+      operationId: listAssets
+      responses:
+        "200":
+          description: Asset list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AssetOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/assets/status:
+    get:
+      tags: [assets]
+      summary: Asset and variant stats
+      description: Returns counts of assets and transcoding variant statuses.
+      operationId: getAssetStatus
+      responses:
+        "200":
+          description: Asset statistics.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetStatusResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/assets/upload:
+    post:
+      tags: [assets]
+      summary: Upload asset
+      description: >
+        Upload a media file (up to 2 GB). Images in HEIC, AVIF, WebP, BMP,
+        TIFF, or GIF format are auto-converted to JPEG. Videos are queued for
+        transcoding against all device profiles.
+      operationId: uploadAsset
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Asset uploaded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetOut"
+        "400":
+          description: Invalid file type or filename.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/assets/{asset_id}:
+    get:
+      tags: [assets]
+      summary: Get asset details
+      description: Returns asset metadata including transcoding variant statuses.
+      operationId: getAsset
+      parameters:
+        - $ref: "#/components/parameters/AssetId"
+      responses:
+        "200":
+          description: Asset details with variants.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Asset not found.
+    delete:
+      tags: [assets]
+      summary: Delete asset
+      description: Delete an asset. Fails if the asset is referenced by any schedule.
+      operationId: deleteAsset
+      parameters:
+        - $ref: "#/components/parameters/AssetId"
+      responses:
+        "200":
+          description: Asset deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          description: Asset is in use by one or more schedules.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Asset not found.
+
+  /api/assets/{asset_id}/preview:
+    get:
+      tags: [assets]
+      summary: Preview source file
+      description: Download the original source file for preview.
+      operationId: previewAsset
+      parameters:
+        - $ref: "#/components/parameters/AssetId"
+      responses:
+        "200":
+          description: Source file stream.
+          content:
+            application/octet-stream: {}
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Asset not found.
+
+  /api/assets/{asset_id}/download:
+    get:
+      tags: [assets]
+      summary: Download source asset
+      description: Download source asset file. No authentication required (used by devices).
+      security: []
+      operationId: downloadAsset
+      parameters:
+        - $ref: "#/components/parameters/AssetId"
+      responses:
+        "200":
+          description: Asset file stream.
+          content:
+            application/octet-stream: {}
+        "404":
+          description: Asset not found.
+
+  /api/assets/variants/{variant_id}/download:
+    get:
+      tags: [assets]
+      summary: Download transcoded variant
+      description: Download a transcoded variant. Only available when variant status is READY. No authentication required.
+      security: []
+      operationId: downloadVariant
+      parameters:
+        - name: variant_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Variant file stream.
+          content:
+            application/octet-stream: {}
+        "404":
+          description: Variant not found or not ready.
+
+  # ── Schedules ──
+  /api/schedules:
+    get:
+      tags: [schedules]
+      summary: List schedules
+      description: Returns all schedules ordered by priority (desc) then name.
+      operationId: listSchedules
+      responses:
+        "200":
+          description: Schedule list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ScheduleOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [schedules]
+      summary: Create schedule
+      description: >
+        Create a new schedule targeting a device or group. Exactly one of
+        device_id or group_id must be set. Triggers sync push to affected devices.
+      operationId: createSchedule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScheduleCreate"
+      responses:
+        "201":
+          description: Schedule created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScheduleOut"
+        "400":
+          description: Validation error (e.g., must set exactly one target).
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/schedules/{schedule_id}:
+    get:
+      tags: [schedules]
+      summary: Get schedule
+      operationId: getSchedule
+      parameters:
+        - $ref: "#/components/parameters/ScheduleId"
+      responses:
+        "200":
+          description: Schedule details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScheduleOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Schedule not found.
+    patch:
+      tags: [schedules]
+      summary: Update schedule
+      description: Update schedule fields. Triggers sync push to affected devices.
+      operationId: updateSchedule
+      parameters:
+        - $ref: "#/components/parameters/ScheduleId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScheduleUpdate"
+      responses:
+        "200":
+          description: Updated schedule.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScheduleOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Schedule not found.
+    delete:
+      tags: [schedules]
+      summary: Delete schedule
+      description: Delete a schedule and sync affected devices.
+      operationId: deleteSchedule
+      parameters:
+        - $ref: "#/components/parameters/ScheduleId"
+      responses:
+        "200":
+          description: Schedule deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Schedule not found.
+
+  /api/schedules/{schedule_id}/end-now:
+    post:
+      tags: [schedules]
+      summary: End current occurrence
+      description: Skip the current occurrence of a schedule until its end time.
+      operationId: endScheduleNow
+      parameters:
+        - $ref: "#/components/parameters/ScheduleId"
+      responses:
+        "200":
+          description: Schedule skipped.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Schedule not found.
+
+  # ── Profiles ──
+  /api/profiles:
+    get:
+      tags: [profiles]
+      summary: List profiles
+      description: Returns all device profiles with device counts and variant statistics.
+      operationId: listProfiles
+      responses:
+        "200":
+          description: Profile list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProfileOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [profiles]
+      summary: Create profile
+      description: Create a device profile. Queues transcoding for all existing video assets.
+      operationId: createProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfileCreate"
+      responses:
+        "201":
+          description: Profile created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/profiles/{profile_id}:
+    put:
+      tags: [profiles]
+      summary: Update profile
+      operationId: updateProfile
+      parameters:
+        - name: profile_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProfileUpdate"
+      responses:
+        "200":
+          description: Updated profile.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileOut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Profile not found.
+    delete:
+      tags: [profiles]
+      summary: Delete profile
+      description: Delete a profile. Fails if it is built-in or has devices assigned.
+      operationId: deleteProfile
+      parameters:
+        - name: profile_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Profile deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          description: Cannot delete built-in profile or profile with assigned devices.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Profile not found.
+
+  # ── Settings ──
+  /settings/password:
+    post:
+      tags: [settings]
+      summary: Change admin password
+      operationId: changePassword
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [current_password, new_password]
+              properties:
+                current_password:
+                  type: string
+                new_password:
+                  type: string
+      responses:
+        "303":
+          description: Redirect to settings page.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /settings/timezone:
+    post:
+      tags: [settings]
+      summary: Set CMS timezone
+      operationId: setTimezone
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [timezone]
+              properties:
+                timezone:
+                  type: string
+                  example: America/New_York
+      responses:
+        "303":
+          description: Redirect to settings page.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: agora_cms_session
+      description: Signed session cookie (set after web login).
+
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Device identifier (CPU serial or UUID).
+    AssetId:
+      name: asset_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    ScheduleId:
+      name: schedule_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+  responses:
+    Unauthorized:
+      description: Authentication required.
+
+  schemas:
+    OkResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          example: true
+
+    DeviceStatus:
+      type: string
+      enum: [pending, approved, offline]
+
+    AssetType:
+      type: string
+      enum: [video, image]
+
+    VariantStatus:
+      type: string
+      enum: [pending, processing, ready, failed]
+
+    DeviceOut:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          $ref: "#/components/schemas/DeviceStatus"
+        group_id:
+          type: string
+          format: uuid
+          nullable: true
+        group_name:
+          type: string
+          nullable: true
+        default_asset_id:
+          type: string
+          format: uuid
+          nullable: true
+        firmware_version:
+          type: string
+        device_type:
+          type: string
+        storage_capacity_mb:
+          type: integer
+        storage_used_mb:
+          type: integer
+        last_seen:
+          type: string
+          format: date-time
+          nullable: true
+        registered_at:
+          type: string
+          format: date-time
+
+    DeviceUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        status:
+          $ref: "#/components/schemas/DeviceStatus"
+        group_id:
+          type: string
+          format: uuid
+          nullable: true
+        default_asset_id:
+          type: string
+          format: uuid
+          nullable: true
+
+    DeviceGroupOut:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        default_asset_id:
+          type: string
+          format: uuid
+          nullable: true
+        device_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    DeviceGroupCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          default: ""
+        default_asset_id:
+          type: string
+          format: uuid
+          nullable: true
+
+    DeviceGroupUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        default_asset_id:
+          type: string
+          format: uuid
+          nullable: true
+
+    AssetOut:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        filename:
+          type: string
+        original_filename:
+          type: string
+          nullable: true
+        asset_type:
+          $ref: "#/components/schemas/AssetType"
+        size_bytes:
+          type: integer
+        checksum:
+          type: string
+        uploaded_at:
+          type: string
+          format: date-time
+
+    AssetVariantOut:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        profile_id:
+          type: string
+          format: uuid
+        profile_name:
+          type: string
+        filename:
+          type: string
+        size_bytes:
+          type: integer
+        checksum:
+          type: string
+        status:
+          $ref: "#/components/schemas/VariantStatus"
+        progress:
+          type: number
+          format: float
+        error_message:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    AssetStatusResponse:
+      type: object
+      properties:
+        asset_count:
+          type: integer
+        variant_ready:
+          type: integer
+        variant_processing:
+          type: integer
+        variant_failed:
+          type: integer
+
+    ScheduleOut:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        device_id:
+          type: string
+          nullable: true
+        group_id:
+          type: string
+          format: uuid
+          nullable: true
+        asset_id:
+          type: string
+          format: uuid
+        asset_filename:
+          type: string
+          nullable: true
+        device_name:
+          type: string
+          nullable: true
+        group_name:
+          type: string
+          nullable: true
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        start_time:
+          type: string
+          format: time
+          example: "14:00"
+        end_time:
+          type: string
+          format: time
+          example: "16:00"
+        days_of_week:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+            maximum: 7
+          nullable: true
+          description: ISO weekday numbers (1=Monday, 7=Sunday). Null means every day.
+        priority:
+          type: integer
+        enabled:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    ScheduleCreate:
+      type: object
+      required: [name, asset_id, start_time, end_time]
+      properties:
+        name:
+          type: string
+        device_id:
+          type: string
+          description: Target device (exactly one of device_id or group_id required).
+        group_id:
+          type: string
+          format: uuid
+          description: Target group (exactly one of device_id or group_id required).
+        asset_id:
+          type: string
+          format: uuid
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        start_time:
+          type: string
+          format: time
+          example: "14:00"
+        end_time:
+          type: string
+          format: time
+          example: "16:00"
+        days_of_week:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+            maximum: 7
+          nullable: true
+        priority:
+          type: integer
+          default: 0
+        enabled:
+          type: boolean
+          default: true
+
+    ScheduleUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        device_id:
+          type: string
+        group_id:
+          type: string
+          format: uuid
+        asset_id:
+          type: string
+          format: uuid
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        start_time:
+          type: string
+          format: time
+        end_time:
+          type: string
+          format: time
+        days_of_week:
+          type: array
+          items:
+            type: integer
+          nullable: true
+        priority:
+          type: integer
+        enabled:
+          type: boolean
+
+    ProfileOut:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        video_codec:
+          type: string
+        video_profile:
+          type: string
+        max_width:
+          type: integer
+        max_height:
+          type: integer
+        max_fps:
+          type: integer
+        video_bitrate:
+          type: string
+        crf:
+          type: integer
+        audio_codec:
+          type: string
+        audio_bitrate:
+          type: string
+        builtin:
+          type: boolean
+        device_count:
+          type: integer
+        total_variants:
+          type: integer
+        ready_variants:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    ProfileCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          default: ""
+        video_codec:
+          type: string
+          default: h264
+        video_profile:
+          type: string
+          default: main
+        max_width:
+          type: integer
+          default: 1920
+        max_height:
+          type: integer
+          default: 1080
+        max_fps:
+          type: integer
+          default: 30
+        video_bitrate:
+          type: string
+          default: ""
+        crf:
+          type: integer
+          default: 23
+        audio_codec:
+          type: string
+          default: aac
+        audio_bitrate:
+          type: string
+          default: 128k
+
+    ProfileUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        video_profile:
+          type: string
+        max_width:
+          type: integer
+        max_height:
+          type: integer
+        max_fps:
+          type: integer
+        video_bitrate:
+          type: string
+        crf:
+          type: integer
+        audio_codec:
+          type: string
+        audio_bitrate:
+          type: string
+
+    DashboardResponse:
+      type: object
+      properties:
+        now_playing:
+          type: object
+          description: Map of device_id to current playback info.
+        pending_ids:
+          type: array
+          items:
+            type: string
+        offline_ids:
+          type: array
+          items:
+            type: string
+        device_states:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              mode:
+                type: string
+              asset:
+                type: string
+                nullable: true
+        upcoming:
+          type: array
+          items:
+            type: object
+          description: Upcoming schedules in the next 24 hours.


### PR DESCRIPTION
Updates README and adds a comprehensive OpenAPI spec:

- **README**: quick start, full feature overview (transcoding, profiles, scheduling, flash-aware distribution), complete endpoint tables for all routers, protocol flow details, configuration reference, data model summary, project structure
- **OpenAPI**: new \docs/openapi.yaml\ covering all endpoints — devices, groups, assets, variants, schedules, profiles, settings, dashboard — with complete request/response schemas