### PR TITLE
test(nightly): collect CMS line coverage from compose stack (#300)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,42 @@ jobs:
           NIGHTLY_KEEP_STACK: ${{ inputs.keep_stack == true && '1' || '' }}
           NIGHTLY_STARTUP_TIMEOUT: "360"
         run: |
+          mkdir -p tests/nightly/coverage-data
           pytest tests/nightly -v --tb=short -o log_cli=true -o log_cli_level=INFO
+
+      - name: Combine nightly coverage
+        if: always()
+        working-directory: agora-cms
+        run: |
+          set -e
+          python -m pip install --quiet 'coverage<8'
+          if compgen -G "tests/nightly/coverage-data/.coverage*" > /dev/null; then
+            cat > .coveragerc.combine <<'EOF'
+          [paths]
+          source =
+              .
+              /app
+          [run]
+          branch = false
+          source = cms,shared
+          EOF
+            COVERAGE_RCFILE=.coveragerc.combine coverage combine tests/nightly/coverage-data/ || true
+            COVERAGE_RCFILE=.coveragerc.combine coverage xml -o nightly-coverage.xml || true
+            COVERAGE_RCFILE=.coveragerc.combine coverage report --skip-covered | tail -40 >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            echo "::warning::no nightly coverage data produced (did CMS shut down cleanly?)"
+          fi
+
+      - name: Upload nightly coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-coverage
+          path: |
+            agora-cms/nightly-coverage.xml
+            agora-cms/tests/nightly/coverage-data/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Capture compose logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ cookies.txt
 .pr_body.md
 
 e2e_log.txt
+
+# Coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+tests/nightly/coverage-data/
+

--- a/tests/nightly/.coveragerc.nightly
+++ b/tests/nightly/.coveragerc.nightly
@@ -1,0 +1,29 @@
+# Coverage config used only by the nightly compose overlay.
+#
+# Container-side: coverage runs as PID 1 under `coverage run --parallel-mode`.
+# --parallel-mode writes one data file per process (e.g. .coverage.{host}.{pid}.{rand}),
+# which the post-test workflow step combines on the host via a bind mount.
+#
+# Distinct from pyproject.toml's [tool.coverage] so host and container configs
+# don't fight each other.
+
+[run]
+branch = false
+parallel = true
+data_file = /coverage/.coverage
+source =
+    cms
+    shared
+omit =
+    */tests/*
+    */tests_e2e/*
+    */alembic/*
+    */__main__.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if TYPE_CHECKING:
+    if __name__ == .__main__.:
+    \.\.\.

--- a/tests/nightly/docker-compose.nightly.yml
+++ b/tests/nightly/docker-compose.nightly.yml
@@ -30,6 +30,29 @@ services:
       # SMTP config in cms_settings (set via /setup/smtp wizard step).
       - AGORA_CMS_DEFAULT_SMTP_HOST=mailpit
       - AGORA_CMS_DEFAULT_SMTP_PORT=1025
+      # Tell coverage where to write + which rcfile to use. --parallel-mode
+      # is set on the command below so each process produces its own data
+      # file under /coverage for post-run combining on the host.
+      - COVERAGE_RCFILE=/app/.coveragerc.nightly
+    # Run uvicorn under `coverage` so we get line coverage of whatever the
+    # E2E suite exercises. Exec-form so coverage is PID 1 and can forward
+    # SIGTERM into uvicorn's graceful shutdown (which triggers coverage's
+    # atexit flush).
+    command:
+      - coverage
+      - run
+      - --rcfile=/app/.coveragerc.nightly
+      - --parallel-mode
+      - -m
+      - uvicorn
+      - cms.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+    volumes:
+      - ./.coveragerc.nightly:/app/.coveragerc.nightly:ro
+      - ./coverage-data:/coverage
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/healthz',timeout=2).status==200 else 1)\""]
       interval: 5s


### PR DESCRIPTION
Closes #300.

## What

Instrument the nightly compose stack to collect line coverage from the CMS container, and surface it as a workflow artifact.

- New `tests/nightly/.coveragerc.nightly` — coverage config used inside the CMS container. `parallel = true` so each worker process writes its own data file under `/coverage`.
- `docker-compose.nightly.yml` — CMS service now overrides `command:` to run uvicorn under `coverage run --parallel-mode`, bind-mounts the rcfile and a host `coverage-data` dir into `/coverage`.
- `.github/workflows/nightly.yml`:
  - Creates the `coverage-data` dir before running tests.
  - After pytest (always), installs `coverage` on the runner, runs `coverage combine` + `coverage xml`, dumps a condensed report into the job summary, uploads `nightly-coverage.xml` + raw data files as the `nightly-coverage` artifact.
- `.gitignore` — ignore `.coverage*`, `coverage.xml`, `htmlcov/`, `tests/nightly/coverage-data/`.

## Design notes

- **CMS-only for MVP.** The CMS container covers the HTTP/API/WebSocket surface that E2E exercises. Worker coverage is a nice-to-have but requires installing `coverage` into the worker image too — deferred as a follow-up. The issue explicitly called out "informational, not gated," so partial coverage is still useful signal.
- **Exec-form command.** `coverage` runs as PID 1 so `docker compose down` SIGTERM reaches it cleanly, which lets uvicorn shut down gracefully and coverage's `atexit` hook flushes data files before the container dies.
- **Bind mount, not named volume.** Named volumes get wiped by `docker compose down -v` (which the nightly conftest does in its `finally`). A bind mount into the workspace survives teardown.
- **Path remapping.** Container writes absolute paths (`/app/cms/...`); the post-test `coverage combine` uses a host-side rcfile with `[paths]` that maps `/app` → `.` so reports resolve against the checkout.
- **No gating.** Matches the issue ask — coverage is informational, aimed at spotting dead code and untested flows. Not combined with unit coverage yet; that'd be a small follow-up PR.

## Test plan

- YAML parse verified for both modified workflow and compose overlay.
- End-to-end validation will happen on the first real nightly run (or a manual `workflow_dispatch`). If `coverage combine` finds no data files, the step prints a warning and continues — so the new step can't fail the nightly build.

## Follow-ups (not in this PR)

- Worker container coverage (requires `coverage` package in Dockerfile.worker).
- Merge nightly coverage with unit coverage into a single combined report.
- Promote to Codecov once we like the shape of the data.
