### PR TITLE
ci: nightly as pre-deploy gate + post-deploy smoke probe

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'tests/nightly/**'
       - '.github/workflows/nightly.yml'
+  # Runs on every main push so it can serve as the pre-deploy gate
+  # (Publish & Deploy is triggered off a successful Nightly E2E run).
+  push:
+    branches: [main]
 
 concurrency:
   group: nightly-e2e

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Publish & Deploy
 
 on:
   workflow_run:
-    workflows: [Tests]
+    workflows: [Nightly E2E]
     types: [completed]
     branches: [main]
 
@@ -260,6 +260,31 @@ jobs:
         run: |
           echo "::error::Deployment verification failed — expected version ${{ needs.publish.outputs.version }} but got ${{ steps.health.outputs.last_version }}"
           exit 1
+
+      - name: Post-deploy smoke probes
+        run: |
+          FQDN=$(az containerapp show \
+            --name ${{ vars.INFRA_PREFIX }}-cms \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query "properties.configuration.ingress.fqdn" -o tsv)
+
+          fail=0
+
+          # System health endpoint — exercises the CMS↔MCP service-key trust chain.
+          echo "── GET /api/system/health ──"
+          CODE=$(curl -s -o /tmp/sys.json -w '%{http_code}' "https://${FQDN}/api/system/health" --max-time 10 || echo "000")
+          echo "  HTTP $CODE"
+          cat /tmp/sys.json 2>/dev/null || true
+          echo ""
+          if [ "$CODE" != "200" ]; then
+            echo "::error::/api/system/health returned HTTP $CODE"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ All post-deploy smoke probes passed"
 
   # Commit the auto-incremented version back to main so the next deploy
   # starts from the newly-released version.  Runs only after verify passes,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ on:
       - '.gitignore'
       - '.github/workflows/nightly.yml'
       - '.github/workflows/ci-gate.yml'
-  push:
-    branches: [main]
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Phase 3: nightly as pre-deploy gate + post-deploy smoke

Re-wires the pipeline so that what runs before a deploy is the full compose-stack nightly suite (real integration signal) instead of a redundant re-run of PR-level unit + e2e.

### Changes

- **`nightly.yml`** — added `push: branches: [main]` trigger so the nightly suite runs on every merge to main, not just the 07:00 UTC cron.
- **`publish-image.yml`** —
  - `workflow_run.workflows` changed from `[Tests]` → `[Nightly E2E]`. Publish & Deploy now waits for nightly to go green before building/deploying.
  - Added a **post-deploy smoke probe** step after the version-check: `GET /api/system/health` against the live Azure FQDN. Exercises the CMS↔MCP service-key trust chain with real in-cloud credentials, which `/healthz` alone does not.
- **`tests.yml`** — dropped `push: branches: [main]` trigger. Tests already ran on the PR; re-running on main was pure redundancy.

### Pipeline shape (after this PR)

```
 PR  → Tests (+ CI Gate)  → merge
       ↓ (main push)
       Nightly E2E (full compose stack, ~20–30 min)
       ↓ (only on success)
       Publish & Deploy → /healthz version check → /api/system/health smoke probe → auto-bump version on main
```

If nightly fails on main, deploy does not run — gives us time to revert or fix forward while production keeps serving the previous version.

### Not in scope (future work)

- Phase 4: PR-CI migration-safety job with seeded synthetic dataset (catch migrations that break on populated DBs).
- More post-deploy probes (authed `/api/profiles`, MCP `/health/api` with service key).
