### PR TITLE
ci: add concurrency guard to Publish & Deploy

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: publish-deploy
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
Adds a \concurrency\ group to the Publish & Deploy workflow so runs queue instead of running in parallel.

**Problem**: When two pushes to main land close together, both trigger deploys. Azure rejects the second with \ContainerAppOperationInProgress\ (seen in run #149).

**Fix**: \concurrency: group: publish-deploy\ with \cancel-in-progress: false\ — runs wait for the previous one to finish rather than cancelling, so the latest version always gets deployed.

No version bump needed (CI-only change).