### PR TITLE
fix: scope upgrade button disable to target device only

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -246,15 +246,16 @@ async function rebootDevice(deviceId, deviceName) {
 
 async function upgradeDevice(deviceId, deviceName) {
     if (!await showConfirm("Upgrade device \"" + deviceName + "\"?\n\nThe device will update its software and reboot.")) return;
-    // Disable all upgrade buttons to prevent concurrent upgrades
-    document.querySelectorAll('[onclick*="upgradeDevice"]').forEach(b => { b.disabled = true; b.textContent = 'Upgrading…'; });
+    // Disable this device's upgrade button to prevent double-clicks
+    const btn = document.querySelector(`[onclick*="upgradeDevice('${deviceId}'"]`);
+    if (btn) { btn.disabled = true; btn.textContent = 'Upgrading…'; }
     const resp = await apiCall("POST", `/api/devices/${deviceId}/upgrade`);
     if (resp && resp.ok) showToast("Upgrade command sent to " + deviceName);
     else if (resp) {
         const err = await resp.json().catch(() => null);
         showToast(err?.detail || "Failed to upgrade device", true);
         // Re-enable on failure
-        document.querySelectorAll('[onclick*="upgradeDevice"]').forEach(b => { b.disabled = false; b.textContent = 'Update'; });
+        if (btn) { btn.disabled = false; btn.textContent = 'Update'; }
     }
 }
 


### PR DESCRIPTION
The upgrade button was disabling all Update buttons on the page. Now only the specific device being upgraded shows 'Upgrading...' while other devices remain clickable.