### PR TITLE
Disable primary action buttons until required inputs are filled (#315)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1640,3 +1640,65 @@ async function deleteRole(roleId, roleName) {
         showToast(extractErrorMsg(err), true);
     }
 }
+
+
+// ── Required-input gating ──────────────────────────────────────────────
+// Disables primary action buttons until required inputs have values.
+// See issue #315.
+
+/**
+ * Check whether a form control has a non-empty value.
+ * Checkboxes/radios: must be checked. Everything else: trimmed value non-empty.
+ */
+function _hasValue(el) {
+    if (!el) return false;
+    if (el.type === "checkbox" || el.type === "radio") return el.checked;
+    if (el.disabled) return false;
+    return (el.value || "").trim() !== "";
+}
+
+/**
+ * Disable `button` until every element in `inputs` has a value.
+ * Re-evaluates on input/change events. Safe to call multiple times — idempotent.
+ *
+ * @param {HTMLElement|string} button - button element or CSS selector
+ * @param {Array<HTMLElement|string>} inputs - input elements or CSS selectors
+ */
+function gateButtonOnInputs(button, inputs) {
+    const btn = typeof button === "string" ? document.querySelector(button) : button;
+    if (!btn) return;
+    const els = (inputs || [])
+        .map(i => typeof i === "string" ? document.querySelector(i) : i)
+        .filter(Boolean);
+    if (!els.length) return;
+
+    const update = () => {
+        btn.disabled = !els.every(_hasValue);
+    };
+    els.forEach(el => {
+        if (el.__gateBound) return;
+        el.__gateBound = true;
+        el.addEventListener("input", update);
+        el.addEventListener("change", update);
+    });
+    update();
+    return update;
+}
+
+/**
+ * Auto-bind: for every <form data-gate-required>, disable its submit button
+ * until all [required] fields inside are non-empty.
+ */
+function bindFormsRequiredGating(root) {
+    (root || document).querySelectorAll("form[data-gate-required]").forEach(form => {
+        if (form.__gateBound) return;
+        form.__gateBound = true;
+        const btn = form.querySelector('button[type="submit"], button.btn-primary');
+        if (!btn) return;
+        const required = Array.from(form.querySelectorAll("[required]"));
+        if (!required.length) return;
+        gateButtonOnInputs(btn, required);
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => bindFormsRequiredGating());

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -54,7 +54,7 @@
     </div>
 
     <div id="add-tab-webpage" class="tab-content" style="padding:1.25rem;">
-    <form id="webpage-form" onsubmit="event.preventDefault(); addWebpageAsset(this)">
+    <form id="webpage-form" onsubmit="event.preventDefault(); addWebpageAsset(this)" data-gate-required>
         <div class="form-group">
             <label for="webpage-url">URL</label>
             <input type="url" id="webpage-url" name="url" placeholder="https://example.com" required class="form-control">
@@ -80,12 +80,12 @@
         </div>
         {% endif %}
         <div id="webpage-status" class="form-status"></div>
-        <button type="submit" class="btn btn-primary" id="webpage-submit" style="margin-top:0.75rem">Add URL</button>
+        <button type="submit" class="btn btn-primary" id="webpage-submit" style="margin-top:0.75rem" disabled>Add URL</button>
     </form>
     </div>
 
     <div id="add-tab-stream" class="tab-content" style="padding:1.25rem;">
-    <form id="stream-form" onsubmit="event.preventDefault(); addStreamAsset(this)">
+    <form id="stream-form" onsubmit="event.preventDefault(); addStreamAsset(this)" data-gate-required>
         <div class="form-group">
             <label for="stream-url">Stream URL</label>
             <input type="url" id="stream-url" name="url" placeholder="https://example.com/live/stream.m3u8" required class="form-control"
@@ -149,7 +149,7 @@
         </div>
         {% endif %}
         <div id="stream-status" class="form-status"></div>
-        <button type="submit" class="btn btn-primary" id="stream-submit" style="margin-top:0.75rem">Add Stream</button>
+        <button type="submit" class="btn btn-primary" id="stream-submit" style="margin-top:0.75rem" disabled>Add Stream</button>
     </form>
     </div>
 </div>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -374,7 +374,7 @@
         <div class="form-group" style="margin: 0; flex: 2;">
             <input type="text" id="group-desc" placeholder="Description (optional)">
         </div>
-        <button class="btn btn-primary" onclick="createGroup()">Add Group</button>
+        <button class="btn btn-primary" id="add-group-btn" onclick="createGroup()" disabled>Add Group</button>
     </div>
     {% endif %}
 </div>
@@ -651,5 +651,10 @@ async function checkForUpdates() {
         btn.textContent = 'Check for Updates';
     }
 }
+
+// Gate "Add Group" button until group name has input (issue #315).
+document.addEventListener("DOMContentLoaded", () => {
+    gateButtonOnInputs("#add-group-btn", ["#group-name"]);
+});
 </script>
 {% endblock %}

--- a/cms/templates/profiles.html
+++ b/cms/templates/profiles.html
@@ -10,7 +10,7 @@
 {% if 'profiles:write' in user_perms %}
 <div class="card">
     <h2>Create Profile</h2>
-    <form onsubmit="event.preventDefault(); createProfile(this)">
+    <form onsubmit="event.preventDefault(); createProfile(this)" data-gate-required>
         <div class="form-row">
             <div class="form-group">
                 <label>Name</label>
@@ -102,7 +102,7 @@
             </div>
         </div>
         <div id="profile-create-status" class="form-status"></div>
-        <button type="submit" class="btn btn-primary">Create Profile</button>
+        <button type="submit" class="btn btn-primary" disabled>Create Profile</button>
     </form>
 </div>
 {% endif %}

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -17,7 +17,7 @@
         before you can create a schedule.
     </p>
     {% else %}
-    <form onsubmit="event.preventDefault(); createSchedule(this)" novalidate>
+    <form onsubmit="event.preventDefault(); createSchedule(this)" novalidate data-gate-required>
         <div class="form-row">
             <div class="form-group">
                 <label><span class="has-tooltip">Name<span class="tooltip">A friendly name for this schedule, e.g. &ldquo;Morning Promo&rdquo; or &ldquo;Weekend Loop&rdquo;</span></span></label>
@@ -96,7 +96,7 @@
             </div>
         </div>
         <div id="schedule-summary" class="schedule-summary" style="display:none;"></div>
-        <button type="submit" class="btn btn-primary">Create Schedule</button>
+        <button type="submit" class="btn btn-primary" disabled>Create Schedule</button>
     </form>
     {% endif %}
 </div>

--- a/cms/templates/users.html
+++ b/cms/templates/users.html
@@ -16,7 +16,7 @@
 {% if can_write %}
 <div class="card">
     <h3>Create User</h3>
-    <form onsubmit="event.preventDefault(); createUser(this)">
+    <form onsubmit="event.preventDefault(); createUser(this)" data-gate-required>
         <div class="form-row">
             <div class="form-group">
                 <label for="new-email">Email</label>
@@ -50,7 +50,7 @@
             </div>
         </div>
         <p class="text-muted" style="font-size: 0.85rem; margin-bottom: 0.5rem;">A temporary password will be generated and emailed to the user. They will be required to set a new password on first sign-in.</p>
-        <button type="submit" class="btn btn-primary">Create User</button>
+        <button type="submit" class="btn btn-primary" disabled>Create User</button>
     </form>
 </div>
 {% endif %}
@@ -127,7 +127,7 @@
 {% if can_write_roles %}
 <div class="card">
     <h3>Create Role</h3>
-    <form onsubmit="event.preventDefault(); createRole(this)">
+    <form onsubmit="event.preventDefault(); createRole(this)" data-gate-required>
         <div class="form-row">
             <div class="form-group">
                 <label for="new-role-name">Role Name</label>
@@ -166,7 +166,7 @@
             </details>
             {% endfor %}
         </div>
-        <button type="submit" class="btn btn-primary">Create Role</button>
+        <button type="submit" class="btn btn-primary" disabled>Create Role</button>
     </form>
 </div>
 {% endif %}


### PR DESCRIPTION
## Disable primary action buttons until required inputs are filled

Fixes #315.

### Problem
Primary submit / action buttons were enabled by default even when
required fields were empty. Clicking them with no data silently did
nothing or triggered a server-side validation error — confusing.

The most visible offender (from the issue) was the **Add Group**
button on the Devices page: stayed enabled with an empty name field.

### Approach
Added a small reusable JS helper in `cms/static/app.js`:

- `gateButtonOnInputs(button, inputs)` — low-level helper that
  disables a button until every listed input has a non-empty value
  (checkboxes must be checked).
- `bindFormsRequiredGating()` — auto-binds on `DOMContentLoaded`:
  any `<form data-gate-required>` gets its primary submit button
  disabled until every `[required]` field inside is non-empty.

Forms opt in by adding `data-gate-required` and initial `disabled`
attr on the submit button (consistent with the existing upload
button pattern in `assets.html`).

### Forms gated
| File | Form / Button |
|------|--------------|
| `devices.html` | Add Group (wrapped via `gateButtonOnInputs`, not in a `<form>`) |
| `schedules.html` | Create Schedule |
| `profiles.html` | Create Profile |
| `users.html` | Create User, Create Role |
| `assets.html` | Add URL (webpage), Add Stream |

Upload button in `assets.html` was already gated with its own custom
file-drop logic — left untouched.

### Out of scope
- Settings-page save buttons: fields are pre-populated, enabled makes sense.
- Edit modals (users/profiles/schedules): already pre-populated; most
  already have their own dirty-state wiring. Can be revisited later if
  needed — issue #315 can stay open for a follow-up sweep.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
