### PR TITLE
fix(ui): match variant rows by ID during polling (#196)

### DIFF
--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -425,7 +425,7 @@
                             </thead>
                             <tbody data-live-variant-table="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}">
                                 {% for v in a.visible_variants %}
-                                <tr>
+                                <tr data-variant-id="{{ v.id }}">
                                     <td>{{ v.profile.name if v.profile else '—' }}</td>
                                     <td>
                                         {% if v.status.value == 'ready' %}
@@ -751,11 +751,13 @@
         const tbody = document.querySelector('[data-live-variant-table="' + assetId + '"]');
         if (!tbody) return;
         const isImage = tbody.getAttribute('data-asset-type') === 'image';
-        const rows = tbody.querySelectorAll('tr');
-        // Update each row's status cell (2nd column, index 1) and size (last col)
-        variants.forEach((v, i) => {
-            if (i >= rows.length) return;
-            const cells = rows[i].querySelectorAll('td');
+        // Match each variant to its row by variant ID (not array index) so polling
+        // doesn't swap progress between rows when the API returns variants in a
+        // different order (e.g. as statuses change).
+        variants.forEach((v) => {
+            const row = tbody.querySelector('tr[data-variant-id="' + v.id + '"]');
+            if (!row) return;
+            const cells = row.querySelectorAll('td');
             if (cells.length < 2) return;
             // Status cell
             cells[1].innerHTML = buildVariantStatusCell(v);

--- a/tests/test_variant_row_stable_id.py
+++ b/tests/test_variant_row_stable_id.py
@@ -1,0 +1,47 @@
+"""Regression test for issue #196.
+
+The variant table in the asset detail panel used to map API response rows
+to DOM rows by array index. When the /api/assets/status endpoint returned
+variants in a different order on successive polls (e.g. as statuses
+flipped from processing → ready), progress from one variant could render
+on another variant's row, making it impossible to tell which variant was
+actually transcoding.
+
+The fix: give each variant row a stable `data-variant-id` attribute
+sourced from the variant UUID, and match by that ID in the polling JS
+rather than by array index.
+
+These are lightweight source-level checks so the contract can't silently
+regress. Full UI integration tests live elsewhere.
+"""
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "cms" / "templates" / "assets.html"
+
+
+def test_variant_row_has_stable_data_variant_id():
+    """The Jinja-rendered variant row must include data-variant-id."""
+    src = TEMPLATE.read_text(encoding="utf-8")
+    # The loop body is the only place we render variant rows inside the
+    # live-variant-table tbody.
+    assert "{% for v in a.visible_variants %}" in src
+    # Must render data-variant-id on the <tr>
+    assert 'data-variant-id="{{ v.id }}"' in src, (
+        "variant row <tr> is missing data-variant-id; polling JS will fall "
+        "back to index-based matching and swap progress between rows "
+        "(regression of #196)"
+    )
+
+
+def test_update_variant_table_matches_by_id_not_index():
+    """Polling JS must look up rows by data-variant-id, not rows[i]."""
+    src = TEMPLATE.read_text(encoding="utf-8")
+    # The ID-based selector must be present.
+    assert (
+        'tr[data-variant-id="\' + v.id + \'"]' in src
+    ), "updateVariantTable no longer matches by variant ID (regression of #196)"
+    # The old index-based pattern must be gone so we don't regress silently.
+    assert "rows[i].querySelectorAll" not in src, (
+        "updateVariantTable still has index-based row lookup; this caused "
+        "#196 where progress jumped between variant rows during polling."
+    )


### PR DESCRIPTION
Fixes #196.

## Problem
During multi-variant transcoding the asset detail panel showed progress
jumping between rows: a variant's % would briefly render on a different
variant's row, making it impossible to tell which variant was actually
transcoding.

## Root cause
`updateVariantTable()` in `cms/templates/assets.html` matched API
response entries to DOM rows **by array index**:

```js
variants.forEach((v, i) => {
    if (i >= rows.length) return;
    const cells = rows[i].querySelectorAll('td');
```

When `/api/assets/status` returned variants in a different order on
successive polls (e.g. as one variant flipped from `processing` →
`ready` and the sequential semaphore moved on to the next), `variants[0]`
still updated `rows[0]` — even if the underlying variant had moved.

## Fix
- Give each variant `<tr>` a stable `data-variant-id="{{ v.id }}"`.
- Look the row up by that ID in the polling JS instead of by index.

The API already emits `id` on each variant (`cms/routers/assets.py`
L224) so no backend change was needed.

## Tests
Added `tests/test_variant_row_stable_id.py` with two source-level checks
that lock in the contract:
1. Variant rows carry `data-variant-id`.
2. Polling JS uses `tr[data-variant-id="…"]` and no longer has the
   `rows[i]` indexing pattern.

Both pass locally.

## Risk
UI-only, bounded to the variant table on the assets page. No API, no DB,
no worker/transcoder changes.
