### PR TITLE
fix(audit): make JSONB.details queries portable on SQLite

### DIFF
--- a/cms/services/json_compat.py
+++ b/cms/services/json_compat.py
@@ -1,0 +1,63 @@
+"""Dialect-portable JSON key-extraction helpers.
+
+SQLAlchemy's Postgres ``JSONB.Comparator`` exposes ``.astext`` which
+compiles to ``col ->> 'key'``.  On SQLite (used in the test suite),
+``details[key]`` yields a generic JSON comparator that has no
+``astext`` attribute, so any query that uses it raises
+``AttributeError`` at build time.
+
+``json_as_text(col, key)`` returns an expression that compiles to:
+
+* PostgreSQL: ``col ->> 'key'`` (identical to ``.astext``)
+* SQLite:     ``json_extract(col, '$.key')`` (returns unquoted TEXT)
+* Other:      best-effort ``json_extract`` fallback (same as SQLite)
+
+Use it anywhere we need to read a string out of a ``JSON``/``JSONB``
+column in a query that should run on both Postgres (prod) and SQLite
+(tests).
+"""
+from __future__ import annotations
+
+from sqlalchemy import String
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
+
+
+class _JsonAsText(expression.FunctionElement):
+    """SQL expression node representing ``col ->> key`` as portable TEXT."""
+
+    type = String()
+    inherit_cache = True
+    name = "json_as_text"
+
+
+@compiles(_JsonAsText, "postgresql")
+def _json_as_text_pg(element, compiler, **kw):  # pragma: no cover - exercised in prod
+    col, key = list(element.clauses)
+    return "(%s ->> %s)" % (compiler.process(col, **kw), compiler.process(key, **kw))
+
+
+@compiles(_JsonAsText, "sqlite")
+def _json_as_text_sqlite(element, compiler, **kw):
+    col, key = list(element.clauses)
+    # json_extract with a string key returns an unquoted TEXT value for
+    # string-typed JSON leaves — which matches Postgres's ->> behaviour.
+    return "json_extract(%s, '$.' || %s)" % (
+        compiler.process(col, **kw),
+        compiler.process(key, **kw),
+    )
+
+
+@compiles(_JsonAsText)
+def _json_as_text_default(element, compiler, **kw):
+    # Fallback: same as SQLite; most modern RDBMSes have json_extract.
+    col, key = list(element.clauses)
+    return "json_extract(%s, '$.' || %s)" % (
+        compiler.process(col, **kw),
+        compiler.process(key, **kw),
+    )
+
+
+def json_as_text(col, key: str):
+    """Portable ``col ->> 'key'`` returning TEXT on Postgres and SQLite."""
+    return _JsonAsText(col, expression.literal(key))

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from itsdangerous import URLSafeTimedSerializer
-from sqlalchemy import func, select
+from sqlalchemy import String, cast, func, select
 import sqlalchemy
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -49,6 +49,7 @@ from cms.models.group_asset import GroupAsset
 from cms.models.user import User, UserGroup
 from cms.services.device_manager import device_manager
 from cms.services.audit_service import audit_log
+from cms.services.json_compat import json_as_text
 from cms.services.version_checker import get_latest_device_version, is_update_available
 from cms.routers.devices import _upgrading as _devices_upgrading
 
