### PR TITLE
ci: add version bump check for PRs targeting main

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,57 @@
+name: Version Bump Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version was bumped
+        run: |
+          # Skip check if PR only touches CI/docs files (no runtime changes)
+          git fetch origin main
+          CHANGED=$(git diff --name-only origin/main...HEAD)
+          RUNTIME_CHANGES=$(echo "$CHANGED" | grep -v -E '^\.(github|gitignore)|^docs/|^README|^LICENSE' || true)
+
+          if [ -z "$RUNTIME_CHANGES" ]; then
+            echo "✅ Skipped — PR only changes CI/docs files, no version bump needed."
+            exit 0
+          fi
+
+          # Extract version from the PR branch
+          PR_VERSION=$(python -c "
+          with open('cms/__init__.py') as f:
+              for line in f:
+                  if '__version__' in line:
+                      print(line.split('\"')[1])
+                      break
+          ")
+
+          # Extract version from the base branch (main)
+          MAIN_VERSION=$(git show origin/main:cms/__init__.py | python -c "
+          import sys
+          for line in sys.stdin:
+              if '__version__' in line:
+                  print(line.split('\"')[1])
+                  break
+          ")
+
+          echo "Main version: $MAIN_VERSION"
+          echo "PR version:   $PR_VERSION"
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo ""
+            echo "::error::Version in cms/__init__.py was not bumped ($MAIN_VERSION). Please bump the version before merging."
+            echo ""
+            echo "Azure Container Apps won't pull a new image if the tag is unchanged."
+            echo "Bump the patch version at minimum: $MAIN_VERSION → ?"
+            exit 1
+          fi
+
+          echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that fails PR checks if the version in \cms/__init__.py\ hasn't been bumped compared to \main\. This prevents the Azure Container Apps tag-reuse issue we hit with PR #159, where the deploy succeeded but the old image kept running because the tag didn't change.

## How it works

1. Extracts version from \cms/__init__.py\ on the PR branch
2. Extracts version from \cms/__init__.py\ on \main\
3. Fails with a clear error message if they match

Lightweight — no dependencies, runs in ~5 seconds.

Closes #163