### PR TITLE
fix: add HDR-to-SDR tone mapping when source is HDR and target is SDR

### DIFF
--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -45,10 +45,19 @@ COLOR_SPACE_MAP: dict[str, dict[str, str]] = {
 }
 
 
+# Transfer characteristics that indicate HDR content
+_HDR_TRCS = {"smpte2084", "arib-std-b67"}
+
+# Target color spaces that are HDR (no tone mapping needed when targeting these)
+_HDR_TARGET_CS = {"bt2020-pq", "bt2020-hlg"}
+
+
 def _build_ffmpeg_args_safe(
     source_path: Path,
     output_path: Path,
     profile: DeviceProfile,
+    *,
+    source_color_trc: str | None = None,
 ) -> list[str]:
     """Build ffmpeg command-line arguments for a given profile.
 
@@ -62,16 +71,28 @@ def _build_ffmpeg_args_safe(
     cs_key = profile.color_space or "auto"
     cs = COLOR_SPACE_MAP.get(cs_key) if cs_key != "auto" else None
 
+    # Determine if we need HDR → SDR tone mapping:
+    # Source is HDR (PQ or HLG) and target is not an HDR color space.
+    needs_tonemap = (
+        source_color_trc in _HDR_TRCS
+        and cs_key not in _HDR_TARGET_CS
+    )
+
     # When pixel format is "auto", force yuv420p for codecs/profiles that
     # only support 4:2:0 — passing through a 4:2:2 source would fail.
+    # Also force yuv420p when tone-mapping HDR → SDR (output is always 8-bit).
     if pix_fmt == "auto":
         _420_only_profiles = {
             "h264": {"baseline", "main", "high", "high10"},
             "h265": {"main", "main10"},
         }
         restricted = _420_only_profiles.get(profile.video_codec, set())
-        if profile.video_codec == "av1" or profile.video_profile in restricted:
+        if needs_tonemap or profile.video_codec == "av1" or profile.video_profile in restricted:
             pix_fmt = "yuv420p"
+
+    # When tone-mapping HDR → SDR, force BT.709 output regardless of profile setting
+    if needs_tonemap:
+        cs = COLOR_SPACE_MAP["bt709"]
 
     # Scale filter: only shrink (never upscale), maintain aspect ratio,
     # ensure dimensions are divisible by 2
@@ -80,6 +101,16 @@ def _build_ffmpeg_args_safe(
         f":force_original_aspect_ratio=decrease",
         "pad=ceil(iw/2)*2:ceil(ih/2)*2",
     ]
+
+    # HDR → SDR tone-mapping filter chain (must come after scale, before format)
+    if needs_tonemap:
+        scale_parts.extend([
+            "zscale=t=linear:npl=100",
+            "format=gbrpf32le",
+            "tonemap=hable",
+            "zscale=p=bt709:t=bt709:m=bt709:r=tv",
+        ])
+
     if pix_fmt != "auto":
         scale_parts.append(f"format={pix_fmt}")
     if cs:
@@ -165,7 +196,7 @@ async def probe_media(file_path: Path) -> dict:
     result: dict = {
         "width": None, "height": None, "duration_seconds": None,
         "video_codec": None, "audio_codec": None, "bitrate": None,
-        "frame_rate": None, "color_space": None,
+        "frame_rate": None, "color_space": None, "color_transfer": None,
     }
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -214,6 +245,9 @@ async def probe_media(file_path: Path) -> dict:
             cs = stream.get("color_space") or stream.get("color_primaries") or stream.get("color_transfer")
             if cs:
                 result["color_space"] = cs
+            ct = stream.get("color_transfer")
+            if ct:
+                result["color_transfer"] = ct
         elif codec_type == "audio" and result["audio_codec"] is None:
             result["audio_codec"] = stream.get("codec_name")
 
@@ -326,7 +360,13 @@ async def _transcode_one(variant: AssetVariant, db: AsyncSession, asset_dir: Pat
     # Get source duration for progress tracking
     duration = await _get_duration(source_path)
 
-    args = _build_ffmpeg_args_safe(source_path, output_path, profile)
+    # Probe source for HDR detection (tone mapping)
+    source_meta = await probe_media(source_path)
+
+    args = _build_ffmpeg_args_safe(
+        source_path, output_path, profile,
+        source_color_trc=source_meta.get("color_transfer"),
+    )
 
     try:
         # Run ffmpeg with low priority

--- a/tests/test_transcoder_args.py
+++ b/tests/test_transcoder_args.py
@@ -284,3 +284,109 @@ class TestCombinedScenarios:
         assert args[args.index("-crf") + 1] == "20"
         assert args[args.index("-c:v") + 1] == "libx265"
         assert "-profile:v" in args  # H.265 still gets profile flag
+
+
+# ── HDR → SDR tone mapping (issue #82) ──────────────────────────────
+
+class TestHdrToneMapping:
+    """When source is HDR and target profile is SDR, the transcoder must
+    insert zscale + tonemap filters to avoid washed-out output."""
+
+    def test_pq_source_auto_colorspace_inserts_tonemap(self):
+        """PQ (HDR10) source + auto color space → must tone-map to SDR."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" in vf
+        assert "zscale" in vf
+
+    def test_hlg_source_auto_colorspace_inserts_tonemap(self):
+        """HLG source + auto color space → must tone-map to SDR."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc="arib-std-b67")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" in vf
+        assert "zscale" in vf
+
+    def test_pq_source_bt709_target_inserts_tonemap(self):
+        """PQ source + explicit BT.709 target → must tone-map."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="bt709",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" in vf
+
+    def test_pq_source_smpte170m_target_inserts_tonemap(self):
+        """PQ source + SMPTE 170M (SD) target → must tone-map."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="smpte170m",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" in vf
+
+    def test_pq_source_bt2020_pq_target_no_tonemap(self):
+        """PQ source + PQ target → no tone mapping needed (HDR pass-through)."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="bt2020-pq",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" not in vf
+
+    def test_hlg_source_bt2020_hlg_target_no_tonemap(self):
+        """HLG source + HLG target → no tone mapping needed."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="bt2020-hlg",
+        ), source_color_trc="arib-std-b67")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" not in vf
+
+    def test_sdr_source_no_tonemap(self):
+        """SDR source (bt709 TRC) + auto target → no tone mapping."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc="bt709")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" not in vf
+
+    def test_no_source_trc_no_tonemap(self):
+        """No source TRC info (None) → no tone mapping (backward compat)."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc=None)
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" not in vf
+
+    def test_no_source_trc_arg_no_tonemap(self):
+        """Calling without source_color_trc at all → no tone mapping."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ))
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap" not in vf
+
+    def test_tonemap_sets_bt709_output_color(self):
+        """When tone mapping, output must be tagged BT.709."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc="smpte2084")
+        assert args[args.index("-colorspace") + 1] == "bt709"
+        assert args[args.index("-color_primaries") + 1] == "bt709"
+        assert args[args.index("-color_trc") + 1] == "bt709"
+
+    def test_tonemap_forces_yuv420p(self):
+        """HDR → SDR tone mapping must output yuv420p (8-bit SDR)."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            pixel_format="auto", color_space="auto",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "format=yuv420p" in vf
+
+    def test_tonemap_uses_hable(self):
+        """Tone mapping should use the hable algorithm."""
+        args = _build_ffmpeg_args_safe(SRC, OUT, _make_profile(
+            color_space="auto",
+        ), source_color_trc="smpte2084")
+        vf = args[args.index("-vf") + 1]
+        assert "tonemap=hable" in vf


### PR DESCRIPTION
When a source video uses HDR (PQ or HLG transfer characteristics) and the target profile is SDR, the transcoder now automatically inserts a zscale + tonemap=hable filter chain to properly convert the dynamic range.

## Changes

- Add `source_color_trc` parameter to `_build_ffmpeg_args_safe()`
- Probe source `color_transfer` in `_transcode_one()` via `probe_media()`
- Force BT.709 output color tagging when tone mapping
- Add `color_transfer` field to `probe_media()` result dict
- Add 12 unit tests covering all HDR/SDR combinations

Fixes #82