@@ -2093,7 +2094,7 @@ async def audit_page(
             conditions.append(AuditLog.user_id == uid)
         except ValueError:
             conditions.append(
-                AuditLog.details["actor_username"].astext == uval
+                json_as_text(AuditLog.details, "actor_username") == uval
             )
     if since.strip():
         from datetime import datetime as _dt
@@ -2160,11 +2161,12 @@ async def audit_page(
             user_map[str(u.id)] = u.display_name or u.username
 
     # Also pull distinct actor_username from details JSON
+    _actor_text = json_as_text(AuditLog.details, "actor_username")
     actor_result = await db.execute(
-        select(AuditLog.details["actor_username"].astext)
+        select(_actor_text)
         .distinct()
-        .where(AuditLog.details["actor_username"].astext.isnot(None))
-        .where(AuditLog.details["actor_username"].astext != "")
+        .where(_actor_text.isnot(None))
+        .where(_actor_text != "")
     )
     for r in actor_result.all():
         name = r[0]

--- a/tests/test_json_compat.py
+++ b/tests/test_json_compat.py
@@ -1,0 +1,69 @@
+"""Unit tests for the dialect-portable ``json_as_text`` helper.
+
+The helper replaces PostgreSQL-only ``JSONB.Comparator.astext`` so queries
+that extract a string value out of a JSON(B) column compile cleanly on
+both production (Postgres) and the test suite (SQLite).
+"""
+from __future__ import annotations
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from cms.services.json_compat import json_as_text
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class _Row(_Base):
+    __tablename__ = "rows"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    details: Mapped[dict] = mapped_column(JSONB)
+
+
+def _compile(dialect_url: str, stmt) -> str:
+    eng = create_engine(dialect_url)
+    return str(
+        stmt.compile(
+            dialect=eng.dialect, compile_kwargs={"literal_binds": True}
+        )
+    )
+
+
+def test_compiles_to_arrow_arrow_on_postgres():
+    stmt = select(json_as_text(_Row.details, "actor_username"))
+    sql = _compile("postgresql://", stmt)
+    # Postgres idiom: col ->> 'key'
+    assert "->>" in sql
+    assert "actor_username" in sql
+    # Must not leak sqlite's json_extract
+    assert "json_extract" not in sql.lower()
+
+
+def test_compiles_to_json_extract_on_sqlite():
+    stmt = select(json_as_text(_Row.details, "actor_username"))
+    sql = _compile("sqlite:///:memory:", stmt)
+    # SQLite idiom: json_extract(col, '$.key')
+    assert "json_extract" in sql.lower()
+    assert "actor_username" in sql
+    # Must not leak postgres operator
+    assert "->>" not in sql
+
+
+def test_usable_in_where_and_distinct():
+    """Regression guard — the original AttributeError fired when building
+    these clauses, never mind compiling them."""
+    expr = json_as_text(_Row.details, "actor_username")
+    # These must all be legal at query-build time on every dialect.
+    stmt = (
+        select(expr)
+        .distinct()
+        .where(expr.isnot(None))
+        .where(expr != "")
+        .where(expr == "alice")
+    )
+    # And compile on both dialects.
+    _compile("postgresql://", stmt)
+    _compile("sqlite:///:memory:", stmt)


### PR DESCRIPTION
## Problem
All 9 `TestAuditUI` tests in `tests/test_audit_log.py` were failing on
SQLite with:

```
AttributeError: 'Comparator' object has no attribute 'astext'
  at cms/ui.py:2164
  select(AuditLog.details["actor_username"].astext)
```

`AuditLog.details` is typed `JSONB` (from
`sqlalchemy.dialects.postgresql`). Under Postgres the comparator exposes
`.astext` which compiles to `col ->> 'key'`. Under SQLite the comparator
falls back to generic JSON, which has no `.astext` attribute — so the
expression raises `AttributeError` at *query-build* time, never mind
compile time.

## Fix
Added `cms/services/json_compat.py` with a dialect-portable
`json_as_text(col, key)` helper. It's a small SQLAlchemy
`FunctionElement` + `@compiles` dispatcher:

| Dialect | Emitted SQL |
|---|---|
| `postgresql` | `(col ->> 'key')` — identical semantics to `.astext` |
| `sqlite` | `json_extract(col, '$.' || 'key')` — returns unquoted TEXT |
| default | `json_extract` fallback (covers MySQL 5.7+ etc.) |

Replaced the three `.astext` call-sites in `cms/ui.py :: audit_page`
(lines ~2096 and ~2164–2167).

## Tests
- `tests/test_audit_log.py` — **43 pass** (was 9 fail / 34 pass).
- `tests/test_json_compat.py` — new, 3 checks:
  1. Compiles to `->>` on Postgres, not `json_extract`.
  2. Compiles to `json_extract` on SQLite, not `->>`.
  3. Build-time contract: `json_as_text(col, k)` is usable in `SELECT`,
     `WHERE expr.isnot(None)`, `WHERE expr != ""`, `.distinct()`, and
     equality comparisons on both dialects — guarding against the exact
     AttributeError pattern.

## Risk
- **Production (Postgres)**: emits the *same* SQL the old `.astext`
  produced. No behaviour change.
- **Tests (SQLite)**: now compiles successfully instead of erroring; the
  existing `TestAuditUI` assertions cover correctness.
