### PR TITLE
Show duration for saved-stream assets in dropdowns (#316)

### DIFF
--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -48,7 +48,7 @@
         <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
             <option value="">None (use group)</option>
             {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
             {% endfor %}
         </select>
         {% else %}
@@ -335,7 +335,7 @@
                 <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
                     <option value="">No default asset</option>
                     {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
                 {% if g.schedule_count %}

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -28,7 +28,7 @@
                 <select name="asset_id" required onchange="onAssetTypeChange(this)">
                     <option value="">Select asset...</option>
                     {% for a in assets %}
-                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}"{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{% if a.asset_type.value == 'video' and a.duration_seconds %} ({{ '%d:%02d'|format((a.duration_seconds|int) // 60, (a.duration_seconds|int) % 60) }}){% elif a.asset_type.value == 'webpage' %} 🌐{% elif a.asset_type.value == 'stream' %} 📡{% endif %}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}"{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -212,7 +212,7 @@
 <input type="hidden" id="_tzOptions" value='{{ tz_options | tojson }}'>
 <script>
 const _scheduleData = {
-    assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.asset_type.value == 'video' else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
+    assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.duration_seconds else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
     groups: [{% for g in groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}],
     isAdmin: {{ 'true' if is_admin else 'false' }}
 };

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -81,6 +81,29 @@ def select_days(day_names, day_numbers):
 templates.env.filters["select_days"] = select_days
 
 
+def asset_label_suffix(asset):
+    """Return a human-readable suffix for asset labels in dropdowns.
+
+    Shows duration `(mm:ss)` for any asset with a duration (video or
+    saved stream), a 🌐 globe for webpages, and a 📡 antenna for live
+    streams. Returns an empty string for assets with no meaningful
+    suffix (e.g. images). See issue #316.
+    """
+    duration = getattr(asset, "duration_seconds", None)
+    if duration:
+        total = int(duration)
+        return f" ({total // 60}:{total % 60:02d})"
+    asset_type = getattr(asset, "asset_type", None)
+    type_val = getattr(asset_type, "value", asset_type)
+    if type_val == "webpage":
+        return " 🌐"
+    if type_val == "stream":
+        return " 📡"
+    return ""
+
+templates.env.filters["asset_label_suffix"] = asset_label_suffix
+
+
 def schedule_json(s):
     """Serialize a schedule ORM object to a JSON string for the edit modal."""
     data = {

--- a/tests/test_asset_label_suffix.py
+++ b/tests/test_asset_label_suffix.py
@@ -1,0 +1,61 @@
+"""Unit tests for the ``asset_label_suffix`` Jinja filter.
+
+Ensures saved-stream assets surface their duration in asset dropdowns
+the same way videos do, and that webpage/live-stream icons and
+empty-suffix cases still render correctly (issue #316).
+"""
+
+from types import SimpleNamespace
+
+from cms.models.asset import AssetType
+from cms.ui import asset_label_suffix
+
+
+def _asset(asset_type, duration_seconds=None):
+    return SimpleNamespace(
+        asset_type=asset_type,
+        duration_seconds=duration_seconds,
+    )
+
+
+def test_video_with_duration_shows_mmss():
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 332)) == " (5:32)"
+
+
+def test_saved_stream_with_duration_shows_mmss():
+    # The bug this is protecting: saved streams were falling through
+    # because the template only rendered duration for VIDEO.
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, 125)) == " (2:05)"
+
+
+def test_saved_stream_without_duration_no_suffix():
+    # Capture still in progress — don't render "(None)" or similar.
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, None)) == ""
+
+
+def test_webpage_shows_globe():
+    assert asset_label_suffix(_asset(AssetType.WEBPAGE)) == " 🌐"
+
+
+def test_live_stream_shows_antenna():
+    assert asset_label_suffix(_asset(AssetType.STREAM)) == " 📡"
+
+
+def test_image_no_suffix():
+    assert asset_label_suffix(_asset(AssetType.IMAGE)) == ""
+
+
+def test_duration_pads_seconds():
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 65)) == " (1:05)"
+
+
+def test_duration_zero_falsy_no_suffix():
+    # A zero-duration asset is effectively unknown — don't render "(0:00)".
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 0)) == ""
+
+
+def test_accepts_string_type_value():
+    # Filter is also used on dict-like objects in some paths; tolerate
+    # a raw string type (as emitted via `asset_type.value`).
+    asset = SimpleNamespace(asset_type="webpage", duration_seconds=None)
+    assert asset_label_suffix(asset) == " 🌐"


### PR DESCRIPTION
Fixes #316.

Saved-stream assets have a real duration once capture completes (populated from the capture worker just like video `duration_seconds`), but the schedule and splash dropdowns only surfaced duration when the asset type was literally `video`. Saved streams fell through all branches and rendered with no suffix at all, so users couldn't tell a 2-minute capture from a 2-hour one in the picker.

## Change

- Introduce an `asset_label_suffix(asset)` Jinja filter in `cms/ui.py` that returns:
  - `" (mm:ss)"` for any asset with a non-zero `duration_seconds` (covers video **and** saved_stream once captured),
  - `" 🌐"` for webpages,
  - `" 📡"` for live streams,
  - `""` otherwise (images, saved-streams mid-capture).
- Use the filter in:
  - `cms/templates/schedules.html` — the new-schedule form option list (L31).
  - `cms/templates/schedules.html` — the JS `_scheduleData.assets` feed (L215), so the edit-modal renderer (which already renders `a.duration`) now receives it for saved streams too.
  - `cms/templates/devices.html` — the per-device splash dropdown (L51).
  - `cms/templates/devices.html` — the per-group splash dropdown (L338).

The filter also DRYs up the old `{% if video and duration %} … {% elif webpage %} 🌐 {% elif stream %} 📡 {% endif %}` chain that was duplicated in the schedule form.

## Tests

New `tests/test_asset_label_suffix.py` covers:

- video with duration → `" (5:32)"`
- **saved-stream with duration → `" (2:05)"`** (the regression this fix closes)
- saved-stream without duration (mid-capture) → `""` (no `(None)`)
- webpage → `" 🌐"`, live stream → `" 📡"`, image → `""`
- zero-second padding (`65s → "(1:05)"`)
- falsy-zero-duration handled gracefully
- filter tolerates a raw string `asset_type` as well as the enum

All 9 new tests pass. No other tests changed.
