### PR TITLE
feat: surface device playback errors on CMS dashboard

### DIFF
--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -269,13 +269,14 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                 device.storage_used_mb = msg.get("storage_used_mb", device.storage_used_mb)
                 await db.commit()
 
-                # Track playback state
+                # Track playback state (including error)
                 device_manager.update_status(
                     device_id,
                     mode=msg.get("mode", "unknown"),
                     asset=msg.get("asset"),
                     uptime_seconds=msg.get("uptime_seconds", 0),
                     cpu_temp_c=msg.get("cpu_temp_c"),
+                    error=msg.get("error"),
                 )
 
                 # Rotate API key if due

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -66,6 +66,8 @@ class StatusMessage(BaseMessage):
     uptime_seconds: int = 0
     storage_used_mb: int = 0
     cpu_temp_c: Optional[float] = None
+    error: Optional[str] = None
+    error_timestamp: Optional[str] = None
 
 
 class AssetAckMessage(BaseMessage):

--- a/cms/services/device_manager.py
+++ b/cms/services/device_manager.py
@@ -20,6 +20,9 @@ class ConnectedDevice:
         self.asset: Optional[str] = None
         self.uptime_seconds: int = 0
         self.cpu_temp_c: Optional[float] = None
+        # Error state from last STATUS message
+        self.error: Optional[str] = None
+        self.error_since: Optional[datetime] = None
 
     async def send_json(self, data: dict):
         await self.websocket.send_json(data)
@@ -70,13 +73,18 @@ class DeviceManager:
         for device_id in list(self._connections.keys()):
             await self.send_to_device(device_id, message)
 
-    def update_status(self, device_id: str, mode: str, asset: str | None, uptime_seconds: int = 0, cpu_temp_c: float | None = None):
+    def update_status(self, device_id: str, mode: str, asset: str | None, uptime_seconds: int = 0, cpu_temp_c: float | None = None, error: str | None = None):
         conn = self._connections.get(device_id)
         if conn:
             conn.mode = mode
             conn.asset = asset
             conn.uptime_seconds = uptime_seconds
             conn.cpu_temp_c = cpu_temp_c
