### PR TITLE
fix(tests_e2e): mark uploaded assets READY to satisfy #312 readiness gate

### DIFF
--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -291,13 +291,59 @@ def api(context: BrowserContext, base_url: str):
         def delete(self, path, **kwargs):
             return self._client.delete(path, **kwargs)
 
-        def create_asset(self, filename="test-video.mp4", content=b"fake-mp4-content"):
-            """Upload a fake asset file."""
+        def create_asset(self, filename="test-video.mp4", content=b"fake-mp4-content", ready=True):
+            """Upload a fake asset file.
+
+            By default the uploaded asset has all its variants marked as READY
+            so it can immediately be scheduled or assigned as a splash.  The
+            E2E server runs without a transcoder worker, so variants would
+            otherwise stay in PENDING forever and the PR #312 readiness gate
+            (``cms.services.asset_readiness``) would reject any subsequent
+            ``POST /api/schedules`` or splash-assignment call with a 422.
+
+            Pass ``ready=False`` if you are specifically testing the gate.
+            """
             import io
-            return self._client.post(
+            resp = self._client.post(
                 "/api/assets/upload",
                 files={"file": (filename, io.BytesIO(content), "video/mp4")},
             )
+            if ready and resp.status_code == 201:
+                try:
+                    asset_id = resp.json()["id"]
+                except (ValueError, KeyError):
+                    return resp
+                self.mark_asset_ready(asset_id)
+            return resp
+
+        def mark_asset_ready(self, asset_id):
+            """Mark every variant of ``asset_id`` as VariantStatus.READY.
+
+            Used by :meth:`create_asset` to bypass the transcode-readiness
+            gate for tests that aren't specifically exercising it.  Performs
+            a short-lived async DB update on a fresh engine so the caller
+            doesn't have to contend with the server's event loop.
+            """
+            from sqlalchemy import text as sa_text
+            from sqlalchemy.ext.asyncio import create_async_engine
+
+            db_url = os.environ["AGORA_CMS_DATABASE_URL"]
+
+            async def _exec():
+                engine = create_async_engine(db_url)
+                try:
+                    async with engine.begin() as conn:
+                        await conn.execute(
+                            sa_text(
+                                "UPDATE asset_variants SET status = 'READY' "
+                                "WHERE source_asset_id = :aid"
+                            ),
+                            {"aid": str(asset_id)},
+                        )
+                finally:
+                    await engine.dispose()
+
+            run_async(_exec())
 
     helper = ApiHelper()
     yield helper


### PR DESCRIPTION
# Fix #318: E2E test_ui_schedules.py 56 failures — readiness-gate incompatibility

## Root cause

PR #312 ("Gate asset selection on transcode readiness (#201)") added a pre-check in `cms/services/asset_readiness.py` that rejects `POST /api/schedules` and splash-assignment calls with HTTP 422 when the target asset has any variants still in PENDING/PROCESSING.

The E2E server runs without a transcoder worker.  Uploaded assets create variants in PENDING state that stay there forever.  Before #312 this was fine — schedules didn't care about variant readiness.  After #312, every test that uploads an asset and then tries to schedule it with it (`tests_e2e/test_ui_schedules.py`, `test_ui_devices.py`, `test_ui_history.py`, `test_ui_schedule_loops.py`, ...) fails with `assert 422 == 201` and the message:

```
{"detail":"Asset is not ready for assignment (transcoding…)."}
```

Last green `Tests/e2e` was before #312 merged.  The failure wasn't caught at the time because `Tests/e2e` is not a required check.

## Fix

Add a `mark_asset_ready(asset_id)` helper to the E2E `ApiHelper` that performs a short-lived async DB update (`UPDATE asset_variants SET status='READY' WHERE source_asset_id=:aid`) on a fresh engine — mirroring the pattern already used by `setup_incomplete` for `cms_settings`.

Wire it into `create_asset` behind a default `ready=True` keyword.  All existing callers already expect a usable asset (none of them are exercising the readiness gate — that's covered by unit tests in `tests/test_asset_readiness_gate.py`), so no callsite changes are needed.  Tests that do want to test the gate can pass `ready=False`.

## Verified

- `ast.parse` clean.
- Enum value in the DB is uppercase `'READY'` (checked `alembic/versions/0001_baseline.py` line 189); helper uses the correct case.
- FK column is `source_asset_id`, not `asset_id` (verified against `shared/models/asset.py`).

CI `Tests/e2e` is the real verification.

## Follow-up (not in this PR)

Issue #318 also asks "should `Tests/e2e` go back on the required list?"  Worth a separate discussion — if the suite is stable for a week after this fix, we could promote it.  For now the pre-existing `Tests/e2e` PR check should go green again.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
