### PR TITLE
fix: make ffmpeg installation architecture-aware for ARM64 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,12 @@ jobs:
       - name: Install system dependencies
         run: |
           # BtbN static build — includes libsvtav1, libaom-av1, libx265, libopus, etc.
-          curl -sL https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-06-13-14/ffmpeg-n8.1-7-ga3475e2554-linux64-gpl-8.1.tar.xz | \
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in
+            arm64|aarch64) FFARCH=linuxarm64 ;;
+            *)             FFARCH=linux64 ;;
+          esac
+          curl -sL "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-06-13-14/ffmpeg-n8.1-7-ga3475e2554-${FFARCH}-gpl-8.1.tar.xz" | \
             sudo tar -xJ --strip-components=1 -C /usr/local
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,19 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# BtbN static FFmpeg 8.1 build (GPL, linux64)
-ARG FFMPEG_URL=https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-06-13-14/ffmpeg-n8.1-7-ga3475e2554-linux64-gpl-8.1.tar.xz
+# BtbN static FFmpeg 8.1 build (GPL) — auto-select arch
+ARG TARGETARCH
+ARG FFMPEG_VERSION=n8.1-7-ga3475e2554
+ARG FFMPEG_RELEASE=autobuild-2026-04-06-13-14
 
 # libheif-examples for HEIC grid assembly, curl + xz-utils to fetch FFmpeg
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libheif-examples \
     curl \
     xz-utils \
-    && curl -fsSL "$FFMPEG_URL" | tar -xJ --strip-components=1 -C /usr/local \
+    && ARCH=$(case "$TARGETARCH" in arm64) echo linuxarm64;; *) echo linux64;; esac) \
+    && curl -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_RELEASE}/ffmpeg-${FFMPEG_VERSION}-${ARCH}-gpl-8.1.tar.xz" \
+       | tar -xJ --strip-components=1 -C /usr/local \
     && apt-get purge -y curl xz-utils && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Dockerfile and CI workflow now auto-detect the runner/build architecture and select the correct BtbN static FFmpeg build (linux64 for x86_64, linuxarm64 for ARM64).

- **Dockerfile**: Uses Docker's \TARGETARCH\ build arg to pick the right binary
- **CI workflow**: Uses \dpkg --print-architecture\ to detect runner arch

Previously the BtbN URL was hardcoded to \linux64\, which breaks on ARM64 runners/hosts.