### PR TITLE
fix: constrain checksum column width

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -617,7 +617,7 @@ select.inline-edit option { background: var(--card-bg); color: var(--text); }
 .detail-item-wide { grid-column: 1 / -1; }
 .detail-value.monospace { font-family: monospace; font-size: 0.8rem; word-break: break-all; white-space: normal; }
 .checksum-wrap { display: inline-flex; align-items: center; gap: 0.4rem; max-width: 100%; }
-.checksum-text { font-family: monospace; font-size: 0.8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.checksum-text { font-family: monospace; font-size: 0.8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; max-width: 8ch; }
 .checksum-wrap.has-tooltip .tooltip { word-break: break-all; max-width: 420px; font-family: monospace; }
 .btn-copy { background: none; border: 1px solid var(--border); border-radius: 4px; color: var(--text-muted); cursor: pointer; padding: 0.15rem 0.4rem; font-size: 0.7rem; line-height: 1; transition: color 0.2s, border-color 0.2s; flex-shrink: 0; }
 .btn-copy:hover { color: var(--text); border-color: var(--text); }


### PR DESCRIPTION
Adds max-width: 8ch to .checksum-text so the SHA-256 hash truncates with ellipsis instead of stretching the column. The copy button and full-hash tooltip remain unchanged.

Affects all three checksum display locations:
- Asset detail grid checksum
- Variants table checksum column
- JS live-updated variant checksums

All share the same .checksum-text CSS class, so a single rule handles everything.