### PR TITLE
Stop silently dropping video_codec on profile updates (#261)

### DIFF
--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -234,7 +234,7 @@ async def update_profile(
 
     # Validate codec/profile compatibility with the merged state
     _validate_profile_compat(
-        video_codec=profile.video_codec,  # codec is immutable
+        video_codec=updates.get("video_codec", profile.video_codec),
         video_profile=updates.get("video_profile", profile.video_profile),
         pixel_format=updates.get("pixel_format", profile.pixel_format),
         color_space=updates.get("color_space", profile.color_space),

--- a/cms/schemas/profile.py
+++ b/cms/schemas/profile.py
@@ -66,6 +66,7 @@ class ProfileCreate(BaseModel):
 
 class ProfileUpdate(BaseModel):
     description: Optional[str] = None
+    video_codec: Optional[str] = None
     video_profile: Optional[str] = None
     max_width: Optional[int] = None
     max_height: Optional[int] = None

--- a/tests/test_profile_retranscode.py
+++ b/tests/test_profile_retranscode.py
@@ -273,6 +273,67 @@ class TestProfileUpdateRetranscode:
         assert variants[2].id in jobs_by_target, "V_new2 should have a job"
         assert jobs_by_target[variants[2].id].cancel_requested is False
 
+    async def test_changing_codec_persists_and_creates_new_variant(self, client, db_session):
+        """Changing video_codec must persist to the DB and create a new
+        PENDING variant — regression guard for issue #261 where codec was
+        silently dropped by the ``ProfileUpdate`` schema."""
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="retrans-codec", video_codec="h264", crf=23)
+        db_session.add(profile)
+        await db_session.flush()
+
+        asset = Asset(
+            filename="vid-codec.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum="abc",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        orig = AssetVariant(
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.mp4",
+            status=VariantStatus.READY,
+            size_bytes=500,
+        )
+        db_session.add(orig)
+        await db_session.commit()
+        orig_id = orig.id
+        profile_id = profile.id
+
+        resp = await client.put(
+            f"/api/profiles/{profile_id}",
+            json={"video_codec": "hevc"},
+        )
+        assert resp.status_code == 200, resp.text
+        # Response body must reflect the new codec
+        assert resp.json()["video_codec"] == "hevc"
+
+        # DB row must reflect the new codec
+        db_session.expunge_all()
+        refreshed = await db_session.get(DeviceProfile, profile_id)
+        assert refreshed.video_codec == "hevc", (
+            "video_codec change must persist — it was being dropped by "
+            "ProfileUpdate in issue #261"
+        )
+
+        # A new PENDING variant must have been created (codec is in
+        # _TRANSCODE_FIELDS so supersede fires)
+        result = await db_session.execute(
+            select(AssetVariant).where(AssetVariant.profile_id == profile_id)
+        )
+        variants = result.scalars().all()
+        assert len(variants) == 2, (
+            f"codec change must supersede — expected 2 variants, got {len(variants)}"
+        )
+        old = next(v for v in variants if v.id == orig_id)
+        new = next(v for v in variants if v.id != orig_id)
+        assert old.status == VariantStatus.READY
+        assert old.deleted_at is None
+        assert new.status == VariantStatus.PENDING
+
 
 @pytest.mark.asyncio
 class TestProfileChangeFlagsActiveJobs:


### PR DESCRIPTION
Fixes #261.

## The bug

Editing a device profile's codec via the UI/API (e.g. `hevc → h264`) returned 200 OK but silently had no effect: the DB column was unchanged, no variants were superseded, and devices kept playing the old-codec blob forever.

Two stacked mistakes caused this:

1. **`ProfileUpdate` schema (cms/schemas/profile.py)** had no `video_codec` field. Pydantic's `model_dump(exclude_unset=True)` therefore dropped it unconditionally — the server never saw a codec change at all.
2. **`update_profile` (cms/routers/profiles.py:237)** defensively hard-coded `video_codec=profile.video_codec` when calling `_validate_profile_compat`, with a `# codec is immutable` comment. So even if the schema had forwarded the codec, compatibility validation would have been computed against the old value.

## Fix

- Add `video_codec: Optional[str] = None` to `ProfileUpdate`.
- In `update_profile`, use `updates.get("video_codec", profile.video_codec)` — the same merge pattern already used for `video_profile`, `pixel_format`, `color_space`. This both validates compatibility against the *new* codec and lets the field flow through the existing setattr loop.
- `_TRANSCODE_FIELDS` already contained `"video_codec"`, so the existing `compute_diff → supersede_profile_variants → enqueue_variants` path fires automatically once the setattr actually happens. No changes needed there.
- `reset_profile` was already correct (it writes every default field and checks `_TRANSCODE_FIELDS`).

## Test

New `test_changing_codec_persists_and_creates_new_variant` in `tests/test_profile_retranscode.py` asserts that a PUT with `{"video_codec": "hevc"}`:

- Returns 200 with the new codec in the response body.
- Persists to the DB (`profile.video_codec == "hevc"`).
- Creates a fresh PENDING variant while keeping the old READY variant intact (the latest-READY-wins swap model).

All 39 tests in `test_profile_validation.py` + `test_profile_retranscode.py` + `test_cancel_transcode.py` still pass.
