### PR TITLE
docs: persist CI pipeline knowledge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to agora-cms
+
+## Development quickstart
+
+See the top-level `README.md` for local setup, running tests, and the compose
+stack used for end-to-end testing.
+
+## Pull request flow
+
+1. Branch from `main`.
+2. Push your branch and open a PR — do **not** bump `cms/__init__.py`'s
+   `__version__`; that is auto-bumped post-deploy.
+3. Wait for CI:
+   - `CI Gate` — always-pass sentinel (required).
+   - `Tests/test` and `Tests/e2e` — the test suite.
+   - `Migration Safety` — **required**; seeds main's schema with synthetic
+     data, runs your PR's migrations against it, and verifies the DB is
+     still queryable.  See [docs/CI.md](docs/CI.md) for details.
+   - `Smoke Test` — full-stack compose E2E; also runs nightly and on every
+     main push as the pre-deploy gate.
+4. Use `gh pr merge --auto --squash` (or the "Enable auto-merge" UI button).
+   `Migration Safety` being required means auto-merge waits for real
+   validation, so it's safe to enable on any PR.
+
+## Changing the CI pipeline
+
+**Read [docs/CI.md](docs/CI.md) first** — it documents the pipeline shape,
+required checks, branch-protection config, the seed-script quirks, common
+failure modes, and future cleanup items.
+
+Key files if you need to touch CI:
+
+- `.github/workflows/ci-gate.yml` — the required always-pass sentinel.
+- `.github/workflows/tests.yml` — unit + e2e PR tests.
+- `.github/workflows/migration-safety.yml` — PR migration guard-rail.
+- `.github/workflows/nightly.yml` — **display name `Smoke Test`**; runs
+  nightly, on main push (pre-deploy gate), and on PRs.
+- `.github/workflows/publish-image.yml` — build/push/deploy, triggered by a
+  successful Smoke Test on main.  Also auto-bumps `__version__`.
+- `scripts/ci_seed_synthetic.py` — synthetic data seeder.  **Has a quirks
+  list at the top — read it before editing.**
+- `scripts/ci_verify_post_migration.py` — post-migration verifier.
+
+### If you rename a workflow
+
+`publish-image.yml`'s `workflow_run` trigger keys off the workflow
+**display name** (not the filename).  If you change `name:` on
+`nightly.yml`, update `workflows: [...]` in `publish-image.yml` in the
+same PR.
+
+### If you add a new required check
+
+Update branch protection on `main` to include the new check context:
+
+```powershell
+'{"strict":false,"contexts":["ci-gate","migration-safety","<new-check>"]}' |
+  gh api -X PATCH repos/sslivins/agora-cms/branches/main/protection/required_status_checks --input -
+```
+
+## Coding conventions
+
+Match the style of surrounding code.  Run the existing linters/tests before
+pushing; do not add new tooling without discussion.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,173 @@
+# CI / CD Pipeline
+
+This document describes how code gets from a PR to production in `agora-cms`,
+which checks are required to merge, and the quirks in the pipeline that future
+maintainers (human or AI) need to know about to avoid regressions.
+
+## End-to-end flow
+
+```
+PR opened / updated
+  ├─ CI Gate          (always-pass sentinel — REQUIRED)
+  ├─ Tests/test       (pytest suite)
+  ├─ Tests/e2e        (compose-based e2e)
+  ├─ Migration Safety (REQUIRED — see below)
+  └─ Smoke Test       (full-stack compose E2E)
+
+Merge to main (squash)
+  └─ Smoke Test (on main push)        .github/workflows/nightly.yml
+       └─ Publish & Deploy             .github/workflows/publish-image.yml
+            ├─ build + push image
+            ├─ deploy
+            ├─ post-deploy /api/system/health probe
+            └─ auto-bump cms/__init__.py __version__ (commits back to main)
+```
+
+Smoke Test also runs on a nightly cron.
+
+## Required status checks on `main`
+
+- `ci-gate` — always-pass sentinel (`.github/workflows/ci-gate.yml`). It
+  exists so branch protection has *something* mandatory to key off when the
+  real checks are path-filtered / conditional.
+- `migration-safety` — the real PR gate (see below).
+
+Branch protection is classic (not rulesets) with `enforce_admins: false` and
+`strict: false` (no up-to-date-before-merge requirement, so PRs don't have to
+rebase every time main moves).
+
+Smoke Test is intentionally **not** a required check — it's too slow for a
+per-PR block, and nightly + post-merge coverage is sufficient.
+
+## Migration Safety (`.github/workflows/migration-safety.yml`)
+
+The critical guard-rail that stops a PR from silently breaking migrations
+against a populated database.
+
+Flow:
+
+1. Check out the PR (`pr/`) and `main` (`base/`) in parallel directories.
+2. Copy `pr/scripts/ci_seed_synthetic.py` → `base/scripts/` so seeding always
+   uses the latest seed logic even when testing against main's code.
+3. Install `base/` deps. Initialise schema from main. Run
+   `scripts/ci_seed_synthetic.py` with `PYTHONPATH=base/` — this seeds
+   synthetic data into a DB with main's schema.
+4. Install `pr/` deps. Run the PR's migrations against that populated DB.
+5. Run `scripts/ci_verify_post_migration.py` with `PYTHONPATH=pr/` — asserts
+   that the populated DB is still queryable and the required tables are
+   non-empty.
+
+If step 4 or 5 fails, the PR cannot merge.
+
+### Quirks / don't-regress list
+
+These have all bitten us. They are documented in `scripts/ci_seed_synthetic.py`
+as well, but listed here for cross-referenceability.
+
+- **`assets.asset_type`** is an enum at the DB level. Caller must supply
+  `asset_type="VIDEO"` (or another valid enum value), **not** `type="VIDEO"`.
+  The auto-placeholder generator would produce `"seed_asset_type_NN"` which is
+  not a valid enum value.
+- **`asset_variants`** FK column is `source_asset_id`, **not** `asset_id`.
+- **`devices.id`** is `VARCHAR(64)`, not `UUID`. Must pass
+  `str(uuid.uuid4())`, not a `UUID` object — asyncpg refuses to coerce.
+- **`api_keys.key_hash`** is unique and `VARCHAR(64)`. The seed value must be
+  structured so that truncation at 64 chars does not collapse rows to
+  identical values — put the differentiator *at the start*, not the end.
+
+## Nightly / Smoke Test (`.github/workflows/nightly.yml`)
+
+Display name: **Smoke Test**. File is still called `nightly.yml` and tests
+live in `tests/nightly/` — these paths are kept for history/URL stability.
+
+Triggered by:
+- `schedule:` — nightly cron.
+- `push: branches: [main]` — every main merge, as the pre-deploy gate.
+- Path-filtered PR trigger.
+
+The `workflow_run` trigger in `publish-image.yml` is keyed off the workflow's
+**display name** (`Smoke Test`), not its filename. If you ever rename it
+again, update both files together.
+
+## Publish & Deploy (`.github/workflows/publish-image.yml`)
+
+- Triggered by a successful Smoke Test run on main (`workflow_run` →
+  `workflows: [Smoke Test]`).
+- Builds + pushes the image, deploys, then hits
+  `/api/system/health` as a post-deploy smoke probe.
+- Finally, auto-bumps `cms/__init__.py`'s `__version__` and commits the bump
+  back to `main` using a PAT stored in `VERSION_BUMP_TOKEN` (repo secret).
+
+### `VERSION_BUMP_TOKEN`
+
+- Personal Access Token (classic, not fine-grained) with `contents: write`
+  on this repo.
+- Currently has a **90-day expiry**. Rotate before expiry or deploys will
+  stop bumping the version.
+- The bot identity is whatever user owns the PAT — bypasses branch
+  protection because admins are not enforced (`enforce_admins: false`).
+
+## Seed script shape (`scripts/ci_seed_synthetic.py`)
+
+Key helpers:
+
+- `_table_info(conn, table)` — introspects columns: name, nullable, default,
+  data_type, max_len.
+- `_fk_targets(conn, table)` — introspects FK constraints so we can skip
+  rows whose FK targets don't yet exist.
+- `_any_existing_pk(conn, table)` — picks an arbitrary existing PK for an
+  FK target.
+- `_placeholder_for(col)` — generates a placeholder value based on type:
+  - `ARRAY` → `[]`
+  - `JSON`/`JSONB` → `{}`
+  - `UUID` → `uuid.uuid4()`
+  - `VARCHAR(n)` → string truncated to `n`
+  - ints, bools, datetimes handled appropriately
+- `_insert(conn, table, values)` — caller-supplied string values are also
+  truncated to the column's max_len. Each insert runs inside a savepoint
+  (`conn.begin_nested()`) so a bad row doesn't poison subsequent inserts.
+
+Seeding order is FK-aware:
+
+```
+roles → users → device_groups → device_profiles → devices
+     → assets → asset_variants → schedules → api_keys
+```
+
+## Verify script (`scripts/ci_verify_post_migration.py`)
+
+- `REQUIRED_NONEMPTY = {"users", "devices", "assets"}` — if any of these is
+  empty after migrations, the job fails. Other tables may legitimately be
+  empty (e.g. if their FK chain broke during seed).
+- Runs sanity join queries:
+  - `devices ⋈ device_groups ⋈ device_profiles`
+  - `assets ⋈ asset_variants ON v.source_asset_id = a.id`
+
+## Auto-merge etiquette
+
+- Use `gh pr merge --auto --squash` (or equivalent in the UI) once the PR
+  looks ready. Because `migration-safety` is now required, auto-merge will
+  actually wait for real validation before merging.
+- Historical trap (now fixed): prior to migration-safety being required,
+  auto-merge would fire the moment `ci-gate` was green, merging PRs whose
+  other checks were still failing/pending. If you ever remove
+  migration-safety from the required list, remember this.
+
+## Common failure modes & fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `invalid input value for enum assettype: "seed_asset_type_NN"` | seed caller passing wrong key (e.g. `type` instead of `asset_type`) | pass `asset_type="VIDEO"` |
+| `invalid input for query argument $1: UUID(...) (expected str, got UUID)` | `devices.id` is VARCHAR, not UUID | `str(uuid.uuid4())` |
+| `duplicate key value violates unique constraint ... key_hash ...` | truncation collapsing unique suffix | put differentiator at start of string |
+| `column v.asset_id does not exist` | wrong FK column name on `asset_variants` | use `source_asset_id` |
+| `TypeError: init_db() missing 1 required positional argument: 'settings'` | calling `await init_db()` | it's sync; `init_db(get_settings())` then `await wait_for_db()` |
+
+## Future improvements
+
+- Enum-aware placeholder generation: query `pg_enum` instead of requiring
+  callers to hard-code enum values.
+- Move the inline `python - <<'PY'` block in `migration-safety.yml` to a
+  proper script (e.g. `scripts/ci_run_migrations.py`) for testability.
+- Rename file/dirs: `nightly.yml` → `smoke.yml`, `tests/nightly/` →
+  `tests/smoke/`. Kept out of the initial rename to minimise diff.

