### PR TITLE
fix: validate pixel format and color space compatibility in profile form and API

### DIFF
--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -17,6 +17,63 @@ from cms.services.transcoder import enqueue_for_new_profile
 
 router = APIRouter(prefix="/api/profiles", dependencies=[Depends(require_auth)])
 
+# ── Codec/profile compatibility rules ────────────────────────────────
+
+# Profiles restricted to 4:2:0 chroma subsampling
+_PROFILES_420_ONLY: dict[str, set[str]] = {
+    "h264": {"baseline", "main", "high", "high10"},
+    "h265": {"main", "main10"},
+}
+
+# 8-bit-only profiles: cannot use 10-bit pixel formats or HDR color spaces
+_PROFILES_8BIT_ONLY: dict[str, set[str]] = {
+    "h264": {"baseline", "main", "high"},
+    "h265": {"main"},
+}
+
+_PIX_FMT_422_OR_444 = {"yuv422p", "yuv422p10le", "yuv444p", "yuv444p10le"}
+_PIX_FMT_10BIT = {"yuv420p10le", "yuv422p10le", "yuv444p10le"}
+_AV1_ALLOWED_PIX_FMT = {"auto", "yuv420p", "yuv420p10le"}
+_HDR_COLOR_SPACES = {"bt2020-pq", "bt2020-hlg"}
+
+
+def _validate_profile_compat(
+    video_codec: str, video_profile: str,
+    pixel_format: str, color_space: str,
+) -> None:
+    """Raise HTTPException 422 if pixel_format or color_space is
+    incompatible with the codec/profile combination."""
+    forces_420 = (
+        video_codec == "av1"
+        or video_profile in _PROFILES_420_ONLY.get(video_codec, set())
+    )
+    is_8bit_only = video_profile in _PROFILES_8BIT_ONLY.get(video_codec, set())
+
+    # Pixel format checks
+    if pixel_format != "auto":
+        if video_codec == "av1" and pixel_format not in _AV1_ALLOWED_PIX_FMT:
+            raise HTTPException(
+                status_code=422,
+                detail=f"AV1 only supports pixel formats: {', '.join(sorted(_AV1_ALLOWED_PIX_FMT - {'auto'}))}",
+            )
+        if forces_420 and pixel_format in _PIX_FMT_422_OR_444:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{video_codec}/{video_profile} only supports 4:2:0 pixel formats",
+            )
+        if is_8bit_only and pixel_format in _PIX_FMT_10BIT:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{video_codec}/{video_profile} is 8-bit only — 10-bit pixel formats are not supported",
+            )
+
+    # Color space checks
+    if color_space in _HDR_COLOR_SPACES and is_8bit_only:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{video_codec}/{video_profile} is 8-bit only — HDR color space '{color_space}' requires a 10-bit profile",
+        )
+
 
 @router.get("", response_model=List[ProfileOut])
 async def list_profiles(db: AsyncSession = Depends(get_db)):
@@ -66,6 +123,12 @@ async def list_profiles(db: AsyncSession = Depends(get_db)):
 
 @router.post("", response_model=ProfileOut, status_code=201)
 async def create_profile(data: ProfileCreate, db: AsyncSession = Depends(get_db)):
