### PR TITLE
feat(device-events): log display + error transitions, merge into dashboard (#122)

### DIFF
--- a/cms/models/device_event.py
+++ b/cms/models/device_event.py
@@ -16,6 +16,10 @@ class DeviceEventType(str, PyEnum):
     OFFLINE = "offline"
     TEMP_HIGH = "temp_high"
     TEMP_CLEARED = "temp_cleared"
+    DISPLAY_CONNECTED = "display_connected"
+    DISPLAY_DISCONNECTED = "display_disconnected"
+    ERROR = "error"
+    ERROR_CLEARED = "error_cleared"
     CMS_STARTED = "cms_started"
     CMS_STOPPED = "cms_stopped"
 

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import logging
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -402,6 +403,13 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                     _group_name = device.group.name or ""
 
                 # Track playback state (including error)
+                # Capture previous values for transition detection *before* update_status overwrites them.
+                _prev_conn = device_manager.get(device_id)
+                _prev_display = _prev_conn.display_connected if _prev_conn else None
+                _prev_error = _prev_conn.error if _prev_conn else None
+                _new_display = msg.get("display_connected")
+                _new_error = msg.get("error")
+
                 device_manager.update_status(
                     device_id,
                     mode=msg.get("mode", "unknown"),
@@ -416,6 +424,80 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                     local_api_enabled=msg.get("local_api_enabled"),
                     display_connected=msg.get("display_connected"),
                 )
+
+                # Emit DISPLAY_CONNECTED / DISPLAY_DISCONNECTED transitions.
+                # Only fire on explicit True<->False flips. A None->bool
+                # transition is treated as an initial observation and is
+                # ignored to avoid noise on every reconnect.
+                try:
+                    if (
+                        _new_display is not None
+                        and _prev_display is not None
+                        and bool(_new_display) != bool(_prev_display)
+                    ):
+                        from cms.models.device_event import DeviceEvent, DeviceEventType
+                        _ev_type = (
+                            DeviceEventType.DISPLAY_CONNECTED
+                            if _new_display
+                            else DeviceEventType.DISPLAY_DISCONNECTED
+                        )
+                        _gid_uuid = None
+                        if _group_id:
+                            try:
+                                _gid_uuid = uuid.UUID(_group_id)
+                            except (TypeError, ValueError):
+                                _gid_uuid = None
+                        db.add(DeviceEvent(
+                            device_id=device_id,
+                            device_name=_device_name,
+                            group_id=_gid_uuid,
+                            group_name=_group_name,
+                            event_type=_ev_type.value,
+                        ))
+                        await db.commit()
+                except Exception:
+                    logger.exception("Failed to log display transition for %s", device_id)
+
+                # Emit ERROR / ERROR_CLEARED transitions. ERROR fires on a
+                # None->str transition *or* when the error string changes.
+                # ERROR_CLEARED fires on str->None.
+                try:
+                    _had_err = bool(_prev_error)
+                    _has_err = bool(_new_error)
+                    _emit_error = False
+                    _emit_cleared = False
+                    if _has_err and not _had_err:
+                        _emit_error = True
+                    elif _has_err and _had_err and _new_error != _prev_error:
+                        _emit_error = True
+                    elif _had_err and not _has_err:
+                        _emit_cleared = True
+
+                    if _emit_error or _emit_cleared:
+                        from cms.models.device_event import DeviceEvent, DeviceEventType
+                        _ev_type = (
+                            DeviceEventType.ERROR
+                            if _emit_error
+                            else DeviceEventType.ERROR_CLEARED
+                        )
+                        _gid_uuid = None
+                        if _group_id:
+                            try:
+                                _gid_uuid = uuid.UUID(_group_id)
+                            except (TypeError, ValueError):
+                                _gid_uuid = None
+                        _details = {"error": _new_error} if _emit_error else {"previous_error": _prev_error}
+                        db.add(DeviceEvent(
+                            device_id=device_id,
+                            device_name=_device_name,
+                            group_id=_gid_uuid,
+                            group_name=_group_name,
+                            event_type=_ev_type.value,
+                            details=_details,
+                        ))
+                        await db.commit()
+                except Exception:
+                    logger.exception("Failed to log error transition for %s", device_id)
 
                 # Check temperature thresholds
                 alert_service.check_temperature(

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -247,9 +247,11 @@
             </tr>
         </thead>
         <tbody>
-            {% for log in recent_activity %}
+            {% for entry in recent_activity %}
+            {% set log = entry.log %}
             <tr>
-                <td data-utc="{{ log.timestamp.isoformat() }}">{{ log.timestamp.astimezone(tz).strftime('%I:%M:%S %p').lstrip('0') }}</td>
+                <td data-utc="{{ entry.timestamp.isoformat() }}">{{ entry.timestamp.astimezone(tz).strftime('%I:%M:%S %p').lstrip('0') }}</td>
+                {% if entry.kind == 'schedule' %}
                 <td>
                     {% if log.event.value == 'STARTED' %}
                     <span class="badge badge-started">Started</span>
@@ -265,6 +267,38 @@
                 <td>{{ log.device_name }}</td>
                 <td>{{ log.asset_filename }}</td>
                 <td class="text-muted">{{ log.details or '' }}</td>
+                {% else %}
+                <td>
+                    {% set et = log.event_type %}
+                    {% if et == 'online' %}
+                    <span class="badge badge-started">Online</span>
+                    {% elif et == 'offline' %}
+                    <span class="badge badge-missed">Offline</span>
+                    {% elif et == 'display_connected' %}
+                    <span class="badge badge-started">Display On</span>
+                    {% elif et == 'display_disconnected' %}
+                    <span class="badge badge-missed">Display Off</span>
+                    {% elif et == 'temp_high' %}
+                    <span class="badge badge-missed">Temp High</span>
+                    {% elif et == 'temp_cleared' %}
+                    <span class="badge badge-started">Temp Cleared</span>
+                    {% elif et == 'error' %}
+                    <span class="badge badge-missed">Error</span>
+                    {% elif et == 'error_cleared' %}
+                    <span class="badge badge-started">Error Cleared</span>
+                    {% elif et == 'cms_started' %}
+                    <span class="badge badge-started">CMS Started</span>
+                    {% elif et == 'cms_stopped' %}
+                    <span class="badge badge-skipped">CMS Stopped</span>
+                    {% else %}
+                    <span class="badge">{{ et }}</span>
+                    {% endif %}
+                </td>
+                <td class="text-muted">—</td>
+                <td>{{ log.device_name or '—' }}</td>
+                <td class="text-muted">—</td>
+                <td class="text-muted">{{ log.details or '' }}</td>
+                {% endif %}
             </tr>
             {% endfor %}
         </tbody>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -693,16 +693,33 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     upcoming_today = [u for u in upcoming if u["day_label"] == "today"]
     upcoming_tomorrow = [u for u in upcoming if u["day_label"] == "tomorrow"]
 
-    # Recent activity (last 24h)
+    # Recent activity (last 24h) — merges schedule history with device events
+    # (online/offline, display connect/disconnect, temp, error transitions).
     from datetime import timedelta
+    from cms.models.device_event import DeviceEvent
     cutoff_24h = now - timedelta(hours=24)
     recent_q = await db.execute(
         select(ScheduleLog)
         .where(ScheduleLog.timestamp >= cutoff_24h)
         .order_by(ScheduleLog.timestamp.desc())
-        .limit(10)
+        .limit(20)
     )
-    recent_activity = recent_q.scalars().all()
+    sched_entries = recent_q.scalars().all()
+    dev_q = await db.execute(
+        select(DeviceEvent)
+        .where(DeviceEvent.created_at >= cutoff_24h)
+        .order_by(DeviceEvent.created_at.desc())
+        .limit(20)
+    )
+    dev_entries = dev_q.scalars().all()
+
+    def _merged_ts(obj):
+        return getattr(obj, "timestamp", None) or getattr(obj, "created_at", None)
+
+    recent_activity = [{"kind": "schedule", "log": s, "timestamp": _merged_ts(s)} for s in sched_entries]
+    recent_activity += [{"kind": "device", "log": d, "timestamp": _merged_ts(d)} for d in dev_entries]
+    recent_activity.sort(key=lambda e: e["timestamp"], reverse=True)
+    recent_activity = recent_activity[:10]
 
     # Groups for the adoption modal dropdown
     # Admins see all groups; scoped users see only their assigned groups.

--- a/tests/test_device_event_transitions.py
+++ b/tests/test_device_event_transitions.py
@@ -1,0 +1,171 @@
+"""Tests for display_connected / error transition -> DeviceEvent emission (#122)."""
+
+import hashlib
+import time
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.device import Device, DeviceStatus
+from cms.models.device_event import DeviceEvent, DeviceEventType
+
+
+def _make_adopted_device(device_id: str) -> tuple[Device, str]:
+    token = f"tok-{device_id}"
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    dev = Device(
+        id=device_id,
+        name=device_id,
+        status=DeviceStatus.ADOPTED,
+        device_auth_token_hash=token_hash,
+    )
+    return dev, token
+
+
+def _register(ws, device_id, token):
+    ws.send_json({
+        "type": "register",
+        "protocol_version": 1,
+        "device_id": device_id,
+        "auth_token": token,
+        "firmware_version": "1.0.0",
+        "storage_capacity_mb": 500,
+    })
+    # Consume sync + config (adopted device)
+    ws.receive_json()
+    ws.receive_json()
+
+
+def _status(ws, device_id, **kwargs):
+    payload = {
+        "type": "status",
+        "device_id": device_id,
+        "mode": "splash",
+        "storage_used_mb": 100,
+    }
+    payload.update(kwargs)
+    ws.send_json(payload)
+
+
+@pytest.mark.asyncio
+class TestDeviceEventTransitions:
+    async def test_display_transition_emits_events(self, app, db_session):
+        from starlette.testclient import TestClient
+
+        dev, token = _make_adopted_device("evt-display-001")
+        db_session.add(dev)
+        await db_session.commit()
+        await db_session.close()
+
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/device") as ws:
+                _register(ws, "evt-display-001", token)
+                # First observation: display_connected=True (no prior -> no event)
+                _status(ws, "evt-display-001", display_connected=True)
+                time.sleep(0.3)
+                # Flip to False -> DISPLAY_DISCONNECTED
+                _status(ws, "evt-display-001", display_connected=False)
+                time.sleep(0.3)
+                # Flip back to True -> DISPLAY_CONNECTED
+                _status(ws, "evt-display-001", display_connected=True)
+                time.sleep(0.3)
+                ws.close()
+
+        rows = (await db_session.execute(
+            select(DeviceEvent)
+            .where(DeviceEvent.device_id == "evt-display-001")
+            .order_by(DeviceEvent.created_at.asc())
+        )).scalars().all()
+        types = [r.event_type for r in rows]
+        assert DeviceEventType.DISPLAY_DISCONNECTED.value in types
+        assert DeviceEventType.DISPLAY_CONNECTED.value in types
+        # First status should NOT have emitted anything (None -> True)
+        # so we expect exactly 2 display transitions.
+        display_rows = [r for r in rows if r.event_type.startswith("display_")]
+        assert len(display_rows) == 2
+
+    async def test_error_set_and_cleared_emits_events(self, app, db_session):
+        from starlette.testclient import TestClient
+
+        dev, token = _make_adopted_device("evt-err-001")
+        db_session.add(dev)
+        await db_session.commit()
+        await db_session.close()
+
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/device") as ws:
+                _register(ws, "evt-err-001", token)
+                # Clean status (no prior, no error) — no event
+                _status(ws, "evt-err-001")
+                time.sleep(0.3)
+                # Error appears
+                _status(ws, "evt-err-001", error="pipeline stalled")
+                time.sleep(0.3)
+                # Error cleared
+                _status(ws, "evt-err-001", error=None)
+                time.sleep(0.3)
+                ws.close()
+
+        rows = (await db_session.execute(
+            select(DeviceEvent)
+            .where(DeviceEvent.device_id == "evt-err-001")
+            .order_by(DeviceEvent.created_at.asc())
+        )).scalars().all()
+        err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
+        assert len(err_rows) == 2
+        assert err_rows[0].event_type == DeviceEventType.ERROR.value
+        assert err_rows[0].details and err_rows[0].details.get("error") == "pipeline stalled"
+        assert err_rows[1].event_type == DeviceEventType.ERROR_CLEARED.value
+
+    async def test_error_string_change_emits_new_error_event(self, app, db_session):
+        from starlette.testclient import TestClient
+
+        dev, token = _make_adopted_device("evt-err-002")
+        db_session.add(dev)
+        await db_session.commit()
+        await db_session.close()
+
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/device") as ws:
+                _register(ws, "evt-err-002", token)
+                _status(ws, "evt-err-002", error="first fault")
+                time.sleep(0.3)
+                # Different error string while still in error state → another ERROR event
+                _status(ws, "evt-err-002", error="second fault")
+                time.sleep(0.3)
+                ws.close()
+
+        rows = (await db_session.execute(
+            select(DeviceEvent)
+            .where(DeviceEvent.device_id == "evt-err-002")
+            .order_by(DeviceEvent.created_at.asc())
+        )).scalars().all()
+        err_rows = [r for r in rows if r.event_type == DeviceEventType.ERROR.value]
+        assert len(err_rows) == 2
+        assert err_rows[-1].details.get("error") == "second fault"
+
+    async def test_no_event_on_stable_state(self, app, db_session):
+        """Repeated identical status messages must NOT emit spurious events."""
+        from starlette.testclient import TestClient
+
+        dev, token = _make_adopted_device("evt-stable-001")
+        db_session.add(dev)
+        await db_session.commit()
+        await db_session.close()
+
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/device") as ws:
+                _register(ws, "evt-stable-001", token)
+                for _ in range(3):
+                    _status(ws, "evt-stable-001", display_connected=True)
+                    time.sleep(0.15)
+                ws.close()
+
+        rows = (await db_session.execute(
+            select(DeviceEvent)
+            .where(DeviceEvent.device_id == "evt-stable-001")
+        )).scalars().all()
+        display_rows = [r for r in rows if r.event_type.startswith("display_")]
+        err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
+        assert display_rows == []
+        assert err_rows == []


### PR DESCRIPTION
## Summary

Closes #122.

Completes the device event log by recording the remaining two transition
families called out in the issue, and merges device events into the
dashboard **Recent Activity** card alongside schedule events.

Prior PRs already shipped the `DeviceEvent` model, the `/api/device-events`
router, the `/event-log` UI page, and emit hooks for `ONLINE`, `OFFLINE`,
`TEMP_HIGH`, `TEMP_CLEARED`, `CMS_STARTED`, `CMS_STOPPED`. This PR fills
in what was missing.

## Changes

### New event types
`cms/models/device_event.py` — four new `DeviceEventType` values:

- `DISPLAY_CONNECTED`
- `DISPLAY_DISCONNECTED`
- `ERROR`
- `ERROR_CLEARED`

No migration needed: `device_events.event_type` is `String(20)`, not a
Postgres enum.

### Transition detection (ws.py)
Before calling `device_manager.update_status(...)` the WS handler now
captures the previous `display_connected` and `error` values from the
connection registry, then compares them to the incoming STATUS payload:

- `display_connected` flipping `True<->False` writes a `DISPLAY_CONNECTED`
  or `DISPLAY_DISCONNECTED` row. A `None->bool` initial observation is
  ignored to avoid noise on every reconnect.
- `error` flipping to a new truthy value writes an `ERROR` row (with the
  error string in `details.error`). If the error string *changes* while
  still in the error state, another `ERROR` row is written (new fault
  class). A `str->None` flip writes `ERROR_CLEARED`.

Each emit is wrapped in try/except; a logging failure never kills the
STATUS path.

### Dashboard merge (ui.py + dashboard.html)
`/dashboard` Recent Activity now unions the last-24h `ScheduleLog` rows
with the last-24h `DeviceEvent` rows, sorts by timestamp desc, caps at
10. The template renders both shapes with distinct badges (Online, Offline,
Display On, Display Off, Temp High, Temp Cleared, Error, Error Cleared,
CMS Started, CMS Stopped).

### Tests
`tests/test_device_event_transitions.py` (4 cases):

- `True->False->True` display flips write exactly one row each, initial
  `None->True` writes nothing
- `error=None -> "x" -> None` writes `ERROR` + `ERROR_CLEARED` with the
  error string captured in `details`
- `error="a" -> "b"` writes a second `ERROR` row (new fault class)
- Stable state (3 identical STATUS messages) writes zero events

39/39 pass across `test_websocket + test_device_alerts + new file`.

## Not in scope

- #122 also mentions filtering the history page to show device events.
  The `/event-log` page + `/api/device-events` API already cover this;
  no change here.
- No `display_connected` or `error` transition notifications (just log
  entries). If we want those surfaced in the bell, it's a natural follow-up
  alongside the #263 thermal emitter work.
