### PR TITLE
fix(ui): make error toasts prominent and longer-lived (#248)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -94,12 +94,48 @@ function showPrompt(message, defaultValue = "", isPassword = false) {
 }
 
 // ── Toast notification (replaces native alert()) ──
-function showToast(message, isError = false) {
+// Second arg accepts:
+//   - boolean: true = error, false/undefined = success (legacy)
+//   - string:  'error' | 'success' | 'warning' | 'info'
+// Error toasts stay on-screen longer and use a shake-in animation so users
+// are less likely to miss them after a failed action (#248).
+function showToast(message, variant) {
+    let kind = "success";
+    if (variant === true) kind = "error";
+    else if (typeof variant === "string") {
+        const v = variant.toLowerCase();
+        if (v === "error" || v === "success" || v === "warning" || v === "info") {
+            kind = v;
+        }
+    }
+    const isError = kind === "error";
+    const isWarning = kind === "warning";
     const el = document.createElement("div");
-    el.className = "toast" + (isError ? " toast-error" : "");
-    el.textContent = message;
+    el.className = "toast toast-" + kind;
+    el.setAttribute("role", isError ? "alert" : "status");
+    el.setAttribute("aria-live", isError ? "assertive" : "polite");
+
+    const icon = document.createElement("span");
+    icon.className = "toast-icon";
+    icon.setAttribute("aria-hidden", "true");
+    icon.textContent = isError ? "✕" : isWarning ? "⚠" : kind === "info" ? "ℹ" : "✓";
+    const body = document.createElement("span");
+    body.className = "toast-body";
+    body.textContent = message;
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "toast-close";
+    close.setAttribute("aria-label", "Dismiss");
+    close.textContent = "×";
+    close.onclick = () => el.remove();
+    el.appendChild(icon);
+    el.appendChild(body);
+    el.appendChild(close);
     document.body.appendChild(el);
-    setTimeout(() => el.remove(), 3000);
+
+    // Error toasts linger longer so they're harder to miss.
+    const lifetimeMs = isError ? 7000 : isWarning ? 5000 : 3000;
+    setTimeout(() => el.remove(), lifetimeMs);
 }
 
 function extractErrorMsg(err, fallback) {

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -756,18 +756,79 @@ select.inline-edit:hover { border-color: var(--accent); }
     position: fixed;
     bottom: 1.5rem;
     right: 1.5rem;
+    min-width: 280px;
+    max-width: 480px;
     background: var(--surface);
     border: 1px solid var(--primary);
     border-radius: var(--radius);
-    padding: 0.75rem 1.25rem;
+    padding: 0.85rem 1rem 0.85rem 1rem;
     color: var(--text);
+    font-size: 0.95rem;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     z-index: 1001;
     animation: slideUp 0.2s ease, fadeOut 0.3s ease 2.7s forwards;
 }
+.toast .toast-icon {
+    flex: 0 0 auto;
+    width: 1.4rem;
+    height: 1.4rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-weight: bold;
+    font-size: 0.9rem;
+    color: #fff;
+    background: var(--primary);
+}
+.toast .toast-body {
+    flex: 1 1 auto;
+    line-height: 1.35;
+    word-break: break-word;
+}
+.toast .toast-close {
+    flex: 0 0 auto;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 0.25rem;
+    cursor: pointer;
+    opacity: 0.65;
+}
+.toast .toast-close:hover { opacity: 1; }
 
+.toast.toast-success .toast-icon { background: var(--success, #4caf50); }
+.toast.toast-info    .toast-icon { background: var(--primary); }
+.toast.toast-warning .toast-icon { background: #f59e0b; color: #111; }
+
+/* Error toasts are bigger, stay longer, get a shake-in animation and a */
+/* bolder red border so users don't miss a failed action (#248).       */
 .toast.toast-error {
     border-color: var(--danger);
+    border-width: 2px;
+    background: color-mix(in srgb, var(--danger) 12%, var(--surface));
+    font-size: 1rem;
+    font-weight: 500;
+    box-shadow: 0 6px 24px rgba(220, 38, 38, 0.35);
+    animation: shakeIn 0.45s ease, fadeOut 0.5s ease 6.5s forwards;
+}
+.toast.toast-error .toast-icon { background: var(--danger); }
+.toast.toast-warning {
+    border-color: #f59e0b;
+    animation: slideUp 0.2s ease, fadeOut 0.5s ease 4.5s forwards;
+}
+
+@keyframes shakeIn {
+    0%   { transform: translateY(20px); opacity: 0; }
+    30%  { transform: translate(-6px, 0); opacity: 1; }
+    50%  { transform: translate(6px, 0); }
+    70%  { transform: translate(-3px, 0); }
+    100% { transform: translate(0, 0); opacity: 1; }
 }
 
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }

--- a/tests/test_toast_prominence.py
+++ b/tests/test_toast_prominence.py
@@ -1,0 +1,63 @@
+"""Regression tests for issue #248: error toasts must be hard to miss.
+
+The toast component used to:
+  - Treat the 2nd arg strictly as a boolean, which meant
+    `showToast("ok", "success")` rendered as an error (string 'success'
+    is truthy) — a latent bug in users.html that this PR also fixes.
+  - Auto-dismiss all toasts (including errors) after 3s with no dismiss
+    button, so failed actions were easy to miss.
+
+These source-level checks lock in the new contract:
+  - Error toasts use a longer lifetime (≥ 6s) and the shake-in animation.
+  - `showToast` accepts 'error' / 'success' / 'warning' / 'info' strings.
+  - Every toast gets a dismiss button.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "cms" / "static" / "app.js"
+STYLE_CSS = ROOT / "cms" / "static" / "style.css"
+
+
+def test_show_toast_accepts_string_variants():
+    src = APP_JS.read_text(encoding="utf-8")
+    # New signature normalizes variant from strings.
+    assert 'v === "error"' in src
+    assert 'v === "success"' in src
+    assert 'v === "warning"' in src
+    # Shouldn't silently treat 'success' (truthy string) as error anymore.
+    assert "isError = false" not in src, (
+        "showToast still uses the old truthy-boolean signature; "
+        "showToast('x', 'success') will render as an error (regression of #248)"
+    )
+
+
+def test_show_toast_emits_dismiss_button():
+    src = APP_JS.read_text(encoding="utf-8")
+    assert 'class = "toast-close"' in src or 'className = "toast-close"' in src
+    assert 'setAttribute("aria-label", "Dismiss")' in src
+
+
+def test_error_toasts_linger_longer_than_success():
+    src = APP_JS.read_text(encoding="utf-8")
+    # Error toasts should be well over the old 3000ms default.
+    assert "isError ? 7000" in src or "isError ? 6000" in src or "isError ? 8000" in src, (
+        "error toast lifetime was not extended; they'll still disappear "
+        "before users notice them (regression of #248)"
+    )
+
+
+def test_error_toast_has_shake_animation():
+    css = STYLE_CSS.read_text(encoding="utf-8")
+    assert "@keyframes shakeIn" in css
+    assert ".toast.toast-error" in css
+    assert "shakeIn" in css.split(".toast.toast-error", 1)[1][:600], (
+        ".toast-error no longer uses the shakeIn animation (regression of #248)"
+    )
+
+
+def test_error_toast_role_alert():
+    """Error toasts should be assertive ARIA live regions for screen readers."""
+    src = APP_JS.read_text(encoding="utf-8")
+    assert 'role", isError ? "alert" : "status"' in src
+    assert 'aria-live", isError ? "assertive"' in src


### PR DESCRIPTION
Fixes #248.

## Problem
Error toasts (duplicate upload 409, failed schedule update, "test email
failed", etc.) were the same size and same duration as success toasts,
parked in the bottom-right corner with a 3s fade. Users would see the
upload progress bar hit 100%, the spinner stop, and miss the small red
toast — leaving the impression that everything worked.

## Fix

### Behavior changes in `cms/static/app.js`
`showToast(message, variant)` now:

| variant arg | treated as |
|---|---|
| `true` | `error` (legacy) |
| `false` / `undefined` | `success` (legacy) |
| `'error'` / `'success'` / `'warning'` / `'info'` | that kind |
| anything else | `success` |

- Error toasts linger **7s**, warnings **5s**, info/success **3s**.
- Every toast gets an **icon**, a **✕ dismiss button**, and proper
  ARIA (`role="alert"` + `aria-live="assertive"` for errors,
  `role="status"` otherwise).

### Visual changes in `cms/static/style.css`
- Base toast is bigger (min-width 280px, 0.95rem font, flex layout with
  icon + body + close).
- `.toast-error`: 2px red border, red-tinted background
  (`color-mix(in srgb, var(--danger) 12%, var(--surface))`), larger
  bolder text, deeper red shadow, and a `shakeIn` entrance animation
  so it visibly "announces itself".
- Added `.toast-warning` (amber) and `.toast-info` (primary) variants.

### Bonus bug fixed
The old signature was `showToast(msg, isError=false)` — a strict boolean
check. `users.html` calls `showToast('Activation email sent', 'success')`.
Since `'success'` is truthy, **success toasts on that page were
rendering as error toasts**. The new variant-string handling fixes
this automatically.

## Tests
`tests/test_toast_prominence.py` — 5 source-level checks that lock in
the new contract:
1. `showToast` accepts string variants.
2. Toasts emit a dismiss button.
3. Error toasts linger ≥ 6s.
4. `.toast-error` uses the `shakeIn` animation.
5. Error toasts set `role="alert"` / `aria-live="assertive"`.

All 5 pass locally. No backend changes.

## Risk
Purely frontend. `color-mix()` is supported everywhere Chromium 111+ /
Firefox 113+ / Safari 16.2+ runs; older browsers just fall back to the
plain `var(--surface)` background which still has the red border.
