### PR TITLE
test(migrations): destructive-forward guard + no-downgrade policy (#298)

### DIFF
--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -65,18 +65,29 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # Copy the seed script from the PR into main's tree so it's
-      # guaranteed to exist even when running against the baseline.
-      - name: Stage seed script into base
+      # Copy scripts that live only on the PR branch into main's tree so
+      # they're available when running against the baseline.
+      - name: Stage PR-only scripts into base
         run: |
           mkdir -p base/scripts
           cp pr/scripts/ci_seed_synthetic.py base/scripts/ci_seed_synthetic.py
+          cp pr/scripts/ci_capture_row_counts.py base/scripts/ci_capture_row_counts.py
 
       - name: Initialise schema + seed synthetic data (using main's code)
         working-directory: base
         env:
           PYTHONPATH: ${{ github.workspace }}/base
         run: python scripts/ci_seed_synthetic.py
+
+      # Snapshot row counts on the seeded baseline BEFORE running the PR
+      # branch's migrations.  After the migrations run, the verify step
+      # compares current counts against this file and fails if any table
+      # shrank — catching destructive forward migrations.
+      - name: Capture baseline row counts (pre-migration)
+        working-directory: base
+        env:
+          PYTHONPATH: ${{ github.workspace }}/base
+        run: python scripts/ci_capture_row_counts.py ${{ github.workspace }}/baseline-counts.json
 
       - name: Install PR branch dependencies
         working-directory: pr
@@ -106,4 +117,4 @@ jobs:
         working-directory: pr
         env:
           PYTHONPATH: ${{ github.workspace }}/pr
-        run: python scripts/ci_verify_post_migration.py
+        run: python scripts/ci_verify_post_migration.py ${{ github.workspace }}/baseline-counts.json

--- a/scripts/ci_capture_row_counts.py
+++ b/scripts/ci_capture_row_counts.py
@@ -1,0 +1,67 @@
+"""Capture row counts for every user table to a JSON file.
+
+Used by the ``migration-safety`` workflow to detect destructive forward
+migrations: we snapshot row counts on the seeded baseline database
+*before* running the PR branch's migrations, then verify-post-migration
+fails if any still-existing table has fewer rows than it did.
+
+Silent data loss — e.g. a migration that drops a column without a
+backfill, or one that rewrites a table and loses rows in the process —
+doesn't show up in the existing verify (which only checks REQUIRED
+tables are non-empty). Row-count comparison catches wholesale deletes
+and replace-table-with-empty patterns.
+
+Usage:
+    python scripts/ci_capture_row_counts.py <output.json>
+
+Writes ``{"tablename": N, ...}`` for every non-internal table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+from sqlalchemy import text
+
+from cms.auth import get_settings
+from cms.database import dispose_db, init_db, wait_for_db
+from shared import database as _shared_db
+
+
+async def capture(out_path: str) -> int:
+    init_db(get_settings())
+    await wait_for_db()
+
+    counts: dict[str, int] = {}
+    async with _shared_db._engine.connect() as conn:
+        res = await conn.execute(text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' "
+            "  AND table_type = 'BASE TABLE' "
+            "  AND table_name NOT LIKE 'alembic_%' "
+            "ORDER BY table_name"
+        ))
+        tables = [r[0] for r in res.fetchall()]
+
+        for t in tables:
+            res = await conn.execute(text(f'SELECT COUNT(*) FROM "{t}"'))
+            counts[t] = int(res.scalar() or 0)
+
+    await dispose_db()
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(counts, f, indent=2, sort_keys=True)
+
+    print(f"Captured row counts for {len(counts)} tables → {out_path}")
+    for t, n in sorted(counts.items()):
+        print(f"  {t}: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: ci_capture_row_counts.py <output.json>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(asyncio.run(capture(sys.argv[1])))

--- a/scripts/ci_verify_post_migration.py
+++ b/scripts/ci_verify_post_migration.py
@@ -11,6 +11,8 @@ Asserts that the database is still queryable after a fresh round of
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import sys
 
 from sqlalchemy import text
@@ -32,12 +34,18 @@ EXPECTED_TABLES = [
 ]
 
 
-async def verify() -> int:
+async def verify(baseline_counts_path: str | None = None) -> int:
     init_db(get_settings())
     await wait_for_db()
     await run_migrations()
 
     failures: list[str] = []
+
+    baseline_counts: dict[str, int] = {}
+    if baseline_counts_path and os.path.exists(baseline_counts_path):
+        with open(baseline_counts_path, "r", encoding="utf-8") as f:
+            baseline_counts = json.load(f)
+        print(f"Loaded baseline row counts for {len(baseline_counts)} tables")
 
     # Tables we have high confidence will be seeded — empty == catastrophe.
     REQUIRED_NONEMPTY = {"users", "devices", "assets"}
@@ -81,6 +89,39 @@ async def verify() -> int:
         except Exception as exc:
             failures.append(f"assets⋈variants query failed: {exc}")
 
+        # 4. Destructive-forward guard: for every table that existed in the
+        #    baseline and STILL exists post-migration, row count must not
+        #    decrease. Catches silent data loss (DROP + CREATE, bad copy,
+        #    wholesale DELETE, etc.) that a schema-only check would miss.
+        #    A migration that intentionally deletes rows should explicitly
+        #    re-seed to the expected count in its own logic, or the seed
+        #    script should be updated in lockstep.
+        if baseline_counts:
+            print("")
+            print("Row-count preservation check:")
+            res = await conn.execute(text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'"
+            ))
+            current_tables = {r[0] for r in res.fetchall()}
+
+            for t, baseline_n in sorted(baseline_counts.items()):
+                if t not in current_tables:
+                    # Dropping a table is an explicit schema change; not
+                    # flagged here. Schema-level review catches it.
+                    print(f"  {t}: DROPPED (baseline had {baseline_n})")
+                    continue
+                res = await conn.execute(text(f'SELECT COUNT(*) FROM "{t}"'))
+                current_n = int(res.scalar() or 0)
+                if current_n < baseline_n:
+                    failures.append(
+                        f"destructive migration: {t} row count dropped "
+                        f"{baseline_n} → {current_n}"
+                    )
+                    print(f"  {t}: {baseline_n} → {current_n} ❌")
+                else:
+                    print(f"  {t}: {baseline_n} → {current_n}")
+
     await dispose_db()
 
     if failures:
@@ -95,4 +136,5 @@ async def verify() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(verify()))
+    baseline = sys.argv[1] if len(sys.argv) > 1 else None
+    sys.exit(asyncio.run(verify(baseline)))

--- a/tests/test_migration_policy.py
+++ b/tests/test_migration_policy.py
@@ -1,0 +1,122 @@
+"""Migration policy enforcement tests (#298).
+
+Project policy: Alembic ``downgrade()`` functions are intentionally
+**unsupported**.  Rollbacks are forbidden — if you need to revert a
+schema change, write a new forward migration that undoes it.
+
+This is enforced at runtime by every ``downgrade()`` raising
+``NotImplementedError``.  These tests make that a hard-coded
+contract so someone can't silently add a half-baked downgrade that
+gets relied on in an incident.
+
+Rationale for tightening this into CI:
+- The alternative is "catch a broken downgrade during a production
+  rollback", which is the worst possible time.
+- A real, tested, production-safe downgrade is a LOT of work
+  (foreign-key teardown order, back-fill on re-upgrade, etc.).  The
+  project has chosen to pay the cost on forward migrations only.
+- If the policy is ever revisited, revisit these tests too.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MIGRATIONS_DIR = Path(__file__).parent.parent / "alembic" / "versions"
+
+
+def _migration_files() -> list[Path]:
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.py") if not p.name.startswith("_"))
+
+
+def _load(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migrations_dir_exists():
+    assert MIGRATIONS_DIR.exists(), f"alembic versions dir missing: {MIGRATIONS_DIR}"
+
+
+def test_at_least_one_migration_exists():
+    assert _migration_files(), "no migrations found in alembic/versions"
+
+
+@pytest.mark.parametrize("mig_path", _migration_files(), ids=lambda p: p.name)
+def test_migration_defines_upgrade_and_downgrade(mig_path: Path):
+    mod = _load(mig_path)
+    assert callable(getattr(mod, "upgrade", None)), f"{mig_path.name}: missing upgrade()"
+    assert callable(getattr(mod, "downgrade", None)), f"{mig_path.name}: missing downgrade()"
+
+
+@pytest.mark.parametrize("mig_path", _migration_files(), ids=lambda p: p.name)
+def test_downgrade_raises_not_implemented(mig_path: Path):
+    """Project policy: every downgrade() must raise NotImplementedError.
+
+    Prevents accidental half-implemented rollback paths from sneaking in.
+    If this test fails, you've probably tried to implement a real
+    downgrade — talk to the maintainer before removing this guard.
+    """
+    mod = _load(mig_path)
+    with pytest.raises(NotImplementedError):
+        mod.downgrade()
+
+
+@pytest.mark.parametrize("mig_path", _migration_files(), ids=lambda p: p.name)
+def test_migration_has_revision_id(mig_path: Path):
+    mod = _load(mig_path)
+    assert getattr(mod, "revision", None), f"{mig_path.name}: missing revision ID"
+    assert hasattr(mod, "down_revision"), f"{mig_path.name}: missing down_revision attribute"
+
+
+def test_revision_ids_unique():
+    """Two migrations can't share a revision ID — alembic picks one arbitrarily."""
+    ids: dict[str, str] = {}
+    for p in _migration_files():
+        mod = _load(p)
+        rev = mod.revision
+        if rev in ids:
+            pytest.fail(f"duplicate revision id {rev!r} in {p.name} and {ids[rev]}")
+        ids[rev] = p.name
+
+
+def test_revision_chain_is_linear():
+    """down_revision chain forms a single line from None → head (no forks/merges)."""
+    mods = [_load(p) for p in _migration_files()]
+    by_rev = {m.revision: m for m in mods}
+
+    # Exactly one root (down_revision is None).
+    roots = [m.revision for m in mods if m.down_revision is None]
+    assert len(roots) == 1, f"expected exactly 1 root migration, got {roots}"
+
+    # Every non-root down_revision must reference a known revision.
+    for m in mods:
+        if m.down_revision is None:
+            continue
+        # down_revision can be a string or a tuple (merge points).
+        # We forbid merges: should be a single string.
+        assert isinstance(m.down_revision, str), (
+            f"{m.revision}: down_revision is a tuple ({m.down_revision!r}) — "
+            "merge migrations are not allowed"
+        )
+        assert m.down_revision in by_rev, (
+            f"{m.revision}: references unknown down_revision {m.down_revision!r}"
+        )
+
+    # No two migrations share a down_revision (that's a fork).
+    parents: dict[str, str] = {}
+    for m in mods:
+        if m.down_revision is None:
+            continue
+        if m.down_revision in parents:
+            pytest.fail(
+                f"fork detected: {m.revision} and {parents[m.down_revision]} "
+                f"both have down_revision={m.down_revision!r}"
+            )
+        parents[m.down_revision] = m.revision


### PR DESCRIPTION
Closes #298.

Adapts the issue's proposal to the project's no-rollback policy (every `downgrade()` raises `NotImplementedError` by design — see `alembic/versions/0001_baseline.py`).

## 1. Destructive-forward migration guard (migration-safety CI)

**New:** `scripts/ci_capture_row_counts.py` — snapshots row counts of every public user table to JSON.

**Extended:** `scripts/ci_verify_post_migration.py` — accepts an optional baseline-counts JSON path; after PR migrations, compares current counts against baseline and fails if any still-existing table shrank. Catches silent data loss from DROP+CREATE patterns, bad copy-then-swap, wholesale DELETEs, etc.

**Extended:** `.github/workflows/migration-safety.yml` — adds *Capture baseline row counts* step between seed and PR migrations. Stages the new script into `base/` alongside the existing `ci_seed_synthetic.py` staging.

Flow:
```
seed (main's code)  ->  capture counts  ->  run PR migrations  ->  verify (schema + row counts)
```

## 2. No-downgrade policy enforcement (unit test)

**New:** `tests/test_migration_policy.py` (7 tests)
- Every migration defines `upgrade()` and `downgrade()`
- Every `downgrade()` raises `NotImplementedError` (**policy**)
- Every migration has a revision ID
- Revision IDs are unique across `alembic/versions/`
- Revision chain is linear (single root, no forks, no merges)

The downgrade-raises-NotImplementedError test is what #298 originally flagged ("a broken `downgrade()` is only discovered when we need to roll back in prod"). Since the project has chosen to never use downgrades, we enforce the policy rather than test downgrade behaviour. If that policy is ever revisited, revisit this test.

## Verification

Local: `pytest tests/test_migration_policy.py` -> **7 passed**.

Workflow YAML parses clean. Scripts parse clean.

Cannot exercise the workflow end-to-end locally (needs a postgres service) — CI on this PR will. With only the baseline migration, the row-count check is a no-op (PR migrations == main migrations). It'll bite on the first real schema change.

## Not in scope
- Actual downgrade implementation for any migration (policy says no).
- Schema-level checksum (row count is the issue's primary ask; column-level diffs would be a larger effort).
