### PR TITLE
fix(schedules): scope End Now to the clicked device (#240)

### DIFF
--- a/alembic/versions/0002_schedule_device_skips.py
+++ b/alembic/versions/0002_schedule_device_skips.py
@@ -1,0 +1,39 @@
+"""per-device schedule skips
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-20
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '0002'
+down_revision: Union[str, None] = '0001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'schedule_device_skips',
+        sa.Column('schedule_id', sa.UUID(), nullable=False),
+        sa.Column('device_id', sa.String(length=64), nullable=False),
+        sa.Column('skip_until', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['schedule_id'], ['schedules.id'], ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['device_id'], ['devices.id'], ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('schedule_id', 'device_id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('schedule_device_skips')

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -10,6 +10,7 @@ from cms.models.group_asset import GroupAsset  # noqa: F401
 from cms.models.notification import Notification  # noqa: F401
 from cms.models.notification_pref import UserNotificationPref  # noqa: F401
 from cms.models.schedule import Schedule  # noqa: F401
+from cms.models.schedule_device_skip import ScheduleDeviceSkip  # noqa: F401
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent  # noqa: F401
 from cms.models.setting import CMSSetting  # noqa: F401
 from cms.models.user import Role, User, UserGroup  # noqa: F401

--- a/cms/models/schedule_device_skip.py
+++ b/cms/models/schedule_device_skip.py
@@ -1,0 +1,34 @@
+"""Per-device schedule skip ORM model.
+
+Used by the "End Now" feature so an operator can end a schedule for a single
+device without affecting other devices that share the same schedule (e.g. via
+a group target).  When ``device_id`` is used the scheduler skips just that
+device; a schedule-wide skip is still persisted on ``Schedule.skipped_until``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cms.database import Base
+
+
+class ScheduleDeviceSkip(Base):
+    __tablename__ = "schedule_device_skips"
+
+    schedule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("schedules.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    device_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("devices.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    skip_until: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -390,15 +390,35 @@ async def delete_schedule(schedule_id: uuid.UUID, request: Request, db: AsyncSes
 
 
 @router.post("/{schedule_id}/end-now", dependencies=[Depends(require_permission(SCHEDULES_WRITE))])
-async def end_schedule_now(schedule_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
+async def end_schedule_now(
+    schedule_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
     """End the current occurrence of a schedule immediately.
 
-    The schedule is skipped until its end_time today (or tomorrow for
+    Body (optional): ``{"device_id": "<id>"}`` — when provided, skips the
+    schedule only for that device; other devices keep playing.  When omitted,
+    the schedule is skipped for every target (legacy behavior).
+
+    The skip runs until the schedule's ``end_time`` today (or tomorrow for
     overnight spans), then resumes on its next regular occurrence.
     """
     from datetime import datetime, timezone
     from zoneinfo import ZoneInfo
     from cms.models.setting import CMSSetting
+    from cms.models.schedule_device_skip import ScheduleDeviceSkip
+
+    # Optional JSON body with device_id scoping
+    device_id: str | None = None
+    try:
+        body = await request.json()
+        if isinstance(body, dict):
+            raw = body.get("device_id")
+            if isinstance(raw, str) and raw.strip():
+                device_id = raw.strip()
+    except Exception:
+        device_id = None
 
     result = await db.execute(
         select(Schedule).options(*_eager_options()).where(Schedule.id == schedule_id)
@@ -422,30 +442,63 @@ async def end_schedule_now(schedule_id: uuid.UUID, request: Request, db: AsyncSe
     if schedule.end_time <= schedule.start_time:
         end_today += timedelta(days=1)
 
-    skip_schedule_until(str(schedule.id), end_today)
+    # Resolve targets so we can log + push, and (for per-device) verify scope
+    from cms.models.device import Device
+    target_ids = await _get_target_device_ids(schedule, db)
+    if device_id is not None and device_id not in target_ids:
+        raise HTTPException(
+            status_code=400,
+            detail="Device is not a target of this schedule",
+        )
+
+    affected_ids = [device_id] if device_id else target_ids
+
+    skip_schedule_until(str(schedule.id), end_today, device_id=device_id)
 
     # Persist to DB so it survives restarts
-    schedule.skipped_until = end_today
-    db.add(schedule)
+    if device_id is None:
+        schedule.skipped_until = end_today
+        db.add(schedule)
+    else:
+        # Upsert a per-device skip row
+        existing = await db.execute(
+            select(ScheduleDeviceSkip).where(
+                (ScheduleDeviceSkip.schedule_id == schedule.id)
+                & (ScheduleDeviceSkip.device_id == device_id)
+            )
+        )
+        row = existing.scalar_one_or_none()
+        if row is None:
+            db.add(ScheduleDeviceSkip(
+                schedule_id=schedule.id,
+                device_id=device_id,
+                skip_until=end_today,
+            ))
+        else:
+            row.skip_until = end_today
+            db.add(row)
+
+    scope = "all devices" if device_id is None else f"device {device_id}"
     await audit_log(
         db, user=getattr(request.state, "user", None),
         action="schedule.end_now", resource_type="schedule",
         resource_id=str(schedule_id),
-        description=f"Ended schedule '{schedule.name}' early (resumes at {end_today.isoformat()})",
-        details={"resumes_after": end_today.isoformat()},
+        description=f"Ended schedule '{schedule.name}' early for {scope} (resumes at {end_today.isoformat()})",
+        details={
+            "resumes_after": end_today.isoformat(),
+            "device_id": device_id,
+        },
         request=request,
     )
     await db.commit()
 
-    # Log SKIPPED event for each target device
-    from cms.models.device import Device
-    target_ids = await _get_target_device_ids(schedule, db)
-    if target_ids:
+    # Log SKIPPED event for each affected device
+    if affected_ids:
         name_q = await db.execute(
-            select(Device.id, Device.name).where(Device.id.in_(target_ids))
+            select(Device.id, Device.name).where(Device.id.in_(affected_ids))
         )
         dev_names = {r[0]: (r[1] or r[0]) for r in name_q.all()}
-        for did in target_ids:
+        for did in affected_ids:
             db.add(ScheduleLog(
                 schedule_id=schedule.id,
                 schedule_name=schedule.name,
@@ -457,9 +510,13 @@ async def end_schedule_now(schedule_id: uuid.UUID, request: Request, db: AsyncSe
             ))
         await db.commit()
 
-    # Clear sync hash and re-push so devices drop this schedule immediately
-    for did in target_ids:
+    # Clear sync hash and re-push so affected devices drop this schedule immediately
+    for did in affected_ids:
         clear_sync_hash(did)
         await push_sync_to_device(did, db)
 
-    return {"ended": str(schedule_id), "resumes_after": end_today.isoformat()}
+    return {
+        "ended": str(schedule_id),
+        "resumes_after": end_today.isoformat(),
+        "device_id": device_id,
+    }

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -36,13 +36,17 @@ _last_sync_hash: dict[str, str] = {}
 _confirmed_playing: dict[str, dict] = {}
 _now_playing = _confirmed_playing  # backwards-compat alias for tests
 
-# Skipped schedule occurrences: {schedule_id: skip_until_local_datetime}
+# Skipped schedule occurrences: {schedule_id: skip_until_local_datetime}.
+# Schedule-wide skips (applies to every device targeted by the schedule).
 _skipped: dict[str, datetime] = {}
+# Per-device skips: {(schedule_id, device_id): skip_until_local_datetime}.
+# Used when an operator ends a schedule for a single device via the dashboard.
+_device_skipped: dict[tuple[str, str], datetime] = {}
 _skipped_loaded: bool = False
 
 
 async def _ensure_skips_loaded(db) -> None:
-    """Load persisted skips from DB on first call after restart."""
+    """Load persisted skips (schedule-wide + per-device) from DB on first call."""
     global _skipped_loaded
     if _skipped_loaded:
         return
@@ -52,9 +56,37 @@ async def _ensure_skips_loaded(db) -> None:
     )
     for sid, until in skip_result.all():
         _skipped[str(sid)] = until.replace(tzinfo=None) if until.tzinfo else until
+
+    from cms.models.schedule_device_skip import ScheduleDeviceSkip
+    dev_skip_result = await db.execute(
+        select(
+            ScheduleDeviceSkip.schedule_id,
+            ScheduleDeviceSkip.device_id,
+            ScheduleDeviceSkip.skip_until,
+        )
+    )
+    for sid, did, until in dev_skip_result.all():
+        key = (str(sid), did)
+        _device_skipped[key] = until.replace(tzinfo=None) if until.tzinfo else until
+
     _skipped_loaded = True
-    if _skipped:
-        logger.info("Loaded %d persisted schedule skips from DB", len(_skipped))
+    if _skipped or _device_skipped:
+        logger.info(
+            "Loaded %d schedule skips and %d per-device skips from DB",
+            len(_skipped), len(_device_skipped),
+        )
+
+
+def is_schedule_skipped_for_device(schedule_id: str, device_id: str) -> bool:
+    """Return True if this schedule is currently skipped for the given device.
+
+    Covers both schedule-wide (``_skipped``) and per-device (``_device_skipped``)
+    skips.  The scheduler should treat a skipped schedule/device combo as if the
+    schedule were not active.
+    """
+    if schedule_id in _skipped:
+        return True
+    return (schedule_id, device_id) in _device_skipped
 
 # Track which schedule+device combos we've already logged as MISSED this eval cycle
 # Key: (schedule_id, device_id), cleared when the schedule/device combo resolves
@@ -134,18 +166,47 @@ def clear_now_playing(device_id: str) -> dict | None:
     return _confirmed_playing.pop(device_id, None)
 
 
-def skip_schedule_until(schedule_id: str, until: datetime) -> None:
-    """Skip a schedule's current occurrence until the given local datetime."""
-    _skipped[schedule_id] = until
-    # Remove from confirmed_playing immediately
-    to_remove = [did for did, info in _confirmed_playing.items() if info.get("schedule_id") == schedule_id]
-    for did in to_remove:
-        _confirmed_playing.pop(did, None)
+def skip_schedule_until(
+    schedule_id: str,
+    until: datetime,
+    device_id: str | None = None,
+) -> None:
+    """Skip a schedule until ``until``.
+
+    If ``device_id`` is omitted, the skip applies to every device targeted by
+    the schedule (legacy behavior).  If provided, only that device is skipped —
+    other devices on the same schedule continue to play.
+
+    The function also removes matching entries from ``_confirmed_playing`` so
+    the dashboard reflects the change immediately.
+    """
+    if device_id is None:
+        _skipped[schedule_id] = until
+        to_remove = [did for did, info in _confirmed_playing.items() if info.get("schedule_id") == schedule_id]
+        for did in to_remove:
+            _confirmed_playing.pop(did, None)
+        return
+
+    _device_skipped[(schedule_id, device_id)] = until
+    info = _confirmed_playing.get(device_id)
+    if info and info.get("schedule_id") == schedule_id:
+        _confirmed_playing.pop(device_id, None)
 
 
-def clear_schedule_skip(schedule_id: str) -> None:
-    """Remove any active skip for a schedule so it can be re-evaluated."""
-    _skipped.pop(schedule_id, None)
+def clear_schedule_skip(schedule_id: str, device_id: str | None = None) -> None:
+    """Remove an active skip so the schedule can be re-evaluated.
+
+    With ``device_id=None`` the schedule-wide skip AND all per-device skips
+    for this schedule are cleared.  With a specific ``device_id`` only that
+    one per-device skip is cleared.
+    """
+    if device_id is None:
+        _skipped.pop(schedule_id, None)
+        keys = [k for k in _device_skipped if k[0] == schedule_id]
+        for k in keys:
+            _device_skipped.pop(k, None)
+        return
+    _device_skipped.pop((schedule_id, device_id), None)
 
 
 def clear_sync_hash(device_id: str) -> None:
@@ -187,7 +248,7 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
     if not active:
         return []
 
-    # Resolve target devices for each active schedule
+    # Resolve target devices for each active schedule (filter per-device skips)
     now_playing = []
     live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
 
@@ -198,6 +259,13 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
         if not s.asset:
             continue
         target_ids = await _get_target_device_ids(s, db)
+        # Drop any device with an active per-device skip on this schedule
+        target_ids = [
+            did for did in target_ids
+            if (str(s.id), did) not in _device_skipped
+        ]
+        if not target_ids:
+            continue
         schedule_targets.append((s, target_ids))
         all_device_ids.update(target_ids)
 
@@ -736,7 +804,8 @@ async def build_device_sync(device_id: str, db) -> SyncMessage | None:
         target_ids = await _get_target_device_ids(s, db)
         if device_id in target_ids:
             # Skip if this schedule's current occurrence is being skipped
-            if str(s.id) in _skipped:
+            # (either schedule-wide, or just for this device).
+            if is_schedule_skipped_for_device(str(s.id), device_id):
                 continue
             entries.append(_schedule_to_entry(s, variant_checksums))
 
@@ -824,7 +893,7 @@ async def evaluate_schedules() -> None:
         )
         schedules = result.scalars().all()
 
-        # Purge expired skips (memory + DB)
+        # Purge expired skips (memory + DB) — schedule-wide
         expired = [sid for sid, until in _skipped.items() if local_now >= until]
         for sid in expired:
             _skipped.pop(sid, None)
@@ -838,6 +907,22 @@ async def evaluate_schedules() -> None:
             for did in connected:
                 _last_sync_hash.pop(did, None)
         if expired:
+            await db.commit()
+
+        # Purge expired per-device skips
+        from cms.models.schedule_device_skip import ScheduleDeviceSkip
+        dev_expired = [k for k, until in _device_skipped.items() if local_now >= until]
+        for key in dev_expired:
+            _device_skipped.pop(key, None)
+            sid, did = key
+            await db.execute(
+                ScheduleDeviceSkip.__table__.delete().where(
+                    (ScheduleDeviceSkip.schedule_id == sid)
+                    & (ScheduleDeviceSkip.device_id == did)
+                )
+            )
+            _last_sync_hash.pop(did, None)
+        if dev_expired:
             await db.commit()
 
         active = [
@@ -860,6 +945,10 @@ async def evaluate_schedules() -> None:
             target_ids = await _get_target_device_ids(s, db)
             for did in target_ids:
                 key = (str(s.id), did)
+                # Don't flag MISSED for a device whose skip is active.
+                if key in _device_skipped:
+                    _offline_since.pop(key, None)
+                    continue
                 if did in connected or did not in all_adopted:
                     # Device is online or not adopted — clear offline tracking
                     _offline_since.pop(key, None)

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -154,7 +154,7 @@
                 </td>
                 <td>{{ np.end_time }}</td>
                 <td data-remaining="{{ np.remaining_seconds }}">{{ np.remaining }}</td>
-                <td>{% if 'schedules:write' in user_perms %}<button class="btn btn-sm btn-danger" onclick="endNow('{{ np.schedule_id }}')">End Now</button>{% endif %}</td>
+                <td>{% if 'schedules:write' in user_perms %}<button class="btn btn-sm btn-danger" onclick="endNow('{{ np.schedule_id }}', '{{ np.device_id }}')">End Now</button>{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -289,10 +289,14 @@ window._adoptionProfiles = [
     {% endfor %}
 ];
 
-async function endNow(scheduleId) {
-    if (!await showConfirm('End this schedule now? It will resume at its next scheduled time.')) return;
+async function endNow(scheduleId, deviceId) {
+    if (!await showConfirm('End this schedule on this device now? It will resume at its next scheduled time.')) return;
     try {
-        const res = await fetch(`/api/schedules/${scheduleId}/end-now`, { method: 'POST' });
+        const res = await fetch(`/api/schedules/${scheduleId}/end-now`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(deviceId ? { device_id: deviceId } : {}),
+        });
         if (res.ok) location.reload();
         else showToast('Failed to end schedule', true);
     } catch (e) { showToast('Failed to end schedule', true); }

--- a/tests/test_end_now_per_device.py
+++ b/tests/test_end_now_per_device.py
@@ -1,0 +1,181 @@
+"""Tests for per-device End Now skips (issue #240).
+
+The End Now button on the dashboard should only affect the clicked device.
+Prior behavior skipped the schedule for every device in the target group.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, time, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from cms.models.asset import Asset, AssetType
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.schedule import Schedule
+from cms.models.schedule_device_skip import ScheduleDeviceSkip
+from cms.models.setting import CMSSetting
+from cms.services import scheduler as sched_mod
+from cms.services.scheduler import (
+    build_device_sync,
+    clear_schedule_skip,
+    is_schedule_skipped_for_device,
+    skip_schedule_until,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler_state():
+    """Per-test isolation for module-level skip dicts."""
+    sched_mod._skipped.clear()
+    sched_mod._device_skipped.clear()
+    sched_mod._skipped_loaded = False
+    yield
+    sched_mod._skipped.clear()
+    sched_mod._device_skipped.clear()
+    sched_mod._skipped_loaded = False
+
+
+class TestInMemorySkipHelpers:
+    def test_schedule_wide_skip(self):
+        sid = str(uuid.uuid4())
+        until = datetime(2030, 1, 1, 12, 0)
+        skip_schedule_until(sid, until)
+        assert is_schedule_skipped_for_device(sid, "dev-a")
+        assert is_schedule_skipped_for_device(sid, "dev-b")
+
+    def test_per_device_skip_isolation(self):
+        sid = str(uuid.uuid4())
+        until = datetime(2030, 1, 1, 12, 0)
+        skip_schedule_until(sid, until, device_id="dev-a")
+        assert is_schedule_skipped_for_device(sid, "dev-a")
+        assert not is_schedule_skipped_for_device(sid, "dev-b")
+
+    def test_schedule_wide_overrides_per_device(self):
+        sid = str(uuid.uuid4())
+        until = datetime(2030, 1, 1, 12, 0)
+        skip_schedule_until(sid, until, device_id="dev-a")
+        skip_schedule_until(sid, until)  # schedule-wide
+        assert is_schedule_skipped_for_device(sid, "dev-a")
+        assert is_schedule_skipped_for_device(sid, "dev-b")
+
+    def test_clear_device_skip_only(self):
+        sid = str(uuid.uuid4())
+        until = datetime(2030, 1, 1, 12, 0)
+        skip_schedule_until(sid, until, device_id="dev-a")
+        skip_schedule_until(sid, until, device_id="dev-b")
+        clear_schedule_skip(sid, device_id="dev-a")
+        assert not is_schedule_skipped_for_device(sid, "dev-a")
+        assert is_schedule_skipped_for_device(sid, "dev-b")
+
+    def test_clear_all_drops_per_device_skips(self):
+        sid = str(uuid.uuid4())
+        until = datetime(2030, 1, 1, 12, 0)
+        skip_schedule_until(sid, until, device_id="dev-a")
+        skip_schedule_until(sid, until, device_id="dev-b")
+        clear_schedule_skip(sid)
+        assert not is_schedule_skipped_for_device(sid, "dev-a")
+        assert not is_schedule_skipped_for_device(sid, "dev-b")
+
+    def test_per_device_skip_clears_only_that_confirmed_playing(self):
+        sid = str(uuid.uuid4())
+        sched_mod._confirmed_playing["dev-a"] = {"schedule_id": sid, "since": "t"}
+        sched_mod._confirmed_playing["dev-b"] = {"schedule_id": sid, "since": "t"}
+        skip_schedule_until(sid, datetime(2030, 1, 1, 12, 0), device_id="dev-a")
+        assert "dev-a" not in sched_mod._confirmed_playing
+        assert "dev-b" in sched_mod._confirmed_playing
+        sched_mod._confirmed_playing.clear()
+
+    def test_schedule_wide_skip_clears_all_confirmed_playing(self):
+        sid = str(uuid.uuid4())
+        sched_mod._confirmed_playing["dev-a"] = {"schedule_id": sid, "since": "t"}
+        sched_mod._confirmed_playing["dev-b"] = {"schedule_id": sid, "since": "t"}
+        skip_schedule_until(sid, datetime(2030, 1, 1, 12, 0))
+        assert "dev-a" not in sched_mod._confirmed_playing
+        assert "dev-b" not in sched_mod._confirmed_playing
+        sched_mod._confirmed_playing.clear()
+
+
+@pytest.mark.asyncio
+class TestPerDeviceSkipAgainstDB:
+    @pytest_asyncio.fixture
+    async def db(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+        async with factory() as session:
+            yield session
+
+    async def _setup(self, db):
+        """Two devices in one group sharing one schedule."""
+        db.add(CMSSetting(key="timezone", value="UTC"))
+        asset = Asset(
+            filename="v.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1, checksum="c",
+        )
+        group = DeviceGroup(name="Lobby")
+        db.add_all([asset, group])
+        await db.flush()
+        d1 = Device(id="pi-240-a", name="A", status=DeviceStatus.ADOPTED, group_id=group.id)
+        d2 = Device(id="pi-240-b", name="B", status=DeviceStatus.ADOPTED, group_id=group.id)
+        db.add_all([d1, d2])
+        sched = Schedule(
+            name="Always",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+        )
+        db.add(sched)
+        await db.commit()
+        return sched, d1, d2
+
+    async def test_build_sync_drops_schedule_only_for_skipped_device(self, db):
+        """Skipping for device A must not affect device B's sync."""
+        sched, d1, d2 = await self._setup(db)
+        skip_schedule_until(str(sched.id), datetime(2099, 1, 1), device_id=d1.id)
+
+        sync_a = await build_device_sync(d1.id, db)
+        sync_b = await build_device_sync(d2.id, db)
+
+        assert sync_a is not None and len(sync_a.schedules) == 0
+        assert sync_b is not None and len(sync_b.schedules) == 1
+        assert sync_b.schedules[0].name == "Always"
+
+    async def test_build_sync_honors_schedule_wide_skip(self, db):
+        """Schedule-wide skip still removes schedule from every device."""
+        sched, d1, d2 = await self._setup(db)
+        skip_schedule_until(str(sched.id), datetime(2099, 1, 1))
+
+        sync_a = await build_device_sync(d1.id, db)
+        sync_b = await build_device_sync(d2.id, db)
+
+        assert len(sync_a.schedules) == 0
+        assert len(sync_b.schedules) == 0
+
+    async def test_persisted_per_device_skip_is_loaded_on_first_use(self, db):
+        """_ensure_skips_loaded picks up schedule_device_skips rows."""
+        sched, d1, d2 = await self._setup(db)
+        db.add(ScheduleDeviceSkip(
+            schedule_id=sched.id,
+            device_id=d1.id,
+            skip_until=datetime(2099, 1, 1),
+        ))
+        await db.commit()
+
+        # Simulate cold boot: wipe in-memory, then trigger a build that loads
+        sched_mod._device_skipped.clear()
+        sched_mod._skipped_loaded = False
+
+        # Force the load and verify it populated the dict
+        await sched_mod._ensure_skips_loaded(db)
+        assert (str(sched.id), d1.id) in sched_mod._device_skipped, (
+            f"expected ({str(sched.id)!r}, {d1.id!r}) in {sched_mod._device_skipped}"
+        )
+
+        sync_a = await build_device_sync(d1.id, db)
+        sync_b = await build_device_sync(d2.id, db)
+
+        assert len(sync_a.schedules) == 0
+        assert len(sync_b.schedules) == 1

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -588,3 +588,106 @@ class TestEndNowClearedOnEdit:
         # Toggle enabled off then on
         await client.patch(f"/api/schedules/{sched_id}", json={"enabled": False})
         assert sched_id not in _skipped
+
+
+@pytest.mark.asyncio
+class TestEndNowPerDevice:
+    """Issue #240: End Now on one device must not stop the schedule on others."""
+
+    async def _seed_two_devices(self, db_session):
+        from cms.models.asset import Asset, AssetType
+        from cms.models.device import Device, DeviceGroup, DeviceStatus
+
+        group = DeviceGroup(name="Two Device Group")
+        d1 = Device(id="pi-240-a", name="A", status=DeviceStatus.ADOPTED)
+        d2 = Device(id="pi-240-b", name="B", status=DeviceStatus.ADOPTED)
+        asset = Asset(filename="p.mp4", asset_type=AssetType.VIDEO, size_bytes=1, checksum="c")
+        db_session.add_all([group, d1, d2, asset])
+        await db_session.flush()
+        d1.group_id = group.id
+        d2.group_id = group.id
+        await db_session.commit()
+        return str(group.id), str(asset.id), d1.id, d2.id
+
+    async def test_end_now_with_device_id_scopes_skip(self, client, db_session):
+        from cms.services import scheduler as sched_mod
+        from cms.models.schedule_device_skip import ScheduleDeviceSkip
+        from sqlalchemy import select
+
+        group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)
+
+        created = await client.post("/api/schedules", json={
+            "name": "Per-Device End Now",
+            "group_id": group_id,
+            "asset_id": asset_id,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        assert created.status_code == 201
+        sched_id = created.json()["id"]
+
+        sched_mod._skipped.clear()
+        sched_mod._device_skipped.clear()
+
+        resp = await client.post(
+            f"/api/schedules/{sched_id}/end-now",
+            json={"device_id": dev_a},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["device_id"] == dev_a
+
+        # Schedule-wide skip must NOT be set; per-device skip must be set.
+        assert sched_id not in sched_mod._skipped
+        assert (sched_id, dev_a) in sched_mod._device_skipped
+        assert (sched_id, dev_b) not in sched_mod._device_skipped
+
+        # And persisted to DB
+        import uuid
+        rows = (await db_session.execute(
+            select(ScheduleDeviceSkip.device_id).where(
+                ScheduleDeviceSkip.schedule_id == uuid.UUID(sched_id)
+            )
+        )).scalars().all()
+        assert rows == [dev_a]
+
+    async def test_end_now_without_body_still_schedule_wide(self, client, db_session):
+        """Back-compat: POST with no body skips all devices on the schedule."""
+        from cms.services import scheduler as sched_mod
+
+        group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)
+
+        created = await client.post("/api/schedules", json={
+            "name": "No Body End Now",
+            "group_id": group_id,
+            "asset_id": asset_id,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        sched_id = created.json()["id"]
+
+        sched_mod._skipped.clear()
+        sched_mod._device_skipped.clear()
+
+        resp = await client.post(f"/api/schedules/{sched_id}/end-now")
+        assert resp.status_code == 200
+        assert sched_id in sched_mod._skipped
+        assert not any(k[0] == sched_id for k in sched_mod._device_skipped)
+
+    async def test_end_now_rejects_unknown_device(self, client, db_session):
+        group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)
+
+        created = await client.post("/api/schedules", json={
+            "name": "Bad Device End Now",
+            "group_id": group_id,
+            "asset_id": asset_id,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        sched_id = created.json()["id"]
+
+        resp = await client.post(
+            f"/api/schedules/{sched_id}/end-now",
+            json={"device_id": "not-a-target"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Fixes #240

When a schedule targets a group with multiple devices, clicking **End Now** on
one device row on the dashboard stopped the schedule for *every* device in
that group. The button only passed `scheduleId`, and the server always wrote
`Schedule.skipped_until`, which scopes to the schedule, not the device.

## Fix

Add an optional **per-device** skip alongside the existing schedule-wide skip.

- New table `schedule_device_skips` with composite PK `(schedule_id, device_id)`
  and cascade FKs — Alembic migration `0002`.
- New scheduler state `_device_skipped: dict[(schedule_id, device_id), until]`
  loaded from the DB on first use, purged on expiry.
- `skip_schedule_until(sid, until, device_id=None)` — schedule-wide when
  `device_id` is `None` (back-compat), else per-device.
- All six skip check-sites updated (`compute_now_playing`, `build_device_sync`,
  `evaluate_schedules` purge, MISSED detection, etc.).
- `POST /api/schedules/{id}/end-now` accepts optional JSON body
  `{"device_id": "..."}`. Empty body keeps old behavior. Returns `400` if the
  device isn't one of the schedule's resolved targets.
- Dashboard template passes `np.device_id` to `endNow()`, which POSTs JSON.

Schedule-wide skip still wins if both are set (simpler precedence, matches
user expectation that "stop the whole schedule" overrides any per-device
exception).

## Back-compat

- API: no body ⇒ same schedule-wide skip as before.
- Scheduler: `_skipped` kept; `is_schedule_skipped_for_device` returns true
  if either is active.
- Existing `TestEndNowClearedOnEdit` tests still pass unchanged.

## Tests

- `tests/test_end_now_per_device.py` — 10 unit tests covering helpers,
  `build_device_sync` DB-backed behavior, and cold-boot persisted-load.
- `tests/test_schedules.py::TestEndNowPerDevice` — 3 API tests:
  - per-device `end-now` scopes the skip (memory + DB)
  - no body stays schedule-wide (back-compat)
  - unknown `device_id` ⇒ 400

Suite: `pytest tests/test_schedules.py tests/test_end_now_per_device.py` →
**40 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
