### PR TITLE
feat: add timezone picker to settings page

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -23,6 +23,30 @@
 </div>
 
 <div class="card">
+    <h2>Timezone</h2>
+    <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
+        Default timezone used for schedule evaluation and device time sync.
+        Devices set to "CMS default" will use this timezone.
+    </p>
+    <form method="POST" action="/settings/timezone" class="settings-form">
+        <div class="form-group">
+            <label for="timezone">CMS Timezone</label>
+            <select id="timezone" name="timezone" style="max-width: 400px;">
+                {% for tz in timezones %}
+                <option value="{{ tz.value }}"{% if tz.value == current_timezone %} selected{% endif %}>{{ tz.label }}</option>
+                {% endfor %}
+            </select>
+            {% if not timezone_saved %}
+            <p class="text-muted" style="margin-top: 0.5rem; font-size: 0.8rem; color: var(--warning, #e6a817);">
+                ⚠ No timezone has been set — defaulting to UTC. Select your timezone and save.
+            </p>
+            {% endif %}
+        </div>
+        <button type="submit" class="btn btn-primary">Save Timezone</button>
+    </form>
+</div>
+
+<div class="card">
     <h2>Change Password</h2>
     <form method="POST" action="/settings/password" class="settings-form">
         <div class="form-group">

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -628,6 +628,19 @@ async def settings_page(
     mcp_enabled = (await get_setting(db, SETTING_MCP_ENABLED)) == "true"
     mcp_api_key = await get_setting(db, SETTING_MCP_API_KEY) or ""
 
+    # Timezone
+    current_timezone = await get_setting(db, SETTING_TIMEZONE) or "UTC"
+    timezone_saved = (await get_setting(db, SETTING_TIMEZONE)) is not None
+    now_utc = datetime.now(_tz.utc)
+    tz_options = []
+    for tz_name in sorted(available_timezones()):
+        offset = now_utc.astimezone(ZoneInfo(tz_name)).utcoffset()
+        total_sec = int(offset.total_seconds())
+        sign = "+" if total_sec >= 0 else "-"
+        h, m = divmod(abs(total_sec) // 60, 60)
+        label = f"{tz_name.replace('_', ' ')} (UTC{sign}{h:02d}:{m:02d})"
+        tz_options.append({"value": tz_name, "label": label})
+
     # Device list for log download panel
     from cms.models.device import Device
     result = await db.execute(select(Device).order_by(Device.name))
@@ -645,6 +658,9 @@ async def settings_page(
         "asset_storage": str(settings.asset_storage_path),
         "mcp_enabled": mcp_enabled,
         "mcp_api_key": mcp_api_key,
+        "current_timezone": current_timezone,
+        "timezone_saved": timezone_saved,
+        "timezones": tz_options,
         "devices": device_list,
         "success": None,
         "error": None,
@@ -923,19 +939,45 @@ async def change_timezone(
     tz_name = form.get("timezone", "").strip()
 
     username = await get_setting(db, SETTING_USERNAME) or settings.admin_username
-    timezones = sorted(available_timezones())
+    mcp_enabled = (await get_setting(db, SETTING_MCP_ENABLED)) == "true"
+    mcp_api_key = await get_setting(db, SETTING_MCP_API_KEY) or ""
+
+    now_utc = datetime.now(_tz.utc)
+    tz_options = []
+    for tz in sorted(available_timezones()):
+        offset = now_utc.astimezone(ZoneInfo(tz)).utcoffset()
+        total_sec = int(offset.total_seconds())
+        sign = "+" if total_sec >= 0 else "-"
+        h, m = divmod(abs(total_sec) // 60, 60)
+        label = f"{tz.replace('_', ' ')} (UTC{sign}{h:02d}:{m:02d})"
+        tz_options.append({"value": tz, "label": label})
+
+    from cms.models.device import Device
+    result = await db.execute(select(Device).order_by(Device.name))
+    devices = result.scalars().all()
+    device_list = [
+        {"id": d.id, "name": d.name, "connected": device_manager.is_connected(d.id)}
+        for d in devices
+    ]
+
+    base_ctx = {
+        "active_tab": "settings",
+        "version": __version__,
+        "username": username,
+        "online_count": device_manager.connected_count,
+        "asset_storage": str(settings.asset_storage_path),
+        "mcp_enabled": mcp_enabled,
+        "mcp_api_key": mcp_api_key,
+        "timezones": tz_options,
+        "devices": device_list,
+    }
 
     if tz_name not in available_timezones():
         current_timezone = await get_setting(db, SETTING_TIMEZONE) or "UTC"
         return templates.TemplateResponse(request, "settings.html", {
-            "active_tab": "settings",
-            "version": __version__,
-            "username": username,
-            "online_count": device_manager.connected_count,
-            "asset_storage": str(settings.asset_storage_path),
+            **base_ctx,
             "current_timezone": current_timezone,
             "timezone_saved": True,
-            "timezones": timezones,
             "success": None,
             "error": f"Invalid timezone: {tz_name}",
         }, status_code=400)
@@ -943,14 +985,9 @@ async def change_timezone(
     await set_setting(db, SETTING_TIMEZONE, tz_name)
 
     return templates.TemplateResponse(request, "settings.html", {
-        "active_tab": "settings",
-        "version": __version__,
-        "username": username,
-        "online_count": device_manager.connected_count,
-        "asset_storage": str(settings.asset_storage_path),
+        **base_ctx,
         "current_timezone": tz_name,
         "timezone_saved": True,
-        "timezones": timezones,
         "success": f"Timezone set to {tz_name}",
         "error": None,
     })

--- a/tests/test_settings_timezone.py
+++ b/tests/test_settings_timezone.py
@@ -1,0 +1,285 @@
+"""Tests for the CMS global timezone setting.
+
+Covers the settings page UI, the POST endpoint, build_device_sync timezone
+propagation, per-device overrides, and the default UTC fallback.
+"""
+
+from datetime import datetime, time, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from cms.auth import get_setting, set_setting, SETTING_TIMEZONE
+from cms.models.asset import Asset, AssetType
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.schedule import Schedule
+from cms.models.setting import CMSSetting
+from cms.services.scheduler import build_device_sync
+
+
+# ── Settings page UI tests ──
+
+
+@pytest.mark.asyncio
+class TestSettingsTimezoneUI:
+    """Test the settings page timezone picker."""
+
+    async def test_settings_page_shows_timezone_picker(self, client):
+        """Settings page should render the timezone dropdown."""
+        resp = await client.get("/settings")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'name="timezone"' in text
+        assert "Save Timezone" in text
+
+    async def test_settings_page_shows_utc_default_warning(self, client):
+        """When no timezone is saved, show a warning about UTC default."""
+        resp = await client.get("/settings")
+        assert resp.status_code == 200
+        assert "defaulting to UTC" in resp.text
+
+    async def test_settings_page_no_warning_after_save(self, client, db_session):
+        """Warning disappears once a timezone has been explicitly saved."""
+        await set_setting(db_session, SETTING_TIMEZONE, "America/New_York")
+        resp = await client.get("/settings")
+        assert resp.status_code == 200
+        assert "defaulting to UTC" not in resp.text
+
+    async def test_settings_page_shows_current_timezone(self, client, db_session):
+        """Settings page should highlight the currently saved timezone."""
+        await set_setting(db_session, SETTING_TIMEZONE, "America/Chicago")
+        resp = await client.get("/settings")
+        assert resp.status_code == 200
+        # The selected option should have 'selected' attribute
+        assert "America/Chicago" in resp.text
+
+
+# ── POST /settings/timezone endpoint tests ──
+
+
+@pytest.mark.asyncio
+class TestChangeTimezone:
+    """Test the POST /settings/timezone endpoint."""
+
+    async def test_set_timezone(self, client, db_session):
+        """Setting a valid timezone should persist it."""
+        resp = await client.post(
+            "/settings/timezone",
+            data={"timezone": "America/Los_Angeles"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+        assert "America/Los_Angeles" in resp.text
+        assert "Timezone set to" in resp.text
+
+        # Verify it's persisted in the database
+        saved = await get_setting(db_session, SETTING_TIMEZONE)
+        assert saved == "America/Los_Angeles"
+
+    async def test_change_timezone(self, client, db_session):
+        """Changing from one timezone to another should update."""
+        await set_setting(db_session, SETTING_TIMEZONE, "UTC")
+
+        resp = await client.post(
+            "/settings/timezone",
+            data={"timezone": "Europe/London"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+
+        saved = await get_setting(db_session, SETTING_TIMEZONE)
+        assert saved == "Europe/London"
+
+    async def test_invalid_timezone_rejected(self, client, db_session):
+        """An invalid timezone name should return 400."""
+        resp = await client.post(
+            "/settings/timezone",
+            data={"timezone": "Not/A/Timezone"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+        assert "Invalid timezone" in resp.text
+
+    async def test_empty_timezone_rejected(self, client, db_session):
+        """An empty timezone should return 400."""
+        resp = await client.post(
+            "/settings/timezone",
+            data={"timezone": ""},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+
+    async def test_timezone_change_does_not_break_page(self, client, db_session):
+        """After saving timezone, the page should still render all sections."""
+        resp = await client.post(
+            "/settings/timezone",
+            data={"timezone": "Asia/Tokyo"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+        text = resp.text
+        # Page must still contain other settings sections
+        assert "System Info" in text
+        assert "Change Password" in text
+        assert "MCP Server" in text
+
+    async def test_requires_auth(self, unauthed_client):
+        """Unauthenticated requests should be rejected."""
+        resp = await unauthed_client.post(
+            "/settings/timezone",
+            data={"timezone": "UTC"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401
+
+
+# ── build_device_sync timezone propagation tests ──
+
+
+@pytest.mark.asyncio
+class TestSyncTimezone:
+    """Test that build_device_sync sends the correct timezone to devices."""
+
+    @pytest_asyncio.fixture
+    async def db(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+        async with factory() as session:
+            yield session
+
+    async def _setup_device(self, db, device_id="tz-pi-01", timezone=None, group=None):
+        device = Device(
+            id=device_id,
+            name="TZ Test",
+            status=DeviceStatus.ADOPTED,
+            timezone=timezone,
+        )
+        if group:
+            device.group = group
+        db.add(device)
+        await db.commit()
+        return device
+
+    async def test_default_utc_when_no_setting(self, db):
+        """When no CMS timezone is configured, devices should get UTC."""
+        await self._setup_device(db)
+        sync = await build_device_sync("tz-pi-01", db)
+        assert sync is not None
+        assert sync.timezone == "UTC"
+
+    async def test_cms_timezone_sent_to_device(self, db):
+        """Device gets the CMS global timezone in sync message."""
+        db.add(CMSSetting(key="timezone", value="America/Los_Angeles"))
+        await db.commit()
+        await self._setup_device(db)
+
+        sync = await build_device_sync("tz-pi-01", db)
+        assert sync.timezone == "America/Los_Angeles"
+
+    async def test_device_override_takes_precedence(self, db):
+        """Per-device timezone overrides the CMS global timezone."""
+        db.add(CMSSetting(key="timezone", value="America/Los_Angeles"))
+        await db.commit()
+        await self._setup_device(db, timezone="Europe/Berlin")
+
+        sync = await build_device_sync("tz-pi-01", db)
+        assert sync.timezone == "Europe/Berlin"
+
+    async def test_device_override_cleared_falls_back_to_cms(self, db):
+        """When device timezone is cleared (None), it falls back to CMS global."""
+        db.add(CMSSetting(key="timezone", value="Asia/Tokyo"))
+        await db.commit()
+        await self._setup_device(db, timezone=None)
+
+        sync = await build_device_sync("tz-pi-01", db)
+        assert sync.timezone == "Asia/Tokyo"
+
+    async def test_timezone_changes_reflected_in_next_sync(self, db):
+        """Changing the CMS timezone should be reflected in the next sync."""
+        db.add(CMSSetting(key="timezone", value="UTC"))
+        await db.commit()
+        await self._setup_device(db)
+
+        sync1 = await build_device_sync("tz-pi-01", db)
+        assert sync1.timezone == "UTC"
+
+        # Change timezone
+        setting = (await db.execute(
+            __import__("sqlalchemy").select(CMSSetting).where(CMSSetting.key == "timezone")
+        )).scalar_one()
+        setting.value = "America/New_York"
+        await db.commit()
+
+        sync2 = await build_device_sync("tz-pi-01", db)
+        assert sync2.timezone == "America/New_York"
+
+    async def test_multiple_devices_different_timezones(self, db):
+        """Two devices can have different effective timezones."""
+        db.add(CMSSetting(key="timezone", value="America/Chicago"))
+        await db.commit()
+
+        # Device 1 uses CMS default
+        await self._setup_device(db, device_id="tz-pi-01", timezone=None)
+        # Device 2 has per-device override
+        await self._setup_device(db, device_id="tz-pi-02", timezone="Europe/London")
+
+        sync1 = await build_device_sync("tz-pi-01", db)
+        sync2 = await build_device_sync("tz-pi-02", db)
+
+        assert sync1.timezone == "America/Chicago"
+        assert sync2.timezone == "Europe/London"
+
+    async def test_sync_includes_timezone_with_schedules(self, db):
+        """Timezone is present in sync message alongside schedules."""
+        db.add(CMSSetting(key="timezone", value="America/Denver"))
+        await db.commit()
+
+        asset = Asset(
+            filename="tz-video.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=1000,
+            checksum="abc",
+        )
+        db.add(asset)
+        await db.flush()
+
+        await self._setup_device(db)
+
+        sched = Schedule(
+            name="TZ Schedule",
+            device_id="tz-pi-01",
+            asset_id=asset.id,
+            start_time=time(9, 0),
+            end_time=time(17, 0),
+        )
+        db.add(sched)
+        await db.commit()
+
+        sync = await build_device_sync("tz-pi-01", db)
+        assert sync.timezone == "America/Denver"
+        assert len(sync.schedules) == 1
+
+
+# ── Server time API tests ──
+
+
+@pytest.mark.asyncio
+class TestServerTimeAPI:
+    """Test the /api/server-time endpoint reflects the configured timezone."""
+
+    async def test_server_time_default_utc(self, client):
+        """When no timezone is set, /api/server-time should return UTC."""
+        resp = await client.get("/api/server-time")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["timezone"] == "UTC"
+
+    async def test_server_time_reflects_setting(self, client, db_session):
+        """After setting timezone, /api/server-time should return it."""
+        await set_setting(db_session, SETTING_TIMEZONE, "America/Los_Angeles")
+        resp = await client.get("/api/server-time")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["timezone"] == "America/Los_Angeles"
+        assert "local" in data
+        assert "utc" in data


### PR DESCRIPTION
## Summary

Adds a **CMS Default Timezone** card to the Settings page so admins can set the global timezone used for schedule evaluation and device time sync. Previously, there was no way to set this in the UI — it silently defaulted to UTC.

## Problem

When the CMS runs in Azure (or any server with UTC system time), devices get `UTC` as their timezone because the `CMSSetting` row for `timezone` was never created. The only timezone picker was on the Schedules page, which sets per-schedule timezone — not the global default.

## Changes

### `cms/templates/settings.html`
- New **Timezone** card between System Info and Change Password
- Dropdown with all IANA timezones and UTC offset labels
- Warning banner when no timezone has been explicitly saved

### `cms/ui.py`
- `settings_page` GET handler now loads and passes timezone data (`current_timezone`, `timezone_saved`, `timezones` options list)
- `change_timezone` POST handler now includes all required template context (`mcp_enabled`, `mcp_api_key`, `devices`) so the page renders completely after saving

### `tests/test_settings_timezone.py` — **19 new tests**

| Test Group | Count | What's Tested |
|---|---|---|
| `TestSettingsTimezoneUI` | 4 | Page renders picker, UTC warning, current selection |
| `TestChangeTimezone` | 6 | Set/change/invalid/empty timezone, page integrity, auth |
| `TestSyncTimezone` | 7 | `build_device_sync` sends correct TZ, device overrides, fallback, multi-device |
| `TestServerTimeAPI` | 2 | `/api/server-time` reflects the configured timezone |

## Testing

`pytest tests/test_settings_timezone.py tests/test_scheduler.py tests/test_expired_schedules.py tests/test_devices.py tests/test_scheduler_advanced.py` — **185 passed**