### PR TITLE
Fix Watchtower API version

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,10 +24,11 @@ services:
       retries: 5
 
   watchtower:
-    image: containrrr/watchtower
+    image: containrrr/watchtower:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - DOCKER_API_VERSION=1.43
       - WATCHTOWER_POLL_INTERVAL=300
       - WATCHTOWER_LABEL_ENABLE=true
       - WATCHTOWER_CLEANUP=true


### PR DESCRIPTION
Set DOCKER_API_VERSION=1.43 to fix client version too old error