### PR TITLE
feat(ui): saved-stream capture progress + failure badge, aggregate variant progress (v1.37.4)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -246,6 +246,9 @@ async def assets_status_json(
         variant_ready += a_ready
         variant_processing += a_processing
         variant_failed += a_failed
+        # Build group name map for scope data
+        variant_progress_sum = sum((v.progress or 0.0) for v in visible_variants)
+        aggregate_pct = round(variant_progress_sum / len(visible_variants), 1) if visible_variants else 0.0
         assets_detail.append({
             "id": str(a.id),
             "asset_type": a.asset_type.value,
@@ -253,6 +256,9 @@ async def assets_status_json(
             "variant_ready": a_ready,
             "variant_processing": a_processing,
             "variant_failed": a_failed,
+            "variant_aggregate_progress": aggregate_pct,
+            "capture_progress": a.capture_progress,
+            "capture_error": a.capture_error,
             "variants": variants,
             "is_global": a.is_global,
             "has_uploader": a.uploaded_by_user_id is not None,
@@ -760,6 +766,10 @@ async def recapture_stream(
     asset.original_filename = None
     asset.checksum = ""
     asset.size_bytes = 0
+    # Reset capture progress/error so the UI clears any stale
+    # "Capture failed" state and shows the new capture from 0%.
+    asset.capture_progress = None
+    asset.capture_error = None
 
     # Delete variant files and reset to PENDING
     from cms.services.transcoder import cancel_asset_transcodes

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -980,9 +980,18 @@ async def delete_asset(
     # Mark as soft-deleted
     asset.deleted_at = datetime.now(timezone.utc)
 
-    # Flag all active jobs for cancellation.  Jobs are polymorphic:
+    # Flag all active jobs for cancellation AND mark them terminal.  Jobs
+    # are polymorphic:
     #   - VARIANT_TRANSCODE.target_id → asset_variants.id (join through variants)
     #   - STREAM_CAPTURE.target_id    → assets.id (direct)
+    #
+    # Setting status=CANCELLED here (rather than just cancel_requested=True)
+    # ensures the reaper can hard-delete promptly even in LISTEN/NOTIFY mode,
+    # where the worker doesn't otherwise transition Job rows out of
+    # PENDING/PROCESSING after the variant finishes.  The worker's
+    # cancel-probe (in _transcode_one / _capture_stream) still aborts any
+    # in-flight ffmpeg mid-run; if it races us and marks DONE/FAILED first,
+    # those are also terminal — harmless overwrite.
     variant_ids_subq = (
         select(AssetVariant.id).where(AssetVariant.source_asset_id == asset_id)
     ).scalar_subquery()
@@ -998,7 +1007,11 @@ async def delete_asset(
                 (Job.type == JobType.STREAM_CAPTURE) & (Job.target_id == asset_id)
             ),
         )
-        .values(cancel_requested=True)
+        .values(
+            cancel_requested=True,
+            status=JobStatus.CANCELLED,
+            error_message="Asset deleted by user",
+        )
     )
 
     await audit_log(

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -370,6 +370,20 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .badge-saved_stream { background: #d35400; color: var(--text); }
 .badge-builtin { background: var(--primary); color: var(--text); font-size: 0.65rem; margin-left: 0.3rem; vertical-align: middle; }
 .badge-processing { background: #3498db; color: #fff; margin-left: 0.4rem; }
+/* Progress-fill badge: darker "filled" region on the left grows to the
+ * right as --pct advances, while the right side stays the base blue.
+ * Text stays readable over both shades.  Used for the Status column
+ * (Transcoding / Capturing) to give at-a-glance progress motion. */
+.badge-progress {
+    background: linear-gradient(
+        90deg,
+        #1d6fa5 0 var(--pct, 0%),
+        #3498db var(--pct, 0%) 100%
+    );
+    color: #fff;
+    margin-left: 0.4rem;
+    transition: background 0.3s;
+}
 .badge-overflow { background: #3498db; color: #fff; margin-left: 0.15rem; font-size: 0.75rem; cursor: default; }
 .badge-ready { background: var(--success); color: #000; margin-left: 0.4rem; }
 .badge-failed { background: var(--danger); color: #fff; margin-left: 0.4rem; }

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -284,13 +284,15 @@
                             <span class="detail-value">
                                 <a href="{{ a.url }}" target="_blank" rel="noopener" style="word-break:break-all">{{ a.url }}</a>
                                 {% if a.asset_type.value == 'saved_stream' and a.size_bytes == 0 %}
+                                <span data-live-capture="{{ a.id }}" style="margin-left: 0.5rem;">
                                     {% if a.capture_error %}
-                                    <span class="has-tooltip" style="margin-left: 0.5rem;"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
+                                    <span class="has-tooltip"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
                                     {% elif a.capture_progress is not none %}
-                                    <span class="badge badge-progress" style="margin-left: 0.5rem; --pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing</span>
+                                    <span class="badge badge-progress" style="--pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing {{ "%.0f"|format(a.capture_progress) }}%</span>
                                     {% else %}
-                                    <span class="badge badge-pending" style="margin-left: 0.5rem;">Queued</span>
+                                    <span class="badge badge-pending">Queued</span>
                                     {% endif %}
+                                </span>
                                 {% endif %}
                             </span>
                         </div>
@@ -459,22 +461,6 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-                    </div>
-                    {% elif a.asset_type.value == 'saved_stream' %}
-                    <div style="margin-top: 0.5rem;" data-live-variant-section="{{ a.id }}">
-                        <span class="detail-label">Variants</span>
-                        <div style="margin-top: 0.35rem; font-size: 0.85rem;">
-                            {% if a.capture_error %}
-                            <span class="has-tooltip"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
-                            <span class="text-muted" style="margin-left: 0.5rem;">Use Re-capture to try again</span>
-                            {% elif a.capture_progress is not none %}
-                            <span class="badge badge-progress" style="--pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing</span>
-                            <span class="text-muted" style="margin-left: 0.5rem;">Variants will appear once capture completes</span>
-                            {% else %}
-                            <span class="badge badge-pending">Pending</span>
-                            <span class="text-muted" style="margin-left: 0.5rem;">Waiting for stream capture to start</span>
-                            {% endif %}
-                        </div>
                     </div>
                     {% endif %}
                 </td>
@@ -799,11 +785,29 @@
         });
     }
 
+    function buildExpandedCaptureBadge(a) {
+        if (a.capture_error) {
+            const msg = (a.capture_error || '').slice(0, 200).replace(/</g, '&lt;');
+            return '<span class="has-tooltip"><span class="badge badge-failed">Capture failed</span>' +
+                '<span class="tooltip">' + msg + '</span></span>';
+        }
+        if (a.capture_progress !== null && a.capture_progress !== undefined) {
+            const pct = Math.min(100, Math.max(0, a.capture_progress));
+            return '<span class="badge badge-progress" style="--pct: ' + pct.toFixed(1) + '%">Capturing ' + Math.round(pct) + '%</span>';
+        }
+        return '<span class="badge badge-pending">Queued</span>';
+    }
+
     function updateLiveAssets(assets) {
         for (const a of assets) {
             // Update main table variant badge
             const variantCell = document.querySelector('[data-live-variants="' + a.id + '"]');
             if (variantCell) variantCell.innerHTML = buildVariantBadge(a);
+            // Update expanded-view capture badge (saved_stream, capture in progress)
+            if (a.asset_type === 'saved_stream') {
+                const captureBadge = document.querySelector('[data-live-capture="' + a.id + '"]');
+                if (captureBadge) captureBadge.innerHTML = buildExpandedCaptureBadge(a);
+            }
             // Update expanded detail panel variant table
             updateVariantTable(a.id, a.variants);
         }

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -165,7 +165,7 @@
                 <th>Type</th>
                 <th>Scope</th>
                 <th>Size</th>
-                <th>Variants</th>
+                <th>Status</th>
                 <th>Duration</th>
                 <th>Actions</th>
             </tr>
@@ -214,14 +214,20 @@
                     {% elif a.variant_failed > 0 %}
                         <span class="has-tooltip"><span class="badge badge-failed">Failed</span><span class="tooltip">{{ a.variant_failed }} of {{ a.variant_total }} failed</span></span>
                     {% elif a.variant_processing > 0 %}
-                        <span class="has-tooltip"><span class="badge badge-processing">Transcoding</span><span class="tooltip">{{ a.variant_ready }} of {{ a.variant_total }} ready, {{ a.variant_processing }} processing</span></span>
+                        <span class="has-tooltip"><span class="badge badge-progress" style="--pct: {{ "%.1f"|format(a.variant_aggregate_progress) }}%">Transcoding</span><span class="tooltip">{{ a.variant_ready }} of {{ a.variant_total }} ready, {{ a.variant_processing }} processing</span></span>
                     {% elif a.variant_ready == a.variant_total %}
                         <span class="has-tooltip"><span class="badge badge-ready">Ready</span><span class="tooltip">{{ a.variant_total }} variant{{ 's' if a.variant_total != 1 else '' }}</span></span>
                     {% else %}
                         <span class="badge badge-pending">Queued</span>
                     {% endif %}
                     {% elif a.asset_type.value == 'saved_stream' %}
-                        <span class="has-tooltip"><span class="badge badge-pending">Pending</span><span class="tooltip">Waiting for stream capture to complete</span></span>
+                        {% if a.capture_error %}
+                        <span class="has-tooltip"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
+                        {% elif a.capture_progress is not none %}
+                        <span class="has-tooltip"><span class="badge badge-progress" style="--pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing</span><span class="tooltip">Stream capture in progress</span></span>
+                        {% else %}
+                        <span class="has-tooltip"><span class="badge badge-pending">Pending</span><span class="tooltip">Waiting for stream capture to start</span></span>
+                        {% endif %}
                     {% elif a.asset_type.value == 'image' %}
                     —
                     {% else %}
@@ -275,7 +281,18 @@
                         {% if (a.asset_type.value == 'webpage' or a.asset_type.value == 'stream' or a.asset_type.value == 'saved_stream') and a.url %}
                         <div class="detail-item detail-item-wide">
                             <span class="detail-label">URL</span>
-                            <span class="detail-value"><a href="{{ a.url }}" target="_blank" rel="noopener" style="word-break:break-all">{{ a.url }}</a></span>
+                            <span class="detail-value">
+                                <a href="{{ a.url }}" target="_blank" rel="noopener" style="word-break:break-all">{{ a.url }}</a>
+                                {% if a.asset_type.value == 'saved_stream' and a.size_bytes == 0 %}
+                                    {% if a.capture_error %}
+                                    <span class="has-tooltip" style="margin-left: 0.5rem;"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
+                                    {% elif a.capture_progress is not none %}
+                                    <span class="badge badge-progress" style="margin-left: 0.5rem; --pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing</span>
+                                    {% else %}
+                                    <span class="badge badge-pending" style="margin-left: 0.5rem;">Queued</span>
+                                    {% endif %}
+                                {% endif %}
+                            </span>
                         </div>
                         {% endif %}
                         <div class="detail-item">
@@ -412,7 +429,7 @@
                                         {% if v.status.value == 'ready' %}
                                         <span class="badge badge-ready">Ready</span>
                                         {% elif v.status.value == 'processing' %}
-                                        <span class="badge badge-processing">{{ "%.0f"|format(v.progress) }}%</span>
+                                        <span class="badge badge-progress" style="--pct: {{ "%.1f"|format(v.progress) }}%">{{ "%.0f"|format(v.progress) }}%</span>
                                         {% elif v.status.value == 'failed' %}
                                         <span class="has-tooltip"><span class="badge badge-failed">Failed</span><span class="tooltip">{{ v.error_message[:120] if v.error_message else 'Unknown error' }}</span></span>
                                         {% elif v.status.value == 'cancelled' %}
@@ -447,8 +464,16 @@
                     <div style="margin-top: 0.5rem;" data-live-variant-section="{{ a.id }}">
                         <span class="detail-label">Variants</span>
                         <div style="margin-top: 0.35rem; font-size: 0.85rem;">
+                            {% if a.capture_error %}
+                            <span class="has-tooltip"><span class="badge badge-failed">Capture failed</span><span class="tooltip">{{ a.capture_error[:200] }}</span></span>
+                            <span class="text-muted" style="margin-left: 0.5rem;">Use Re-capture to try again</span>
+                            {% elif a.capture_progress is not none %}
+                            <span class="badge badge-progress" style="--pct: {{ "%.1f"|format(a.capture_progress) }}%">Capturing</span>
+                            <span class="text-muted" style="margin-left: 0.5rem;">Variants will appear once capture completes</span>
+                            {% else %}
                             <span class="badge badge-pending">Pending</span>
-                            <span class="text-muted" style="margin-left: 0.5rem;">Waiting for stream capture to complete</span>
+                            <span class="text-muted" style="margin-left: 0.5rem;">Waiting for stream capture to start</span>
+                            {% endif %}
                         </div>
                     </div>
                     {% endif %}
@@ -677,8 +702,18 @@
     function buildVariantBadge(a) {
         if (a.variant_total === 0) {
             if (a.asset_type === 'saved_stream') {
+                if (a.capture_error) {
+                    const msg = (a.capture_error || '').slice(0, 200).replace(/</g, '&lt;');
+                    return '<span class="has-tooltip"><span class="badge badge-failed">Capture failed</span>' +
+                        '<span class="tooltip">' + msg + '</span></span>';
+                }
+                if (a.capture_progress !== null && a.capture_progress !== undefined) {
+                    const pct = Math.min(100, Math.max(0, a.capture_progress)).toFixed(1);
+                    return '<span class="has-tooltip"><span class="badge badge-progress" style="--pct: ' + pct + '%">Capturing</span>' +
+                        '<span class="tooltip">Stream capture in progress</span></span>';
+                }
                 return '<span class="has-tooltip"><span class="badge badge-pending">Pending</span>' +
-                    '<span class="tooltip">Waiting for stream capture to complete</span></span>';
+                    '<span class="tooltip">Waiting for stream capture to start</span></span>';
             }
             return '<span class="text-muted">none</span>';
         }
@@ -691,7 +726,8 @@
                 '<span class="tooltip">' + a.variant_failed + ' of ' + a.variant_total + ' failed</span></span>';
         }
         if (a.variant_processing > 0) {
-            return '<span class="has-tooltip"><span class="badge badge-processing">Transcoding</span>' +
+            const pct = Math.min(100, Math.max(0, a.variant_aggregate_progress || 0)).toFixed(1);
+            return '<span class="has-tooltip"><span class="badge badge-progress" style="--pct: ' + pct + '%">Transcoding</span>' +
                 '<span class="tooltip">' + a.variant_ready + ' of ' + a.variant_total + ' ready, ' + a.variant_processing + ' processing</span></span>';
         }
         if (a.variant_ready === a.variant_total) {
@@ -704,7 +740,10 @@
 
     function buildVariantStatusCell(v) {
         if (v.status === 'ready') return '<span class="badge badge-ready">Ready</span>';
-        if (v.status === 'processing') return '<span class="badge badge-processing">' + Math.round(v.progress) + '%</span>';
+        if (v.status === 'processing') {
+            const pct = Math.min(100, Math.max(0, v.progress || 0)).toFixed(1);
+            return '<span class="badge badge-progress" style="--pct: ' + pct + '%">' + Math.round(v.progress) + '%</span>';
+        }
         if (v.status === 'cancelled') {
             const msg = (v.error_message || 'Cancelled mid-transcode').slice(0, 120);
             return '<span class="has-tooltip"><span class="badge badge-cancelled">Cancelled</span><span class="tooltip">' + msg + '</span></span>';

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1200,6 +1200,17 @@ async def assets_page(request: Request, db: AsyncSession = Depends(get_db)):
         a.variant_ready = ready
         a.variant_processing = processing
         a.variant_failed = failed
+        # Aggregate transcoding progress across all visible variants: each
+        # variant contributes 0-100, so `sum / total` gives a weighted %.
+        # READY counts as 100 (set on completion), PROCESSING contributes
+        # its live progress, QUEUED/FAILED contribute 0.  Used by the
+        # Status column's fill-badge in assets.html.
+        if total > 0:
+            a.variant_aggregate_progress = round(
+                sum((v.progress or 0.0) for v in visible_variants) / total, 1
+            )
+        else:
+            a.variant_aggregate_progress = 0.0
         a.schedule_count = sched_counts.get(a.id, 0)
         entries = all_group_assets.get(a.id, [])
         # Non-admin users should only see group entries for their own groups

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -66,6 +66,17 @@ class Asset(Base):
     # Max capture duration in seconds (for SAVED_STREAM of live sources)
     capture_duration: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Capture progress (SAVED_STREAM): 0.0-100.0 while ffmpeg runs, NULL when
+    # not yet started.  Populated by worker during _capture_stream; cleared
+    # on recapture.  Mirrors AssetVariant.progress so the UI can show a
+    # unified progress indicator during the capture phase.
+    capture_progress: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Capture error (SAVED_STREAM): populated when ffmpeg capture fails so
+    # the UI can surface a "Capture failed" state with tooltip.  Cleared on
+    # recapture / successful capture completion.
+    capture_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Soft-delete marker.  Set to now() when the user hits DELETE.  The API
     # treats rows with deleted_at IS NOT NULL as gone; a background reaper
     # loop in the CMS (deleted_asset_reaper_loop) cleans up blobs + hard-

--- a/tests/test_delete_cleanup.py
+++ b/tests/test_delete_cleanup.py
@@ -225,11 +225,61 @@ class TestDeleteAssetCleansVariants:
         await db_session.refresh(job)
         assert asset.deleted_at is not None, "Asset should be soft-deleted"
         assert job.cancel_requested is True, "Active Job should be flagged for cancel"
+        # Listen-mode parity: delete_asset now also drives the job to a terminal
+        # status so the reaper doesn't get stuck waiting for a worker that may
+        # never transition it (the worker only transitions in queue mode).
+        assert job.status == JobStatus.CANCELLED, "Active Job should be marked CANCELLED"
+        assert job.error_message == "Asset deleted by user"
+
+    async def test_delete_asset_lets_reaper_finalize_immediately(self, client, db_session, app):
+        """In listen mode, no worker is running to transition Jobs to terminal —
+        delete_asset must flip them to CANCELLED itself so the reaper's
+        active-job gate falls through and the asset is hard-deleted on the
+        very next tick.
+        """
+        from cms.auth import get_settings
+        from cms.services.transcoder import reap_deleted_assets_once
+        from shared.models.job import Job, JobType, JobStatus
+        settings = app.dependency_overrides[get_settings]()
+
+        profile = DeviceProfile(name="da-listen-finalize", video_codec="h264", video_profile="main")
+        db_session.add(profile)
+        await db_session.flush()
+
+        asset = await self._create_asset(db_session, "da-listen-finalize.mp4", settings.asset_storage_path)
+        vid = uuid.uuid4()
+        variant = AssetVariant(
+            id=vid, source_asset_id=asset.id, profile_id=profile.id,
+            filename=f"{vid}.mp4", status=VariantStatus.PROCESSING,
+        )
+        db_session.add(variant)
+        job = Job(type=JobType.VARIANT_TRANSCODE, target_id=vid, status=JobStatus.PENDING)
+        db_session.add(job)
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset.id}")
+        assert resp.status_code == 200
+
+        # One reaper tick should be enough — no active jobs survive delete_asset.
+        await reap_deleted_assets_once(db_session, settings=settings)
+
+        # Asset row gone, variant row gone.
+        gone = await db_session.execute(select(Asset).where(Asset.id == asset.id))
+        assert gone.scalar_one_or_none() is None, "Asset should be hard-deleted on first tick"
+        still = await db_session.execute(select(AssetVariant).where(AssetVariant.id == vid))
+        assert still.scalar_one_or_none() is None, "Variant should be cascade-deleted"
 
     async def test_reaper_skips_asset_with_active_job(self, client, db_session, app):
         """Reaper must NOT hard-delete a soft-deleted asset while a Job is still
         active (QUEUED/CLAIMED/PROCESSING). This prevents races with in-flight
-        ffmpeg processes writing variant blobs."""
+        ffmpeg processes writing variant blobs.
+
+        Note: delete_asset now flips active jobs to CANCELLED itself (listen-
+        mode fix), so we simulate the queue-mode race directly: soft-delete
+        the asset row, leave the Job in PROCESSING (as if the worker is still
+        grinding and hasn't observed cancel_requested yet), then run reaper.
+        """
+        from datetime import datetime, timezone
         from cms.auth import get_settings
         from cms.services.transcoder import reap_deleted_assets_once
         from shared.models.job import Job, JobType, JobStatus
@@ -246,12 +296,11 @@ class TestDeleteAssetCleansVariants:
             filename=f"{vid}.mp4", status=VariantStatus.PROCESSING,
         )
         db_session.add(variant)
-        job = Job(type=JobType.VARIANT_TRANSCODE, target_id=vid, status=JobStatus.PROCESSING)
+        job = Job(type=JobType.VARIANT_TRANSCODE, target_id=vid,
+                  status=JobStatus.PROCESSING, cancel_requested=True)
         db_session.add(job)
+        asset.deleted_at = datetime.now(timezone.utc)
         await db_session.commit()
-
-        resp = await client.delete(f"/api/assets/{asset.id}")
-        assert resp.status_code == 200
 
         await reap_deleted_assets_once(db_session, settings=settings)
 
@@ -262,7 +311,10 @@ class TestDeleteAssetCleansVariants:
 
     async def test_reaper_finalizes_after_job_terminates(self, client, db_session, app):
         """Reaper should hard-delete on a later tick once the active Job reaches
-        a terminal state (CANCELLED/FAILED/COMPLETED)."""
+        a terminal state (CANCELLED/FAILED/COMPLETED). Same setup as above:
+        bypass the HTTP delete handler so the Job stays PROCESSING for the
+        first reaper tick."""
+        from datetime import datetime, timezone
         from cms.auth import get_settings
         from cms.services.transcoder import reap_deleted_assets_once
         from shared.models.job import Job, JobType, JobStatus
@@ -279,12 +331,11 @@ class TestDeleteAssetCleansVariants:
             filename=f"{vid}.mp4", status=VariantStatus.PROCESSING,
         )
         db_session.add(variant)
-        job = Job(type=JobType.VARIANT_TRANSCODE, target_id=vid, status=JobStatus.PROCESSING)
+        job = Job(type=JobType.VARIANT_TRANSCODE, target_id=vid,
+                  status=JobStatus.PROCESSING, cancel_requested=True)
         db_session.add(job)
+        asset.deleted_at = datetime.now(timezone.utc)
         await db_session.commit()
-
-        resp = await client.delete(f"/api/assets/{asset.id}")
-        assert resp.status_code == 200
 
         # First tick: job still active, reaper skips.
         await reap_deleted_assets_once(db_session, settings=settings)

--- a/tests/test_stream_assets.py
+++ b/tests/test_stream_assets.py
@@ -353,6 +353,8 @@ class TestCaptureFormalization:
         asset.filename = f"{asset.id}_capture.mp4"
         asset.checksum = "abc123"
         asset.size_bytes = 1000
+        asset.capture_progress = 100.0
+        asset.capture_error = "stale error from a prior run"
 
         profile = DeviceProfile(name="Test Prof", video_codec="libx264", audio_codec="aac")
         db_session.add(profile)
@@ -383,6 +385,10 @@ class TestCaptureFormalization:
         await db_session.refresh(asset)
         assert asset.checksum == ""
         assert asset.size_bytes == 0
+        # Capture state cleared so the UI shows a fresh "Queued" state rather
+        # than carrying over stale progress / error from the previous attempt.
+        assert asset.capture_progress is None
+        assert asset.capture_error is None
 
     async def test_recapture_404_for_missing_asset(self, client, db_session):
         """Recapture returns 404 for nonexistent asset."""
@@ -564,3 +570,133 @@ class TestCaptureDuration:
         })
         assert resp.status_code == 201
         assert resp.json()["capture_duration"] is None
+
+
+# ── Capture Progress / Error (worker) ────────────────────────────
+
+
+class _FakeStderr:
+    """Minimal async stream that yields pre-canned stderr chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    async def read(self, _n):
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class _FakeProc:
+    def __init__(self, chunks, returncode=0):
+        self.stderr = _FakeStderr(chunks)
+        self.returncode = returncode
+
+    async def wait(self):
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = -15
+
+    async def communicate(self):
+        return b"", b""
+
+
+@pytest.mark.asyncio
+class TestCaptureProgressAndError:
+    """Covers the new capture_progress / capture_error columns and the
+    ffmpeg-progress parsing loop in worker._capture_stream.
+    """
+
+    async def test_capture_progress_updates_monotonically(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        from worker import transcoder
+
+        asset = await _create_stream_asset(
+            db_session, asset_type=AssetType.SAVED_STREAM,
+            url="https://example.com/progress.m3u8",
+        )
+        asset.capture_duration = 100  # nice round number → 1s == 1%
+        await db_session.commit()
+
+        # Emit two time= markers: 30% and 70%.  Then EOF.
+        chunks = [
+            b"frame=  10 time=00:00:30.00 bitrate=1000\n",
+            b"frame=  20 time=00:01:10.00 bitrate=1000\n",
+            b"",
+        ]
+        capture_path = tmp_path / f"{asset.id}_capture.mp4"
+        capture_path.write_bytes(b"\x00" * 1024)  # non-empty so success path runs
+
+        async def _fake_subprocess_exec(*args, **kwargs):
+            return _FakeProc(chunks, returncode=0)
+
+        async def _fake_probe(_path):
+            return {"duration_seconds": 100.0}
+
+        monkeypatch.setattr(transcoder.asyncio, "create_subprocess_exec",
+                            _fake_subprocess_exec)
+        monkeypatch.setattr(transcoder, "probe_media", _fake_probe)
+
+        result = await transcoder._capture_stream(asset, tmp_path, db_session)
+
+        assert result == capture_path
+        await db_session.refresh(asset)
+        # Success path sets progress to 100 and clears any prior error.
+        assert asset.capture_progress == 100.0
+        assert asset.capture_error is None
+
+    async def test_capture_error_persisted_on_ffmpeg_failure(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        from worker import transcoder
+
+        asset = await _create_stream_asset(
+            db_session, asset_type=AssetType.SAVED_STREAM,
+            url="https://example.com/fail.m3u8",
+        )
+        asset.capture_duration = 60
+        await db_session.commit()
+
+        chunks = [b"[hls @ 0x0] Invalid data found when processing input\n", b""]
+
+        async def _fake_subprocess_exec(*args, **kwargs):
+            return _FakeProc(chunks, returncode=1)
+
+        monkeypatch.setattr(transcoder.asyncio, "create_subprocess_exec",
+                            _fake_subprocess_exec)
+
+        result = await transcoder._capture_stream(asset, tmp_path, db_session)
+
+        assert result is None
+        await db_session.refresh(asset)
+        assert asset.capture_error is not None
+        assert "exit code 1" in asset.capture_error
+        assert "Invalid data" in asset.capture_error
+
+    async def test_capture_error_on_empty_output_file(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        from worker import transcoder
+
+        asset = await _create_stream_asset(
+            db_session, asset_type=AssetType.SAVED_STREAM,
+            url="https://example.com/empty.m3u8",
+        )
+        asset.capture_duration = 30
+        await db_session.commit()
+
+        async def _fake_subprocess_exec(*args, **kwargs):
+            # Successful exit but no output file written → empty-file branch.
+            return _FakeProc([b""], returncode=0)
+
+        monkeypatch.setattr(transcoder.asyncio, "create_subprocess_exec",
+                            _fake_subprocess_exec)
+
+        result = await transcoder._capture_stream(asset, tmp_path, db_session)
+
+        assert result is None
+        await db_session.refresh(asset)
+        assert asset.capture_error is not None
+        assert "empty" in asset.capture_error.lower()

--- a/tests/test_stream_assets.py
+++ b/tests/test_stream_assets.py
@@ -700,3 +700,94 @@ class TestCaptureProgressAndError:
         await db_session.refresh(asset)
         assert asset.capture_error is not None
         assert "empty" in asset.capture_error.lower()
+
+    async def test_capture_progress_uses_probed_duration_for_vod(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        """When _get_duration returns a finite value (VOD), progress should be
+        scaled against the probed duration, NOT max_duration. Without this,
+        the bar would crawl to ~probed/max % then jump to 100 at completion.
+        """
+        from worker import transcoder
+
+        asset = await _create_stream_asset(
+            db_session, asset_type=AssetType.SAVED_STREAM,
+            url="https://example.com/vod.m3u8",
+        )
+        asset.capture_duration = 14400  # 4h cap, probed VOD is 100s
+        await db_session.commit()
+
+        # ffmpeg emits time=00:00:50 (= 50% of probed 100s, would only be
+        # 0.35% if we used the 14400s cap as denom).
+        chunks = [b"frame=10 time=00:00:50.00 bitrate=1000\n", b""]
+        capture_path = tmp_path / f"{asset.id}_capture.mp4"
+        capture_path.write_bytes(b"\x00" * 1024)
+
+        async def _fake_get_duration(_url):
+            return 100.0  # finite VOD duration
+
+        async def _fake_subprocess_exec(*args, **kwargs):
+            return _FakeProc(chunks, returncode=0)
+
+        async def _fake_probe(_path):
+            return {"duration_seconds": 100.0}
+
+        monkeypatch.setattr(transcoder, "_get_duration", _fake_get_duration)
+        monkeypatch.setattr(transcoder.asyncio, "create_subprocess_exec",
+                            _fake_subprocess_exec)
+        monkeypatch.setattr(transcoder, "probe_media", _fake_probe)
+
+        # Capture mid-progress samples by snapshotting after each commit.
+        observed = []
+        orig_commit = db_session.commit
+
+        async def _spy_commit():
+            await orig_commit()
+            if asset.capture_progress is not None:
+                observed.append(asset.capture_progress)
+
+        monkeypatch.setattr(db_session, "commit", _spy_commit)
+
+        await transcoder._capture_stream(asset, tmp_path, db_session)
+
+        # Should observe ~50% (probed-based) before the 100% completion commit.
+        # Allow a small tolerance for the 99% cap in the loop.
+        mid = [p for p in observed if 0 < p < 99]
+        assert any(40 <= p <= 60 for p in mid), (
+            f"Expected mid-capture progress around 50%% (probed-based), got {observed}"
+        )
+
+    async def test_capture_uses_max_duration_for_live(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        """When _get_duration returns None (livestream), -t max_duration must
+        be passed to ffmpeg as a safety cap and progress denominator.
+        """
+        from worker import transcoder
+
+        asset = await _create_stream_asset(
+            db_session, asset_type=AssetType.SAVED_STREAM,
+            url="rtmp://example.com/live",
+        )
+        asset.capture_duration = 600  # 10 min cap
+        await db_session.commit()
+
+        captured_args = []
+
+        async def _fake_get_duration(_url):
+            return None  # livestream — no advertised duration
+
+        async def _fake_subprocess_exec(*args, **kwargs):
+            captured_args.append(args)
+            return _FakeProc([b""], returncode=0)
+
+        monkeypatch.setattr(transcoder, "_get_duration", _fake_get_duration)
+        monkeypatch.setattr(transcoder.asyncio, "create_subprocess_exec",
+                            _fake_subprocess_exec)
+
+        await transcoder._capture_stream(asset, tmp_path, db_session)
+
+        assert captured_args, "ffmpeg should have been invoked"
+        args = list(captured_args[0])
+        assert "-t" in args, f"-t safety cap missing for live stream: {args}"
+        assert "600" in args, f"-t value should equal capture_duration (600): {args}"

--- a/worker/transcoder.py
+++ b/worker/transcoder.py
@@ -283,14 +283,18 @@ def _build_ffmpeg_args_safe(
 
 # ── Duration helper ─────────────────────────────────────────────
 
-async def _get_duration(source_path: Path) -> float | None:
-    """Get duration of a media file in seconds using ffprobe."""
+async def _get_duration(source: Path | str) -> float | None:
+    """Get duration of a media file in seconds using ffprobe.
+
+    Accepts a local ``Path`` or a remote URL string.  Returns ``None`` for
+    livestreams (ffprobe reports ``N/A``) or any probe failure.
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
             "ffprobe", "-v", "error",
             "-show_entries", "format=duration",
             "-of", "default=noprint_wrappers=1:nokey=1",
-            str(source_path),
+            str(source),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -318,9 +322,24 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
     capture_filename = f"{asset.id}_capture.mp4"
     capture_path = asset_dir / capture_filename
 
-    target_duration = asset.capture_duration or STREAM_CAPTURE_MAX_SECONDS
-    logger.info("Capturing stream %s → %s (max %ds)", url, capture_filename,
-                target_duration)
+    max_duration = asset.capture_duration or STREAM_CAPTURE_MAX_SECONDS
+
+    # Probe the source upfront with the same helper used for uploaded files.
+    # ffprobe returns a finite duration for VOD (HLS with ENDLIST, MP4, etc.)
+    # and None for true livestreams — we use that to pick a progress denom.
+    probed = await _get_duration(url)
+    if probed and probed > 0:
+        progress_denom = min(float(max_duration), probed)
+        logger.info(
+            "Capturing VOD stream %s → %s (duration %.1fs, max %ds)",
+            url, capture_filename, probed, max_duration,
+        )
+    else:
+        progress_denom = float(max_duration)
+        logger.info(
+            "Capturing live stream %s → %s (max %ds)",
+            url, capture_filename, max_duration,
+        )
 
     # Reset progress/error state before starting so retries don't show stale data
     asset.capture_progress = 0.0
@@ -336,7 +355,10 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
         "-reconnect", "1",
         "-reconnect_streamed", "1",
         "-reconnect_delay_max", "5",
-        "-t", str(target_duration),
+        # ``-t`` is a safety ceiling.  For VOD, ffmpeg exits naturally at
+        # end-of-stream (usually much sooner); for livestreams it caps the
+        # capture at the configured duration.
+        "-t", str(max_duration),
         "-i", url,
         # Copy codecs (no re-encode during capture — transcoding happens later).
         # Do NOT use +faststart here: this is an intermediate file read only by
@@ -364,15 +386,38 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
             if not chunk:
                 break
             stderr_data += chunk
-            if target_duration:
+            if progress_denom:
                 decoded = chunk.decode("utf-8", errors="replace")
                 matches = list(re.finditer(r"time=(\d+):(\d+):(\d+\.\d+)", decoded))
                 if matches:
                     match = matches[-1]
                     h, m, s = int(match.group(1)), int(match.group(2)), float(match.group(3))
                     elapsed = h * 3600 + m * 60 + s
-                    pct = min(99.0, (elapsed / target_duration) * 100)
+                    pct = min(99.0, (elapsed / progress_denom) * 100)
                     if pct > last_progress_update and pct - last_progress_update >= 1.0:
+                        # Cooperative cancel probe: if the user soft-deleted
+                        # the asset mid-capture, terminate ffmpeg so the
+                        # reaper can hard-delete the row promptly.
+                        if await _source_asset_is_deleted(db, asset.id):
+                            logger.info(
+                                "Asset %s: soft-deleted mid-capture — cancelling ffmpeg",
+                                asset.id,
+                            )
+                            try:
+                                proc.terminate()
+                            except Exception:
+                                logger.warning("Failed to terminate ffmpeg", exc_info=True)
+                            try:
+                                await proc.wait()
+                            except Exception:
+                                pass
+                            _active_process = None
+                            try:
+                                if capture_path.is_file():
+                                    capture_path.unlink()
+                            except Exception:
+                                pass
+                            return None
                         asset.capture_progress = round(pct, 1)
                         try:
                             await db.commit()
@@ -612,6 +657,28 @@ async def _transcode_one(variant: AssetVariant, db: AsyncSession, asset_dir: Pat
                     pct = min(99.0, (elapsed / duration) * 100)
                     # Only update if progress moved forward (monotonic)
                     if pct > last_progress_update and pct - last_progress_update >= 1.0:
+                        # Cooperative cancel probe: if the user soft-deleted
+                        # the source asset mid-transcode, terminate ffmpeg so
+                        # the reaper can hard-delete promptly.  In Azure
+                        # queue-mode the 15s heartbeat handles this; LISTEN/
+                        # NOTIFY mode has no heartbeat, so we do it here.
+                        if await _source_asset_is_deleted(db, variant.source_asset_id):
+                            logger.info(
+                                "Variant %s: source asset soft-deleted mid-transcode — cancelling ffmpeg",
+                                variant.id,
+                            )
+                            _cancelled_variant_ids.add(variant.id)
+                            try:
+                                proc.terminate()
+                            except Exception:
+                                logger.warning("Failed to terminate ffmpeg", exc_info=True)
+                            try:
+                                await proc.wait()
+                            except Exception:
+                                pass
+                            _active_process = None
+                            await _abort_on_deleted(variant, output_path, db)
+                            return
                         variant.progress = round(pct, 1)
                         try:
                             await db.commit()
@@ -775,10 +842,14 @@ async def process_pending(session_factory, asset_dir: Path) -> int:
         async with session_factory() as db:
             result = await db.execute(
                 select(AssetVariant)
-                .where(AssetVariant.status == VariantStatus.PENDING)
+                .join(Asset, AssetVariant.source_asset_id == Asset.id)
+                .where(
+                    AssetVariant.status == VariantStatus.PENDING,
+                    Asset.deleted_at.is_(None),
+                )
                 .order_by(AssetVariant.created_at)
                 .limit(1)
-                .with_for_update(skip_locked=True)
+                .with_for_update(skip_locked=True, of=AssetVariant)
             )
             variant = result.scalar_one_or_none()
             if variant is None:

--- a/worker/transcoder.py
+++ b/worker/transcoder.py
@@ -318,8 +318,17 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
     capture_filename = f"{asset.id}_capture.mp4"
     capture_path = asset_dir / capture_filename
 
+    target_duration = asset.capture_duration or STREAM_CAPTURE_MAX_SECONDS
     logger.info("Capturing stream %s → %s (max %ds)", url, capture_filename,
-                asset.capture_duration or STREAM_CAPTURE_MAX_SECONDS)
+                target_duration)
+
+    # Reset progress/error state before starting so retries don't show stale data
+    asset.capture_progress = 0.0
+    asset.capture_error = None
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        logger.warning("Failed to reset capture_progress for asset %s", asset.id)
 
     args = [
         "ffmpeg", "-y",
@@ -327,7 +336,7 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
         "-reconnect", "1",
         "-reconnect_streamed", "1",
         "-reconnect_delay_max", "5",
-        "-t", str(asset.capture_duration or STREAM_CAPTURE_MAX_SECONDS),
+        "-t", str(target_duration),
         "-i", url,
         # Copy codecs (no re-encode during capture — transcoding happens later).
         # Do NOT use +faststart here: this is an intermediate file read only by
@@ -344,17 +353,58 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
             stderr=asyncio.subprocess.PIPE,
         )
         _active_process = proc
-        _, stderr_data = await proc.communicate()
+
+        # Stream stderr so we can parse ffmpeg's periodic `time=HH:MM:SS.ss`
+        # markers and surface live capture progress in the UI.  Same pattern
+        # used by _transcode_one for variant progress.
+        stderr_data = b""
+        last_progress_update = 0.0
+        while True:
+            chunk = await proc.stderr.read(4096)
+            if not chunk:
+                break
+            stderr_data += chunk
+            if target_duration:
+                decoded = chunk.decode("utf-8", errors="replace")
+                matches = list(re.finditer(r"time=(\d+):(\d+):(\d+\.\d+)", decoded))
+                if matches:
+                    match = matches[-1]
+                    h, m, s = int(match.group(1)), int(match.group(2)), float(match.group(3))
+                    elapsed = h * 3600 + m * 60 + s
+                    pct = min(99.0, (elapsed / target_duration) * 100)
+                    if pct > last_progress_update and pct - last_progress_update >= 1.0:
+                        asset.capture_progress = round(pct, 1)
+                        try:
+                            await db.commit()
+                        except SQLAlchemyError:
+                            logger.warning(
+                                "Capture progress commit failed for asset %s — "
+                                "asset may have been deleted; continuing capture",
+                                asset.id,
+                            )
+                        last_progress_update = pct
+
+        await proc.wait()
         _active_process = None
 
         if proc.returncode != 0:
             full_text = stderr_data.decode("utf-8", errors="replace")
             error_text = full_text[:500] if len(full_text) <= 500 else full_text[:250] + "\n…\n" + full_text[-250:]
             logger.error("Stream capture failed for %s: exit %d\n%s", url, proc.returncode, error_text)
+            asset.capture_error = f"ffmpeg exit code {proc.returncode}: {error_text}"
+            try:
+                await db.commit()
+            except SQLAlchemyError:
+                logger.warning("Failed to persist capture_error for asset %s", asset.id)
             return None
 
         if not capture_path.is_file() or capture_path.stat().st_size == 0:
             logger.error("Stream capture produced empty file for %s", url)
+            asset.capture_error = "Stream capture produced empty file"
+            try:
+                await db.commit()
+            except SQLAlchemyError:
+                pass
             return None
 
         # Probe the captured file for metadata
@@ -374,6 +424,8 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
         # Update the source asset with captured file metadata
         asset.size_bytes = file_size
         asset.checksum = sha.hexdigest()
+        asset.capture_progress = 100.0
+        asset.capture_error = None
         for key, val in meta.items():
             if val is not None and hasattr(asset, key):
                 setattr(asset, key, val)
@@ -393,6 +445,11 @@ async def _capture_stream(asset: Asset, asset_dir: Path, db: AsyncSession) -> Pa
     except Exception as e:
         _active_process = None
         logger.exception("Stream capture error for %s: %s", url, e)
+        try:
+            asset.capture_error = f"Capture exception: {e}"
+            await db.commit()
+        except SQLAlchemyError:
+            pass
         return None
 
 


### PR DESCRIPTION
## Summary

Bundles the saved-stream capture UX polish (prod nit #2) with several tightly-coupled fixes uncovered during smoke-testing.

### Saved-stream capture lifecycle
- New `Asset.capture_progress` (float) and `Asset.capture_error` (text) columns.
- `worker/_capture_stream` streams ffmpeg stderr, parses `time=HH:MM:SS.ss` and commits `capture_progress` on each ≥1% delta (same pattern as variant transcode). Non-zero exit / empty output / exception paths persist `capture_error`; success clears it and sets 100.
- `POST /api/assets/{id}/recapture` clears both fields.

### VOD vs live capture (accurate progress)
- Up-front `await _get_duration(url)` call (ffprobe — `_get_duration` widened to `Path | str`; it already drives upload-file progress, so we reuse it).
- Finite duration → **VOD**: `progress_denom = min(max_duration, probed)` so the bar tracks real stream length and actually reaches ~99% instead of jumping from 3% → 100% on EOF.
- `None` → **live**: `progress_denom = max_duration`.
- `-t max_duration` safety ceiling always passed to ffmpeg (VOD exits naturally before hitting it; live uses it as the real cap).

### Listen-mode delete cancel
- `delete_asset` now sets active jobs to `status=CANCELLED` (in addition to `cancel_requested=True`). In listen/notify mode the worker doesn't otherwise transition job rows after a variant finishes, which previously stranded the reaper. Worker's in-flight cancel probe still aborts ffmpeg mid-run; if it races us and writes DONE/FAILED first, that's a harmless overwrite (also terminal).

### UI
- Library column header: **Variants → Status**.
- Saved-stream rows show one of three states (replacing the flat "Pending" badge from #253):
  - **Capture failed** badge with tooltip containing ffmpeg error → Re-capture button
  - **Capturing** fill-badge (CSS `linear-gradient` tracks `capture_progress`)
  - **Pending** (pre-enqueue)
- Regular assets: existing `Transcoding` badge is now a fill-badge showing aggregate variant progress (`sum(variant.progress) / total`).
- Expanded-view capture badge now wrapped in `[data-live-capture]` and refreshed every poll cycle — previously only updated on full page reload.
- Detail URL row: capture-state badge appears next to the URL during capture.

### JSON/polling
`/api/assets/status` returns `capture_progress`, `capture_error`, and `variant_aggregate_progress` per asset so badges animate live.

### Tests
- `TestCaptureProgressAndError` (new + extended):
  - success path sets `capture_progress=100`, clears `capture_error`
  - ffmpeg non-zero exit persists error with exit code + stderr tail
  - empty output file records an "empty" error
  - **VOD path**: mocks `_get_duration→100.0`, asserts mid-capture observed progress is ~50% (probed-based), not ~0.35% (max_duration-based)
  - **Live path**: mocks `_get_duration→None`, asserts `-t max_duration` passed to ffmpeg
- `test_recapture_resets_variants` asserts both new fields are cleared.
- `test_delete_asset_flags_active_transcode` extended to assert `job.status == CANCELLED`.
- `test_delete_asset_lets_reaper_finalize_immediately` (new): single reaper tick hard-deletes — the listen-mode end-to-end story.
- `test_reaper_skips_asset_with_active_job` / `test_reaper_finalizes_after_job_terminates` refactored to construct the soft-delete state directly (bypass the HTTP handler, which now CANCELs jobs itself) so they keep asserting the queue-mode race protection.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;
