### PR TITLE
fix(devices): render display_connected badge on initial page load

### DIFF
--- a/cms/ui.py
+++ b/cms/ui.py
@@ -979,11 +979,12 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         d.playback_position_ms = state["playback_position_ms"] if state else None
         d.ssh_enabled = state["ssh_enabled"] if state else None
         d.local_api_enabled = state["local_api_enabled"] if state else None
+        d.display_connected = state["display_connected"] if state else None
         d.update_available = is_update_available(d.firmware_version)
         d.is_upgrading = d.id in _devices_upgrading
         d.has_active_schedule = d.id in scheduled_device_ids
 
-    groups_query = (
+    groups_query= (
         select(DeviceGroup)
         .options(selectinload(DeviceGroup.devices))
         .order_by(DeviceGroup.name)
@@ -1026,6 +1027,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
             d.playback_position_ms = state["playback_position_ms"] if state else None
             d.ssh_enabled = state["ssh_enabled"] if state else None
             d.local_api_enabled = state["local_api_enabled"] if state else None
+            d.display_connected = state["display_connected"] if state else None
             d.update_available = is_update_available(d.firmware_version)
             d.is_upgrading = d.id in _devices_upgrading
             d.has_active_schedule = d.id in scheduled_device_ids

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -356,6 +356,26 @@ class TestDevicesUILiveUpdates:
         assert resp.status_code == 200
         assert "10.0.0.42" in resp.text
 
+    async def test_display_connected_badge_rendered_on_initial_page_load(self, client, device_with_live_state):
+        """Regression: /devices should render the Connected badge on first render
+        (not wait for a WebSocket push). The fixture sets display_connected=True,
+        so the detail panel must show 'Connected' — not 'Disconnected' or '—'.
+        Prior to the fix, d.display_connected was never populated from live_states
+        on the server-side template context, so Jinja saw Undefined and fell
+        through to the 'Disconnected' else-branch until the WS heartbeat arrived.
+        """
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        text = resp.text
+        idx = text.find(f'data-live-display="{device_with_live_state}"')
+        assert idx > -1
+        # Slice the ~300 chars after the anchor — the badge is within that span.
+        snippet = text[idx:idx + 300]
+        assert 'badge-online">Connected<' in snippet, (
+            "Expected Connected badge on initial render; got:\n" + snippet
+        )
+        assert 'Disconnected' not in snippet
+
 
 @pytest.mark.asyncio
 class TestFirmwareBadgePermission:


### PR DESCRIPTION
# fix(devices): render display_connected badge on initial page load

## Bug

On a `/devices` page refresh, the Display badge rendered as "Disconnected"
for 5–10s before flipping to "Connected" once the next WebSocket heartbeat
arrived.

## Root cause

`DeviceManager` holds `display_connected` in memory on the `ConnectedDevice`
state record. The `/devices` page handler copies live-state fields onto each
ORM `Device` object before handing it to Jinja. Every other live field gets
this treatment (`cpu_temp_c`, `ip_address`, `pipeline_state`, …) — but
`display_connected` was missing from both device-iteration loops (ungrouped
and grouped). The SQLAlchemy `Device` model has no `display_connected`
column, so Jinja was reading `Undefined` → `{% elif d.display_connected %}`
fell through to `{% else %}Disconnected` on first paint. JS at
`templates/devices.html:561-564` then flipped the DOM a heartbeat later.

## Fix

One-line addition in each of the two loops in `cms/ui.py`:

```python
d.display_connected = state["display_connected"] if state else None
```

## Test

New test in `tests/test_device_live_updates.py`:
`test_display_connected_badge_rendered_on_initial_page_load` asserts that the
initial HTML response contains `badge-online">Connected<` anchored at the
device's `data-live-display` marker, and no "Disconnected" in the same
region.

38 existing tests in the file continue to pass.

## Known follow-up

Tracked in #344 (CMS multi-replica safety): this whole pattern of copying
in-memory live-state onto ORM objects per request is per-process state and
won't survive sharding. Fixing the badge properly means either denormalizing
`display_connected` onto the DB or pulling state from a shared store. That
refactor belongs to #344; this PR only plumbs the existing field through so
the current single-replica behavior matches the heartbeat-updated DOM.
