### PR TITLE
feat: show mismatch indicator when device isn't playing scheduled content

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -94,6 +94,10 @@ h2 { font-size: 1.2rem; margin-bottom: 1rem; }
     border: 1px solid var(--success);
     background: linear-gradient(135deg, var(--surface) 0%, rgba(46,204,113,0.08) 100%);
 }
+.card-playing-mismatch {
+    border: 1px solid var(--warning);
+    background: linear-gradient(135deg, var(--surface) 0%, rgba(243,156,18,0.08) 100%);
+}
 .card-danger {
     border: 1px solid var(--accent);
     background: linear-gradient(135deg, var(--surface) 0%, rgba(233,69,96,0.08) 100%);

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -4,7 +4,8 @@
 <h1>Dashboard</h1>
 
 {# ── Currently Playing ── #}
-<div class="card{{ ' card-playing' if now_playing }}">
+{% set has_mismatch = now_playing | selectattr("mismatch") | list %}
+<div class="card{{ ' card-playing-mismatch' if has_mismatch else ' card-playing' if now_playing }}">
     <h2>Currently Playing</h2>
     {% if now_playing %}
     <table>
@@ -13,6 +14,7 @@
                 <th>Device</th>
                 <th>Schedule</th>
                 <th>Asset</th>
+                <th>Status</th>
                 <th>Ends At</th>
                 <th>Time Remaining</th>
                 <th></th>
@@ -24,6 +26,13 @@
                 <td>{{ np.device_name }}</td>
                 <td>{{ np.schedule_name }}</td>
                 <td>{{ np.asset_filename }}</td>
+                <td>
+                    {% if np.mismatch %}
+                    <span class="has-tooltip"><span class="badge badge-missed">Not Playing</span><span class="tooltip">Device is {{ np.actual_mode }}{% if np.actual_asset %} ({{ np.actual_asset }}){% endif %} instead of {{ np.asset_filename }}</span></span>
+                    {% else %}
+                    <span class="badge badge-started">Playing</span>
+                    {% endif %}
+                </td>
                 <td>{{ np.end_time }}</td>
                 <td>{{ np.remaining }}</td>
                 <td><button class="btn btn-sm btn-danger" onclick="endNow('{{ np.schedule_id }}')">End Now</button></td>
@@ -265,7 +274,7 @@ async function endNow(scheduleId) {
         // Bucket temperatures to avoid constant reloads from minor fluctuations
         function tempBucket(t) { return t == null ? 'n' : t >= 80 ? 'c' : t >= 70 ? 'w' : 'ok'; }
         return JSON.stringify({
-            playing: (data.now_playing || []).map(p => p.schedule_id).sort(),
+            playing: (data.now_playing || []).map(p => p.schedule_id + ':' + (p.mismatch ? '!' : '')).sort(),
             devices: (data.device_states || []).map(d => d.id + ':' + d.mode + ':' + tempBucket(d.cpu_temp_c) + ':' + (d.error || '')).sort(),
             pending: (data.pending_ids || []).sort(),
             orphaned: (data.orphaned_ids || []).sort(),

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -160,11 +160,21 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     )
     orphaned_devices = orphaned_q.scalars().all()
 
-    # Now Playing
+    # Now Playing — enrich with actual device state for mismatch detection
     now_playing = get_now_playing()
+    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    for np in now_playing:
+        did = np["device_id"]
+        live = live_states.get(did, {})
+        actual_mode = live.get("mode", "unknown")
+        actual_asset = live.get("asset")
+        expected_asset = np.get("asset_filename")
+        # Mismatch: schedule says play this asset, but device isn't playing it
+        np["actual_mode"] = actual_mode
+        np["actual_asset"] = actual_asset
+        np["mismatch"] = actual_mode != "play" or actual_asset != expected_asset
 
     # Build device status with live playback state
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
     device_states = []
     for d in all_devices:
         state = live_states.get(d.id)
@@ -254,6 +264,13 @@ async def dashboard_json(db: AsyncSession = Depends(get_db)):
     now_playing = get_now_playing()
 
     live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    for np in now_playing:
+        did = np["device_id"]
+        live = live_states.get(did, {})
+        actual_mode = live.get("mode", "unknown")
+        actual_asset = live.get("asset")
+        np["mismatch"] = actual_mode != "play" or actual_asset != np.get("asset_filename")
+
     device_states = [
         {
             "id": did,

--- a/tests/test_dashboard_mismatch.py
+++ b/tests/test_dashboard_mismatch.py
@@ -1,0 +1,130 @@
+"""Tests for dashboard schedule mismatch detection.
+
+When a schedule is active for a device but the device is not actually playing
+the expected asset, the dashboard should show a 'Not Playing' warning badge.
+"""
+
+import hashlib
+
+import pytest
+import pytest_asyncio
+from cms.models.device import Device, DeviceStatus
+from cms.services.device_manager import device_manager
+from cms.services import scheduler as _sched
+
+
+async def _seed_device(db_session, device_id="mismatch-01", name="Test Device"):
+    device = Device(
+        id=device_id,
+        name=name,
+        status=DeviceStatus.ADOPTED,
+        device_auth_token_hash=hashlib.sha256(b"tok").hexdigest(),
+    )
+    db_session.add(device)
+    await db_session.commit()
+    return device
+
+
+def _fake_connect(device_id, mode="splash", asset=None):
+    class FakeWS:
+        pass
+    device_manager.register(device_id, FakeWS())
+    device_manager.update_status(device_id, mode=mode, asset=asset)
+
+
+def _seed_now_playing(device_id, device_name, schedule_name, asset_filename):
+    _sched._now_playing[device_id] = {
+        "device_id": device_id,
+        "device_name": device_name,
+        "schedule_id": "sched-1",
+        "schedule_name": schedule_name,
+        "asset_filename": asset_filename,
+        "end_time": "5:00 PM",
+        "remaining": "30 minutes",
+        "remaining_seconds": 1800,
+    }
+
+
+@pytest.mark.asyncio
+class TestDashboardMismatch:
+    async def test_mismatch_shown_when_device_on_splash(self, app, db_session, client):
+        """Device should be playing per schedule but is on splash → 'Not Playing' badge."""
+        await _seed_device(db_session)
+        _fake_connect("mismatch-01", mode="splash", asset=None)
+        _seed_now_playing("mismatch-01", "Test Device", "Sony Schedule", "sony-clip.mp4")
+
+        try:
+            resp = await client.get("/")
+            assert resp.status_code == 200
+            html = resp.text
+            assert "Not Playing" in html
+            assert "badge-missed" in html
+            assert "card-playing-mismatch" in html
+        finally:
+            device_manager.disconnect("mismatch-01")
+            _sched._now_playing.pop("mismatch-01", None)
+
+    async def test_no_mismatch_when_playing_correct_asset(self, app, db_session, client):
+        """Device is playing the scheduled asset → 'Playing' badge, no warning."""
+        await _seed_device(db_session)
+        _fake_connect("mismatch-01", mode="play", asset="sony-clip.mp4")
+        _seed_now_playing("mismatch-01", "Test Device", "Sony Schedule", "sony-clip.mp4")
+
+        try:
+            resp = await client.get("/")
+            assert resp.status_code == 200
+            html = resp.text
+            assert "badge-started" in html
+            assert "Not Playing" not in html
+            assert "card-playing-mismatch" not in html
+        finally:
+            device_manager.disconnect("mismatch-01")
+            _sched._now_playing.pop("mismatch-01", None)
+
+    async def test_mismatch_when_playing_wrong_asset(self, app, db_session, client):
+        """Device is playing a different asset than scheduled → mismatch warning."""
+        await _seed_device(db_session)
+        _fake_connect("mismatch-01", mode="play", asset="other-video.mp4")
+        _seed_now_playing("mismatch-01", "Test Device", "Sony Schedule", "sony-clip.mp4")
+
+        try:
+            resp = await client.get("/")
+            assert resp.status_code == 200
+            html = resp.text
+            assert "Not Playing" in html
+            assert "badge-missed" in html
+        finally:
+            device_manager.disconnect("mismatch-01")
+            _sched._now_playing.pop("mismatch-01", None)
+
+    async def test_mismatch_in_json_api(self, app, db_session, client):
+        """The /api/dashboard JSON endpoint should include mismatch flag in now_playing."""
+        await _seed_device(db_session)
+        _fake_connect("mismatch-01", mode="splash", asset=None)
+        _seed_now_playing("mismatch-01", "Test Device", "Sony Schedule", "sony-clip.mp4")
+
+        try:
+            resp = await client.get("/api/dashboard")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["now_playing"]) == 1
+            assert data["now_playing"][0]["mismatch"] is True
+        finally:
+            device_manager.disconnect("mismatch-01")
+            _sched._now_playing.pop("mismatch-01", None)
+
+    async def test_no_mismatch_in_json_api(self, app, db_session, client):
+        """JSON endpoint shows mismatch=False when device is playing correctly."""
+        await _seed_device(db_session)
+        _fake_connect("mismatch-01", mode="play", asset="sony-clip.mp4")
+        _seed_now_playing("mismatch-01", "Test Device", "Sony Schedule", "sony-clip.mp4")
+
+        try:
+            resp = await client.get("/api/dashboard")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["now_playing"]) == 1
+            assert data["now_playing"][0]["mismatch"] is False
+        finally:
+            device_manager.disconnect("mismatch-01")
+            _sched._now_playing.pop("mismatch-01", None)


### PR DESCRIPTION
The Currently Playing section on the dashboard now compares what the scheduler expects a device to play against what the device actually reports via its status heartbeat.

## Changes

- **Status column** added to the Currently Playing table
  - Green **Playing** badge when the device is playing the correct asset
  - Red **Not Playing** badge with tooltip when there's a mismatch (shows what the device is actually doing)
- **Card border** changes from green to amber when any device has a mismatch
- **Auto-refresh** includes mismatch state in the polling fingerprint so the page reloads when status changes
- Both HTML dashboard and \/api/dashboard\ JSON endpoint include mismatch data

## Tests

5 new tests covering:
- Mismatch shown when device is on splash instead of scheduled asset
- No mismatch when device is playing the correct asset
- Mismatch when device is playing a different asset
- JSON API returns \mismatch: true/false\ correctly