+    # Validate codec/profile compatibility
+    _validate_profile_compat(
+        data.video_codec, data.video_profile,
+        data.pixel_format, data.color_space,
+    )
+
     # Check duplicate name
     existing = await db.execute(
         select(DeviceProfile).where(DeviceProfile.name == data.name)
@@ -126,6 +189,14 @@ async def update_profile(
         raise HTTPException(status_code=404, detail="Profile not found")
 
     updates = data.model_dump(exclude_unset=True)
+
+    # Validate codec/profile compatibility with the merged state
+    _validate_profile_compat(
+        video_codec=profile.video_codec,  # codec is immutable
+        video_profile=updates.get("video_profile", profile.video_profile),
+        pixel_format=updates.get("pixel_format", profile.pixel_format),
+        color_space=updates.get("color_space", profile.color_space),
+    )
 
     # Detect whether any transcoding-relevant field actually changed
     transcode_changed = any(

--- a/cms/templates/profiles.html
+++ b/cms/templates/profiles.html
@@ -236,41 +236,69 @@ function toggleBitrateEdit() {
     }
 }
 
-// ── Encoder-aware pixel format constraints ──
+// ── Encoder-aware pixel format & color space constraints ──
 const AV1_ALLOWED_PIX_FMT = ['auto', 'yuv420p', 'yuv420p10le'];
 const PROFILES_420_ONLY = {
     h264: ['baseline', 'main', 'high', 'high10'],
     h265: ['main', 'main10'],
 };
+// 8-bit-only profiles: cannot use 10-bit pixel formats or HDR color spaces
+const PROFILES_8BIT_ONLY = {
+    h264: ['baseline', 'main', 'high'],
+    h265: ['main'],
+};
+const PIX_FMT_10BIT = ['yuv420p10le', 'yuv422p10le', 'yuv444p10le'];
+const PIX_FMT_422_OR_444 = ['yuv422p', 'yuv422p10le', 'yuv444p', 'yuv444p10le'];
+const HDR_COLOR_SPACES = ['bt2020-pq', 'bt2020-hlg'];
 
-function applyCodecConstraints(codecSelect, pixFmtSelect, profileValue) {
+function applyCodecConstraints(codecSelect, pixFmtSelect, profileValue, csSelect) {
     const codec = codecSelect.value;
-    const opts = pixFmtSelect.querySelectorAll('option');
     const forces420 = codec === 'av1'
         || (PROFILES_420_ONLY[codec] || []).includes(profileValue);
-    opts.forEach(opt => {
-        if (codec === 'av1' && !AV1_ALLOWED_PIX_FMT.includes(opt.value)) {
-            opt.disabled = true;
-            if (opt.selected) pixFmtSelect.value = 'auto';
-        } else {
-            opt.disabled = false;
+    const is8bitOnly = (PROFILES_8BIT_ONLY[codec] || []).includes(profileValue);
+
+    // ── Pixel format constraints ──
+    const pfOpts = pixFmtSelect.querySelectorAll('option');
+    pfOpts.forEach(opt => {
+        const v = opt.value;
+        let disabled = false;
+        if (codec === 'av1' && !AV1_ALLOWED_PIX_FMT.includes(v)) {
+            disabled = true;
+        } else if (forces420 && PIX_FMT_422_OR_444.includes(v)) {
+            disabled = true;
         }
-        // Update the "auto" label to clarify behavior per encoder/profile
-        if (opt.value === 'auto') {
+        if (is8bitOnly && PIX_FMT_10BIT.includes(v)) {
+            disabled = true;
+        }
+        opt.disabled = disabled;
+        if (disabled && opt.selected) pixFmtSelect.value = 'auto';
+
+        if (v === 'auto') {
             opt.textContent = forces420
                 ? 'Auto (will use yuv420p for this codec/profile)'
                 : 'Auto (keep source format)';
         }
     });
+
+    // ── Color space constraints ──
+    if (csSelect) {
+        const csOpts = csSelect.querySelectorAll('option');
+        csOpts.forEach(opt => {
+            const disabled = is8bitOnly && HDR_COLOR_SPACES.includes(opt.value);
+            opt.disabled = disabled;
+            if (disabled && opt.selected) csSelect.value = 'auto';
+        });
+    }
 }
 
-// Apply constraints on create form codec change
+// Apply constraints on create form codec/profile change
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.querySelector('form');
     const codecSel = form.querySelector('[name="video_codec"]');
     const pfSel = form.querySelector('[name="pixel_format"]');
     const profSel = form.querySelector('[name="video_profile"]');
-    const refresh = () => applyCodecConstraints(codecSel, pfSel, profSel.value);
+    const csSel = form.querySelector('[name="color_space"]');
+    const refresh = () => applyCodecConstraints(codecSel, pfSel, profSel.value, csSel);
     codecSel.addEventListener('change', refresh);
     profSel.addEventListener('change', refresh);
     refresh();
@@ -361,10 +389,15 @@ async function editProfile(profileId) {
     overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
     box.querySelector("#ep-cancel").onclick = () => overlay.remove();
 
-    // Apply encoder constraints for pixel format in edit modal
+    // Apply encoder constraints for pixel format and color space in edit modal
     const epCodec = document.createElement('input');
     epCodec.type = 'hidden'; epCodec.value = p.video_codec;
-    applyCodecConstraints(epCodec, box.querySelector("#ep-pf"), p.video_profile);
+    const epPfSel = box.querySelector("#ep-pf");
+    const epCsSel = box.querySelector("#ep-cs");
+    const epVpSel = box.querySelector("#ep-vprofile");
+    const refreshEditConstraints = () => applyCodecConstraints(epCodec, epPfSel, epVpSel.value, epCsSel);
+    epVpSel.addEventListener('change', refreshEditConstraints);
+    refreshEditConstraints();
     toggleBitrateEdit();
 
     box.querySelector("#ep-save").onclick = async () => {

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -1,0 +1,210 @@
+"""Tests for profile pixel_format and color_space validation.
+
+Verifies the API rejects incompatible combinations of codec/profile
+with pixel format and color space (Fixes #83).
+"""
+
+import pytest
+
+
+# ── Valid pixel formats per codec/profile ─────────────────────────────
+
+VALID_420_FORMATS = {"auto", "yuv420p", "yuv420p10le"}
+VALID_422_FORMATS = VALID_420_FORMATS | {"yuv422p", "yuv422p10le"}
+ALL_FORMATS = VALID_422_FORMATS | {"yuv444p", "yuv444p10le"}
+
+# 8-bit-only profiles cannot use 10-bit pixel formats
+FORMATS_8BIT_ONLY = {"auto", "yuv420p", "yuv422p", "yuv444p"}
+FORMATS_10BIT = {"yuv420p10le", "yuv422p10le", "yuv444p10le"}
+
+# HDR color spaces require at least 10-bit capable profiles
+HDR_COLOR_SPACES = {"bt2020-pq", "bt2020-hlg"}
+SDR_COLOR_SPACES = {"auto", "bt709", "smpte170m"}
+
+
+def _base_profile(**overrides):
+    defaults = {
+        "name": "test-validation",
+        "video_codec": "h264",
+        "video_profile": "main",
+        "pixel_format": "auto",
+        "color_space": "auto",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+@pytest.mark.asyncio
+class TestPixelFormatValidation:
+    """API should reject pixel formats incompatible with codec/profile."""
+
+    async def test_h264_main_rejects_yuv422p(self, client):
+        """H.264 main only supports 4:2:0 — yuv422p should be rejected."""
+        body = _base_profile(name="h264-main-422", pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_main_rejects_yuv444p(self, client):
+        """H.264 main only supports 4:2:0 — yuv444p should be rejected."""
+        body = _base_profile(name="h264-main-444", pixel_format="yuv444p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_baseline_rejects_yuv422p(self, client):
+        body = _base_profile(name="h264-bl-422", video_profile="baseline",
+                             pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_main_rejects_10bit(self, client):
+        """H.264 main is 8-bit only — yuv420p10le should be rejected."""
+        body = _base_profile(name="h264-main-10bit", pixel_format="yuv420p10le")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_high10_accepts_yuv420p10le(self, client):
+        """H.264 high10 supports 10-bit 4:2:0."""
+        body = _base_profile(name="h264-hi10-10bit", video_profile="high10",
+                             pixel_format="yuv420p10le")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h264_high10_rejects_yuv422p(self, client):
+        """H.264 high10 is still 4:2:0 only."""
+        body = _base_profile(name="h264-hi10-422", video_profile="high10",
+                             pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_high422_accepts_yuv422p(self, client):
+        """H.264 high422 supports 4:2:2."""
+        body = _base_profile(name="h264-hi422-422", video_profile="high422",
+                             pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h265_main_rejects_yuv422p(self, client):
+        body = _base_profile(name="h265-main-422", video_codec="h265",
+                             video_profile="main", pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h265_main10_rejects_yuv422p(self, client):
+        body = _base_profile(name="h265-m10-422", video_codec="h265",
+                             video_profile="main10", pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_av1_rejects_yuv422p(self, client):
+        body = _base_profile(name="av1-422", video_codec="av1",
+                             pixel_format="yuv422p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_av1_accepts_yuv420p(self, client):
+        body = _base_profile(name="av1-420", video_codec="av1",
+                             pixel_format="yuv420p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h264_main_accepts_auto(self, client):
+        """Auto should always be accepted — the transcoder handles it."""
+        body = _base_profile(name="h264-main-auto", pixel_format="auto")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h264_main_accepts_yuv420p(self, client):
+        body = _base_profile(name="h264-main-420", pixel_format="yuv420p")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+class TestColorSpaceValidation:
+    """API should reject HDR color spaces for 8-bit-only codec/profiles."""
+
+    async def test_h264_main_rejects_bt2020_pq(self, client):
+        """H.264 main is 8-bit SDR — bt2020-pq (HDR10) is nonsensical."""
+        body = _base_profile(name="h264-main-pq", color_space="bt2020-pq")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_main_rejects_bt2020_hlg(self, client):
+        body = _base_profile(name="h264-main-hlg", color_space="bt2020-hlg")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_baseline_rejects_hdr(self, client):
+        body = _base_profile(name="h264-bl-hdr", video_profile="baseline",
+                             color_space="bt2020-pq")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h264_high10_accepts_bt2020_pq(self, client):
+        """H.264 high10 supports 10-bit — HDR color space is allowed."""
+        body = _base_profile(name="h264-hi10-pq", video_profile="high10",
+                             color_space="bt2020-pq")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h265_main_rejects_hdr(self, client):
+        body = _base_profile(name="h265-main-hdr", video_codec="h265",
+                             video_profile="main", color_space="bt2020-pq")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 422
+
+    async def test_h265_main10_accepts_hdr(self, client):
+        """H.265 main10 supports 10-bit — HDR is fine."""
+        body = _base_profile(name="h265-m10-hdr", video_codec="h265",
+                             video_profile="main10", color_space="bt2020-pq")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h264_main_accepts_bt709(self, client):
+        body = _base_profile(name="h264-main-709", color_space="bt709")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+    async def test_h264_main_accepts_auto(self, client):
+        body = _base_profile(name="h264-main-csauto", color_space="auto")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+class TestUpdateValidation:
+    """PUT /api/profiles/{id} should also validate pixel_format and color_space."""
+
+    async def test_update_rejects_incompatible_pixel_format(self, client):
+        """Updating pixel_format to an incompatible value should be rejected."""
+        body = _base_profile(name="update-pf-test")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+        pid = resp.json()["id"]
+
+        resp = await client.put(f"/api/profiles/{pid}", json={
+            "pixel_format": "yuv422p",
+        })
+        assert resp.status_code == 422
+
+    async def test_update_rejects_incompatible_color_space(self, client):
+        body = _base_profile(name="update-cs-test")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+        pid = resp.json()["id"]
+
+        resp = await client.put(f"/api/profiles/{pid}", json={
+            "color_space": "bt2020-pq",
+        })
+        assert resp.status_code == 422
+
+    async def test_update_accepts_compatible_pixel_format(self, client):
+        body = _base_profile(name="update-pf-ok")
+        resp = await client.post("/api/profiles", json=body)
+        assert resp.status_code == 201
+        pid = resp.json()["id"]
+
+        resp = await client.put(f"/api/profiles/{pid}", json={
+            "pixel_format": "yuv420p",
+        })
+        assert resp.status_code == 200

--- a/tests_e2e/test_ui_profile_constraints.py
+++ b/tests_e2e/test_ui_profile_constraints.py
@@ -1,0 +1,115 @@
+"""E2E tests for profile form pixel format / color space constraints.
+
+Verifies the UI disables incompatible pixel format and color space
+options based on the selected codec/profile (Fixes #83).
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+class TestCreateFormPixelFormatConstraints:
+    """Create form should disable incompatible pixel format options."""
+
+    def test_h264_main_disables_422_formats(self, page: Page, e2e_server):
+        """H.264 main should disable yuv422p and yuv444p options."""
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        # Default is H.264 main — check that 422/444 are disabled
+        pf_select = page.locator('select[name="pixel_format"]')
+        expect(pf_select.locator('option[value="yuv422p"]')).to_be_disabled()
+        expect(pf_select.locator('option[value="yuv444p"]')).to_be_disabled()
+        expect(pf_select.locator('option[value="yuv422p10le"]')).to_be_disabled()
+        expect(pf_select.locator('option[value="yuv444p10le"]')).to_be_disabled()
+
+    def test_h264_main_disables_10bit_formats(self, page: Page, e2e_server):
+        """H.264 main is 8-bit — 10-bit formats should be disabled."""
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        pf_select = page.locator('select[name="pixel_format"]')
+        expect(pf_select.locator('option[value="yuv420p10le"]')).to_be_disabled()
+
+    def test_h264_main_allows_auto_and_yuv420p(self, page: Page, e2e_server):
+        """Auto and yuv420p should remain enabled for H.264 main."""
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        pf_select = page.locator('select[name="pixel_format"]')
+        expect(pf_select.locator('option[value="auto"]')).to_be_enabled()
+        expect(pf_select.locator('option[value="yuv420p"]')).to_be_enabled()
+
+
+@pytest.mark.e2e
+class TestCreateFormColorSpaceConstraints:
+    """Create form should disable HDR color spaces for 8-bit profiles."""
+
+    def test_h264_main_disables_hdr_color_spaces(self, page: Page, e2e_server):
+        """H.264 main is 8-bit SDR — HDR color spaces should be disabled."""
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        cs_select = page.locator('select[name="color_space"]')
+        expect(cs_select.locator('option[value="bt2020-pq"]')).to_be_disabled()
+        expect(cs_select.locator('option[value="bt2020-hlg"]')).to_be_disabled()
+
+    def test_h264_main_allows_sdr_color_spaces(self, page: Page, e2e_server):
+        """SDR color spaces should remain enabled."""
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        cs_select = page.locator('select[name="color_space"]')
+        expect(cs_select.locator('option[value="auto"]')).to_be_enabled()
+        expect(cs_select.locator('option[value="bt709"]')).to_be_enabled()
+        expect(cs_select.locator('option[value="smpte170m"]')).to_be_enabled()
+
+
+@pytest.mark.e2e
+class TestEditModalConstraints:
+    """Edit modal should also enforce pixel format / color space constraints."""
+
+    def test_edit_modal_disables_422_for_h264_main(self, page: Page, api, e2e_server):
+        """Edit modal for an H.264 main profile should disable 4:2:2 formats."""
+        resp = api.post("/api/profiles", json={
+            "name": "edit-constraint-test",
+            "video_codec": "h264",
+            "video_profile": "main",
+        })
+        assert resp.status_code == 201
+
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        row = page.locator("tr", has_text="edit-constraint-test")
+        row.locator("button", has_text="Edit").click()
+
+        modal = page.locator(".modal-box")
+        expect(modal).to_be_visible(timeout=3000)
+
+        pf_select = modal.locator("#ep-pf")
+        expect(pf_select.locator('option[value="yuv422p"]')).to_be_disabled()
+        expect(pf_select.locator('option[value="yuv444p"]')).to_be_disabled()
+
+    def test_edit_modal_disables_hdr_for_h264_main(self, page: Page, api, e2e_server):
+        """Edit modal for H.264 main should disable HDR color spaces."""
+        resp = api.post("/api/profiles", json={
+            "name": "edit-cs-constraint",
+            "video_codec": "h264",
+            "video_profile": "main",
+        })
+        assert resp.status_code == 201
+
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        row = page.locator("tr", has_text="edit-cs-constraint")
+        row.locator("button", has_text="Edit").click()
+
+        modal = page.locator(".modal-box")
+        expect(modal).to_be_visible(timeout=3000)
+
+        cs_select = modal.locator("#ep-cs")
+        expect(cs_select.locator('option[value="bt2020-pq"]')).to_be_disabled()
+        expect(cs_select.locator('option[value="bt2020-hlg"]')).to_be_disabled()


### PR DESCRIPTION
Fixes #83

## Changes

**UI (profiles.html):**
- Extended \pplyCodecConstraints()\ to disable incompatible pixel format options (4:2:2/4:4:4 for 4:2:0-only profiles, 10-bit for 8-bit-only profiles)
- Added HDR color space disabling for 8-bit-only profiles
- Applied constraints to both create form and edit modal
- Edit modal now re-evaluates constraints when video profile is changed

**API (profiles.py):**
- Added \_validate_profile_compat()\ server-side validation
- Both POST and PUT endpoints reject incompatible pixel_format/color_space combinations with HTTP 422

**Tests:**
- 24 unit tests covering pixel format, color space, create and update validation
- 8 E2E tests verifying UI constraint enforcement in create form and edit modal