### PR TITLE
fix(ui): refresh required-input gate on autofill and dynamic required changes (#348)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1105,7 +1105,12 @@ function onSaveLocallyChanged() {
         durSelect.required = false;
         durSelect.value = '';
         customInput.style.display = 'none';
+        customInput.required = false;
     }
+    // Toggling `required` programmatically doesn't emit input/change —
+    // re-run the form's gate updater so the submit button reflects the
+    // new required set. See issue #348.
+    document.getElementById('stream-form')?.__gateUpdate?.();
 }
 
 // Handle custom duration dropdown
@@ -1114,8 +1119,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const custom = document.getElementById('stream-capture-custom');
     if (sel) {
         sel.addEventListener('change', () => {
-            custom.style.display = sel.value === 'custom' ? 'inline-block' : 'none';
-            if (sel.value !== 'custom') custom.value = '';
+            const isCustom = sel.value === 'custom';
+            custom.style.display = isCustom ? 'inline-block' : 'none';
+            if (!isCustom) custom.value = '';
+            // When "Custom…" is picked, the inline number input becomes
+            // the required field instead of the select — keep the submit
+            // gate honest.
+            custom.required = isCustom;
+            document.getElementById('stream-form')?.__gateUpdate?.();
         });
     }
 });
@@ -1680,7 +1691,12 @@ async function deleteRole(roleId, roleName) {
 
 // ── Required-input gating ──────────────────────────────────────────────
 // Disables primary action buttons until required inputs have values.
-// See issue #315.
+// See issues #315, #348 (autofill).
+
+// Registry of all active update functions so we can re-run every gate when
+// browser autofill (Chromium) silently populates fields without firing
+// input/change events.
+const _gateUpdaters = new Set();
 
 /**
  * Check whether a form control has a non-empty value.
@@ -1694,6 +1710,10 @@ function _hasValue(el) {
     // end_time that's disabled when loop_count is set, but whose value
     // is explicitly submitted). Only empty values should block submit.
     return (el.value || "").trim() !== "";
+}
+
+function _rerunAllGates() {
+    _gateUpdaters.forEach(fn => { try { fn(); } catch {} });
 }
 
 /**
@@ -1719,14 +1739,30 @@ function gateButtonOnInputs(button, inputs) {
         el.__gateBound = true;
         el.addEventListener("input", update);
         el.addEventListener("change", update);
+        // Autofill detection (Chromium/Edge): the browser's :-webkit-autofill
+        // pseudo-class triggers our dummy CSS animation, which fires
+        // animationstart even when no input/change event is dispatched.
+        el.addEventListener("animationstart", (e) => {
+            if (e.animationName === "onAutoFillStart" ||
+                e.animationName === "onAutoFillCancel") {
+                update();
+            }
+        });
+        // Re-check whenever the user interacts with the field — catches
+        // autofill that lands on focus in some Chromium paths.
+        el.addEventListener("focus", update);
+        el.addEventListener("blur", update);
     });
+    _gateUpdaters.add(update);
     update();
     return update;
 }
 
 /**
  * Auto-bind: for every <form data-gate-required>, disable its submit button
- * until all [required] fields inside are non-empty.
+ * until all [required] fields inside are non-empty. Uses form-level event
+ * delegation so fields that become required dynamically (e.g. a capture
+ * duration select revealed by a toggle) are picked up automatically.
  */
 function bindFormsRequiredGating(root) {
     (root || document).querySelectorAll("form[data-gate-required]").forEach(form => {
@@ -1734,10 +1770,38 @@ function bindFormsRequiredGating(root) {
         form.__gateBound = true;
         const btn = form.querySelector('button[type="submit"], button.btn-primary');
         if (!btn) return;
-        const required = Array.from(form.querySelectorAll("[required]"));
-        if (!required.length) return;
-        gateButtonOnInputs(btn, required);
+
+        const update = () => {
+            const required = Array.from(form.querySelectorAll("[required]"));
+            btn.disabled = required.length > 0 && !required.every(_hasValue);
+        };
+        form.__gateUpdate = update;
+        _gateUpdaters.add(update);
+
+        // Event delegation at the form level catches current and future fields.
+        form.addEventListener("input", update);
+        form.addEventListener("change", update);
+        // animationstart doesn't bubble in some engines — use capture phase.
+        form.addEventListener("animationstart", (e) => {
+            if (e.animationName === "onAutoFillStart" ||
+                e.animationName === "onAutoFillCancel") {
+                update();
+            }
+        }, true);
+
+        update();
     });
 }
 
 document.addEventListener("DOMContentLoaded", () => bindFormsRequiredGating());
+
+// Autofill typically completes between DOMContentLoaded and window.load —
+// re-evaluate every gate once everything is settled.
+window.addEventListener("load", () => {
+    // Double rAF to ensure we run after the browser has applied autofill.
+    requestAnimationFrame(() => requestAnimationFrame(_rerunAllGates));
+});
+
+// pageshow fires on back/forward cache restores, where autofill state
+// may already be present without any events having fired.
+window.addEventListener("pageshow", _rerunAllGates);

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1400,3 +1400,24 @@ tr.highlight-new td {
     padding-top: 0.8rem;
     border-top: 1px solid var(--primary);
 }
+
+
+/* ── Autofill detection hook (issue #348) ─────────────────────────────
+ * Chromium (Edge/Chrome) populates :-webkit-autofill fields without firing
+ * input/change events. Attaching a dummy CSS animation lets us detect
+ * autofill via an animationstart event on the input. See
+ * gateButtonOnInputs() in app.js. */
+@keyframes onAutoFillStart { from {} to {} }
+@keyframes onAutoFillCancel { from {} to {} }
+input:-webkit-autofill,
+select:-webkit-autofill,
+textarea:-webkit-autofill {
+    animation-name: onAutoFillStart;
+    animation-duration: 1ms;
+}
+input:not(:-webkit-autofill),
+select:not(:-webkit-autofill),
+textarea:not(:-webkit-autofill) {
+    animation-name: onAutoFillCancel;
+    animation-duration: 1ms;
+}

--- a/tests_e2e/test_ui_form_gating.py
+++ b/tests_e2e/test_ui_form_gating.py
@@ -1,0 +1,161 @@
+"""Playwright tests for required-input submit-button gating.
+
+Covers the shared `bindFormsRequiredGating` wiring in ``cms/static/app.js``:
+
+1. Submit button starts disabled when required fields are empty.
+2. Button becomes enabled once all required fields are filled via normal input.
+3. Browser-autofill path (issue #348): Chromium autofill silently sets
+   ``input.value`` without emitting ``input``/``change``. We hook
+   ``animationstart`` on a CSS-animation tied to the ``:-webkit-autofill``
+   pseudo-class to re-evaluate the gate. This test simulates that by
+   assigning ``.value`` directly and dispatching a synthetic
+   ``animationstart`` with the expected ``animationName``.
+4. Video Stream card: the "capture duration" select is marked required
+   dynamically when Save-locally is on and the probe reports a live
+   stream. The gate must re-evaluate when ``required`` flips.
+"""
+
+from playwright.sync_api import Page, expect
+
+
+# ── Schedules page ────────────────────────────────────────────────────────
+
+class TestScheduleFormGating:
+    def test_submit_disabled_on_load(self, page: Page, api, base_url: str):
+        # Schedule form only renders when both a group and a ready asset exist.
+        api.create_asset("gate-disabled-test.mp4")
+        api.post("/api/devices/groups/", json={"name": "Gate-Disabled-Group"})
+
+        page.goto(f"{base_url}/schedules")
+        btn = page.locator("form[data-gate-required] button[type='submit']").first
+        expect(btn).to_be_disabled()
+
+    def test_submit_enables_after_filling_required(
+        self, page: Page, api, base_url: str
+    ):
+        # Need at least one asset and one group so the selects have options.
+        api.create_asset("gate-test.mp4")
+        api.post("/api/devices/groups/", json={"name": "Gate-Test-Group"})
+
+        page.goto(f"{base_url}/schedules")
+        form = page.locator("form[data-gate-required]").first
+        btn = form.locator("button[type='submit']")
+        expect(btn).to_be_disabled()
+
+        page.fill('input[name="name"]', "Gating Test")
+        # Pick the first non-placeholder option for each select.
+        page.evaluate("""
+            () => {
+                const form = document.querySelector('form[data-gate-required]');
+                for (const sel of form.querySelectorAll('select')) {
+                    const opt = Array.from(sel.options).find(o => o.value);
+                    if (opt) { sel.value = opt.value;
+                        sel.dispatchEvent(new Event('change', {bubbles: true})); }
+                }
+            }
+        """)
+        page.fill('input[name="start_time"]', "09:00")
+        page.fill('input[name="end_time"]', "17:00")
+
+        expect(btn).to_be_enabled()
+
+    def test_autofill_triggers_gate_reevaluation(
+        self, page: Page, api, base_url: str
+    ):
+        """Autofill sets .value without events; animationstart hook must refresh."""
+        api.create_asset("autofill-test.mp4")
+        api.post("/api/devices/groups/", json={"name": "Autofill-Test-Group"})
+
+        page.goto(f"{base_url}/schedules")
+        form = page.locator("form[data-gate-required]").first
+        btn = form.locator("button[type='submit']")
+        expect(btn).to_be_disabled()
+
+        # Silently mutate every required field (bypasses input/change events).
+        page.evaluate("""
+            () => {
+                const form = document.querySelector('form[data-gate-required]');
+                for (const el of form.querySelectorAll('[required]')) {
+                    if (el.tagName === 'SELECT') {
+                        const opt = Array.from(el.options).find(o => o.value);
+                        if (opt) el.value = opt.value;
+                    } else if (el.type === 'time') {
+                        el.value = '12:00';
+                    } else {
+                        el.value = 'autofilled';
+                    }
+                }
+            }
+        """)
+
+        # Sanity: without events the button must still be disabled.
+        expect(btn).to_be_disabled()
+
+        # Now fire the autofill animation hook.
+        page.evaluate("""
+            () => {
+                const form = document.querySelector('form[data-gate-required]');
+                form.dispatchEvent(new AnimationEvent('animationstart', {
+                    animationName: 'onAutoFillStart',
+                    bubbles: true,
+                }));
+            }
+        """)
+        expect(btn).to_be_enabled()
+
+
+# ── Video Stream card (Assets page) ───────────────────────────────────────
+
+class TestStreamFormGating:
+    def test_submit_disabled_on_load(self, page: Page, base_url: str):
+        page.goto(f"{base_url}/assets")
+        page.evaluate("switchAddTab('stream')")
+        btn = page.locator("#stream-submit")
+        expect(btn).to_be_disabled()
+
+    def test_submit_enables_after_url_filled(self, page: Page, base_url: str):
+        page.goto(f"{base_url}/assets")
+        page.evaluate("switchAddTab('stream')")
+        btn = page.locator("#stream-submit")
+        expect(btn).to_be_disabled()
+        page.fill("#stream-url", "https://example.com/live.m3u8")
+        expect(btn).to_be_enabled()
+
+    def test_dynamically_required_field_regates_button(
+        self, page: Page, base_url: str
+    ):
+        """Regression test for issue #348.
+
+        The Video Stream card makes ``#stream-capture-duration`` required
+        dynamically (via ``onSaveLocallyChanged`` when save-locally is on
+        and the probe reports a live stream). The shared gate originally
+        snapshotted the required set once at DOMContentLoaded and missed
+        later additions. The form-level delegation fix re-evaluates on
+        every input/change/animation, so a field flipped to
+        ``required=true`` programmatically must immediately re-disable
+        the submit button.
+        """
+        page.goto(f"{base_url}/assets")
+        page.evaluate("switchAddTab('stream')")
+        btn = page.locator("#stream-submit")
+
+        # Fill URL (only statically-required field) → button enables.
+        page.fill("#stream-url", "https://example.com/live.m3u8")
+        expect(btn).to_be_enabled()
+
+        # Programmatically mark the duration select as required and
+        # trigger the same refresh path the real onSaveLocallyChanged
+        # uses (which doesn't emit input/change). Also reveal the
+        # parent group so select_option can interact with it.
+        page.evaluate("""
+            () => {
+                document.getElementById('stream-duration-group').style.display = 'block';
+                document.getElementById('stream-capture-duration').required = true;
+                document.getElementById('stream-form').__gateUpdate();
+            }
+        """)
+        expect(btn).to_be_disabled()
+
+        # Picking a duration should re-enable via a normal change event.
+        page.select_option("#stream-capture-duration", value="300")
+        expect(btn).to_be_enabled()


### PR DESCRIPTION
Fixes #348.

## Problem

The per-form submit-button gating shipped in #315 / PR #324 had two gaps:

1. **Browser autofill.** Chromium/Edge silently set `input.value` without emitting `input` / `change`, so the gate never re-evaluated. The button stayed disabled even after autofill populated every required field; users had to manually edit a field to enable it.
2. **Dynamically-required fields.** `bindFormsRequiredGating` snapshotted `[required]` once at DOMContentLoaded. On Assets -> Video Stream, `#stream-capture-duration` is marked required by JS only when Save-locally is on and the probe reports a live stream, so the submit button enabled as soon as the URL was filled.

## Fix

- Refactor `bindFormsRequiredGating` to use **form-level event delegation** (`input` / `change` / `animationstart` on the form). Re-queries `[required]` on every fire, picking up dynamic additions/removals automatically.
- Add a CSS `@keyframes` tied to the `:-webkit-autofill` pseudo-class and its inverse; Chromium fires `animationstart` when a field enters/leaves the autofill state. The form listens in the capture phase and refreshes the gate.
- `onSaveLocallyChanged` now calls `form.__gateUpdate()` after toggling `required` (programmatic attr changes don't emit events).
- Custom-duration dropdown ('Custom...') now toggles `required` on the inline number input.

## Tests

New `tests_e2e/test_ui_form_gating.py` (6 tests, all passing):
- Schedule + Stream forms: disabled on load, enabled after filling required fields.
- Schedule form: **autofill simulation** -- sets values silently, asserts button stays disabled, dispatches synthetic `animationstart` with `animationName='onAutoFillStart'`, asserts button enables.
- Stream form: **dynamic-required regression** -- flips `required` on duration select and calls `__gateUpdate()`, asserts button re-disables.

## Production state

This fix was hot-patched to prod as `agora-cms:hotfix-autofill-1` earlier today (user verified in Edge); subsequent CD run `24637022321` overwrote it, so this PR restores the fix via the proper path.

## Refs
- #315 (original gating ask)
- PR #324 (initial implementation)