--- a/scripts/ci_seed_synthetic.py
+++ b/scripts/ci_seed_synthetic.py
@@ -11,6 +11,28 @@ still have to cope with the pre-existing rows once added).
 Run against a database that already has the schema initialised
 (via ``cms.database.run_migrations``).  Prints row counts on exit so
 the CI log clearly shows the seeded volume.
+
+--------------------------------------------------------------------
+QUIRKS — don't regress these.  See also docs/CI.md.
+--------------------------------------------------------------------
+
+* ``assets.asset_type`` is an enum at the DB level.  Caller must supply
+  ``asset_type="VIDEO"`` (a valid enum value), NOT ``type="VIDEO"``.
+  The auto-placeholder would generate ``seed_asset_type_NN`` which is
+  not a valid enum value.
+
+* ``asset_variants`` FK column is ``source_asset_id``, NOT ``asset_id``.
+
+* ``devices.id`` is ``VARCHAR(64)``, not ``UUID``.  Must pass
+  ``str(uuid.uuid4())`` — asyncpg won't coerce a ``UUID`` object.
+
+* ``api_keys.key_hash`` is UNIQUE and ``VARCHAR(64)``.  Put the
+  differentiator at the START of the seed string so truncation at 64
+  chars doesn't collapse rows to identical values.
+
+* ``init_db`` (from ``shared.database``) is SYNC and takes a settings
+  arg: ``init_db(get_settings())``, then ``await wait_for_db()`` before
+  ``await run_migrations()``.  Don't ``await init_db()``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Captures the recent CI overhaul (Phases 1/3/4 + Smoke rename) as durable repo documentation so future contributors don't have to rediscover:

- **docs/CI.md** — pipeline diagram, required checks, branch-protection config, Migration Safety flow, seed-script quirks (asset_type enum, source_asset_id FK, devices.id VARCHAR, key_hash truncation), common failure modes, and future cleanup items.
- **scripts/ci_seed_synthetic.py** — inline quirks header so the gotchas are seen immediately when editing.
- **CONTRIBUTING.md** — PR flow, CI change guidance, how to add a required status check.

Docs only. Everything should stay green.