### PR TITLE
fix: use Host header or config override for asset download URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ AGORA_CMS_ADMIN_USERNAME=admin
 AGORA_CMS_ADMIN_PASSWORD=change-me-to-a-secure-password
 AGORA_CMS_API_KEY_ROTATION_HOURS=24
 
+# Optional — override the base URL for asset download links sent to devices.
+# If unset, derived from the device's WebSocket Host header.
+# Examples: https://cdn.example.com, http://192.168.1.198:8080
+# AGORA_CMS_ASSET_BASE_URL=http://192.168.1.198:8080
+
 # Uncomment to reset admin password to AGORA_CMS_ADMIN_PASSWORD on next restart
 # AGORA_CMS_RESET_PASSWORD=true
 

--- a/cms/config.py
+++ b/cms/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     # Storage
     asset_storage_path: Path = Path("/opt/agora-cms/assets")
 
+    # Asset downloads
+    asset_base_url: str | None = None  # override base URL for device asset downloads
+
     # Device defaults
     default_device_storage_mb: int = 500  # assumed device flash budget for assets
     api_key_rotation_hours: int = 24  # rotate device API keys every N hours

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -246,11 +246,27 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
         device_manager.register(device_id, websocket, ip_address=client_ip)
 
         # ── 4. Build base URL for asset downloads ──
-        ws_url = websocket.url
-        scheme = "https" if ws_url.scheme == "wss" else "http"
-        base_url = f"{scheme}://{ws_url.hostname}"
-        if ws_url.port and ws_url.port not in (80, 443):
-            base_url += f":{ws_url.port}"
+        settings = get_settings()
+        if settings.asset_base_url:
+            base_url = settings.asset_base_url.rstrip("/")
+        else:
+            # Derive from the Host header the device used to connect
+            host_header = None
+            for header_name, header_value in websocket.headers.raw:
+                if header_name == b"host":
+                    host_header = header_value.decode("latin-1")
+                    break
+            if host_header:
+                ws_url = websocket.url
+                scheme = "https" if ws_url.scheme == "wss" else "http"
+                base_url = f"{scheme}://{host_header}"
+            else:
+                # Last resort: use the URL as seen by the server
+                ws_url = websocket.url
+                scheme = "https" if ws_url.scheme == "wss" else "http"
+                base_url = f"{scheme}://{ws_url.hostname}"
+                if ws_url.port and ws_url.port not in (80, 443):
+                    base_url += f":{ws_url.port}"
 
         # ── 5. Send full schedule sync ──
         sync = await build_device_sync(device_id, db)
@@ -275,7 +291,6 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
             await _generate_and_push_api_key(device, websocket, db)
 
         # ── 8. Message loop ──
-        settings = get_settings()
         while True:
             try:
                 msg = await asyncio.wait_for(websocket.receive_json(), timeout=WS_RECEIVE_TIMEOUT)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -245,3 +245,129 @@ class TestWebSocket:
                 # Should be rejected
                 msg = ws.receive_json()
                 assert "error" in msg
+
+    async def test_download_url_uses_host_header(self, app, db_session):
+        """fetch_asset download_url should use the Host header the device
+        connected with, not the server-side socket address (fixes #138)."""
+        from cms.models.asset import Asset, AssetType
+        from cms.models.device import Device, DeviceStatus
+
+        token = "dl-url-token"
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+        asset = Asset(
+            filename="test.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=1000,
+            checksum="abc123",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        device = Device(
+            id="ws-dl-url-001",
+            name="dl-url-device",
+            status=DeviceStatus.ADOPTED,
+            device_auth_token_hash=token_hash,
+            default_asset_id=asset.id,
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await db_session.close()
+
+        from starlette.testclient import TestClient
+        with TestClient(app) as tc:
+            with tc.websocket_connect(
+                "/ws/device",
+                headers={"host": "192.168.1.198:8080"},
+            ) as ws:
+                ws.send_json({
+                    "type": "register",
+                    "protocol_version": 1,
+                    "device_id": "ws-dl-url-001",
+                    "auth_token": token,
+                    "firmware_version": "1.0.0",
+                    "storage_capacity_mb": 500,
+                })
+
+                # Consume sync
+                msg = ws.receive_json()
+                assert msg["type"] == "sync"
+
+                # Should receive fetch_asset for default asset
+                msg = ws.receive_json()
+                assert msg["type"] == "fetch_asset"
+                assert msg["download_url"].startswith("http://192.168.1.198:8080/")
+                assert "/api/assets/" in msg["download_url"]
+
+                # Consume config (API key push)
+                msg = ws.receive_json()
+                assert msg["type"] == "config"
+
+                time.sleep(0.5)
+                ws.close()
+
+    async def test_download_url_uses_config_override(self, app, db_session):
+        """When AGORA_CMS_ASSET_BASE_URL is set, fetch_asset download_url
+        should use that value instead of the Host header."""
+        from cms.auth import get_settings
+        from cms.models.asset import Asset, AssetType
+        from cms.models.device import Device, DeviceStatus
+
+        token = "dl-cfg-token"
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+        asset = Asset(
+            filename="test-cfg.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=2000,
+            checksum="def456",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        device = Device(
+            id="ws-dl-cfg-001",
+            name="dl-cfg-device",
+            status=DeviceStatus.ADOPTED,
+            device_auth_token_hash=token_hash,
+            default_asset_id=asset.id,
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await db_session.close()
+
+        settings = get_settings()
+        original_value = settings.asset_base_url
+        settings.asset_base_url = "https://cdn.example.com"
+
+        try:
+            from starlette.testclient import TestClient
+            with TestClient(app) as tc:
+                with tc.websocket_connect("/ws/device") as ws:
+                    ws.send_json({
+                        "type": "register",
+                        "protocol_version": 1,
+                        "device_id": "ws-dl-cfg-001",
+                        "auth_token": token,
+                        "firmware_version": "1.0.0",
+                        "storage_capacity_mb": 500,
+                    })
+
+                    # Consume sync
+                    msg = ws.receive_json()
+                    assert msg["type"] == "sync"
+
+                    # Should receive fetch_asset with CDN URL
+                    msg = ws.receive_json()
+                    assert msg["type"] == "fetch_asset"
+                    assert msg["download_url"].startswith("https://cdn.example.com/")
+
+                    # Consume config (API key push)
+                    msg = ws.receive_json()
+                    assert msg["type"] == "config"
+
+                    time.sleep(0.5)
+                    ws.close()
+        finally:
+            settings.asset_base_url = original_value


### PR DESCRIPTION
The CMS was using `websocket.url` (which resolves to `localhost` inside Docker) to build asset download URLs sent to devices. This caused devices to attempt downloads from `localhost` instead of the real CMS address.

## Changes

- **`cms/config.py`**: Add optional `asset_base_url` setting (`CMS_ASSET_BASE_URL` env var)
- **`cms/routers/ws.py`**: Use config override if set, otherwise derive base URL from the WebSocket `Host` header (the address the device actually connected to)
- **`tests/test_websocket.py`**: 2 new tests — Host header fallback + config override
- **`.env.example`**: Document new setting

## Fallback chain

1. `CMS_ASSET_BASE_URL` config override (for CDN/separate asset server)
2. WebSocket `Host` header (what the device used to reach CMS — always correct)
3. `websocket.url` hostname (last resort, same as old behavior)

Closes #138