### PR TITLE
chore(nightly): run at midnight PDT (07:00 UTC)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@ name: Nightly E2E
 
 on:
   schedule:
-    # 03:00 UTC daily
-    - cron: "0 3 * * *"
+    # 07:00 UTC daily = 00:00 PDT / 23:00 PST
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       keep_stack:


### PR DESCRIPTION
Move the nightly E2E schedule from 03:00 UTC (8pm PDT) to 07:00 UTC (00:00 PDT / 23:00 PST).