### PR TITLE
Gate asset selection on transcode readiness (#201)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -32,6 +32,7 @@ from cms.schemas.protocol import ConfigMessage, FactoryResetMessage, RebootMessa
 from cms.services.device_manager import device_manager
 from cms.services.scheduler import push_sync_to_device
 from cms.services.audit_service import audit_log, compute_diff
+from cms.services.asset_readiness import require_asset_ready
 from cms.services.version_checker import check_now
 
 router = APIRouter(prefix="/api/devices", dependencies=[Depends(require_auth)])
@@ -241,6 +242,10 @@ async def update_device(
                 status_code=403,
                 detail=f"Missing permission: {DEVICES_MANAGE}",
             )
+
+    # Gate splash assignment on variant readiness (issue #201).
+    if updates.get("default_asset_id"):
+        await require_asset_ready(db, updates["default_asset_id"])
 
     # Snapshot before mutation so we can build a true diff for the audit log
     changes = compute_diff(device, updates)
@@ -658,6 +663,10 @@ async def list_groups(request: Request, db: AsyncSession = Depends(get_db)):
 
 @router.post("/groups/", response_model=DeviceGroupOut, status_code=201, dependencies=[Depends(require_permission(GROUPS_WRITE))])
 async def create_group(data: DeviceGroupCreate, request: Request, db: AsyncSession = Depends(get_db)):
+    # Gate splash assignment on variant readiness (issue #201).
+    if data.default_asset_id:
+        await require_asset_ready(db, data.default_asset_id)
+
     group = DeviceGroup(name=data.name, description=data.description, default_asset_id=data.default_asset_id)
     db.add(group)
     await db.flush()
@@ -703,6 +712,11 @@ async def update_group(
 
     updates = data.model_dump(exclude_unset=True)
     changes = compute_diff(group, updates)
+
+    # Gate splash assignment on variant readiness (issue #201).
+    if updates.get("default_asset_id"):
+        await require_asset_ready(db, updates["default_asset_id"])
+
     for field, value in updates.items():
         setattr(group, field, value)
     await audit_log(

--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -20,6 +20,7 @@ from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.schemas.schedule import ScheduleCreate, ScheduleOut, ScheduleUpdate
 from cms.services.scheduler import push_sync_to_affected_devices, push_sync_to_device, _get_target_device_ids, skip_schedule_until, clear_schedule_skip, clear_sync_hash, schedules_conflict, evaluate_schedules
 from cms.services.audit_service import audit_log, compute_diff
+from cms.services.asset_readiness import require_asset_ready
 
 logger = logging.getLogger("agora.cms.schedules")
 
@@ -186,6 +187,10 @@ async def create_schedule(data: ScheduleCreate, request: Request, db: AsyncSessi
     fields = data.model_dump()
     fields["name"] = await _unique_name(fields["name"], db)
 
+    # Gate on variant readiness for new schedules (issue #201).
+    # Webpage/stream assets have no variants and are implicitly ready.
+    await require_asset_ready(db, data.asset_id)
+
     # Check if asset is a webpage type
     asset = await db.get(Asset, data.asset_id)
     if not asset:
@@ -280,6 +285,10 @@ async def update_schedule(
     await _verify_schedule_access(schedule, request, db)
 
     updates = data.model_dump(exclude_unset=True)
+
+    # Gate swaps to a new asset on variant readiness (issue #201).
+    if "asset_id" in updates and updates["asset_id"] != schedule.asset_id:
+        await require_asset_ready(db, updates["asset_id"])
 
     # Snapshot diff before any mutation or auto-computation
     changes = compute_diff(schedule, updates)

--- a/cms/services/asset_readiness.py
+++ b/cms/services/asset_readiness.py
@@ -1,0 +1,52 @@
+"""Asset-readiness gate for splash-screen and schedule assignments (issue #201).
+
+Centralises the "can this asset be assigned to a device / group splash or
+scheduled for playback?" check so routers (devices / schedules) all apply
+the same rule.
+
+The rule itself lives in :func:`cms.services.variant_view.is_asset_ready`.
+This module adds a small async wrapper that loads the asset + its variants
+from the DB and raises an HTTP 422 when the gate fails.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from cms.models.asset import Asset
+from cms.services.variant_view import is_asset_ready
+
+
+async def require_asset_ready(db: AsyncSession, asset_id: uuid.UUID) -> Asset:
+    """Load the asset + variants and raise 422 if it isn't ready.
+
+    Returns the loaded Asset on success so callers don't have to re-fetch.
+
+    Raises:
+        HTTPException(404): asset not found.
+        HTTPException(422): asset exists but isn't ready for assignment —
+            a variant is still PROCESSING/PENDING (``"transcoding…"``) or
+            the only non-READY rows for some profile are FAILED
+            (``"transcode failed"``).
+    """
+    result = await db.execute(
+        select(Asset)
+        .options(selectinload(Asset.variants))
+        .where(Asset.id == asset_id)
+    )
+    asset = result.scalar_one_or_none()
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    ready, reason = is_asset_ready(asset.variants)
+    if not ready:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Asset is not ready for assignment ({reason}).",
+        )
+    return asset

--- a/cms/services/variant_view.py
+++ b/cms/services/variant_view.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TypeVar
 
+from shared.models.asset import VariantStatus
+
 _V = TypeVar("_V")
 
 
@@ -49,3 +51,98 @@ def collapse_to_latest(variants: Iterable[_V]) -> list[_V]:
             ):
                 latest[pid] = v
     return list(latest.values())
+
+
+def collapse_to_ready(variants: Iterable[_V]) -> list[_V]:
+    """Return one READY variant per ``profile_id`` (newest wins).
+
+    Mirror of :func:`collapse_to_latest` but restricted to rows whose
+    ``status`` is ``VariantStatus.READY``. Soft-deleted rows are dropped.
+
+    Used by the "is this asset playable for every profile?" check that
+    gates device/group/schedule asset selection (issue #201). A profile
+    with an older READY variant and a newer PROCESSING row for a fresh
+    re-transcode still appears here, because the old blob can still
+    serve the device until the new one lands.
+    """
+    latest: dict[object, _V] = {}
+    for v in variants:
+        if getattr(v, "deleted_at", None) is not None:
+            continue
+        if getattr(v, "status", None) != VariantStatus.READY:
+            continue
+        pid = getattr(v, "profile_id", None)
+        if pid is None:
+            continue
+        cur = latest.get(pid)
+        if cur is None:
+            latest[pid] = v
+            continue
+        v_created = getattr(v, "created_at", None)
+        cur_created = getattr(cur, "created_at", None)
+        if v_created is not None and cur_created is not None:
+            if v_created > cur_created:
+                latest[pid] = v
+            elif v_created == cur_created and str(getattr(v, "id", "")) > str(
+                getattr(cur, "id", "")
+            ):
+                latest[pid] = v
+    return list(latest.values())
+
+
+def is_asset_ready(variants: Iterable[_V]) -> tuple[bool, str | None]:
+    """Return whether an asset is ready for new splash / schedule assignment.
+
+    An asset is considered **ready** iff, for every profile that has any
+    live (non-deleted) variant row, at least one of that profile's live
+    variants is in :attr:`VariantStatus.READY`.
+
+    Corollaries:
+      * Assets with no variants at all (webpage / stream / upload not
+        yet dispatched) are ready — nothing to gate on.
+      * A profile that has been added globally but for which no variant
+        row exists for this asset yet is ignored (not worth tracking).
+      * Re-transcode case (old READY + new PROCESSING for the same
+        profile) stays ready — the old variant still serves traffic.
+
+    Returns ``(ready, reason)``. ``reason`` is ``None`` when ready, else
+    a short human-readable suffix — ``"transcoding…"`` when any blocking
+    profile still has PENDING/PROCESSING work, or ``"transcode failed"``
+    when the only non-READY variants left for that profile are FAILED.
+    """
+    # Collect live variants; bail early if nothing to check.
+    live: list[_V] = [
+        v for v in variants if getattr(v, "deleted_at", None) is None
+    ]
+    if not live:
+        return True, None
+
+    # Group by profile_id. Variants with no profile_id are defensive-skipped.
+    by_profile: dict[object, list[_V]] = {}
+    for v in live:
+        pid = getattr(v, "profile_id", None)
+        if pid is None:
+            continue
+        by_profile.setdefault(pid, []).append(v)
+
+    if not by_profile:
+        return True, None
+
+    any_in_flight = False
+    any_unready_profile = False
+    for pid, vs in by_profile.items():
+        if any(getattr(v, "status", None) == VariantStatus.READY for v in vs):
+            continue
+        any_unready_profile = True
+        if any(
+            getattr(v, "status", None)
+            in (VariantStatus.PENDING, VariantStatus.PROCESSING)
+            for v in vs
+        ):
+            any_in_flight = True
+            break  # in-flight dominates failed for the user-facing reason
+
+    if not any_unready_profile:
+        return True, None
+    return False, ("transcoding…" if any_in_flight else "transcode failed")
+

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -48,7 +48,7 @@
         <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
             <option value="">None (use group)</option>
             {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}>{{ a.display_name or a.original_filename or a.filename }}</option>
+            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
             {% endfor %}
         </select>
         {% else %}
@@ -335,7 +335,7 @@
                 <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
                     <option value="">No default asset</option>
                     {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}>{{ a.display_name or a.original_filename or a.filename }}</option>
+                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
                 {% if g.schedule_count %}

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -28,7 +28,7 @@
                 <select name="asset_id" required onchange="onAssetTypeChange(this)">
                     <option value="">Select asset...</option>
                     {% for a in assets %}
-                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}">{{ a.display_name or a.original_filename or a.filename }}{% if a.asset_type.value == 'video' and a.duration_seconds %} ({{ '%d:%02d'|format((a.duration_seconds|int) // 60, (a.duration_seconds|int) % 60) }}){% elif a.asset_type.value == 'webpage' %} 🌐{% elif a.asset_type.value == 'stream' %} 📡{% endif %}</option>
+                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}"{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if a.asset_type.value == 'video' and a.duration_seconds %} ({{ '%d:%02d'|format((a.duration_seconds|int) // 60, (a.duration_seconds|int) % 60) }}){% elif a.asset_type.value == 'webpage' %} 🌐{% elif a.asset_type.value == 'stream' %} 📡{% endif %}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -212,7 +212,7 @@
 <input type="hidden" id="_tzOptions" value='{{ tz_options | tojson }}'>
 <script>
 const _scheduleData = {
-    assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.asset_type.value == 'video' else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
+    assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.asset_type.value == 'video' else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
     groups: [{% for g in groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}],
     isAdmin: {{ 'true' if is_admin else 'false' }}
 };
@@ -784,7 +784,9 @@ function editSchedule(s) {
             const m = Math.floor(a.duration / 60), s = Math.round(a.duration % 60);
             label += ` (${m}:${String(s).padStart(2,'0')})`;
         }
-        return `<option value="${a.id}" data-asset-type="${a.type || ''}" ${a.id === s.asset_id ? "selected" : ""}>${label}</option>`;
+        if (!a.ready && a.notReadyReason) label += ` (${a.notReadyReason})`;
+        const disabledAttr = a.ready ? '' : ' disabled';
+        return `<option value="${a.id}" data-asset-type="${a.type || ''}"${disabledAttr} ${a.id === s.asset_id ? "selected" : ""}>${label}</option>`;
     }).join("");
 
     const groupOpts = groups.map(g =>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -907,13 +907,23 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     # Build URL→display name map for resolving playback_asset on URL-based assets
     assets_early_q = await db.execute(
-        select(Asset).where(Asset.deleted_at.is_(None)).order_by(Asset.filename)
+        select(Asset)
+        .options(selectinload(Asset.variants))
+        .where(Asset.deleted_at.is_(None))
+        .order_by(Asset.filename)
     )
     assets_early = assets_early_q.scalars().all()
     _url_display = {}
     for a in assets_early:
         if a.url:
             _url_display.setdefault(a.url, a.filename)
+    # Annotate each asset with a readiness flag for the splash dropdowns
+    # (issue #201). Assets that aren't fully ready are shown but disabled.
+    from cms.services.variant_view import is_asset_ready as _is_asset_ready
+    for a in assets_early:
+        ready, reason = _is_asset_ready(a.variants)
+        a.ready_for_selection = ready
+        a.not_ready_reason = reason
     for d in devices:
         d.is_online = device_manager.is_connected(d.id)
         state = live_states.get(d.id)
@@ -1294,7 +1304,12 @@ async def schedules_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     schedules_q = await db.execute(sched_query)
     all_schedules = schedules_q.scalars().all()
-    asset_q = select(Asset).where(Asset.deleted_at.is_(None)).order_by(Asset.filename)
+    asset_q = (
+        select(Asset)
+        .options(selectinload(Asset.variants))
+        .where(Asset.deleted_at.is_(None))
+        .order_by(Asset.filename)
+    )
     if not is_admin:
         from cms.models.asset import Asset as AssetModel
         global_ids = set(
@@ -1332,6 +1347,12 @@ async def schedules_page(request: Request, db: AsyncSession = Depends(get_db)):
             asset_group_map.setdefault(str(aid), []).append(str(gid))
     for a in assets:
         a._group_ids_json = asset_group_map.get(str(a.id), [])
+    # Readiness flag for schedule asset picker (issue #201).
+    from cms.services.variant_view import is_asset_ready as _is_asset_ready
+    for a in assets:
+        ready, reason = _is_asset_ready(a.variants)
+        a.ready_for_selection = ready
+        a.not_ready_reason = reason
 
     groups_query_sched = select(DeviceGroup).order_by(DeviceGroup.name)
     if not is_admin:

--- a/tests/test_asset_readiness_gate.py
+++ b/tests/test_asset_readiness_gate.py
@@ -1,0 +1,336 @@
+"""Endpoint tests for the asset-readiness gate (issue #201).
+
+Covers the PATCH/POST guards on:
+  * PATCH /api/devices/{id}               (default_asset_id)
+  * POST  /api/devices/groups/            (default_asset_id)
+  * PATCH /api/devices/groups/{id}        (default_asset_id)
+  * POST  /api/schedules                  (asset_id)
+  * PATCH /api/schedules/{id}             (asset_id)
+
+Rule: an asset is selectable iff every profile with any live (non-deleted)
+variant has at least one variant in ``VariantStatus.READY``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def _ready_asset(db_session, *, filename: str = "ready.mp4"):
+    """Create an asset with a single READY variant → selectable."""
+    from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+    from cms.models.device_profile import DeviceProfile
+
+    asset = Asset(
+        filename=filename,
+        asset_type=AssetType.VIDEO,
+        size_bytes=100,
+        checksum=f"ready-{filename}",
+    )
+    profile = DeviceProfile(name=f"profile-{filename}")
+    db_session.add_all([asset, profile])
+    await db_session.flush()
+    db_session.add(
+        AssetVariant(
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{asset.id}.mp4",
+            status=VariantStatus.READY,
+        )
+    )
+    await db_session.commit()
+    return asset
+
+
+async def _in_flight_asset(db_session, *, filename: str = "wip.mp4"):
+    """Create an asset whose lone variant is PROCESSING → NOT selectable."""
+    from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+    from cms.models.device_profile import DeviceProfile
+
+    asset = Asset(
+        filename=filename,
+        asset_type=AssetType.VIDEO,
+        size_bytes=100,
+        checksum=f"wip-{filename}",
+    )
+    profile = DeviceProfile(name=f"profile-{filename}")
+    db_session.add_all([asset, profile])
+    await db_session.flush()
+    db_session.add(
+        AssetVariant(
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{asset.id}.mp4",
+            status=VariantStatus.PROCESSING,
+            progress=45.0,
+        )
+    )
+    await db_session.commit()
+    return asset
+
+
+async def _failed_asset(db_session, *, filename: str = "bad.mp4"):
+    """Create an asset whose lone variant is FAILED → NOT selectable."""
+    from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+    from cms.models.device_profile import DeviceProfile
+
+    asset = Asset(
+        filename=filename,
+        asset_type=AssetType.VIDEO,
+        size_bytes=100,
+        checksum=f"fail-{filename}",
+    )
+    profile = DeviceProfile(name=f"profile-{filename}")
+    db_session.add_all([asset, profile])
+    await db_session.flush()
+    db_session.add(
+        AssetVariant(
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{asset.id}.mp4",
+            status=VariantStatus.FAILED,
+            error_message="ffmpeg died",
+        )
+    )
+    await db_session.commit()
+    return asset
+
+
+@pytest.mark.asyncio
+class TestDeviceSplashReadinessGate:
+    async def test_patch_device_rejects_in_flight_asset(self, client, db_session):
+        from cms.models.device import Device, DeviceStatus
+
+        asset = await _in_flight_asset(db_session)
+        device = Device(id="readiness-pi", name="readiness-pi", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        resp = await client.patch(
+            "/api/devices/readiness-pi",
+            json={"default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 422
+        assert "transcoding" in resp.json()["detail"].lower()
+
+    async def test_patch_device_rejects_failed_asset(self, client, db_session):
+        from cms.models.device import Device, DeviceStatus
+
+        asset = await _failed_asset(db_session)
+        device = Device(id="readiness-pi-2", name="readiness-pi-2", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        resp = await client.patch(
+            "/api/devices/readiness-pi-2",
+            json={"default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 422
+        assert "failed" in resp.json()["detail"].lower()
+
+    async def test_patch_device_accepts_ready_asset(self, client, db_session):
+        from cms.models.device import Device, DeviceStatus
+
+        asset = await _ready_asset(db_session)
+        device = Device(id="readiness-pi-3", name="readiness-pi-3", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        resp = await client.patch(
+            "/api/devices/readiness-pi-3",
+            json={"default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["default_asset_id"] == str(asset.id)
+
+
+@pytest.mark.asyncio
+class TestGroupSplashReadinessGate:
+    async def test_create_group_rejects_in_flight_asset(self, client, db_session):
+        asset = await _in_flight_asset(db_session, filename="grp-wip.mp4")
+
+        resp = await client.post(
+            "/api/devices/groups/",
+            json={"name": "Bad Group", "default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 422
+        assert "transcoding" in resp.json()["detail"].lower()
+
+    async def test_create_group_accepts_ready_asset(self, client, db_session):
+        asset = await _ready_asset(db_session, filename="grp-ok.mp4")
+
+        resp = await client.post(
+            "/api/devices/groups/",
+            json={"name": "Good Group", "default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["default_asset_id"] == str(asset.id)
+
+    async def test_patch_group_rejects_in_flight_asset(self, client, db_session):
+        from cms.models.device import DeviceGroup
+
+        group = DeviceGroup(name="Patch Group")
+        db_session.add(group)
+        await db_session.commit()
+        asset = await _in_flight_asset(db_session, filename="grp-patch-wip.mp4")
+
+        resp = await client.patch(
+            f"/api/devices/groups/{group.id}",
+            json={"default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 422
+
+    async def test_patch_group_accepts_ready_asset(self, client, db_session):
+        from cms.models.device import DeviceGroup
+
+        group = DeviceGroup(name="Patch OK Group")
+        db_session.add(group)
+        await db_session.commit()
+        asset = await _ready_asset(db_session, filename="grp-patch-ok.mp4")
+
+        resp = await client.patch(
+            f"/api/devices/groups/{group.id}",
+            json={"default_asset_id": str(asset.id)},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["default_asset_id"] == str(asset.id)
+
+
+@pytest.mark.asyncio
+class TestScheduleAssetReadinessGate:
+    async def _group(self, db_session, *, name="Sched RG"):
+        from cms.models.device import DeviceGroup
+
+        group = DeviceGroup(name=name)
+        db_session.add(group)
+        await db_session.commit()
+        return group
+
+    async def test_create_schedule_rejects_in_flight_asset(self, client, db_session):
+        group = await self._group(db_session, name="Sched WIP")
+        asset = await _in_flight_asset(db_session, filename="sched-wip.mp4")
+
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "name": "WIP Schedule",
+                "group_id": str(group.id),
+                "asset_id": str(asset.id),
+                "start_time": "08:00",
+                "end_time": "12:00",
+            },
+        )
+        assert resp.status_code == 422
+        assert "transcoding" in resp.json()["detail"].lower()
+
+    async def test_create_schedule_rejects_failed_asset(self, client, db_session):
+        group = await self._group(db_session, name="Sched Failed")
+        asset = await _failed_asset(db_session, filename="sched-bad.mp4")
+
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "name": "Bad Schedule",
+                "group_id": str(group.id),
+                "asset_id": str(asset.id),
+                "start_time": "08:00",
+                "end_time": "12:00",
+            },
+        )
+        assert resp.status_code == 422
+        assert "failed" in resp.json()["detail"].lower()
+
+    async def test_create_schedule_accepts_ready_asset(self, client, db_session):
+        group = await self._group(db_session, name="Sched Good")
+        asset = await _ready_asset(db_session, filename="sched-ok.mp4")
+
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "name": "OK Schedule",
+                "group_id": str(group.id),
+                "asset_id": str(asset.id),
+                "start_time": "08:00",
+                "end_time": "12:00",
+            },
+        )
+        assert resp.status_code == 201
+
+    async def test_patch_schedule_rejects_swap_to_in_flight_asset(
+        self, client, db_session
+    ):
+        group = await self._group(db_session, name="Sched Swap")
+        ready = await _ready_asset(db_session, filename="sched-swap-ok.mp4")
+        wip = await _in_flight_asset(db_session, filename="sched-swap-wip.mp4")
+
+        create = await client.post(
+            "/api/schedules",
+            json={
+                "name": "Swap Schedule",
+                "group_id": str(group.id),
+                "asset_id": str(ready.id),
+                "start_time": "08:00",
+                "end_time": "12:00",
+            },
+        )
+        sched_id = create.json()["id"]
+
+        resp = await client.patch(
+            f"/api/schedules/{sched_id}",
+            json={"asset_id": str(wip.id)},
+        )
+        assert resp.status_code == 422
+
+    async def test_patch_schedule_without_asset_change_still_works(
+        self, client, db_session
+    ):
+        """Editing other fields on a schedule whose asset is now mid-transcode
+        must still succeed — we only gate on new asset assignments."""
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device import DeviceGroup
+        from cms.models.device_profile import DeviceProfile
+
+        group = DeviceGroup(name="Sched Preserve")
+        asset = Asset(
+            filename="sched-preserve.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=100,
+            checksum="preserve1",
+        )
+        profile = DeviceProfile(name="profile-preserve")
+        db_session.add_all([group, asset, profile])
+        await db_session.flush()
+        # Start it READY so the schedule can be created…
+        variant = AssetVariant(
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{asset.id}.mp4",
+            status=VariantStatus.READY,
+        )
+        db_session.add(variant)
+        await db_session.commit()
+
+        create = await client.post(
+            "/api/schedules",
+            json={
+                "name": "Preserve",
+                "group_id": str(group.id),
+                "asset_id": str(asset.id),
+                "start_time": "08:00",
+                "end_time": "12:00",
+            },
+        )
+        assert create.status_code == 201
+        sched_id = create.json()["id"]
+
+        # …then simulate a re-transcode flipping the variant back to PROCESSING
+        variant.status = VariantStatus.PROCESSING
+        await db_session.commit()
+
+        # Editing another field should still succeed — only asset swaps gate.
+        resp = await client.patch(
+            f"/api/schedules/{sched_id}",
+            json={"priority": 7},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["priority"] == 7

--- a/tests/test_asset_readiness_helpers.py
+++ b/tests/test_asset_readiness_helpers.py
@@ -1,0 +1,179 @@
+"""Tests for the asset-readiness helpers (issue #201).
+
+Covers ``collapse_to_ready`` and ``is_asset_ready`` in
+``cms.services.variant_view`` — the rule that gates splash-screen / schedule
+asset selection on "every profile has a live READY variant".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+from cms.services.variant_view import collapse_to_ready, is_asset_ready
+from shared.models.asset import VariantStatus
+
+
+@dataclass
+class _V:
+    """Lightweight stand-in for AssetVariant.
+
+    Only the attributes the helpers actually read are populated.
+    """
+
+    profile_id: UUID
+    created_at: datetime
+    status: VariantStatus
+    deleted_at: datetime | None = None
+    id: UUID = field(default_factory=uuid4)
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+
+NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _mk(
+    profile: UUID,
+    status: VariantStatus,
+    *,
+    offset_minutes: int = 0,
+    deleted: bool = False,
+) -> _V:
+    return _V(
+        profile_id=profile,
+        created_at=NOW + timedelta(minutes=offset_minutes),
+        status=status,
+        deleted_at=(NOW + timedelta(minutes=offset_minutes + 1)) if deleted else None,
+    )
+
+
+class TestCollapseToReady:
+    def test_empty(self):
+        assert collapse_to_ready([]) == []
+
+    def test_filters_non_ready(self):
+        p = uuid4()
+        vs = [_mk(p, VariantStatus.PROCESSING), _mk(p, VariantStatus.PENDING)]
+        assert collapse_to_ready(vs) == []
+
+    def test_returns_ready_variant(self):
+        p = uuid4()
+        v = _mk(p, VariantStatus.READY)
+        assert collapse_to_ready([v]) == [v]
+
+    def test_one_per_profile(self):
+        p1, p2 = uuid4(), uuid4()
+        v1 = _mk(p1, VariantStatus.READY)
+        v2 = _mk(p2, VariantStatus.READY)
+        out = collapse_to_ready([v1, v2])
+        assert set(out) == {v1, v2}
+
+    def test_newest_wins_per_profile(self):
+        p = uuid4()
+        older = _mk(p, VariantStatus.READY, offset_minutes=0)
+        newer = _mk(p, VariantStatus.READY, offset_minutes=5)
+        out = collapse_to_ready([older, newer])
+        assert out == [newer]
+
+    def test_ignores_soft_deleted(self):
+        p = uuid4()
+        live = _mk(p, VariantStatus.READY)
+        dead = _mk(p, VariantStatus.READY, offset_minutes=5, deleted=True)
+        out = collapse_to_ready([live, dead])
+        assert out == [live]
+
+    def test_ignores_rows_with_no_profile(self):
+        v = _V(
+            profile_id=None,  # type: ignore[arg-type]
+            created_at=NOW,
+            status=VariantStatus.READY,
+        )
+        assert collapse_to_ready([v]) == []
+
+
+class TestIsAssetReady:
+    def test_no_variants_is_ready(self):
+        """Webpage/stream/etc. assets have zero variants → always ready."""
+        assert is_asset_ready([]) == (True, None)
+
+    def test_all_ready_is_ready(self):
+        p1, p2 = uuid4(), uuid4()
+        vs = [_mk(p1, VariantStatus.READY), _mk(p2, VariantStatus.READY)]
+        assert is_asset_ready(vs) == (True, None)
+
+    def test_one_profile_still_processing_blocks(self):
+        p1, p2 = uuid4(), uuid4()
+        vs = [_mk(p1, VariantStatus.READY), _mk(p2, VariantStatus.PROCESSING)]
+        ready, reason = is_asset_ready(vs)
+        assert ready is False
+        assert reason == "transcoding…"
+
+    def test_one_profile_pending_blocks(self):
+        p1, p2 = uuid4(), uuid4()
+        vs = [_mk(p1, VariantStatus.READY), _mk(p2, VariantStatus.PENDING)]
+        ready, reason = is_asset_ready(vs)
+        assert ready is False
+        assert reason == "transcoding…"
+
+    def test_all_profiles_failed_reports_failed(self):
+        p = uuid4()
+        vs = [_mk(p, VariantStatus.FAILED)]
+        ready, reason = is_asset_ready(vs)
+        assert ready is False
+        assert reason == "transcode failed"
+
+    def test_in_flight_wins_over_failed_mixed(self):
+        """If at least one unready profile is still in flight, that's the
+        user-facing reason (hope lives)."""
+        p1, p2 = uuid4(), uuid4()
+        vs = [_mk(p1, VariantStatus.FAILED), _mk(p2, VariantStatus.PROCESSING)]
+        ready, reason = is_asset_ready(vs)
+        assert ready is False
+        assert reason == "transcoding…"
+
+    def test_retranscode_case_stays_ready(self):
+        """Old READY + new PROCESSING for the same profile → still ready.
+
+        The old blob keeps serving traffic until the new one lands.
+        """
+        p1, p2 = uuid4(), uuid4()
+        vs = [
+            _mk(p1, VariantStatus.READY, offset_minutes=0),
+            _mk(p1, VariantStatus.PROCESSING, offset_minutes=10),
+            _mk(p2, VariantStatus.READY),
+        ]
+        assert is_asset_ready(vs) == (True, None)
+
+    def test_retranscode_superseded_old_still_ready(self):
+        """Same as above, but the old variant has been soft-deleted —
+        that removes the playable fallback, so the asset is NOT ready."""
+        p = uuid4()
+        vs = [
+            _mk(p, VariantStatus.READY, offset_minutes=0, deleted=True),
+            _mk(p, VariantStatus.PROCESSING, offset_minutes=10),
+        ]
+        ready, reason = is_asset_ready(vs)
+        assert ready is False
+        assert reason == "transcoding…"
+
+    def test_soft_deleted_only_is_ready(self):
+        """All variants soft-deleted → no live profiles to check → ready.
+
+        (This is effectively the "no variants" case.)
+        """
+        p = uuid4()
+        vs = [_mk(p, VariantStatus.READY, deleted=True)]
+        assert is_asset_ready(vs) == (True, None)
+
+    def test_partial_ready_only_counts_live_variants(self):
+        """One profile ready, another has a soft-deleted PROCESSING row
+        → that second profile has no live variants → doesn't count."""
+        p1, p2 = uuid4(), uuid4()
+        vs = [
+            _mk(p1, VariantStatus.READY),
+            _mk(p2, VariantStatus.PROCESSING, deleted=True),
+        ]
+        assert is_asset_ready(vs) == (True, None)


### PR DESCRIPTION
## Gate asset selection on transcode readiness

Fixes #201.

### Problem
Users could assign assets as device/group splash screens or schedule
targets before all required variants finished transcoding. Devices on
profiles whose variant wasn't ready would show nothing / loop splash /
404-retry. HEVC transcodes can take 30+ min for a 10 min video, making
this a real foot-gun.

### Rule
An asset is **selectable** iff, for every profile that has a live
(non-deleted) variant for this asset, at least one of that profile's
live variants is `READY`.

- Zero live variants (webpage / stream / upload-pending) → ready.
- Re-transcode case is preserved: old `READY` + new `PROCESSING` for
  the same profile → still ready (old blob keeps serving until new
  lands). If old `READY` gets soft-deleted before new lands, asset
  flips to not-ready.
- A profile added globally with no row yet for this asset doesn't
  count — not worth the extra bookkeeping.

### UX
- Dropdowns (device/group splash, schedule form + edit modal) show
  not-ready assets as `disabled` with a suffix:
  `Name (transcoding…)` or `Name (transcode failed)`.
- Backend PATCH/POST on `default_asset_id` / `asset_id` rejects with
  422 as a safety net.
- Only gates **new** assignments. Existing assignments are preserved
  when an asset flips to not-ready via re-transcode.

### Changes
**New:**
- `cms/services/variant_view.py` — `collapse_to_ready` + `is_asset_ready`.
- `cms/services/asset_readiness.py` — `require_asset_ready` (raises 422).
- `tests/test_asset_readiness_helpers.py` — 17 unit tests.
- `tests/test_asset_readiness_gate.py` — 12 endpoint tests.

**Gated endpoints:**
- `PATCH /devices/{id}` (default_asset_id)
- `POST /groups` + `PATCH /groups/{id}` (default_asset_id)
- `POST /schedules` + `PATCH /schedules/{id}` (asset_id; PATCH only fires when asset_id changes)

**UI annotated:** `cms/ui.py :: devices_page` + `schedules_page` now
eager-load variants and attach `ready_for_selection` / `not_ready_reason`.

**Templates:** `devices.html` (L50-51, L337-338), `schedules.html`
(L30-31, L215, L787).

### Tests
29 new tests, all green. Full `tests/test_devices.py`,
`tests/test_schedules.py`, `tests/test_library_variant_collapse.py`
pass — 121 tests total in the regression run.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
