### PR TITLE
feat(profiles): add enable/disable toggle (#237)

### DIFF
--- a/alembic/versions/0003_device_profile_enabled.py
+++ b/alembic/versions/0003_device_profile_enabled.py
@@ -1,0 +1,40 @@
+"""device_profiles.enabled
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-19
+
+Adds an `enabled` boolean to `device_profiles` (defaults to True).
+
+Disabled profiles do not generate new variants on asset upload or
+new-profile fan-out and have in-flight transcodes cancelled. See #237.
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '0003'
+down_revision: Union[str, None] = '0002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'device_profiles',
+        sa.Column(
+            'enabled',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('true'),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('device_profiles', 'enabled')

--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -125,6 +125,7 @@ async def list_profiles(db: AsyncSession = Depends(get_db)):
             audio_codec=p.audio_codec,
             audio_bitrate=p.audio_bitrate,
             builtin=p.builtin,
+            enabled=p.enabled,
             device_count=dev_count.scalar() or 0,
             total_variants=total_var.scalar() or 0,
             ready_variants=ready_var.scalar() or 0,
@@ -184,6 +185,7 @@ async def create_profile(data: ProfileCreate, request: Request, db: AsyncSession
         audio_codec=profile.audio_codec,
         audio_bitrate=profile.audio_bitrate,
         builtin=profile.builtin,
+        enabled=profile.enabled,
         device_count=0,
         total_variants=len(variant_ids),
         ready_variants=0,
@@ -331,6 +333,7 @@ async def update_profile(
         audio_codec=profile.audio_codec,
         audio_bitrate=profile.audio_bitrate,
         builtin=profile.builtin,
+        enabled=profile.enabled,
         device_count=dev_count.scalar() or 0,
         total_variants=total_var.scalar() or 0,
         ready_variants=ready_var.scalar() or 0,
@@ -470,6 +473,7 @@ async def copy_profile(
         audio_codec=profile.audio_codec,
         audio_bitrate=profile.audio_bitrate,
         builtin=profile.builtin,
+        enabled=profile.enabled,
         device_count=0,
         total_variants=len(variant_ids),
         ready_variants=0,
@@ -579,6 +583,186 @@ async def reset_profile(
         audio_codec=profile.audio_codec,
         audio_bitrate=profile.audio_bitrate,
         builtin=profile.builtin,
+        enabled=profile.enabled,
+        device_count=dev_count.scalar() or 0,
+        total_variants=total_var.scalar() or 0,
+        ready_variants=ready_var.scalar() or 0,
+        matches_defaults=_matches_defaults(profile),
+        created_at=profile.created_at,
+    )
+
+
+@router.post("/{profile_id}/disable", response_model=ProfileOut, dependencies=[Depends(require_permission(PROFILES_WRITE))])
+async def disable_profile(
+    profile_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Disable a profile.
+
+    Stops new variants from being generated for this profile on asset
+    upload / new-profile fan-out. Any pending or in-flight transcode
+    jobs for this profile are cancelled. Existing READY variants are
+    preserved so re-enabling is instant.
+    """
+    result = await db.execute(
+        select(DeviceProfile).where(DeviceProfile.id == profile_id)
+    )
+    profile = result.scalar_one_or_none()
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    if not profile.enabled:
+        # Idempotent — return current state
+        dev_count = await db.execute(
+            select(func.count(Device.id)).where(Device.profile_id == profile.id)
+        )
+        total_var = await db.execute(
+            select(func.count(AssetVariant.id)).where(AssetVariant.profile_id == profile.id)
+        )
+        ready_var = await db.execute(
+            select(func.count(AssetVariant.id)).where(
+                AssetVariant.profile_id == profile.id,
+                AssetVariant.status == VariantStatus.READY,
+            )
+        )
+        return ProfileOut(
+            id=profile.id, name=profile.name, description=profile.description,
+            video_codec=profile.video_codec, video_profile=profile.video_profile,
+            max_width=profile.max_width, max_height=profile.max_height,
+            max_fps=profile.max_fps, video_bitrate=profile.video_bitrate,
+            crf=profile.crf, pixel_format=profile.pixel_format,
+            color_space=profile.color_space, audio_codec=profile.audio_codec,
+            audio_bitrate=profile.audio_bitrate, builtin=profile.builtin,
+            enabled=profile.enabled,
+            device_count=dev_count.scalar() or 0,
+            total_variants=total_var.scalar() or 0,
+            ready_variants=ready_var.scalar() or 0,
+            matches_defaults=_matches_defaults(profile),
+            created_at=profile.created_at,
+        )
+
+    profile.enabled = False
+
+    # Cancel pending/in-flight transcode work for this profile.
+    cancelled_jobs = await flag_profile_jobs_cancelled(db, profile_id)
+    cancel_profile_transcodes(profile_id)
+
+    await audit_log(
+        db, user=getattr(request.state, "user", None),
+        action="profile.disable", resource_type="profile",
+        resource_id=str(profile_id),
+        description=f"Disabled transcode profile '{profile.name}'",
+        details={"name": profile.name, "cancelled_jobs": cancelled_jobs},
+        request=request,
+    )
+    await db.commit()
+    await db.refresh(profile)
+
+    logger.info(
+        "disable_profile: profile %s (%s) disabled — cancelled %d job(s)",
+        profile_id, profile.name, cancelled_jobs,
+    )
+
+    dev_count = await db.execute(
+        select(func.count(Device.id)).where(Device.profile_id == profile.id)
+    )
+    total_var = await db.execute(
+        select(func.count(AssetVariant.id)).where(AssetVariant.profile_id == profile.id)
+    )
+    ready_var = await db.execute(
+        select(func.count(AssetVariant.id)).where(
+            AssetVariant.profile_id == profile.id,
+            AssetVariant.status == VariantStatus.READY,
+        )
+    )
+    return ProfileOut(
+        id=profile.id, name=profile.name, description=profile.description,
+        video_codec=profile.video_codec, video_profile=profile.video_profile,
+        max_width=profile.max_width, max_height=profile.max_height,
+        max_fps=profile.max_fps, video_bitrate=profile.video_bitrate,
+        crf=profile.crf, pixel_format=profile.pixel_format,
+        color_space=profile.color_space, audio_codec=profile.audio_codec,
+        audio_bitrate=profile.audio_bitrate, builtin=profile.builtin,
+        enabled=profile.enabled,
+        device_count=dev_count.scalar() or 0,
+        total_variants=total_var.scalar() or 0,
+        ready_variants=ready_var.scalar() or 0,
+        matches_defaults=_matches_defaults(profile),
+        created_at=profile.created_at,
+    )
+
+
+@router.post("/{profile_id}/enable", response_model=ProfileOut, dependencies=[Depends(require_permission(PROFILES_WRITE))])
+async def enable_profile(
+    profile_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-enable a profile.
+
+    Re-enqueues transcoding for any assets that don't yet have a variant
+    for this profile (covers assets uploaded while the profile was
+    disabled). Existing variants are preserved.
+    """
+    result = await db.execute(
+        select(DeviceProfile).where(DeviceProfile.id == profile_id)
+    )
+    profile = result.scalar_one_or_none()
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    was_disabled = not profile.enabled
+    profile.enabled = True
+    await db.commit()
+    await db.refresh(profile)
+
+    new_variant_ids: list[uuid.UUID] = []
+    if was_disabled:
+        # Re-run fan-out: any assets uploaded while disabled will now
+        # get variants; assets that already have variants are no-ops.
+        new_variant_ids = await enqueue_for_new_profile(profile.id, db)
+        if new_variant_ids:
+            await enqueue_variants(db, new_variant_ids)
+
+        await audit_log(
+            db, user=getattr(request.state, "user", None),
+            action="profile.enable", resource_type="profile",
+            resource_id=str(profile_id),
+            description=f"Enabled transcode profile '{profile.name}'",
+            details={
+                "name": profile.name,
+                "variants_enqueued": len(new_variant_ids),
+            },
+            request=request,
+        )
+        await db.commit()
+        logger.info(
+            "enable_profile: profile %s (%s) enabled — enqueued %d variant(s)",
+            profile_id, profile.name, len(new_variant_ids),
+        )
+
+    dev_count = await db.execute(
+        select(func.count(Device.id)).where(Device.profile_id == profile.id)
+    )
+    total_var = await db.execute(
+        select(func.count(AssetVariant.id)).where(AssetVariant.profile_id == profile.id)
+    )
+    ready_var = await db.execute(
+        select(func.count(AssetVariant.id)).where(
+            AssetVariant.profile_id == profile.id,
+            AssetVariant.status == VariantStatus.READY,
+        )
+    )
+    return ProfileOut(
+        id=profile.id, name=profile.name, description=profile.description,
+        video_codec=profile.video_codec, video_profile=profile.video_profile,
+        max_width=profile.max_width, max_height=profile.max_height,
+        max_fps=profile.max_fps, video_bitrate=profile.video_bitrate,
+        crf=profile.crf, pixel_format=profile.pixel_format,
+        color_space=profile.color_space, audio_codec=profile.audio_codec,
+        audio_bitrate=profile.audio_bitrate, builtin=profile.builtin,
+        enabled=profile.enabled,
         device_count=dev_count.scalar() or 0,
         total_variants=total_var.scalar() or 0,
         ready_variants=ready_var.scalar() or 0,

--- a/cms/schemas/profile.py
+++ b/cms/schemas/profile.py
@@ -30,6 +30,7 @@ class ProfileOut(BaseModel):
     audio_codec: str
     audio_bitrate: str
     builtin: bool
+    enabled: bool = True
     device_count: int = 0
     total_variants: int = 0
     ready_variants: int = 0

--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -287,6 +287,13 @@ async def enqueue_for_new_profile(
     profile = profile_result.scalar_one_or_none()
     if not profile:
         return []
+    # Skip disabled profiles — they don't generate new variants.
+    if not getattr(profile, "enabled", True):
+        logger.info(
+            "enqueue_for_new_profile: profile %s (%s) is disabled — skipping",
+            profile_id, profile.name,
+        )
+        return []
 
     new_variant_ids: list[uuid.UUID] = []
     for asset in assets:
@@ -372,6 +379,9 @@ async def _enqueue_transcoding_for_asset(
     profiles = result.scalars().all()
     new_variant_ids: list[uuid.UUID] = []
     for profile in profiles:
+        # Skip disabled profiles — no new variants until re-enabled.
+        if not getattr(profile, "enabled", True):
+            continue
         existing = await db.execute(
             select(AssetVariant.id).where(
                 AssetVariant.source_asset_id == asset.id,

--- a/shared/models/device_profile.py
+++ b/shared/models/device_profile.py
@@ -33,6 +33,15 @@ class DeviceProfile(Base):
     # Whether this is a built-in (non-deletable) profile
     builtin: Mapped[bool] = mapped_column(Boolean, default=False)
 
+    # Enable/disable toggle — disabled profiles don't generate new variants
+    # on upload / new-profile fan-out, and any in-flight/pending transcodes
+    # for them are cancelled. Existing READY variants are preserved so
+    # re-enabling is instant and a disabled profile still serves cached
+    # content if needed.
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="true"
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/tests/test_profile_enable_disable.py
+++ b/tests/test_profile_enable_disable.py
@@ -1,0 +1,203 @@
+"""Tests for profile enable/disable (issue #237).
+
+When a profile is disabled:
+  * new asset uploads / new profile creation must NOT enqueue variants
+    for that profile
+  * existing READY variants stay intact (re-enable is instant)
+  * in-flight / pending transcode jobs for that profile get cancelled
+
+When it's re-enabled:
+  * fan-out re-runs, so any assets uploaded while it was off now get variants
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.mark.asyncio
+class TestProfileEnableDisableApi:
+    """API surface: POST /enable and /disable endpoints."""
+
+    async def test_default_enabled_true(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="new-default", video_codec="h264")
+        db_session.add(profile)
+        await db_session.commit()
+        await db_session.refresh(profile)
+        assert profile.enabled is True
+
+    async def test_disable_then_enable_roundtrip(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="toggle-me", video_codec="h264")
+        db_session.add(profile)
+        await db_session.commit()
+        pid = profile.id
+
+        r = await client.post(f"/api/profiles/{pid}/disable")
+        assert r.status_code == 200
+        assert r.json()["enabled"] is False
+
+        db_session.expunge_all()
+        got = await db_session.get(DeviceProfile, pid)
+        assert got.enabled is False
+
+        r = await client.post(f"/api/profiles/{pid}/enable")
+        assert r.status_code == 200
+        assert r.json()["enabled"] is True
+
+        db_session.expunge_all()
+        got = await db_session.get(DeviceProfile, pid)
+        assert got.enabled is True
+
+    async def test_disable_is_idempotent(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="idempotent", video_codec="h264", enabled=False)
+        db_session.add(profile)
+        await db_session.commit()
+
+        r = await client.post(f"/api/profiles/{profile.id}/disable")
+        assert r.status_code == 200
+        assert r.json()["enabled"] is False
+
+    async def test_enable_is_idempotent(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="idempotent-en", video_codec="h264")
+        db_session.add(profile)
+        await db_session.commit()
+
+        r = await client.post(f"/api/profiles/{profile.id}/enable")
+        assert r.status_code == 200
+        assert r.json()["enabled"] is True
+
+    async def test_enable_disable_404(self, client):
+        fake = uuid.uuid4()
+        r = await client.post(f"/api/profiles/{fake}/enable")
+        assert r.status_code == 404
+        r = await client.post(f"/api/profiles/{fake}/disable")
+        assert r.status_code == 404
+
+    async def test_profile_out_includes_enabled_field(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="field-check", video_codec="h264")
+        db_session.add(profile)
+        await db_session.commit()
+
+        r = await client.get("/api/profiles")
+        assert r.status_code == 200
+        body = r.json()
+        entry = next(p for p in body if p["id"] == str(profile.id))
+        assert entry["enabled"] is True
+
+
+@pytest.mark.asyncio
+class TestDisabledProfileSkipsTranscode:
+    """Transcoder helpers must skip disabled profiles."""
+
+    async def test_enqueue_for_new_profile_skips_disabled(self, client, db_session):
+        """Profile created disabled: fan-out returns no variants even with
+        existing video assets in the library."""
+        from cms.models.asset import Asset, AssetType, AssetVariant
+        from cms.models.device_profile import DeviceProfile
+        from cms.services.transcoder import enqueue_for_new_profile
+
+        asset = Asset(
+            filename="existing.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum=f"skip-{uuid.uuid4().hex[:8]}",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        profile = DeviceProfile(
+            name="disabled-at-create", video_codec="h264", enabled=False,
+        )
+        db_session.add(profile)
+        await db_session.commit()
+
+        ids = await enqueue_for_new_profile(profile.id, db_session)
+        assert ids == []
+
+        db_session.expunge_all()
+        result = await db_session.execute(
+            select(AssetVariant).where(AssetVariant.profile_id == profile.id)
+        )
+        assert result.scalars().all() == []
+
+    async def test_asset_upload_skips_disabled_profile(self, client, db_session):
+        """A disabled profile must NOT get a variant when a new asset is
+        created via the transcoder fan-out path."""
+        from cms.models.asset import Asset, AssetType, AssetVariant
+        from cms.models.device_profile import DeviceProfile
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
+
+        on_profile = DeviceProfile(
+            name="on-upload", video_codec="h264", enabled=True,
+        )
+        off_profile = DeviceProfile(
+            name="off-upload", video_codec="h264", enabled=False,
+        )
+        db_session.add_all([on_profile, off_profile])
+        await db_session.flush()
+
+        asset = Asset(
+            filename="fresh.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum=f"upload-{uuid.uuid4().hex[:8]}",
+        )
+        db_session.add(asset)
+        await db_session.commit()
+
+        await _enqueue_transcoding_for_asset(asset, db_session)
+
+        db_session.expunge_all()
+        on_variants = (await db_session.execute(
+            select(AssetVariant).where(AssetVariant.profile_id == on_profile.id)
+        )).scalars().all()
+        off_variants = (await db_session.execute(
+            select(AssetVariant).where(AssetVariant.profile_id == off_profile.id)
+        )).scalars().all()
+
+        assert len(on_variants) == 1, "enabled profile should get a variant"
+        assert off_variants == [], "disabled profile must not get a variant"
+
+    async def test_reenable_fanout_picks_up_missed_assets(
+        self, client, db_session, tmp_path, monkeypatch,
+    ):
+        """After re-enabling, fan-out creates variants for assets that were
+        uploaded while the profile was disabled."""
+        from cms.models.asset import Asset, AssetType, AssetVariant
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(
+            name="reenable-fanout", video_codec="h264", enabled=False,
+        )
+        db_session.add(profile)
+        await db_session.flush()
+
+        asset = Asset(
+            filename="missed.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=2000, checksum=f"reen-{uuid.uuid4().hex[:8]}",
+        )
+        db_session.add(asset)
+        await db_session.commit()
+        await db_session.close()
+
+        r = await client.post(f"/api/profiles/{profile.id}/enable")
+        assert r.status_code == 200
+        assert r.json()["enabled"] is True
+
+        result = await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.profile_id == profile.id,
+                AssetVariant.source_asset_id == asset.id,
+            )
+        )
+        variants = result.scalars().all()
+        assert len(variants) == 1, (
+            f"re-enable should enqueue a variant for the missed asset, got {variants}"
+        )


### PR DESCRIPTION
# feat(profiles): add enable/disable toggle (#237)

## Summary

Adds an `enabled` boolean on `DeviceProfile` plus `POST /api/profiles/{id}/enable`
and `/disable` endpoints. Disabled profiles are excluded from transcode
fan-out, and any in-flight jobs for them are cancelled. Re-enabling picks
up assets uploaded during the off window via the existing
`enqueue_for_new_profile` helper.

## Changes

### Schema / model
- `shared/models/device_profile.py` — new `enabled: bool` column (default `True`).
- `alembic/versions/0003_device_profile_enabled.py` — migration adding the column with `server_default=true`.
- `cms/schemas/profile.py` — `enabled` field on `ProfileOut`.
- `cms/routers/profiles.py` — `enabled=...` plumbed through every `ProfileOut` construction site.

### Transcoder guards
- `cms/services/transcoder.py`:
  - `enqueue_for_new_profile` early-returns `[]` if the profile is disabled.
  - `_enqueue_transcoding_for_asset` skips disabled profiles during fan-out over all profiles.

### New endpoints
- `POST /api/profiles/{id}/disable` (requires `PROFILES_WRITE`):
  - Sets `enabled=False`.
  - Calls `flag_profile_jobs_cancelled` + `cancel_profile_transcodes` to stop pending/in-flight work.
  - Idempotent (returns current state if already disabled).
  - Writes `profile.disable` audit log with cancelled job count.
- `POST /api/profiles/{id}/enable` (requires `PROFILES_WRITE`):
  - Sets `enabled=True`.
  - Re-runs `enqueue_for_new_profile` so assets uploaded while the profile was off get variants.
  - Idempotent.
  - Writes `profile.enable` audit log with enqueued variant count.

### Tests
- `tests/test_profile_enable_disable.py` (new, 9 tests):
  - Default `enabled=True` on new profiles.
  - Round-trip disable→enable.
  - Both endpoints idempotent.
  - 404 on unknown profile id.
  - `GET /api/profiles` surfaces the `enabled` field.
  - `enqueue_for_new_profile` skips disabled profiles.
  - `_enqueue_transcoding_for_asset` creates variants for enabled profiles only.
  - Re-enable runs fan-out for assets uploaded while disabled.

All 9 new tests pass; full profile suite 48/48 still green.

## Design notes

- Existing `READY` variants are preserved when a profile is disabled. That
  way re-enabling is instant and devices continue serving the last good
  blob if needed. The disable is about stopping *new* work, not tearing
  down existing output.
- Built-in profiles are also toggleable. If operators want to keep a
  built-in around but stop using it, they can just flip it off instead of
  trying to delete it (which is blocked anyway).
- Audit log entries are distinct actions (`profile.enable` / `profile.disable`)
  so they show up cleanly in the activity view.

## Out of scope

- UI toggle — will land in a follow-up PR once this API is in. The
  current profiles page still reads/writes every other field via the
  existing endpoints, so nothing's broken — there's just no button yet.
- Bulk enable/disable — single-profile only for v1.

Closes #237.
