### PR TITLE
fix(ui): reset upload label when file picker is cancelled

### DIFF
--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -250,8 +250,11 @@
     });
 
     fileInput.addEventListener("change", () => {
+        const label = document.getElementById("drop-label");
         if (fileInput.files.length) {
-            document.getElementById("drop-label").textContent = fileInput.files[0].name;
+            label.textContent = fileInput.files[0].name;
+        } else {
+            label.textContent = "Drag \u0026 drop a file here, or";
         }
     });
 

--- a/tests_e2e/test_ui_upload_cancel.py
+++ b/tests_e2e/test_ui_upload_cancel.py
@@ -1,0 +1,48 @@
+"""E2E: cancelling the file picker after a drag-drop should reset the label."""
+
+import pytest
+
+
+DEFAULT_LABEL = "Drag & drop a file here, or"
+
+
+def test_cancel_file_picker_resets_label_after_drop(page: "Page"):
+    """After drag-dropping a file, clicking Choose File then cancelling
+    should clear the displayed filename back to the default label."""
+
+    page.goto("/assets")
+
+    # Simulate a file being set on the hidden input (equivalent to drag-drop)
+    file_input = page.locator("#file-input")
+    file_input.set_input_files(
+        {"name": "test-video.mp4", "mimeType": "video/mp4", "buffer": b"\x00" * 10}
+    )
+
+    # Label should now show the filename
+    label = page.locator("#drop-label")
+    assert label.text_content() == "test-video.mp4"
+
+    # Simulate cancelling the file picker — clears the input
+    file_input.set_input_files([])
+
+    # Label should revert to default
+    assert label.text_content() == DEFAULT_LABEL
+
+
+def test_cancel_file_picker_resets_label_after_choose(page: "Page"):
+    """After choosing a file via the button, cancelling the picker
+    should clear the displayed filename back to the default label."""
+
+    page.goto("/assets")
+
+    file_input = page.locator("#file-input")
+    file_input.set_input_files(
+        {"name": "photo.jpg", "mimeType": "image/jpeg", "buffer": b"\xFF\xD8" * 5}
+    )
+
+    label = page.locator("#drop-label")
+    assert label.text_content() == "photo.jpg"
+
+    # Cancel
+    file_input.set_input_files([])
+    assert label.text_content() == DEFAULT_LABEL


### PR DESCRIPTION
After dragging a file onto the upload area (or choosing one via the button), clicking 'Choose File' and then cancelling the file picker left the stale filename displayed. Clicking Upload at that point would silently do nothing since the input was empty.

**Root cause:** The \change\ event handler only updated the label when \ileInput.files.length > 0\. Cancelling the picker fires a \change\ event with an empty file list, so the label was never reset.

**Fix:** Add an \else\ branch to revert the label to the default text when the input is cleared.

**Tests:** Added 2 Playwright E2E tests in \	ests_e2e/test_ui_upload_cancel.py\ covering the cancel-after-drop and cancel-after-choose scenarios.