### PR TITLE
ci: rename 'Nightly E2E' workflow to 'Smoke Test'

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly E2E
+name: Smoke Test
 
 on:
   schedule:
@@ -16,7 +16,7 @@ on:
       - 'tests/nightly/**'
       - '.github/workflows/nightly.yml'
   # Runs on every main push so it can serve as the pre-deploy gate
-  # (Publish & Deploy is triggered off a successful Nightly E2E run).
+  # (Publish & Deploy is triggered off a successful Smoke Test run).
   push:
     branches: [main]
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Publish & Deploy
 
 on:
   workflow_run:
-    workflows: [Nightly E2E]
+    workflows: [Smoke Test]
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
Renames the workflow display name. It serves two roles (nightly schedule + pre-deploy gate on main push) so 'Smoke Test' better describes what it is rather than when it runs.

- .github/workflows/nightly.yml: name → Smoke Test
- .github/workflows/publish-image.yml: workflow_run.workflows → [Smoke Test]

Filename and test directory (tests/nightly/) left unchanged to keep the diff minimal.