### PR TITLE
fix(assets): allow deletion when only expired schedules reference (#177)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -9,7 +9,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -965,15 +965,38 @@ async def delete_asset(
     if not is_admin and asset.uploaded_by_user_id != user.id:
         raise HTTPException(status_code=403, detail="Only the asset owner can delete this asset")
 
-    # Block deletion if any schedule references this asset
-    sched_count = await db.scalar(
-        select(func.count()).select_from(Schedule).where(Schedule.asset_id == asset_id)
+    # Block deletion only if ACTIVE schedules reference this asset.
+    # A schedule is "active" if it is enabled AND either has no end_date
+    # or its end_date is still in the future (hasn't expired yet).
+    # Expired or disabled schedules don't block deletion — their rows
+    # will be removed alongside the asset so the FK stays consistent.
+    now_utc = datetime.now(timezone.utc)
+    active_sched_count = await db.scalar(
+        select(func.count()).select_from(Schedule).where(
+            Schedule.asset_id == asset_id,
+            Schedule.enabled.is_(True),
+            (Schedule.end_date.is_(None)) | (Schedule.end_date >= now_utc),
+        )
     )
-    if sched_count:
+    if active_sched_count:
         raise HTTPException(
             status_code=409,
-            detail=f"Cannot delete — asset is used by {sched_count} schedule(s). Remove it from all schedules first.",
+            detail=(
+                f"Cannot delete — asset is used by {active_sched_count} active "
+                "schedule(s). Remove it from all active schedules (or wait for "
+                "them to expire) first."
+            ),
         )
+
+    # Remove any remaining (expired/disabled) schedule rows that reference
+    # this asset.  Schedule.asset_id is NOT NULL, so we can't null it —
+    # and since those schedules are all inactive, dropping them is safe
+    # and prevents an FK violation when the reaper hard-deletes the row.
+    stale_sched_count = await db.scalar(
+        select(func.count()).select_from(Schedule).where(Schedule.asset_id == asset_id)
+    )
+    if stale_sched_count:
+        await db.execute(delete(Schedule).where(Schedule.asset_id == asset_id))
 
     asset_filename = asset.filename
 

--- a/tests/test_asset_delete_expired_schedules.py
+++ b/tests/test_asset_delete_expired_schedules.py
@@ -1,0 +1,157 @@
+"""Tests for deleting assets that are referenced only by expired or
+disabled schedules (issue #177).
+
+Prior behavior: the DELETE /{asset_id} endpoint blocked the delete with a
+409 if *any* schedule referenced the asset, even if every referencing
+schedule had already expired or been disabled.
+
+New behavior:
+ - Active schedules (enabled AND (end_date is NULL OR end_date >= now))
+   still block deletion with 409.
+ - Expired or disabled schedules are silently removed alongside the asset.
+ - Mixed: any active schedule present → 409; once all active refs are
+   removed the asset becomes deletable.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import datetime, timedelta, time, timezone
+
+import pytest
+
+
+def _make_upload(filename: str, content: bytes = b"fakecontent"):
+    return {"file": (filename, io.BytesIO(content), "application/octet-stream")}
+
+
+async def _make_group(db_session) -> uuid.UUID:
+    from cms.models.device import DeviceGroup
+
+    group = DeviceGroup(id=uuid.uuid4(), name=f"grp-{uuid.uuid4().hex[:8]}")
+    db_session.add(group)
+    await db_session.flush()
+    return group.id
+
+
+async def _make_schedule(
+    db_session,
+    *,
+    asset_id: uuid.UUID,
+    group_id: uuid.UUID,
+    enabled: bool = True,
+    end_date: datetime | None = None,
+) -> uuid.UUID:
+    from cms.models.schedule import Schedule
+
+    sched = Schedule(
+        id=uuid.uuid4(),
+        name=f"sched-{uuid.uuid4().hex[:8]}",
+        asset_id=asset_id,
+        group_id=group_id,
+        start_time=time(0, 0),
+        end_time=time(23, 59),
+        enabled=enabled,
+        end_date=end_date,
+    )
+    db_session.add(sched)
+    await db_session.flush()
+    return sched.id
+
+
+@pytest.mark.asyncio
+class TestAssetDeleteWithExpiredSchedules:
+    async def test_delete_blocked_by_active_schedule(self, client, db_session):
+        """Active schedule (enabled, no end_date) still blocks delete."""
+        upload = await client.post("/api/assets/upload", files=_make_upload("active.mp4"))
+        asset_id = uuid.UUID(upload.json()["id"])
+        group_id = await _make_group(db_session)
+        await _make_schedule(db_session, asset_id=asset_id, group_id=group_id)
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset_id}")
+        assert resp.status_code == 409
+        assert "active schedule" in resp.json()["detail"].lower()
+
+    async def test_delete_blocked_by_future_schedule(self, client, db_session):
+        """Schedule whose end_date is still in the future also blocks delete."""
+        upload = await client.post("/api/assets/upload", files=_make_upload("future.mp4"))
+        asset_id = uuid.UUID(upload.json()["id"])
+        group_id = await _make_group(db_session)
+        future = datetime.now(timezone.utc) + timedelta(days=7)
+        await _make_schedule(
+            db_session, asset_id=asset_id, group_id=group_id, end_date=future
+        )
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset_id}")
+        assert resp.status_code == 409
+
+    async def test_delete_allowed_when_only_expired_schedules(self, client, db_session):
+        """Asset referenced only by past-end_date schedules is deletable, and
+        those schedule rows are removed alongside the asset."""
+        from cms.models.schedule import Schedule
+        from sqlalchemy import select
+
+        upload = await client.post("/api/assets/upload", files=_make_upload("expired.mp4"))
+        asset_id = uuid.UUID(upload.json()["id"])
+        group_id = await _make_group(db_session)
+        past = datetime.now(timezone.utc) - timedelta(days=30)
+        sched_id = await _make_schedule(
+            db_session, asset_id=asset_id, group_id=group_id, end_date=past
+        )
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset_id}")
+        assert resp.status_code == 200
+
+        # Expired schedule row should have been removed.
+        remaining = (await db_session.execute(
+            select(Schedule).where(Schedule.id == sched_id)
+        )).scalar_one_or_none()
+        assert remaining is None
+
+    async def test_delete_allowed_when_only_disabled_schedules(self, client, db_session):
+        """Asset referenced only by disabled schedules is deletable."""
+        from cms.models.schedule import Schedule
+        from sqlalchemy import select
+
+        upload = await client.post("/api/assets/upload", files=_make_upload("disabled.mp4"))
+        asset_id = uuid.UUID(upload.json()["id"])
+        group_id = await _make_group(db_session)
+        sched_id = await _make_schedule(
+            db_session, asset_id=asset_id, group_id=group_id, enabled=False
+        )
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset_id}")
+        assert resp.status_code == 200
+
+        remaining = (await db_session.execute(
+            select(Schedule).where(Schedule.id == sched_id)
+        )).scalar_one_or_none()
+        assert remaining is None
+
+    async def test_delete_blocked_by_mix_with_active_schedule(self, client, db_session):
+        """Mix of expired + one active: still blocked; nothing removed."""
+        from cms.models.schedule import Schedule
+        from sqlalchemy import select, func as _func
+
+        upload = await client.post("/api/assets/upload", files=_make_upload("mix.mp4"))
+        asset_id = uuid.UUID(upload.json()["id"])
+        group_id = await _make_group(db_session)
+        past = datetime.now(timezone.utc) - timedelta(days=30)
+        await _make_schedule(db_session, asset_id=asset_id, group_id=group_id, end_date=past)
+        await _make_schedule(db_session, asset_id=asset_id, group_id=group_id)  # active
+        await db_session.commit()
+
+        resp = await client.delete(f"/api/assets/{asset_id}")
+        assert resp.status_code == 409
+
+        # Neither schedule row should have been touched — the 409 must be
+        # atomic with no partial state changes.
+        count = await db_session.scalar(
+            select(_func.count()).select_from(Schedule).where(Schedule.asset_id == asset_id)
+        )
+        assert count == 2


### PR DESCRIPTION
Fixes #177.

## Problem

Deleting an asset returned HTTP 409 if **any** schedule referenced it,
even if every referencing schedule was already expired (past its
`end_date`) or disabled. Users had to manually prune old schedule rows
before they could clean up the assets they used — tedious housekeeping.

## Solution

Change the delete gate: block only when an **active** schedule references
the asset. A schedule is "active" when it is enabled AND either has no
`end_date` or its `end_date` is still in the future.

When the gate passes, the expired/disabled schedule rows that still point
at the asset are removed in the same transaction. `Schedule.asset_id` is
`NOT NULL` with an FK to `assets.id`, so leaving those rows around would
cause an FK violation when the deleted-asset reaper eventually
hard-deletes the asset. Since those schedules are inactive by definition,
dropping them is safe — and prevents orphaned, unusable schedule rows
that couldn't be re-enabled without a valid asset anyway (see the note in
the issue).

## Before / after

| Schedules referencing asset | Before | After |
|-|-|-|
| None | 200 | 200 |
| 1 active | 409 | 409 |
| 1 expired (`end_date` in past) | 409 | 200 (schedule row removed) |
| 1 disabled (`enabled=false`) | 409 | 200 (schedule row removed) |
| Active + expired | 409 | 409 (no rows touched — atomic) |

## Test coverage

New `tests/test_asset_delete_expired_schedules.py` — 5 cases:

- `test_delete_blocked_by_active_schedule`
- `test_delete_blocked_by_future_schedule` (end_date still in future)
- `test_delete_allowed_when_only_expired_schedules` + row is removed
- `test_delete_allowed_when_only_disabled_schedules` + row is removed
- `test_delete_blocked_by_mix_with_active_schedule` + nothing removed (atomic)

Full `tests/test_assets.py tests/test_schedules.py
tests/test_asset_delete_expired_schedules.py tests/test_end_now_per_device.py`:
**71 passed**.

## Back-compat

- Active/future schedules still block delete with 409 (unchanged behavior
  from the operator's point of view for the case that matters).
- The reaper's asset-cascade continues to work as before; this change
  just removes the pre-reaper FK hazard by cleaning schedule rows up
  front.
- No migration — no schema changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
