### PR TITLE
fix: remove stale PID file before starting chronyd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         rtcsync
         allow all
         EOF
-        exec chronyd -d -s
+        rm -f /var/run/chrony/chronyd.pid && exec chronyd -d -s
     cap_add:
       - SYS_TIME
     ports:


### PR DESCRIPTION
## Problem
The NTP container (chronyd) enters a restart loop after any container restart. The PID file from the previous run persists in the container filesystem, causing chronyd to fail with:

\\\
Fatal error: Another chronyd may already be running (pid=1), check /var/run/chrony/chronyd.pid
\\\

## Fix
Remove the stale PID file before starting chronyd in the docker-compose command.

## Testing
Verified the container starts successfully and syncs with NTP pool after the fix.