### PR TITLE
ci(db): add Alembic drift gate + contributor docs

### DIFF
--- a/.github/workflows/alembic-check.yml
+++ b/.github/workflows/alembic-check.yml
@@ -1,0 +1,67 @@
+name: Alembic Check
+
+# Catches ORM/migration drift — fails the PR if a model change landed
+# without a matching Alembic migration.  This is the guard-rail that
+# would have caught the PR #280 outage (column added to the Asset model
+# with no accompanying ALTER TABLE).
+#
+# Flow:
+#   1. Spin up a fresh Postgres.
+#   2. `alembic upgrade head` — build the DB schema from migrations.
+#   3. `alembic check`       — compare ORM metadata to the DB schema.
+#                              Exits non-zero if autogenerate would
+#                              produce any new operations.
+#
+# This fires on every PR regardless of path; it's fast (seconds) and
+# the false-positive rate is effectively zero.  If you legitimately
+# need to change models, add a migration file in alembic/versions/.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  alembic-check:
+    name: alembic-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: agora_test
+          POSTGRES_PASSWORD: agora_test
+          POSTGRES_DB: agora_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U agora_test -d agora_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      AGORA_CMS_DATABASE_URL: postgresql+asyncpg://agora_test:agora_test@localhost:5432/agora_test
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Upgrade DB to head
+        run: alembic upgrade head
+
+      - name: Check for model/migration drift
+        run: |
+          if ! alembic check; then
+            echo ""
+            echo "::error::ORM models have drifted from the Alembic head revision."
+            echo "::error::A model was changed without a matching migration."
+            echo "::error::Fix: run 'alembic revision --autogenerate -m \"<describe>\"' locally,"
+            echo "::error::     review the generated file under alembic/versions/, and commit it."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,47 @@
 See the top-level `README.md` for local setup, running tests, and the compose
 stack used for end-to-end testing.
 
+## Changing the database schema
+
+All schema changes go through Alembic.  `cms/database.py`'s `run_migrations`
+just calls `alembic upgrade head`; there is no hand-written DDL to update.
+
+**Workflow when you add or change an ORM model:**
+
+1. Edit the model under `shared/models/` or `cms/models/`.
+2. Start a Postgres you can point at (the compose stack works:
+   `docker compose up -d db`).
+3. Generate a migration:
+   ```bash
+   AGORA_CMS_DATABASE_URL=postgresql+asyncpg://agora:agora@localhost:5432/agora_cms \
+     alembic revision --autogenerate -m "describe your change"
+   ```
+4. Review the file that lands in `alembic/versions/`.  Autogenerate is
+   usually right but never blindly trust it — check that `upgrade()` does
+   what you expect, and hand-edit if needed (for example, autogenerate
+   cannot detect column renames; it sees a drop + add).
+5. Apply locally to sanity-check: `alembic upgrade head`.
+6. Commit the model change *and* the new migration file in the same PR.
+
+**Policy:**
+
+- Forward-only.  The generated `downgrade()` raises `NotImplementedError` —
+  don't bother filling it in.  If you need to undo something in prod, write
+  a new forward migration.
+- Never edit an existing migration file after it has merged to `main`.
+  Even a trivial edit breaks stamped deployments.  Add a new migration instead.
+- Revisions use numeric IDs (`0001`, `0002`, ...).  Pass `--rev-id 000N`
+  to `alembic revision` or rename the file after generation.
+
+**What CI enforces:**
+
+- `Alembic Check` runs `alembic upgrade head && alembic check` on a fresh
+  Postgres.  It fails if your ORM models would produce any new autogenerate
+  operations — i.e. the migration you added doesn't match the model change,
+  or you forgot the migration entirely.
+- `Migration Safety` runs your migrations against a populated DB seeded
+  from main, catching destructive or non-idempotent migrations.
+
 ## Pull request flow
 
 1. Branch from `main`.
@@ -13,6 +54,9 @@ stack used for end-to-end testing.
 3. Wait for CI:
    - `CI Gate` — always-pass sentinel (required).
    - `Tests/test` and `Tests/e2e` — the test suite.
