### PR TITLE
Only publish Docker image after tests pass

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,7 +1,9 @@
 name: Publish Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
     branches: [main]
 
 permissions:
@@ -11,6 +13,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Changes publish workflow trigger from `push` to `workflow_run`, so it only executes after the Tests workflow completes successfully on main. If tests fail, no image is published.