### PR TITLE
fix(db): add missing ALTER TABLE for assets.capture_progress/capture_error

### DIFF
--- a/cms/database.py
+++ b/cms/database.py
@@ -411,6 +411,19 @@ async def run_migrations():
                 "ON asset_variants (deleted_at)"
             ))
 
+    # -- assets.capture_progress / assets.capture_error (live SAVED_STREAM progress + failure UI) --
+    async with _shared_db._engine.begin() as conn:
+        has_cap_progress = await conn.run_sync(lambda c: _has_column(c, "assets", "capture_progress"))
+        if not has_cap_progress:
+            await conn.execute(text(
+                "ALTER TABLE assets ADD COLUMN capture_progress DOUBLE PRECISION"
+            ))
+        has_cap_error = await conn.run_sync(lambda c: _has_column(c, "assets", "capture_error"))
+        if not has_cap_error:
+            await conn.execute(text(
+                "ALTER TABLE assets ADD COLUMN capture_error TEXT"
+            ))
+
     # Run create_all again in case migrations added models with new relationships
     async with _shared_db._engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)


### PR DESCRIPTION
**Unblocks production deploys.** PR #280 added capture_progress and capture_error on the Asset model but forgot the corresponding idempotent startup DDL in cms/database.py. Production uses Base.metadata.create_all() which only creates new tables (never adds columns to existing ones), so the new columns never landed. CMS crashlooped on startup with 'column assets.capture_progress does not exist'. Prod stayed up because ACA kept routing to the last healthy revision — digest pinning worked exactly as designed.

This PR adds two idempotent ALTER TABLE ADD COLUMN blocks, matching the pattern already used throughout cms/database.py.