### PR TITLE
fix(ui): move NTP and database panels to correct position in settings

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -41,109 +41,6 @@
     </form>
 </div>
 
-<div class="card" id="mcp-card">
-    <h2>MCP Server <span id="mcp-status-badge" class="badge badge-offline">checking…</span></h2>
-    <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
-        Allow AI agents (e.g. GitHub Copilot) to manage the CMS via the Model Context Protocol.
-    </p>
-
-    <label class="mcp-toggle-row">
-        <input type="checkbox" id="mcp-enabled" {% if mcp_enabled %}checked{% endif %}>
-        <span>Enable MCP Server</span>
-    </label>
-
-    <div id="mcp-key-section" style="max-width: 500px; {% if not mcp_enabled %}display:none{% endif %}">
-        <div class="form-group">
-            <label>API Key</label>
-            <div style="display: flex; gap: 0.5rem; align-items: center;">
-                <input type="text" id="mcp-api-key" value="{{ mcp_api_key }}" readonly
-                       style="flex:1; font-family: monospace; font-size: 0.85rem;"
-                       placeholder="No key generated yet">
-                <button type="button" class="btn btn-secondary" id="mcp-copy-key"
-                        onclick="copyToClipboard(document.getElementById('mcp-api-key').value)">
-                    Copy
-                </button>
-                <button type="button" class="btn btn-primary" id="mcp-generate-key">
-                    {{ 'Regenerate' if mcp_api_key else 'Generate' }}
-                </button>
-            </div>
-        </div>
-
-    </div>
-</div>
-
-<script>
-(function() {
-    const toggle = document.getElementById("mcp-enabled");
-    const keySection = document.getElementById("mcp-key-section");
-    const statusBadge = document.getElementById("mcp-status-badge");
-    const generateBtn = document.getElementById("mcp-generate-key");
-
-    // Check MCP container health
-    async function checkMcpHealth() {
-        try {
-            const resp = await fetch("/api/mcp/status");
-            const data = await resp.json();
-            if (data.online) {
-                statusBadge.textContent = "online";
-                statusBadge.className = "badge badge-online";
-                toggle.disabled = false;
-            } else {
-                statusBadge.textContent = "offline";
-                statusBadge.className = "badge badge-offline";
-                if (!toggle.checked) {
-                    toggle.disabled = true;
-                }
-            }
-        } catch {
-            statusBadge.textContent = "offline";
-            statusBadge.className = "badge badge-offline";
-            if (!toggle.checked) {
-                toggle.disabled = true;
-            }
-        }
-    }
-
-    checkMcpHealth();
-
-    // Toggle MCP on/off
-    toggle.addEventListener("change", async function() {
-        try {
-            const resp = await fetch("/api/mcp/toggle", {
-                method: "POST",
-                headers: {"Content-Type": "application/json"},
-                body: JSON.stringify({enabled: toggle.checked}),
-            });
-            if (!resp.ok) throw new Error("Toggle failed");
-            keySection.style.display = toggle.checked ? "" : "none";
-            showToast(toggle.checked ? "MCP server enabled" : "MCP server disabled");
-        } catch {
-            toggle.checked = !toggle.checked;
-            showToast("Failed to update MCP setting", true);
-        }
-    });
-
-    // Generate API key
-    generateBtn.addEventListener("click", async function() {
-        const ok = await showConfirm("Generate a new API key? Any existing key will stop working.");
-        if (!ok) return;
-        try {
-            const resp = await fetch("/api/mcp/generate-key", {method: "POST"});
-            if (!resp.ok) throw new Error("Generate failed");
-            const data = await resp.json();
-            document.getElementById("mcp-api-key").value = data.key;
-            generateBtn.textContent = "Regenerate";
-            showToast("New API key generated — copy it now");
-        } catch {
-            showToast("Failed to generate API key", true);
-        }
-    });
-})();
-</script>
-
-<div class="card" id="logs-card">
-    <h2>Download Logs</h2>
-
 <div class="card" id="ntp-card">
     <h2>NTP Server <span id="ntp-status-badge" class="badge badge-offline">checking…</span></h2>
     <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
