### PR TITLE
feat(audit): enrich asset share/unshare entries with uploader context (#176)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1087,11 +1087,28 @@ async def share_asset(
         return {"status": "already_shared"}
 
     db.add(GroupAsset(asset_id=asset_id, group_id=group_id))
+
+    # Enrich audit log with uploader context so admins can trace content
+    # propagation (issue #176): original uploader, filename, target group.
+    uploader_email: str | None = None
+    if asset.uploaded_by_user_id is not None:
+        uploader_email = await db.scalar(
+            select(User.email).where(User.id == asset.uploaded_by_user_id)
+        )
     await audit_log(
         db, user=user, action="asset.share", resource_type="asset",
         resource_id=str(asset_id),
         description=f"Shared asset '{asset.filename}' with group '{group.name}'",
-        details={"group_id": str(group_id), "group_name": group.name},
+        details={
+            "asset_filename": asset.filename,
+            "group_id": str(group_id),
+            "group_name": group.name,
+            "uploaded_by_user_id": (
+                str(asset.uploaded_by_user_id)
+                if asset.uploaded_by_user_id is not None else None
+            ),
+            "uploaded_by_email": uploader_email,
+        },
         request=request,
     )
     await db.commit()
@@ -1120,11 +1137,41 @@ async def unshare_asset(
     if not ga:
         raise HTTPException(status_code=404, detail="Asset is not shared with this group")
     await db.delete(ga)
+
+    # Load asset + group + uploader context for a richer audit log entry
+    # (issue #176). Best-effort — audit details shouldn't block the unshare.
+    asset_row = (await db.execute(
+        select(Asset).where(Asset.id == asset_id)
+    )).scalar_one_or_none()
+    group_row = (await db.execute(
+        select(DeviceGroup).where(DeviceGroup.id == group_id)
+    )).scalar_one_or_none()
+    asset_filename = asset_row.filename if asset_row is not None else None
+    group_name = group_row.name if group_row is not None else None
+    uploader_email: str | None = None
+    uploader_id = asset_row.uploaded_by_user_id if asset_row is not None else None
+    if uploader_id is not None:
+        uploader_email = await db.scalar(
+            select(User.email).where(User.id == uploader_id)
+        )
+    description = (
+        f"Unshared asset '{asset_filename}' from group '{group_name}'"
+        if asset_filename and group_name
+        else f"Unshared asset {asset_id} from group {group_id}"
+    )
     await audit_log(
         db, user=user, action="asset.unshare", resource_type="asset",
         resource_id=str(asset_id),
-        description=f"Unshared asset {asset_id} from group {group_id}",
-        details={"group_id": str(group_id)},
+        description=description,
+        details={
+            "asset_filename": asset_filename,
+            "group_id": str(group_id),
+            "group_name": group_name,
+            "uploaded_by_user_id": (
+                str(uploader_id) if uploader_id is not None else None
+            ),
+            "uploaded_by_email": uploader_email,
+        },
         request=request,
     )
     await db.commit()

--- a/tests/test_asset_sharing_audit.py
+++ b/tests/test_asset_sharing_audit.py
@@ -1,0 +1,99 @@
+"""Tests for asset sharing audit log entries (issue #176).
+
+Verifies that:
+  - ``POST /api/assets/{id}/share`` writes an ``asset.share`` audit entry
+    with filename, target group info, and original uploader context.
+  - ``DELETE /api/assets/{id}/share`` writes an ``asset.unshare`` audit
+    entry with the same enrichment.
+  - Both entries are visible through the ``GET /api/audit-log`` endpoint.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+
+import pytest
+
+
+def _make_upload(filename: str, content: bytes = b"fakecontent"):
+    return {"file": (filename, io.BytesIO(content), "application/octet-stream")}
+
+
+async def _make_group(db_session, name: str | None = None) -> uuid.UUID:
+    from cms.models.device import DeviceGroup
+
+    group = DeviceGroup(
+        id=uuid.uuid4(), name=name or f"grp-{uuid.uuid4().hex[:8]}"
+    )
+    db_session.add(group)
+    await db_session.flush()
+    await db_session.commit()
+    return group.id
+
+
+@pytest.mark.asyncio
+class TestAssetSharingAuditLog:
+    async def test_share_writes_audit_entry(self, client, db_session):
+        upload = await client.post(
+            "/api/assets/upload", files=_make_upload("sharing.mp4")
+        )
+        asset_id = upload.json()["id"]
+        group_id = await _make_group(db_session, name="engineering")
+
+        resp = await client.post(
+            f"/api/assets/{asset_id}/share", params={"group_id": str(group_id)}
+        )
+        assert resp.status_code == 200
+
+        audit = await client.get(
+            "/api/audit-log", params={"action": "asset.share", "q": "sharing.mp4"}
+        )
+        assert audit.status_code == 200
+        entries = audit.json()
+        assert entries, "expected an asset.share audit entry"
+        entry = entries[0]
+        assert entry["action"] == "asset.share"
+        assert entry["resource_id"] == asset_id
+        details = entry.get("details") or {}
+        assert details.get("asset_filename") == "sharing.mp4"
+        assert details.get("group_id") == str(group_id)
+        assert details.get("group_name") == "engineering"
+        # Uploader context present (the test user uploaded the asset)
+        assert "uploaded_by_user_id" in details
+        assert "uploaded_by_email" in details
+
+    async def test_unshare_writes_audit_entry(self, client, db_session):
+        upload = await client.post(
+            "/api/assets/upload", files=_make_upload("unshare-me.mp4")
+        )
+        asset_id = upload.json()["id"]
+        group_id = await _make_group(db_session, name="ops")
+
+        share_resp = await client.post(
+            f"/api/assets/{asset_id}/share", params={"group_id": str(group_id)}
+        )
+        assert share_resp.status_code == 200
+        unshare_resp = await client.delete(
+            f"/api/assets/{asset_id}/share", params={"group_id": str(group_id)}
+        )
+        assert unshare_resp.status_code == 200
+
+        audit = await client.get(
+            "/api/audit-log", params={"action": "asset.unshare", "q": "unshare-me.mp4"}
+        )
+        assert audit.status_code == 200
+        entries = audit.json()
+        assert entries, "expected an asset.unshare audit entry"
+        entry = entries[0]
+        assert entry["action"] == "asset.unshare"
+        assert entry["resource_id"] == asset_id
+        details = entry.get("details") or {}
+        assert details.get("asset_filename") == "unshare-me.mp4"
+        assert details.get("group_id") == str(group_id)
+        assert details.get("group_name") == "ops"
+        assert "uploaded_by_user_id" in details
+        assert "uploaded_by_email" in details
+        # Description should use readable names, not bare UUIDs.
+        assert "unshare-me.mp4" in entry["description"]
+        assert "ops" in entry["description"]


### PR DESCRIPTION
Closes #176.

## Problem

Issue #176 asks for asset share/unshare events to be captured in the audit
log so admins can trace how content propagates across groups.

The events were already being written (PR #336 exposed them through the
MCP tool + REST endpoint), but the entries were minimal — the unshare
description only had bare UUIDs, and neither share nor unshare carried
the original uploader in its details. The ticket specifically calls that
out under "Consider including the original uploader in log context."

## Solution

Enrich both audit entries:

- **Share** (`POST /api/assets/{id}/share`)
  - `details.asset_filename` (new)
  - `details.uploaded_by_user_id` (new)
  - `details.uploaded_by_email` (new)
  - `details.group_id`, `details.group_name` (kept)

- **Unshare** (`DELETE /api/assets/{id}/share`)
  - Same fields as share (previously had only `group_id`).
  - Description now uses filename + group name (previously bare UUIDs):
    `"Unshared asset 'promo.mp4' from group 'ops'"`.

Uploader info is looked up via a single `SELECT email FROM users WHERE
id = :uploaded_by_user_id` — scalar query, no extra round-trips per row.

## Acceptance criteria

- [x] Log entries created when an asset is added to a group (who, which
  asset, which group, timestamp) — already present, enriched further
- [x] Log entries created when an asset is removed from a group
- [x] Audit log viewable by admins (UI + API) — `GET /api/audit-log`
  already admin-only; entries now include friendly names
- [x] Original uploader included in log context

## Test coverage

New `tests/test_asset_sharing_audit.py` (2 cases):

- `test_share_writes_audit_entry` — verifies `asset.share` entry contains
  `asset_filename`, `group_id`, `group_name`, uploader keys; visible via
  `GET /api/audit-log?action=asset.share&q=<filename>`.
- `test_unshare_writes_audit_entry` — same for `asset.unshare`, plus
  asserts the description includes the filename and group name.

Full `test_asset_sharing_audit + test_audit_log + test_mcp_audit_log +
test_assets`: **84 passed**.

## No migration

`AuditLog.details` is a JSON column — new keys slot in without a schema
change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
