### PR TITLE
feat: add chrony NTP server container for device clock sync

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,26 @@ services:
       timeout: 3s
       retries: 5
 
+  ntp:
+    image: alpine:3.21
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache chrony &&
+        cat > /etc/chrony/chrony.conf <<'EOF'
+        pool pool.ntp.org iburst
+        driftfile /var/lib/chrony/drift
+        makestep 1.0 3
+        rtcsync
+        allow all
+        EOF
+        exec chronyd -d -s
+    cap_add:
+      - SYS_TIME
+    ports:
+      - "123:123/udp"
+    restart: unless-stopped
+
   watchtower:
     image: containrrr/watchtower:latest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,26 @@ services:
       timeout: 3s
       retries: 5
 
+  ntp:
+    image: alpine:3.21
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache chrony &&
+        cat > /etc/chrony/chrony.conf <<'EOF'
+        pool pool.ntp.org iburst
+        driftfile /var/lib/chrony/drift
+        makestep 1.0 3
+        rtcsync
+        allow all
+        EOF
+        exec chronyd -d -s
+    cap_add:
+      - SYS_TIME
+    ports:
+      - "123:123/udp"
+    restart: unless-stopped
+
 volumes:
   pgdata:
   cms-assets:

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,10 @@ if [ ! -f "$AVAHI_SERVICE" ]; then
     <port>8080</port>
     <txt-record>path=/</txt-record>
   </service>
+  <service>
+    <type>_ntp._udp</type>
+    <port>123</port>
+  </service>
 </service-group>
 AVAHI_EOF
 fi

--- a/todo.md
+++ b/todo.md
@@ -2,6 +2,12 @@
 
 ## Backlog
 
+### NTP server for device clock sync
+- [x] Add a chrony NTP container to `docker-compose.yml` — serves time on UDP 123, inherits host clock
+- [x] Pi devices point `systemd-timesyncd` at CMS server (`agora-cms.local`) for proper NTP slewing
+- [x] Advertise NTP service via Avahi (`_ntp._udp` in `setup.sh`)
+- [x] No application code changes needed — NTP handles slewing correctly (no backward jumps)
+
 ### Security hardening
 - [ ] Move device WebSocket connections to WSS (TLS) — auth tokens currently travel in plaintext over the wire. Low risk on trusted LAN but needed for internet-exposed deployments.
 - [ ] Consider disabling the device-side REST API when CMS-managed — the CMS never calls it (all communication is over WebSocket), so it's extra attack surface. Could be a CMS-pushed config flag.


### PR DESCRIPTION
Pi Zero 2 W has no battery-backed RTC and loses time on power loss without internet.

## Changes

- Add a chrony NTP container to both dev and prod docker-compose files
  - Syncs upstream to pool.ntp.org
  - Serves NTP on UDP 123 for devices on the LAN
  - Requires \CAP_SYS_TIME\ capability
- Advertise the NTP service via Avahi (\_ntp._udp\) in setup.sh
- Update todo.md

## Testing

- Verified chrony container starts and syncs (Stratum 4 via time.cloudflare.com)
- Confirmed Pi device at 192.168.1.148 successfully syncs time from the CMS NTP server
- \	imedatectl timesync-status\ shows \Server: 192.168.1.198 (agora-cms.local)\

## Companion PR

- agora: sslivins/agora (feat/ntp-client) — configures device-side timesyncd