### PR TITLE
fix(dashboard): handle group schedules in transition gap fix

### DIFF
--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -127,20 +127,19 @@ def get_upcoming_schedules(
             resume_at = _find_resume_time(s, schedules, local_now)
             if resume_at is not None:
                 results.append(_preempted_entry(s, local_now, resume_at))
-            elif s.device_id and s.device_id not in _winning_by_did:
-                # Target device has no winner yet — scheduler hasn't evaluated.
-                # Show as "starting" so the schedule doesn't vanish from the
-                # dashboard during the transition gap.
-                results.append(_starting_entry(s, local_now))
             elif s.device_id and s.device_id in _winning_by_did:
-                # Device already has a winner. Check if this schedule has
-                # higher priority — if so, it's about to preempt and should
-                # show as "starting" during the transition.
+                # Device already has a winner. Only show "starting" if this
+                # schedule has higher priority (about to preempt).
                 current_winner = _winning_by_did[s.device_id]
                 current_priority = _sched_priority.get(current_winner["schedule_id"], 0)
                 if s.priority > current_priority:
                     results.append(_starting_entry(s, local_now))
                 # else: same or lower priority → genuinely lost → hide
+            else:
+                # No winner yet for this target (device or group) — scheduler
+                # hasn't evaluated.  Show as "starting" so the schedule
+                # doesn't vanish from the dashboard during the transition.
+                results.append(_starting_entry(s, local_now))
             continue
 
         # Check today

--- a/tests/test_transition_gap.py
+++ b/tests/test_transition_gap.py
@@ -192,3 +192,47 @@ class TestPreemptionTransitionGap:
         assert "duration_mins" in entry
         assert "day_label" in entry
         assert entry["day_label"] == "today"
+
+
+class TestGroupScheduleTransitionGap:
+    """Group-targeted schedules must also show 'starting' during the
+    transition gap — they have device_id=None."""
+
+    def setup_method(self):
+        _skipped.clear()
+
+    def teardown_method(self):
+        _skipped.clear()
+
+    def test_group_schedule_not_yet_in_now_playing_stays_visible(self):
+        """A group schedule entering its window should show as 'starting'."""
+        group_id = uuid.uuid4()
+        s = _make_schedule(
+            time(10, 0), time(11, 0), name="Group Show",
+            device_id=None, group_id=group_id,
+        )
+        now = datetime(2026, 3, 28, 10, 5, tzinfo=timezone.utc)
+        now_playing = []
+
+        result = get_upcoming_schedules([s], now, UTC, now_playing=now_playing)
+        assert len(result) == 1
+        assert result[0]["schedule_name"] == "Group Show"
+        assert result[0].get("starting") is True
+
+    def test_group_schedule_disappears_once_in_now_playing(self):
+        """Once the scheduler processes a group schedule (appears in
+        now_playing for its devices), it should leave upcoming."""
+        group_id = uuid.uuid4()
+        s = _make_schedule(
+            time(10, 0), time(11, 0), name="Group Show",
+            device_id=None, group_id=group_id,
+        )
+        now = datetime(2026, 3, 28, 10, 5, tzinfo=timezone.utc)
+        # Scheduler expanded group to d1, d2 — both entries use same schedule_id
+        now_playing = [
+            _now_playing_entry(s, "d1"),
+            _now_playing_entry(s, "d2"),
+        ]
+
+        result = get_upcoming_schedules([s], now, UTC, now_playing=now_playing)
+        assert len(result) == 0


### PR DESCRIPTION
Fixes the remaining case from #99 where group-targeted schedules still vanished during dashboard transitions.

## Problem
The previous fix (PR #100) only handled device-targeted schedules. Group-targeted schedules have \device_id=None\, so the \elif s.device_id and ...\ conditions all short-circuited to \False\, and group schedules continued to vanish from 'Coming Up' before appearing in 'Currently Playing'.

## Fix
Restructured the if/elif chain to use an \else\ branch as the default, covering both:
- Group schedules (\device_id=None\)
- Device schedules where no winner exists yet

The \else\ branch shows the schedule as 'starting...' until the scheduler processes it. The only case that hides a schedule is when the target device already has a **higher-or-equal priority** winner.

## Tests
Added 2 new tests for group schedule transitions:
- \	est_group_schedule_not_yet_in_now_playing_stays_visible\
- \	est_group_schedule_disappears_once_in_now_playing\

All 43 transition gap + preemption tests pass.