+            if error and not conn.error:
+                conn.error_since = datetime.now(timezone.utc)
+            elif not error:
+                conn.error_since = None
+            conn.error = error
 
     def get_all_states(self) -> list[dict]:
         return [
@@ -88,6 +96,8 @@ class DeviceManager:
                 "connected_at": c.connected_at.isoformat(),
                 "cpu_temp_c": c.cpu_temp_c,
                 "ip_address": c.ip_address,
+                "error": c.error,
+                "error_since": c.error_since.isoformat() if c.error_since else None,
             }
             for c in self._connections.values()
         ]

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -170,6 +170,7 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .badge-failed { background: var(--danger); color: #fff; margin-left: 0.4rem; }
 .badge-temp-warning { background: var(--warning); color: #000; }
 .badge-temp-critical { background: var(--danger); color: #fff; }
+.badge-error { background: var(--danger); color: #fff; }
 .badge-update { background: var(--primary); color: #fff; }
 .badge-started { background: var(--success); color: #000; }
 .badge-ended { background: #7f8c8d; color: #fff; }

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -150,7 +150,8 @@
 {# ── Device Status ── #}
 {% set temp_warning = device_states | selectattr("cpu_temp_c") | selectattr("cpu_temp_c", "ge", 70) | list %}
 {% set temp_critical = temp_warning | selectattr("cpu_temp_c", "ge", 80) | list %}
-{% set has_issues = offline_devices or orphaned_devices or temp_warning %}
+{% set error_devices = device_states | selectattr("error") | list %}
+{% set has_issues = offline_devices or orphaned_devices or temp_warning or error_devices %}
 <div class="card{{ ' card-danger' if has_issues }}">
     <h2>Device Status</h2>
     {% if has_issues %}
@@ -164,6 +165,14 @@
             </tr>
         </thead>
         <tbody>
+            {% for ds in error_devices %}
+            <tr>
+                <td>{{ ds.name }}</td>
+                <td>{{ ds.group_name or '—' }}</td>
+                <td><span class="badge badge-error">Error</span></td>
+                <td class="text-danger">{{ ds.error }}</td>
+            </tr>
+            {% endfor %}
             {% for d in orphaned_devices %}
             <tr>
                 <td>{{ d.name or d.id }}</td>
@@ -257,7 +266,7 @@ async function endNow(scheduleId) {
         function tempBucket(t) { return t == null ? 'n' : t >= 80 ? 'c' : t >= 70 ? 'w' : 'ok'; }
         return JSON.stringify({
             playing: (data.now_playing || []).map(p => p.schedule_id).sort(),
-            devices: (data.device_states || []).map(d => d.id + ':' + d.mode + ':' + tempBucket(d.cpu_temp_c)).sort(),
+            devices: (data.device_states || []).map(d => d.id + ':' + d.mode + ':' + tempBucket(d.cpu_temp_c) + ':' + (d.error || '')).sort(),
             pending: (data.pending_ids || []).sort(),
             orphaned: (data.orphaned_ids || []).sort(),
             offline: (data.offline_ids || []).sort(),

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -176,6 +176,8 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             "mode": state["mode"] if state else "offline",
             "asset": state["asset"] if state else None,
             "cpu_temp_c": state["cpu_temp_c"] if state else None,
+            "error": state["error"] if state else None,
+            "error_since": state["error_since"] if state else None,
         })
 
     # Upcoming schedules (next 24h)
@@ -258,6 +260,7 @@ async def dashboard_json(db: AsyncSession = Depends(get_db)):
             "mode": live_states[did]["mode"] if did in live_states else "offline",
             "asset": live_states[did]["asset"] if did in live_states else None,
             "cpu_temp_c": live_states[did]["cpu_temp_c"] if did in live_states else None,
+            "error": live_states[did]["error"] if did in live_states else None,
         }
         for did in all_device_ids
     ]

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -103,3 +103,84 @@ class TestDeviceManager:
         states = {s["device_id"]: s for s in dm.get_all_states()}
         assert states["dev-1"]["ip_address"] == "10.0.0.1"
         assert states["dev-2"]["ip_address"] == "10.0.0.2"
+
+
+class TestDeviceManagerErrorTracking:
+    """Error state is surfaced from device status heartbeats."""
+
+    def test_error_initially_none(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-1", FakeWS())
+        conn = dm.get("dev-err-1")
+        assert conn.error is None
+        assert conn.error_since is None
+
+    def test_error_set_on_status(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-2", FakeWS())
+        dm.update_status("dev-err-2", mode="play", asset="test.mp4", error="Pipeline error: not-linked")
+        conn = dm.get("dev-err-2")
+        assert conn.error == "Pipeline error: not-linked"
+        assert conn.error_since is not None
+
+    def test_error_cleared_when_resolved(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-3", FakeWS())
+        dm.update_status("dev-err-3", mode="play", asset="test.mp4", error="Pipeline error")
+        assert dm.get("dev-err-3").error is not None
+
+        # Next status has no error — should clear
+        dm.update_status("dev-err-3", mode="play", asset="test.mp4", error=None)
+        conn = dm.get("dev-err-3")
+        assert conn.error is None
+        assert conn.error_since is None
+
+    def test_error_since_preserved_across_updates(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-4", FakeWS())
+        dm.update_status("dev-err-4", mode="play", asset="test.mp4", error="Error A")
+        first_since = dm.get("dev-err-4").error_since
+
+        # Same device, still in error — error_since should NOT reset
+        dm.update_status("dev-err-4", mode="play", asset="test.mp4", error="Error A")
+        assert dm.get("dev-err-4").error_since == first_since
+
+    def test_error_in_get_all_states(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-5", FakeWS())
+        dm.update_status("dev-err-5", mode="play", asset="test.mp4", error="Pipeline error")
+
+        states = {s["device_id"]: s for s in dm.get_all_states()}
+        assert states["dev-err-5"]["error"] == "Pipeline error"
+        assert states["dev-err-5"]["error_since"] is not None
+
+    def test_no_error_in_get_all_states(self):
+        dm = DeviceManager()
+
+        class FakeWS:
+            pass
+
+        dm.register("dev-err-6", FakeWS())
+        states = {s["device_id"]: s for s in dm.get_all_states()}
+        assert states["dev-err-6"]["error"] is None
+        assert states["dev-err-6"]["error_since"] is None


### PR DESCRIPTION
Devices now report errors (pipeline failures, missing assets, codec mismatches) to the CMS via the status heartbeat. The CMS tracks error state in-memory and displays error devices prominently on the Dashboard.

### Problem
When a device had a playback error (e.g. trying to play AV1 through an H.264-only pipeline), the CMS had **no idea**. The dashboard showed everything as healthy. With a large distributed installation, this is unacceptable — you need to know immediately if a device isn't working.

### Solution
- **Protocol**: Add \error\ and \error_timestamp\ fields to \StatusMessage\
- **DeviceManager**: Track \error\ and \error_since\ on each connected device
- **WS handler**: Pass error from status heartbeats through to device manager
- **Dashboard**: Show error devices with red **Error** badge in Device Status card, auto-refresh on change

### Tests
- 6 new unit tests for error tracking in DeviceManager (set, clear, error_since preservation, get_all_states)

### Companion PR
Requires sslivins/agora feature/device-error-reporting to send error in heartbeats.