+   - `Alembic Check` — **required**; fails if you changed an ORM model
+     without adding a matching migration.  See
+     [Changing the database schema](#changing-the-database-schema) below.
    - `Migration Safety` — **required**; seeds main's schema with synthetic
      data, runs your PR's migrations against it, and verifies the DB is
      still queryable.  See [docs/CI.md](docs/CI.md) for details.
@@ -32,6 +76,7 @@ Key files if you need to touch CI:
 
 - `.github/workflows/ci-gate.yml` — the required always-pass sentinel.
 - `.github/workflows/tests.yml` — unit + e2e PR tests.
+- `.github/workflows/alembic-check.yml` — ORM/migration drift gate.
 - `.github/workflows/migration-safety.yml` — PR migration guard-rail.
 - `.github/workflows/nightly.yml` — **display name `Smoke Test`**; runs
   nightly, on main push (pre-deploy gate), and on PRs.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -11,6 +11,7 @@ PR opened / updated
   ├─ CI Gate          (always-pass sentinel — REQUIRED)
   ├─ Tests/test       (pytest suite)
   ├─ Tests/e2e        (compose-based e2e)
+  ├─ Alembic Check    (REQUIRED — model/migration drift)
   ├─ Migration Safety (REQUIRED — see below)
   └─ Smoke Test       (full-stack compose E2E)
 
@@ -30,6 +31,7 @@ Smoke Test also runs on a nightly cron.
 - `ci-gate` — always-pass sentinel (`.github/workflows/ci-gate.yml`). It
   exists so branch protection has *something* mandatory to key off when the
   real checks are path-filtered / conditional.
+- `alembic-check` — ORM/migration drift guard (see below).
 - `migration-safety` — the real PR gate (see below).
 
 Branch protection is classic (not rulesets) with `enforce_admins: false` and
@@ -38,6 +40,33 @@ rebase every time main moves).
 
 Smoke Test is intentionally **not** a required check — it's too slow for a
 per-PR block, and nightly + post-merge coverage is sufficient.
+
+## Alembic Check (`.github/workflows/alembic-check.yml`)
+
+Catches the class of bug that took out production in PR #280 (column added
+to an ORM model with no matching DDL).
+
+Flow:
+
+1. Spin up a fresh Postgres service.
+2. `alembic upgrade head` — build the schema from migrations.
+3. `alembic check` — compare ORM metadata (`target_metadata` in
+   `alembic/env.py`) to the live schema.  If autogenerate would produce
+   any new operations, the check exits non-zero.
+
+The check is fast (seconds) and runs on every PR regardless of path.  To
+fix a failure, add a migration:
+
+```bash
+AGORA_CMS_DATABASE_URL=postgresql+asyncpg://agora:agora@localhost:5432/agora_cms \
+  alembic revision --autogenerate -m "describe your change"
+```
+
+then commit the generated file in `alembic/versions/`.
+
+Forward-only by policy: `alembic/script.py.mako`'s `downgrade()` raises
+`NotImplementedError`, so don't bother filling it in.  Never edit a
+merged migration — add a new one instead.
 
 ## Migration Safety (`.github/workflows/migration-safety.yml`)
 
@@ -49,15 +78,23 @@ Flow:
 1. Check out the PR (`pr/`) and `main` (`base/`) in parallel directories.
 2. Copy `pr/scripts/ci_seed_synthetic.py` → `base/scripts/` so seeding always
    uses the latest seed logic even when testing against main's code.
-3. Install `base/` deps. Initialise schema from main. Run
+3. Install `base/` deps. Initialise schema from main (by calling
+   `run_migrations()`, which now runs `alembic upgrade head` for fresh DBs
+   or `alembic stamp head` for legacy pre-Alembic schemas). Run
    `scripts/ci_seed_synthetic.py` with `PYTHONPATH=base/` — this seeds
    synthetic data into a DB with main's schema.
-4. Install `pr/` deps. Run the PR's migrations against that populated DB.
+4. Install `pr/` deps. Run `run_migrations()` on the PR branch against the
+   populated DB.  Alembic picks up from main's head revision and applies
+   any migrations the PR added.
 5. Run `scripts/ci_verify_post_migration.py` with `PYTHONPATH=pr/` — asserts
    that the populated DB is still queryable and the required tables are
    non-empty.
 
 If step 4 or 5 fails, the PR cannot merge.
+
+`alembic-check` catches *missing* migrations; `migration-safety` catches
+*broken* migrations (destructive, non-idempotent, or incompatible with
+existing data).  They complement each other.
 
 ### Quirks / don't-regress list
 


### PR DESCRIPTION
# Add Alembic drift gate + docs

Follow-up to #313.  Adds the CI guard-rail that would have caught the PR #280 outage at PR review time instead of production.

## What

- **New workflow `.github/workflows/alembic-check.yml`** — spins up a fresh Postgres, runs `alembic upgrade head`, then `alembic check`.  `alembic check` compares the ORM `target_metadata` to the live schema and exits non-zero if autogenerate would produce any new operations.  Fast (seconds) and runs on every PR.
- **`CONTRIBUTING.md`** — new "Changing the database schema" section: how to add a migration, the forward-only / no-edit-merged-migrations policy, and what each CI check enforces.
- **`docs/CI.md`** — new "Alembic Check" section; "Migration Safety" section updated to describe the Alembic-driven reality (stamp/upgrade split, how the two checks complement each other).

## Verified

Reproduced the PR #280 scenario locally — added a bogus column to `shared/models/asset.py` without a migration and ran `alembic check`:

```
FAILED: New upgrade operations detected: [('add_column', None, 'assets', Column('test_drift_column', ...))]
exit: 255
```

After reverting, a clean check passes:

```
No new upgrade operations detected.
```

## Post-merge

Add `alembic-check` to the required-checks list on `main`:

```powershell
'{"strict":false,"contexts":["ci-gate","migration-safety","alembic-check"]}' |
  gh api -X PATCH repos/sslivins/agora-cms/branches/main/protection/required_status_checks --input -
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
