### PR TITLE
Fix migration crash on fresh database

### DIFF
--- a/cms/database.py
+++ b/cms/database.py
@@ -99,16 +99,21 @@ async def run_migrations():
                 await conn.execute(text(f"ALTER TABLE asset_variants ADD COLUMN {col} {col_type}"))
 
         # -- Rename device status enum: approved → adopted, offline → orphaned --
-        has_approved = await conn.execute(
-            text("SELECT 1 FROM pg_enum WHERE enumlabel = 'APPROVED' AND enumtypid = 'devicestatus'::regtype")
+        # Guard: only run if the enum type exists (skip on fresh databases)
+        enum_exists = await conn.execute(
+            text("SELECT 1 FROM pg_type WHERE typname = 'devicestatus'")
         )
-        if has_approved.scalar():
-            await conn.execute(text("ALTER TYPE devicestatus RENAME VALUE 'APPROVED' TO 'ADOPTED'"))
-        has_offline = await conn.execute(
-            text("SELECT 1 FROM pg_enum WHERE enumlabel = 'OFFLINE' AND enumtypid = 'devicestatus'::regtype")
-        )
-        if has_offline.scalar():
-            await conn.execute(text("ALTER TYPE devicestatus RENAME VALUE 'OFFLINE' TO 'ORPHANED'"))
+        if enum_exists.scalar():
+            has_approved = await conn.execute(
+                text("SELECT 1 FROM pg_enum WHERE enumlabel = 'APPROVED' AND enumtypid = 'devicestatus'::regtype")
+            )
+            if has_approved.scalar():
+                await conn.execute(text("ALTER TYPE devicestatus RENAME VALUE 'APPROVED' TO 'ADOPTED'"))
+            has_offline = await conn.execute(
+                text("SELECT 1 FROM pg_enum WHERE enumlabel = 'OFFLINE' AND enumtypid = 'devicestatus'::regtype")
+            )
+            if has_offline.scalar():
+                await conn.execute(text("ALTER TYPE devicestatus RENAME VALUE 'OFFLINE' TO 'ORPHANED'"))
 
 
     # Let create_all handle brand-new tables (device_profiles, asset_variants)


### PR DESCRIPTION
The `run_migrations()` function queries `'devicestatus'::regtype` to check enum values, but on a fresh database the enum type doesn't exist yet (`create_all` runs after migrations). This causes `UndefinedObjectError` and the CMS fails to start.

Fix: check `pg_type` for the enum's existence before attempting renames. Existing databases are unaffected.