@@ -287,6 +184,106 @@
             showToast(data.warning || "Database password changed");
         } catch (err) {
             showToast(err.message || "Failed to change database password", true);
+        }
+    });
+})();
+</script>
+
+<div class="card" id="mcp-card">
+    <h2>MCP Server <span id="mcp-status-badge" class="badge badge-offline">checking…</span></h2>
+    <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
+        Allow AI agents (e.g. GitHub Copilot) to manage the CMS via the Model Context Protocol.
+    </p>
+
+    <label class="mcp-toggle-row">
+        <input type="checkbox" id="mcp-enabled" {% if mcp_enabled %}checked{% endif %}>
+        <span>Enable MCP Server</span>
+    </label>
+
+    <div id="mcp-key-section" style="max-width: 500px; {% if not mcp_enabled %}display:none{% endif %}">
+        <div class="form-group">
+            <label>API Key</label>
+            <div style="display: flex; gap: 0.5rem; align-items: center;">
+                <input type="text" id="mcp-api-key" value="{{ mcp_api_key }}" readonly
+                       style="flex:1; font-family: monospace; font-size: 0.85rem;"
+                       placeholder="No key generated yet">
+                <button type="button" class="btn btn-secondary" id="mcp-copy-key"
+                        onclick="copyToClipboard(document.getElementById('mcp-api-key').value)">
+                    Copy
+                </button>
+                <button type="button" class="btn btn-primary" id="mcp-generate-key">
+                    {{ 'Regenerate' if mcp_api_key else 'Generate' }}
+                </button>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script>
+(function() {
+    const toggle = document.getElementById("mcp-enabled");
+    const keySection = document.getElementById("mcp-key-section");
+    const statusBadge = document.getElementById("mcp-status-badge");
+    const generateBtn = document.getElementById("mcp-generate-key");
+
+    // Check MCP container health
+    async function checkMcpHealth() {
+        try {
+            const resp = await fetch("/api/mcp/status");
+            const data = await resp.json();
+            if (data.online) {
+                statusBadge.textContent = "online";
+                statusBadge.className = "badge badge-online";
+                toggle.disabled = false;
+            } else {
+                statusBadge.textContent = "offline";
+                statusBadge.className = "badge badge-offline";
+                if (!toggle.checked) {
+                    toggle.disabled = true;
+                }
+            }
+        } catch {
+            statusBadge.textContent = "offline";
+            statusBadge.className = "badge badge-offline";
+            if (!toggle.checked) {
+                toggle.disabled = true;
+            }
+        }
+    }
+
+    checkMcpHealth();
+
+    // Toggle MCP on/off
+    toggle.addEventListener("change", async function() {
+        try {
+            const resp = await fetch("/api/mcp/toggle", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({enabled: toggle.checked}),
+            });
+            if (!resp.ok) throw new Error("Toggle failed");
+            keySection.style.display = toggle.checked ? "" : "none";
+            showToast(toggle.checked ? "MCP server enabled" : "MCP server disabled");
+        } catch {
+            toggle.checked = !toggle.checked;
+            showToast("Failed to update MCP setting", true);
+        }
+    });
+
+    // Generate API key
+    generateBtn.addEventListener("click", async function() {
+        const ok = await showConfirm("Generate a new API key? Any existing key will stop working.");
+        if (!ok) return;
+        try {
+            const resp = await fetch("/api/mcp/generate-key", {method: "POST"});
+            if (!resp.ok) throw new Error("Generate failed");
+            const data = await resp.json();
+            document.getElementById("mcp-api-key").value = data.key;
+            generateBtn.textContent = "Regenerate";
+            showToast("New API key generated — copy it now");
+        } catch {
+            showToast("Failed to generate API key", true);
         }
     });
 })();


### PR DESCRIPTION
## Problem

The NTP Server and Database panels were nested inside the Download Logs card due to a stray unclosed <div>. They appeared as sub-sections of the logs panel instead of as independent cards.

## Fix

- Remove the stray <div class=card id=logs-card><h2>Download Logs</h2> that was wrapping them
- Move NTP Server and Database into their own individual .card panels
- Place them between **Change Password** and **MCP Server** (above MCP, below password)

### Panel order (after fix)
1. System Info
2. Change Password
3. NTP Server
4. Database
5. MCP Server
6. Download Logs