### PR TITLE
feat: add profile assignment dropdown to devices page

### DIFF
--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -32,6 +32,7 @@ class DeviceUpdate(BaseModel):
     status: Optional[DeviceStatus] = None
     group_id: Optional[uuid.UUID] = None
     default_asset_id: Optional[uuid.UUID] = None
+    profile_id: Optional[uuid.UUID] = None
 
 
 class DeviceGroupOut(BaseModel):

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -201,6 +201,12 @@ async function setDefaultAsset(deviceId, assetId) {
     else showToast("Update failed", true);
 }
 
+async function setProfile(deviceId, profileId) {
+    const resp = await apiCall("PATCH", `/api/devices/${deviceId}`, { profile_id: profileId || null });
+    if (resp && resp.ok) showToast("Profile updated");
+    else showToast("Profile update failed", true);
+}
+
 async function setGroupDefaultAsset(groupId, assetId) {
     const resp = await apiCall("PATCH", `/api/devices/groups/${groupId}`, { default_asset_id: assetId || null });
     if (resp && resp.ok) showToast("Group default asset updated");

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 {# ── Macro for a device row (reused in main table, groups, ungrouped) ── #}
-{% macro device_row(d, groups, assets, draggable=false) %}
+{% macro device_row(d, groups, assets, profiles, draggable=false) %}
 <tr class="device-row{% if draggable %} draggable-device{% endif %}" onclick="toggleDevice(this)" data-device-id="{{ d.id }}"{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
     <td class="expand-toggle">▶</td>
     <td>
@@ -36,6 +36,14 @@
             {% endfor %}
         </select>
     </td>
+    <td>
+        <select class="inline-edit" onclick="event.stopPropagation()" onchange="setProfile('{{ d.id }}', this.value)">
+            <option value="">None</option>
+            {% for p in profiles %}
+            <option value="{{ p.id }}" {% if d.profile_id == p.id %}selected{% endif %}>{{ p.name }}</option>
+            {% endfor %}
+        </select>
+    </td>
     <td data-storage-pct data-storage-mb="{{ d.storage_capacity_mb }}" data-used-mb="{{ d.storage_used_mb }}">
         {% if d.storage_capacity_mb > 0 %}
         {{ ((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int }}% free
@@ -52,7 +60,7 @@
 </tr>
 <tr class="device-detail" data-detail-for="{{ d.id }}" style="display: none;">
     <td></td>
-    <td colspan="6">
+    <td colspan="7">
         <div class="detail-grid">
             <div class="detail-item">
                 <span class="detail-label">Device ID</span>
@@ -106,6 +114,7 @@
     <th>Status</th>
     <th>Group</th>
     <th>Default Splash Screen</th>
+    <th>Profile</th>
     <th>Storage</th>
     <th>Actions</th>
 </tr>
@@ -121,9 +130,9 @@
         <thead>{{ th_row }}</thead>
         <tbody>
             {% for d in devices %}
-            {{ device_row(d, groups, assets) }}
+            {{ device_row(d, groups, assets, profiles) }}
             {% else %}
-            <tr><td colspan="7" class="empty">No devices registered yet</td></tr>
+            <tr><td colspan="8" class="empty">No devices registered yet</td></tr>
             {% endfor %}
         </tbody>
     </table>
@@ -159,7 +168,7 @@
                 <thead>{{ th_row }}</thead>
                 <tbody>
                     {% for d in g.devices | sort(attribute='name') %}
-                    {{ device_row(d, groups, assets) }}
+                    {{ device_row(d, groups, assets, profiles) }}
                     {% endfor %}
                 </tbody>
             </table>
@@ -191,7 +200,7 @@
         <thead>{{ th_row }}</thead>
         <tbody>
             {% for d in ungrouped %}
-            {{ device_row(d, groups, assets, draggable=true) }}
+            {{ device_row(d, groups, assets, profiles, draggable=true) }}
             {% endfor %}
         </tbody>
     </table>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -334,12 +334,16 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
     assets_q = await db.execute(select(Asset).order_by(Asset.filename))
     assets = assets_q.scalars().all()
 
+    profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
+    profiles = profiles_q.scalars().all()
+
     return templates.TemplateResponse(request, "devices.html", {
         "active_tab": "devices",
         "devices": devices,
         "groups": groups,
         "ungrouped": ungrouped,
         "assets": assets,
+        "profiles": profiles,
         "latest_version": get_latest_device_version(),
     })
 


### PR DESCRIPTION
Adds a **Profile** column to the devices table so admins can assign a transcoding profile (e.g. pi-zero-2w) to each device from the Devices page.

Previously, the \profile_id\ field existed on the Device model but there was no UI to set it, meaning variant resolution in \_resolve_asset_for_device()\ could never activate.

### Changes
- Add \profile_id\ to \DeviceUpdate\ Pydantic schema
- Add Profile dropdown to the \device_row\ macro in \devices.html\
- Query and pass \profiles\ list from \devices_page()\ in \ui.py\
- Add \setProfile()\ JS helper in \pp.js" --base main
echo 
