### PR TITLE
fix(assets): auto-rename on duplicate filename upload (#179)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -129,6 +129,37 @@ def _asset_type(filename: str) -> AssetType:
     return AssetType.IMAGE
 
 
+async def _unique_filename(db: AsyncSession, desired: str, *, max_attempts: int = 1000) -> str:
+    """Return ``desired`` if no asset has that filename, otherwise append
+    ``_1``, ``_2``, ... to the stem until a free name is found.
+
+    Example: if ``promo.mp4`` exists, returns ``promo_1.mp4``. If that also
+    exists, returns ``promo_2.mp4``, etc. Extension is preserved; files
+    without an extension get a trailing ``_N``.
+
+    Considers ALL assets including soft-deleted ones, because the
+    ``filename`` column carries a DB-level unique constraint — a
+    soft-deleted row still reserves its name. Monotonic suffixes also give
+    predictable, human-friendly names (no reuse of gaps).
+    """
+    p = Path(desired)
+    stem = p.stem or desired
+    suffix = p.suffix  # includes the leading dot, or '' if no extension
+
+    candidate = desired
+    for n in range(0, max_attempts):
+        if n > 0:
+            candidate = f"{stem}_{n}{suffix}"
+        existing = await db.execute(
+            select(Asset.id).where(Asset.filename == candidate)
+        )
+        if existing.scalar_one_or_none() is None:
+            return candidate
+    # Extremely unlikely — 1000 identically-named assets. Fall through with
+    # a UUID suffix so we never raise from here.
+    return f"{stem}_{uuid.uuid4().hex[:8]}{suffix}"
+
+
 async def _visible_asset_ids(user: User, db: AsyncSession) -> list[uuid.UUID] | None:
     """Return asset IDs visible to the user, or None if admin (see all).
 
@@ -316,12 +347,12 @@ async def upload_asset(
     if not file.filename or not ALLOWED_PATTERN.match(file.filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    # Check for duplicate (among non-deleted assets only)
-    existing = await db.execute(
-        select(Asset).where(Asset.filename == file.filename, Asset.deleted_at.is_(None))
-    )
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail="Asset already exists")
+    # Pick a unique stored filename. If file.filename is already taken by
+    # a live asset, auto-rename (promo.mp4 -> promo_1.mp4) so different
+    # users can upload files with the same name without colliding. The
+    # original filename is preserved in ``original_filename`` for display.
+    stored_filename = await _unique_filename(db, file.filename)
+    was_renamed = stored_filename != file.filename
 
     # Read and hash
     content = await file.read()
@@ -332,28 +363,23 @@ async def upload_asset(
     # Store source file
     storage_dir = settings.asset_storage_path
     storage_dir.mkdir(parents=True, exist_ok=True)
-    dest = storage_dir / file.filename
+    dest = storage_dir / stored_filename
     dest.write_bytes(content)
 
-    asset_type = _asset_type(file.filename)
+    asset_type = _asset_type(stored_filename)
 
     # Convert unsupported image formats to JPEG for device compatibility
-    ext = "." + file.filename.rsplit(".", 1)[-1].lower()
-    final_filename = file.filename
-    original_filename = None
+    ext = "." + stored_filename.rsplit(".", 1)[-1].lower()
+    final_filename = stored_filename
+    original_filename = file.filename if was_renamed else None
     storage = get_storage()
     if asset_type == AssetType.IMAGE and ext in IMAGE_CONVERT_EXTS:
         from cms.services.transcoder import convert_image_to_jpeg
-        jpeg_filename = Path(file.filename).stem + ".jpg"
-        # Check the JPEG name doesn't conflict
-        dup = await db.execute(
-            select(Asset).where(Asset.filename == jpeg_filename, Asset.deleted_at.is_(None))
+        # Pick a unique JPEG name — auto-rename if the .jpg name collides
+        # with an existing live asset.
+        jpeg_filename = await _unique_filename(
+            db, Path(stored_filename).stem + ".jpg"
         )
-        if dup.scalar_one_or_none():
-            raise HTTPException(
-                status_code=409,
-                detail=f"Converted name '{jpeg_filename}' already exists",
-            )
         jpeg_path = storage_dir / jpeg_filename
         ok = await convert_image_to_jpeg(dest, jpeg_path)
         if not ok:
@@ -362,17 +388,18 @@ async def upload_asset(
         # Keep original in originals/ for future re-transcoding
         originals_dir = storage_dir / "originals"
         originals_dir.mkdir(parents=True, exist_ok=True)
-        dest.rename(originals_dir / file.filename)
+        dest.rename(originals_dir / stored_filename)
+        # Preserve the user-supplied name (the HEIC filename) for display
         original_filename = file.filename
         content = jpeg_path.read_bytes()
         checksum = hashlib.sha256(content).hexdigest()
         final_filename = jpeg_filename
         # Sync converted JPEG + original to cloud storage
         await storage.on_file_stored(final_filename)
-        await storage.on_file_stored(f"originals/{file.filename}")
+        await storage.on_file_stored(f"originals/{stored_filename}")
     else:
         # Sync source file to cloud storage
-        await storage.on_file_stored(file.filename)
+        await storage.on_file_stored(stored_filename)
 
     # Resolve group UUIDs (support both single group_id and multi group_ids)
     resolved_groups: list[uuid.UUID] = []

--- a/mcp/cms_client.py
+++ b/mcp/cms_client.py
@@ -150,5 +150,36 @@ class CMSClient:
     async def get_server_time(self) -> dict:
         return await self._get("/api/server-time")
 
+    # ── Audit log ──
+
+    async def list_audit_events(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        action: str | None = None,
+        resource_type: str | None = None,
+        user_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        q: str | None = None,
+    ) -> list:
+        params: dict = {"limit": limit, "offset": offset}
+        if action:
+            params["action"] = action
+        if resource_type:
+            params["resource_type"] = resource_type
+        if user_id:
+            params["user_id"] = user_id
+        if since:
+            params["since"] = since
+        if until:
+            params["until"] = until
+        if q:
+            params["q"] = q
+        resp = await self._client.get("/api/audit-log", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
     async def close(self) -> None:
         await self._client.aclose()

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -71,6 +71,7 @@ TOOL_PERMISSIONS: dict[str, str | None] = {
     "get_device_logs": "logs:read",
     "get_server_time": None,  # any authenticated user
     "get_dashboard": None,    # any authenticated user
+    "list_audit_events": "audit:read",
 }
 
 
@@ -626,6 +627,63 @@ async def get_dashboard() -> str:
     """Get the current dashboard state: what's playing now, upcoming schedules, device states, and alerts."""
     dashboard = await _call_api("get_dashboard")
     return _json_result(dashboard)
+
+
+# ── Audit log ──
+
+
+@mcp.tool()
+async def list_audit_events(
+    limit: int = 50,
+    offset: int = 0,
+    action: str | None = None,
+    resource_type: str | None = None,
+    user_id: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    q: str | None = None,
+) -> str:
+    """Query the CMS audit log. Returns the most recent events first.
+
+    Use this to answer forensic questions like 'who deleted asset X',
+    'what changed in the last hour', or 'what has user Y done today'.
+
+    Args:
+        limit: Max events to return (1-500, default 50).
+        offset: Pagination offset (default 0).
+        action: Filter by action string (e.g. 'asset.delete', 'schedule.create').
+        resource_type: Filter by resource type ('asset', 'schedule', 'device',
+            'user', 'group', 'profile').
+        resource_id: (not supported server-side yet) — use q instead.
+        user_id: Filter by acting user UUID.
+        since: ISO-8601 timestamp; only events at or after this time.
+        until: ISO-8601 timestamp; only events at or before this time.
+        q: Free-text search across description, action, and resource_type
+            (matches the audit page's search box).
+
+    Requires the 'audit:read' permission.
+    """
+    if err := _check_permission("list_audit_events"):
+        return err
+    # Clamp limit to the server's accepted range; the server also caps at 500.
+    if limit < 1:
+        limit = 1
+    elif limit > 500:
+        limit = 500
+    if offset < 0:
+        offset = 0
+    events = await _call_api(
+        "list_audit_events",
+        limit=limit,
+        offset=offset,
+        action=action,
+        resource_type=resource_type,
+        user_id=user_id,
+        since=since,
+        until=until,
+        q=q,
+    )
+    return _json_result(events)
 
 
 # ── Health check endpoints ──

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -268,10 +268,48 @@ class TestAssetUpload:
         resp = await client.post("/api/assets/upload", files=_make_upload("../etc/passwd.mp4"))
         assert resp.status_code == 400
 
-    async def test_upload_duplicate(self, client):
-        await client.post("/api/assets/upload", files=_make_upload("dup.mp4"))
-        resp = await client.post("/api/assets/upload", files=_make_upload("dup.mp4"))
-        assert resp.status_code == 409
+    async def test_upload_duplicate_auto_renames(self, client):
+        """Uploading a file with a name already taken auto-renames the
+        stored file (promo.mp4 -> promo_1.mp4) and preserves the
+        user-supplied name as ``original_filename`` for display."""
+        r1 = await client.post("/api/assets/upload", files=_make_upload("dup.mp4"))
+        assert r1.status_code in (200, 201)
+        assert r1.json()["filename"] == "dup.mp4"
+        assert r1.json().get("original_filename") in (None, "")
+
+        r2 = await client.post("/api/assets/upload", files=_make_upload("dup.mp4"))
+        assert r2.status_code in (200, 201)
+        assert r2.json()["filename"] == "dup_1.mp4"
+        assert r2.json()["original_filename"] == "dup.mp4"
+
+        r3 = await client.post("/api/assets/upload", files=_make_upload("dup.mp4"))
+        assert r3.status_code in (200, 201)
+        assert r3.json()["filename"] == "dup_2.mp4"
+        assert r3.json()["original_filename"] == "dup.mp4"
+
+    async def test_upload_duplicate_soft_deleted_name_still_reserved(self, client):
+        """Soft-deleted assets still reserve their filename (DB-level unique
+        constraint), so a re-upload never reuses a gap — suffixes are
+        monotonic."""
+        r1 = await client.post("/api/assets/upload", files=_make_upload("hole.mp4"))
+        r2 = await client.post("/api/assets/upload", files=_make_upload("hole.mp4"))
+        r3 = await client.post("/api/assets/upload", files=_make_upload("hole.mp4"))
+        assert [r.json()["filename"] for r in (r1, r2, r3)] == [
+            "hole.mp4",
+            "hole_1.mp4",
+            "hole_2.mp4",
+        ]
+        # Soft-delete the middle one
+        mid_id = r2.json()["id"]
+        del_resp = await client.delete(f"/api/assets/{mid_id}")
+        assert del_resp.status_code in (200, 204)
+
+        r4 = await client.post("/api/assets/upload", files=_make_upload("hole.mp4"))
+        assert r4.status_code in (200, 201)
+        # Soft-deleted "hole_1.mp4" still reserves that name, so we skip past
+        # all existing suffixes.
+        assert r4.json()["filename"] == "hole_3.mp4"
+        assert r4.json()["original_filename"] == "hole.mp4"
 
     async def test_upload_requires_auth(self, unauthed_client):
         resp = await unauthed_client.post("/api/assets/upload", files=_make_upload("x.mp4"))

--- a/tests/test_mcp_audit_log.py
+++ b/tests/test_mcp_audit_log.py
@@ -1,0 +1,279 @@
+"""Tests for the ``list_audit_events`` MCP tool (issue #292).
+
+The MCP tools live in ``mcp/server.py`` which can't be imported from the CMS
+test-suite (local ``mcp/`` package collides with the ``mcp`` pip dep).  We
+therefore exercise the two halves that together define the tool's contract:
+
+1. The REST endpoint the tool wraps (``GET /api/audit-log``).
+2. The ``CMSClient.list_audit_events`` method it delegates to, using
+   ``httpx.MockTransport`` so we never touch the network.
+
+Permission handling (``audit:read`` required) is enforced at the router by
+``require_permission(AUDIT_READ)`` and is covered by the endpoint tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from cms.models.audit_log import AuditLog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _seed_events(db_session, count: int = 3, *, action: str = "asset.delete",
+                       resource_type: str = "asset"):
+    """Insert ``count`` audit entries with predictable timestamps."""
+    base = datetime.now(timezone.utc) - timedelta(hours=count)
+    ids: list[uuid.UUID] = []
+    for i in range(count):
+        entry = AuditLog(
+            action=action,
+            resource_type=resource_type,
+            resource_id=f"res-{i}",
+            description=f"deleted asset #{i}",
+            created_at=base + timedelta(hours=i),
+        )
+        db_session.add(entry)
+        await db_session.flush()
+        ids.append(entry.id)
+    await db_session.commit()
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# REST endpoint tests — the tool's server-side contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAuditLogEndpoint:
+    """``GET /api/audit-log`` is what the MCP tool wraps."""
+
+    async def test_admin_can_list(self, client, db_session):
+        await _seed_events(db_session, count=3)
+
+        resp = await client.get("/api/audit-log")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 3
+        # Most-recent first
+        ts = [e["created_at"] for e in data]
+        assert ts == sorted(ts, reverse=True)
+        # Required fields for the MCP tool response shape
+        for field in ("id", "action", "resource_type", "description", "created_at"):
+            assert field in data[0]
+
+    async def test_filter_by_action(self, client, db_session):
+        await _seed_events(db_session, count=2, action="asset.delete")
+        await _seed_events(db_session, count=2, action="schedule.create",
+                           resource_type="schedule")
+
+        resp = await client.get("/api/audit-log", params={"action": "asset.delete"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert all(e["action"] == "asset.delete" for e in data)
+
+    async def test_filter_by_resource_type(self, client, db_session):
+        await _seed_events(db_session, count=2, action="asset.delete",
+                           resource_type="asset")
+        await _seed_events(db_session, count=3, action="device.reboot",
+                           resource_type="device")
+
+        resp = await client.get("/api/audit-log", params={"resource_type": "device"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+        assert all(e["resource_type"] == "device" for e in data)
+
+    async def test_filter_by_time_window(self, client, db_session):
+        # Seed an old event well before the cutoff
+        old = datetime.now(timezone.utc) - timedelta(days=30)
+        old_entry = AuditLog(
+            action="very.old", resource_type="asset",
+            description="before the cutoff", created_at=old,
+        )
+        # And a fresh event clearly after the cutoff
+        new_entry = AuditLog(
+            action="new.thing", resource_type="asset",
+            description="after the cutoff",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([old_entry, new_entry])
+        await db_session.commit()
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        resp = await client.get("/api/audit-log", params={"since": cutoff})
+        assert resp.status_code == 200
+        data = resp.json()
+        actions = {e["action"] for e in data}
+        assert "very.old" not in actions
+        assert "new.thing" in actions
+
+    async def test_free_text_search(self, client, db_session):
+        # description: "deleted asset #0", "deleted asset #1", ...
+        await _seed_events(db_session, count=3)
+        # Add a distinct entry
+        entry = AuditLog(
+            action="group.create", resource_type="group",
+            description="created special marketing group",
+        )
+        db_session.add(entry)
+        await db_session.commit()
+
+        resp = await client.get("/api/audit-log", params={"q": "marketing"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["description"] == "created special marketing group"
+
+    async def test_limit_and_offset(self, client, db_session):
+        await _seed_events(db_session, count=5)
+
+        first = await client.get("/api/audit-log", params={"limit": 2, "offset": 0})
+        second = await client.get("/api/audit-log", params={"limit": 2, "offset": 2})
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        first_data = first.json()
+        second_data = second.json()
+        assert len(first_data) == 2
+        assert len(second_data) == 2
+        # Pages don't overlap
+        assert {e["id"] for e in first_data} & {e["id"] for e in second_data} == set()
+
+    async def test_limit_clamped_to_500(self, client, db_session):
+        # Server clamps limit via Query(..., le=500); over-large limits 422.
+        resp = await client.get("/api/audit-log", params={"limit": 5000})
+        assert resp.status_code == 422
+
+    async def test_unauthenticated_denied(self, unauthed_client, db_session):
+        await _seed_events(db_session, count=1)
+        resp = await unauthed_client.get("/api/audit-log")
+        # Either a 401 (API-style) or a 302 redirect to login (UI-style)
+        assert resp.status_code in (401, 302, 307)
+
+
+# ---------------------------------------------------------------------------
+# CMSClient tests — the MCP tool's client-side contract
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+def cms_client_module(monkeypatch):
+    """Import mcp/cms_client.py as a top-level module without triggering
+    the ``mcp`` package-vs-pip-package name collision.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[1] / "mcp" / "cms_client.py"
+    spec = importlib.util.spec_from_file_location("agora_mcp_cms_client", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.asyncio
+class TestCMSClientAuditLog:
+    """CMSClient.list_audit_events wire format."""
+
+    async def _client_with_mock(self, cms_client_module, handler):
+        transport = httpx.MockTransport(handler)
+        c = cms_client_module.CMSClient(base_url="http://cms:8080", api_key="k")
+        # Replace the real httpx client with one that uses our mock transport
+        await c._client.aclose()
+        c._client = httpx.AsyncClient(
+            base_url="http://cms:8080",
+            transport=transport,
+            headers={"X-API-Key": "k"},
+        )
+        return c
+
+    async def test_no_params_hits_endpoint_with_defaults(self, cms_client_module):
+        captured = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["url"] = str(req.url)
+            captured["params"] = dict(req.url.params)
+            return httpx.Response(200, json=[])
+
+        c = await self._client_with_mock(cms_client_module, handler)
+        try:
+            result = await c.list_audit_events()
+        finally:
+            await c.close()
+
+        assert result == []
+        assert captured["url"].startswith("http://cms:8080/api/audit-log")
+        assert captured["params"] == {"limit": "50", "offset": "0"}
+
+    async def test_all_params_passthrough(self, cms_client_module):
+        captured = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(req.url.params)
+            return httpx.Response(200, json=[{"id": "x"}])
+
+        c = await self._client_with_mock(cms_client_module, handler)
+        try:
+            result = await c.list_audit_events(
+                limit=25,
+                offset=10,
+                action="asset.delete",
+                resource_type="asset",
+                user_id="0199a1b0-0000-0000-0000-000000000001",
+                since="2026-04-01T00:00:00Z",
+                until="2026-04-19T23:59:59Z",
+                q="marketing",
+            )
+        finally:
+            await c.close()
+
+        assert result == [{"id": "x"}]
+        assert captured["params"] == {
+            "limit": "25",
+            "offset": "10",
+            "action": "asset.delete",
+            "resource_type": "asset",
+            "user_id": "0199a1b0-0000-0000-0000-000000000001",
+            "since": "2026-04-01T00:00:00Z",
+            "until": "2026-04-19T23:59:59Z",
+            "q": "marketing",
+        }
+
+    async def test_none_params_are_omitted(self, cms_client_module):
+        captured = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(req.url.params)
+            return httpx.Response(200, json=[])
+
+        c = await self._client_with_mock(cms_client_module, handler)
+        try:
+            await c.list_audit_events(action="schedule.create")  # only action set
+        finally:
+            await c.close()
+
+        # action must appear; user_id/since/until/q/resource_type must NOT
+        assert captured["params"].get("action") == "schedule.create"
+        for absent in ("user_id", "since", "until", "q", "resource_type"):
+            assert absent not in captured["params"]
+
+    async def test_http_error_propagates(self, cms_client_module):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(401)
+
+        c = await self._client_with_mock(cms_client_module, handler)
+        try:
+            with pytest.raises(httpx.HTTPStatusError):
+                await c.list_audit_events()
+        finally:
+            await c.close()


### PR DESCRIPTION
Fixes #179.

## Problem

Uploading an asset with a filename already in use returned HTTP 409, forcing
the uploader to rename the file locally and retry. This was an unnecessary
friction point — especially painful when multiple users or sources legitimately
want to upload files named `promo.mp4`, `logo.png`, etc.

## Solution

Auto-rename on collision. When a duplicate filename is detected, the upload
is stored under `{stem}_{N}.{ext}` (e.g. `promo.mp4` → `promo_1.mp4`). The
user-supplied filename is preserved in `original_filename` so the display
name the user sees doesn't change.

This matches the behavior already used by webpage and stream asset creation,
which auto-suffix with an MD5 hash of the URL on conflict — file uploads now
follow the same "never 409 on filename" contract, just with a more
human-friendly counter suffix.

### Behavior

| Upload sequence | Stored filenames | `original_filename` |
|-|-|-|
| `promo.mp4` × 3 | `promo.mp4`, `promo_1.mp4`, `promo_2.mp4` | (unset), `promo.mp4`, `promo.mp4` |
| HEIC → JPG collision | target `.jpg` also auto-renamed | user's `.heic` filename |

### Design notes

- **Monotonic suffixes.** The helper considers ALL rows (including
  soft-deleted) because `Asset.filename` carries a DB-level UNIQUE
  constraint — a soft-deleted row still reserves its name. Skipping past
  deleted names keeps suffixes predictable and avoids a `UNIQUE` violation
  on insert.
- **Disk path aligned.** The on-disk storage path now uses the unique name
  too, not the raw uploaded filename. This closes a latent bug where two
  uploads with the same filename could overwrite each other on disk before
  the DB check.
- **HEIC path included.** The `.heic → .jpg` conversion branch previously
  had its own separate 409 if the derived JPEG name collided. That branch
  now also auto-renames using the same helper.

## Test coverage

`tests/test_assets.py`:

- `test_upload_duplicate_auto_renames` — 3× same name → `dup.mp4`,
  `dup_1.mp4`, `dup_2.mp4` with `original_filename` preserved on renamed
  uploads.
- `test_upload_duplicate_soft_deleted_name_still_reserved` — after
  soft-deleting `hole_1.mp4`, the next duplicate upload picks `hole_3.mp4`
  (past the max), proving suffixes are monotonic and the DB unique
  constraint is respected.

Full `tests/test_assets.py tests/test_image_variants.py
tests/test_display_name.py`: **61 passed**.

## No migration needed

Reuses the existing `original_filename` column (already nullable, already
rendered by templates as `display_name or original_filename or filename`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
