### PR TITLE
ci: add pytest-cov gate and coverage artifact (#299)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,10 +69,19 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-timeout httpx aiosqlite
+          pip install pytest pytest-asyncio pytest-timeout pytest-cov httpx aiosqlite
 
       - name: Run tests
-        run: python -m pytest tests/ --ignore=tests/e2e --tb=short -q -rs --durations=20
+        run: python -m pytest tests/ --ignore=tests/e2e --tb=short -q -rs --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+          retention-days: 14
 
   e2e:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = false
+source = ["cms", "shared"]
+omit = [
+    "*/tests/*",
+    "*/tests_e2e/*",
+    "*/alembic/*",
+    "*/__main__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "\\.\\.\\.",
+]
+show_missing = false
+skip_covered = false

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest>=8.0,<9.0
 pytest-asyncio>=0.24,<1.0
 httpx>=0.27,<1.0
 aiosqlite>=0.20,<1.0
+pytest-cov>=5.0,<7.0


### PR DESCRIPTION
Closes #299.

## What

Add pytest-cov gate to the unit test workflow, plus coverage artifact upload.

- Adds `pytest-cov` to `requirements-test.txt` and the ad-hoc install line in `tests.yml`.
- `pytest` now runs with `--cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50`.
- Uploads `coverage.xml` as a workflow artifact (14 day retention).
- Adds `[tool.coverage]` config to `pyproject.toml`: source dirs, omits (tests, alembic), standard exclude_lines.

## Baseline / ratchet

Floor set at **50%** as a deliberately conservative starting line to avoid flakiness on the first run. Once CI reports the actual measurement, we ratchet this up toward the real number (likely 60-70% given recent test coverage work) in a follow-up PR. The goal is a gate that blocks regressions, not one that fires on noise.

## Scope

- No product code changes.
- No change to e2e job (separate concern — tracked under "coverage-nightly-e2e").
- No Codecov integration yet — artifact-only for now; can layer Codecov on top later if we want diff-coverage on PRs.

## Test plan

- Workflow lint: implicit via GHA run.
- CI validates the command line on first run.
- Artifact download verifies `coverage.xml` is produced.
