### PR TITLE
ci(migration-safety): fix init_db call + wait_for_db

### DIFF
--- a/scripts/ci_seed_synthetic.py
+++ b/scripts/ci_seed_synthetic.py
@@ -22,7 +22,8 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import text
 
-from cms.database import dispose_db, init_db, run_migrations
+from cms.auth import get_settings
+from cms.database import dispose_db, init_db, run_migrations, wait_for_db
 from shared import database as _shared_db
 
 
@@ -52,7 +53,8 @@ async def _insert(conn, table: str, row: dict) -> None:
 
 
 async def seed(count: int = 10) -> None:
-    await init_db()
+    init_db(get_settings())
+    await wait_for_db()
     await run_migrations()
 
     async with _shared_db._engine.begin() as conn:

--- a/scripts/ci_verify_post_migration.py
+++ b/scripts/ci_verify_post_migration.py
@@ -15,7 +15,8 @@ import sys
 
 from sqlalchemy import text
 
-from cms.database import dispose_db, init_db, run_migrations
+from cms.auth import get_settings
+from cms.database import dispose_db, init_db, run_migrations, wait_for_db
 from shared import database as _shared_db
 
 
@@ -32,7 +33,8 @@ EXPECTED_TABLES = [
 
 
 async def verify() -> int:
-    await init_db()
+    init_db(get_settings())
+    await wait_for_db()
     await run_migrations()
 
     failures: list[str] = []


### PR DESCRIPTION
Fixes the migration-safety job from #283 — init_db is sync and takes a settings arg; also need wait_for_db() before running migrations.