### PR TITLE
Skip image variants when profile edit only changed video fields

### DIFF
--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -271,7 +271,9 @@ async def update_profile(
         # The OLD variant rows are left in place so devices keep playing the
         # last known good blob; the reaper will soft-delete them once a new
         # READY sibling exists, then hard-delete once jobs are terminal.
-        new_variant_ids = await supersede_profile_variants(db, profile_id)
+        new_variant_ids = await supersede_profile_variants(
+            db, profile_id, changed_fields=set(changes),
+        )
 
     reset_count = len(new_variant_ids)
 
@@ -496,11 +498,14 @@ async def reset_profile(
 
     defaults = BUILTIN_PROFILES[profile.name]
 
-    # Detect whether any transcoding-relevant field will change
-    transcode_changed = any(
-        field in _TRANSCODE_FIELDS and getattr(profile, field) != value
-        for field, value in defaults.items()
-    )
+    # Detect which transcoding-relevant fields will change.  We keep the
+    # set so we can tell supersede_profile_variants whether IMAGE assets
+    # need to be re-rendered (only max_width/max_height affect them).
+    reset_changed_fields: set[str] = {
+        field for field, value in defaults.items()
+        if field in _TRANSCODE_FIELDS and getattr(profile, field) != value
+    }
+    transcode_changed = bool(reset_changed_fields)
 
     # Apply defaults
     for field, value in defaults.items():
@@ -516,7 +521,9 @@ async def reset_profile(
         )
         cancelled_jobs = await flag_profile_jobs_cancelled(db, profile_id)
         cancel_profile_transcodes(profile_id)
-        new_variant_ids = await supersede_profile_variants(db, profile_id)
+        new_variant_ids = await supersede_profile_variants(
+            db, profile_id, changed_fields=reset_changed_fields,
+        )
 
     reset_count = len(new_variant_ids)
 

--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -34,6 +34,14 @@ from shared.services.probe import probe_media  # noqa: F401
 
 logger = logging.getLogger("agora.cms.transcoder")
 
+
+# Profile fields that actually affect image-variant output. ``convert_image``
+# only honours ``max_width``/``max_height``; codec/bitrate/crf/fps/audio/
+# pixel-format/color-space are all video-only knobs.  A profile edit that
+# touches only those video-only fields must NOT re-encode images — see
+# issue #302-ish (image-supersede-over-eager).
+IMAGE_RELEVANT_FIELDS: frozenset[str] = frozenset({"max_width", "max_height"})
+
 # ── Monitor loop intervals ──────────────────────────────────────
 _MONITOR_INTERVAL = int(os.environ.get("AGORA_MONITOR_INTERVAL", "30"))
 _STALE_PROCESSING_TIMEOUT = int(os.environ.get("AGORA_STALE_TIMEOUT", "1800"))  # 30 min
@@ -96,7 +104,9 @@ async def flag_profile_jobs_cancelled(
 
 
 async def supersede_profile_variants(
-    db: AsyncSession, profile_id: uuid.UUID
+    db: AsyncSession,
+    profile_id: uuid.UUID,
+    changed_fields: Iterable[str] | None = None,
 ) -> list[uuid.UUID]:
     """Create fresh PENDING variant rows for every source asset that currently
     has a non-deleted variant under ``profile_id``.
@@ -108,10 +118,23 @@ async def supersede_profile_variants(
     the older sibling(s); once their jobs are terminal it hard-deletes
     them (blob + row).
 
+    ``changed_fields`` is the set of profile fields that triggered this
+    supersession.  When supplied and it intersects none of
+    :data:`IMAGE_RELEVANT_FIELDS`, IMAGE assets are left alone — there is
+    nothing about the changed fields (e.g. video codec/bitrate/crf) that
+    would affect their rendered output, so re-encoding them is pure
+    wasted work.  When omitted (or when a dimension field changes),
+    images are superseded alongside videos, matching the legacy behaviour.
+
     Returns the list of newly-created variant ids (caller passes these to
     :func:`enqueue_variants`).  Caller is responsible for committing the
     surrounding transaction.
     """
+    changed_set = set(changed_fields) if changed_fields is not None else None
+    skip_images = (
+        changed_set is not None
+        and not (changed_set & IMAGE_RELEVANT_FIELDS)
+    )
     profile_result = await db.execute(
         select(DeviceProfile).where(DeviceProfile.id == profile_id)
     )
@@ -165,6 +188,16 @@ async def supersede_profile_variants(
             logger.info(
                 "supersede_profile_variants: skipping soft-deleted asset %s "
                 "for profile %s", asset_id, profile_id,
+            )
+            continue
+
+        # Image variants only depend on max_width/max_height; skip them
+        # when the profile edit doesn't touch either of those fields.
+        if skip_images and asset.asset_type == AssetType.IMAGE:
+            logger.info(
+                "supersede_profile_variants: skipping IMAGE asset %s for "
+                "profile %s — changed fields %s do not affect image output",
+                asset_id, profile_id, sorted(changed_set),
             )
             continue
 

--- a/tests/test_image_supersede_filter.py
+++ b/tests/test_image_supersede_filter.py
@@ -1,0 +1,246 @@
+"""Regression tests for the image-variant supersede filter.
+
+Image variants only depend on ``max_width``/``max_height`` (see
+``shared.services.image.convert_image``).  A profile edit that touches
+only video-specific fields (codec, bitrate, crf, fps, audio, pixel
+format, color space) must NOT create fresh PENDING image variants —
+doing so was producing pointless re-encode jobs that burned CPU and
+briefly dropped image playback readiness for no observable gain.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.mark.asyncio
+class TestImageSupersedeFilter:
+    async def _seed_profile_with_video_and_image(self, db_session):
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(
+            name="img-supersede-guard",
+            video_codec="h264",
+            crf=23,
+            max_width=1920,
+            max_height=1080,
+        )
+        db_session.add(profile)
+        await db_session.flush()
+
+        video = Asset(
+            filename="clip.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum="vidchk",
+        )
+        image = Asset(
+            filename="poster.jpg", asset_type=AssetType.IMAGE,
+            size_bytes=500, checksum="imgchk",
+        )
+        db_session.add_all([video, image])
+        await db_session.flush()
+
+        vv = AssetVariant(
+            source_asset_id=video.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.mp4",
+            status=VariantStatus.READY, size_bytes=800,
+        )
+        iv = AssetVariant(
+            source_asset_id=image.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.jpg",
+            status=VariantStatus.READY, size_bytes=400,
+        )
+        db_session.add_all([vv, iv])
+        await db_session.commit()
+        return profile, video, image, vv, iv
+
+    async def test_codec_change_does_not_supersede_images(self, client, db_session):
+        """Changing video_codec re-transcodes the video variant but must
+        leave image variants untouched."""
+        from cms.models.asset import AssetVariant, AssetType, VariantStatus
+
+        profile, video, image, vv_orig, iv_orig = (
+            await self._seed_profile_with_video_and_image(db_session)
+        )
+
+        resp = await client.put(
+            f"/api/profiles/{profile.id}", json={"video_codec": "hevc"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db_session.expunge_all()
+        variants = (
+            await db_session.execute(
+                select(AssetVariant).where(AssetVariant.profile_id == profile.id)
+            )
+        ).scalars().all()
+
+        video_variants = [v for v in variants if v.source_asset_id == video.id]
+        image_variants = [v for v in variants if v.source_asset_id == image.id]
+
+        # Video got a fresh PENDING variant alongside the old READY one
+        assert len(video_variants) == 2, (
+            f"video should have been superseded, got {len(video_variants)}"
+        )
+        assert {v.status for v in video_variants} == {
+            VariantStatus.READY, VariantStatus.PENDING,
+        }
+
+        # Image was left alone — still exactly one READY variant
+        assert len(image_variants) == 1, (
+            f"image must NOT be superseded on codec-only change, "
+            f"got {len(image_variants)}"
+        )
+        assert image_variants[0].id == iv_orig.id
+        assert image_variants[0].status == VariantStatus.READY
+
+    async def test_resolution_change_supersedes_images_too(self, client, db_session):
+        """Changing max_width DOES affect image output, so images must be
+        re-rendered alongside videos."""
+        from cms.models.asset import AssetVariant, VariantStatus
+
+        profile, video, image, *_ = (
+            await self._seed_profile_with_video_and_image(db_session)
+        )
+
+        resp = await client.put(
+            f"/api/profiles/{profile.id}", json={"max_width": 1280},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db_session.expunge_all()
+        variants = (
+            await db_session.execute(
+                select(AssetVariant).where(AssetVariant.profile_id == profile.id)
+            )
+        ).scalars().all()
+        video_variants = [v for v in variants if v.source_asset_id == video.id]
+        image_variants = [v for v in variants if v.source_asset_id == image.id]
+
+        assert len(video_variants) == 2
+        assert len(image_variants) == 2, (
+            "image must be superseded when max_width changes"
+        )
+        assert {v.status for v in image_variants} == {
+            VariantStatus.READY, VariantStatus.PENDING,
+        }
+
+    async def test_bitrate_change_does_not_supersede_images(self, client, db_session):
+        """video_bitrate is a video-only knob — images stay put."""
+        from cms.models.asset import AssetVariant, VariantStatus
+
+        profile, video, image, *_ = (
+            await self._seed_profile_with_video_and_image(db_session)
+        )
+
+        resp = await client.put(
+            f"/api/profiles/{profile.id}", json={"video_bitrate": "4M"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db_session.expunge_all()
+        image_variants = (
+            await db_session.execute(
+                select(AssetVariant).where(
+                    AssetVariant.profile_id == profile.id,
+                    AssetVariant.source_asset_id == image.id,
+                )
+            )
+        ).scalars().all()
+        assert len(image_variants) == 1
+        assert image_variants[0].status == VariantStatus.READY
+
+
+@pytest.mark.asyncio
+class TestSupersedeHelper:
+    """Direct unit coverage for the supersede helper's changed_fields flag."""
+
+    async def test_no_changed_fields_legacy_behaviour_supersedes_everything(
+        self, db_session
+    ):
+        """When callers don't pass changed_fields (pre-#261 behaviour),
+        every live variant — including images — is superseded.  This
+        preserves backwards compatibility for any future caller that
+        doesn't have a change set handy."""
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+        from cms.services.transcoder import supersede_profile_variants
+
+        profile = DeviceProfile(name="legacy-helper", video_codec="h264")
+        db_session.add(profile)
+        await db_session.flush()
+
+        image = Asset(
+            filename="still.jpg", asset_type=AssetType.IMAGE,
+            size_bytes=100, checksum="c",
+        )
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(AssetVariant(
+            source_asset_id=image.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.jpg",
+            status=VariantStatus.READY, size_bytes=50,
+        ))
+        await db_session.commit()
+
+        new_ids = await supersede_profile_variants(db_session, profile.id)
+        await db_session.commit()
+        assert len(new_ids) == 1, (
+            "legacy (no changed_fields) callers must still supersede images"
+        )
+
+    async def test_video_only_changed_fields_skip_images(self, db_session):
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+        from cms.services.transcoder import supersede_profile_variants
+
+        profile = DeviceProfile(name="helper-codec-only", video_codec="h264")
+        db_session.add(profile)
+        await db_session.flush()
+        image = Asset(
+            filename="pic.jpg", asset_type=AssetType.IMAGE,
+            size_bytes=100, checksum="c2",
+        )
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(AssetVariant(
+            source_asset_id=image.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.jpg",
+            status=VariantStatus.READY, size_bytes=50,
+        ))
+        await db_session.commit()
+
+        new_ids = await supersede_profile_variants(
+            db_session, profile.id, changed_fields={"video_codec", "crf"},
+        )
+        await db_session.commit()
+        assert new_ids == []
+
+    async def test_dimension_change_supersedes_images(self, db_session):
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+        from cms.services.transcoder import supersede_profile_variants
+
+        profile = DeviceProfile(name="helper-dim", video_codec="h264")
+        db_session.add(profile)
+        await db_session.flush()
+        image = Asset(
+            filename="pic2.jpg", asset_type=AssetType.IMAGE,
+            size_bytes=100, checksum="c3",
+        )
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(AssetVariant(
+            source_asset_id=image.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.jpg",
+            status=VariantStatus.READY, size_bytes=50,
+        ))
+        await db_session.commit()
+
+        new_ids = await supersede_profile_variants(
+            db_session, profile.id,
+            changed_fields={"video_codec", "max_height"},
+        )
+        await db_session.commit()
+        assert len(new_ids) == 1


### PR DESCRIPTION
## Problem

`supersede_profile_variants` unconditionally re-transcodes every live variant for every asset on the profile. That's wasteful for **IMAGE** assets when the profile edit only touched video-only knobs — `convert_image` (`shared/services/image.py`) only honours `max_width` and `max_height`, so the re-encoded JPEG/PNG is effectively byte-for-byte identical apart from fresh re-compression noise.

Two concrete symptoms:

- Wasted worker CPU and queue pressure every time an admin tweaks `crf` / `video_bitrate` / `video_codec` / `audio_*`.
- With the new #201 readiness gate, images briefly flip to PENDING and **disappear from splash and schedule dropdowns** during the re-encode — purely a regression for users.

## Fix

- Add `IMAGE_RELEVANT_FIELDS = frozenset({"max_width", "max_height"})` in `cms/services/transcoder.py`.
- Give `supersede_profile_variants` an optional `changed_fields: Iterable[str] | None = None` kwarg. When provided and `changed_fields & IMAGE_RELEVANT_FIELDS == set()`, IMAGE assets are skipped (logged at INFO). When omitted, behaviour is unchanged — all callers that don't have a change set available keep the legacy supersede-everything semantics.
- `update_profile` (cms/routers/profiles.py) now passes `set(changes)` — the diff that was already being computed for the audit log and `_TRANSCODE_FIELDS` check.
- `reset_profile` now builds its `reset_changed_fields` set up front and reuses it for both the `transcode_changed` bool and the supersede call.

## Tests (new `tests/test_image_supersede_filter.py`, 6 cases)

Integration (PUT /api/profiles/{id}):

- `test_codec_change_does_not_supersede_images` — flipping `video_codec` creates a fresh PENDING video variant but leaves the image's single READY variant untouched.
- `test_resolution_change_supersedes_images_too` — `max_width` change supersedes images alongside videos.
- `test_bitrate_change_does_not_supersede_images` — `video_bitrate` is video-only, images stay put.

Helper:

- `test_no_changed_fields_legacy_behaviour_supersedes_everything` — omitting the kwarg preserves the old behaviour.
- `test_video_only_changed_fields_skip_images` — `{video_codec, crf}` → 0 new variants.
- `test_dimension_change_supersedes_images` — `{video_codec, max_height}` → image superseded.

All 71 tests across the profile/transcoder/image-variant suites still pass.
