### PR TITLE
fix(tests): enable SQLite FK pragma; gate add-group JS by permission

### DIFF
--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -652,9 +652,13 @@ async function checkForUpdates() {
     }
 }
 
-// Gate "Add Group" button until group name has input (issue #315).
+// Gate the create-group submit button until a group name is entered
+// (issue #315). Wrapped in a permission check so the literal button
+// id/label only appears when the user can actually create groups.
+{% if 'groups:write' in user_perms %}
 document.addEventListener("DOMContentLoaded", () => {
     gateButtonOnInputs("#add-group-btn", ["#group-name"]);
 });
+{% endif %}
 </script>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,20 @@ async def db_engine(tmp_path):
 
     engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
 
+    # SQLite doesn't enforce foreign keys unless the per-connection
+    # PRAGMA is set. Without this, ON DELETE SET NULL / CASCADE rules
+    # silently no-op in tests, causing real FK regressions to slip past.
+    if "sqlite" in db_url:
+        from sqlalchemy import event
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _enable_sqlite_fk(dbapi_conn, _conn_record):  # pragma: no cover
+            cursor = dbapi_conn.cursor()
+            try:
+                cursor.execute("PRAGMA foreign_keys=ON")
+            finally:
+                cursor.close()
+
     async with engine.begin() as conn:
         # For PostgreSQL: drop and recreate all tables for isolation
         if "postgresql" in db_url:


### PR DESCRIPTION
## Summary

Two small, independent fixes:

### 1. Enable SQLite foreign-key enforcement in tests (`tests/conftest.py`)

SQLite doesn't enforce foreign-key constraints unless the per-connection
`PRAGMA foreign_keys=ON` is set. Without it, `ON DELETE SET NULL` and
`ON DELETE CASCADE` rules silently no-op, so real FK regressions slip
past the unit test suite. Postgres (used in CI for the integration job)
already enforces them.

This was masking a real assertion in
`tests/test_scheduler_advanced.py::test_ended_log_survives_deleted_schedule_fk`,
which expects `schedule_logs.schedule_id` to be `NULL` after the parent
`schedules` row is deleted (per the `ondelete="SET NULL"` declaration on
the model). On SQLite the FK was silently retained and the test failed.

After this change the test passes against SQLite as well, matching the
Postgres semantics.

### 2. Wrap the `gateButtonOnInputs("#add-group-btn", …)` script in a `groups:write` template guard (`cms/templates/devices.html`)

The `Add Group` form (and its submit button) is already wrapped in
`{% if 'groups:write' in user_perms %}`, but the small `<script>` block
that gates the button on input was emitted unconditionally, with the
text `"Add Group"` in a JS comment. That broke
`tests/test_group_permissions.py::test_viewer_no_group_create_form`,
which asserts the substring `"Add Group"` does not appear in the
rendered HTML for users without the permission.

Wrapping the script in the same `{% if %}` keeps the button-gating JS
where it belongs (only when the button exists), and removes the stray
literal from viewer-rendered pages.

## Validation

- `pytest tests/test_scheduler_advanced.py` → all 61 pass (previously 1
  failed).
- `pytest tests/test_group_permissions.py` → all 19 pass (previously 1
  failed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
