### PR TITLE
Fix dashboard showing 'all healthy' when no devices exist

### DIFF
--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -156,7 +156,11 @@
         </tbody>
     </table>
     {% else %}
+    {% if all_devices %}
     <p class="text-success empty-state">All devices are online and healthy.</p>
+    {% else %}
+    <p class="text-muted empty-state">No devices registered yet. Devices will appear here once they connect.</p>
+    {% endif %}
     {% endif %}
 </div>
 


### PR DESCRIPTION
On a fresh install with no devices, the dashboard showed 'All devices are online and healthy' which is misleading. Now shows 'No devices registered yet. Devices will appear here once they connect.' when there are no adopted devices.