### PR TITLE
fix(display): friendly badge label + bell notification after grace period

### DIFF
--- a/cms/models/notification_pref.py
+++ b/cms/models/notification_pref.py
@@ -27,7 +27,7 @@ class UserNotificationPref(Base):
     )
     event_type: Mapped[str] = mapped_column(
         String(50), nullable=False,
-        doc="Event type: offline, online, temp_high, temp_cleared",
+        doc="Event type: offline, online, temp_high, temp_cleared, display_disconnected, display_connected",
     )
     email_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/cms/routers/notification_prefs.py
+++ b/cms/routers/notification_prefs.py
@@ -13,7 +13,8 @@ from cms.schemas.notification_pref import NotificationPrefOut, NotificationPrefU
 router = APIRouter(prefix="/api/notification-preferences")
 
 # Event types that support email notifications
-SUPPORTED_EVENT_TYPES = ["offline", "online", "temp_high", "temp_cleared"]
+SUPPORTED_EVENT_TYPES = ["offline", "online", "temp_high", "temp_cleared",
+                          "display_disconnected", "display_connected"]
 
 
 @router.get("", response_model=list[NotificationPrefOut])

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -455,6 +455,17 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                             event_type=_ev_type.value,
                         ))
                         await db.commit()
+
+                        # Notify alert service so it can manage the bell-notification
+                        # grace period (event log entry written above is unconditional).
+                        alert_service.display_state_changed(
+                            device_id,
+                            device_name=_device_name,
+                            group_id=_group_id,
+                            group_name=_group_name,
+                            status=_device_status,
+                            connected=bool(_new_display),
+                        )
                 except Exception:
                     logger.exception("Failed to log display transition for %s", device_id)
 

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -31,6 +31,7 @@ DEFAULT_OFFLINE_GRACE_SECONDS = 120
 DEFAULT_TEMP_WARNING_C = 70.0
 DEFAULT_TEMP_CRITICAL_C = 80.0
 DEFAULT_TEMP_COOLDOWN_SECONDS = 300
+DEFAULT_DISPLAY_GRACE_SECONDS = 120
 
 
 class _TempState:
@@ -56,19 +57,37 @@ class _OfflineTimer:
         self.group_name = group_name
 
 
+class _DisplayTimer:
+    """Per-device display-disconnected grace-period tracker."""
+
+    __slots__ = ("task", "device_name", "group_id", "group_name")
+
+    def __init__(self, task: asyncio.Task, device_name: str,
+                 group_id: Optional[str], group_name: str):
+        self.task = task
+        self.device_name = device_name
+        self.group_id = group_id
+        self.group_name = group_name
+
+
 class AlertService:
     """Singleton service wired into the WebSocket handler."""
 
     def __init__(self):
         self._offline_timers: dict[str, _OfflineTimer] = {}
         self._temp_states: dict[str, _TempState] = {}
+        self._display_timers: dict[str, _DisplayTimer] = {}
         # Tracks devices that had an OFFLINE event fired (for "back online" logic)
         self._was_offline: set[str] = set()
+        # Tracks devices that had a DISPLAY_DISCONNECTED notification fired
+        # (so we know to send a "display reconnected" notification on recovery)
+        self._was_display_off: set[str] = set()
         # Cached settings (refreshed periodically)
         self._offline_grace_seconds: int = DEFAULT_OFFLINE_GRACE_SECONDS
         self._temp_warning_c: float = DEFAULT_TEMP_WARNING_C
         self._temp_critical_c: float = DEFAULT_TEMP_CRITICAL_C
         self._temp_cooldown_seconds: int = DEFAULT_TEMP_COOLDOWN_SECONDS
+        self._display_grace_seconds: int = DEFAULT_DISPLAY_GRACE_SECONDS
         self._email_enabled: bool = False
 
     # ── Settings ──
@@ -91,6 +110,9 @@ class AlertService:
                 val = await get_setting(db, "alert_temp_cooldown_seconds")
                 if val is not None:
                     self._temp_cooldown_seconds = int(val)
+                val = await get_setting(db, "alert_display_grace_seconds")
+                if val is not None:
+                    self._display_grace_seconds = int(val)
                 val = await get_setting(db, "email_notifications_enabled")
                 self._email_enabled = val == "true"
                 break
@@ -124,6 +146,16 @@ class AlertService:
         existing = self._offline_timers.pop(device_id, None)
         if existing and not existing.task.done():
             existing.task.cancel()
+
+        # Cancel any pending display-disconnected timer too — the device
+        # being entirely offline supersedes a display-only alert.
+        d_timer = self._display_timers.pop(device_id, None)
+        if d_timer and not d_timer.task.done():
+            d_timer.task.cancel()
+        # Clear "was display off" so we don't fire a stale "display reconnected"
+        # notification if the device's first heartbeat after reconnect reports
+        # the display is connected again.
+        self._was_display_off.discard(device_id)
 
         task = asyncio.create_task(
             self._offline_grace_expired(device_id, device_name, group_id, group_name)
@@ -436,6 +468,164 @@ class AlertService:
         except Exception:
             logger.exception("Failed to create temp event for device %s", device_id)
 
+    # ── Display monitoring ──
+
+    def display_state_changed(
+        self,
+        device_id: str,
+        device_name: str,
+        group_id: Optional[str],
+        group_name: str,
+        status: str,
+        connected: bool,
+    ):
+        """Called from ws.py when a device reports a display connect/disconnect transition.
+
+        The DeviceEvent for the transition is written immediately by ws.py
+        (so the event log always shows the moment it happened). This method
+        only manages the bell-notification grace period — momentary HDMI
+        glitches shouldn't spam users, but a display that stays unplugged for
+        the grace period should produce a warning.
+        """
+        if status != "adopted" or not group_id:
+            return
+
+        if connected:
+            # Display came back. Cancel any pending grace timer.
+            timer = self._display_timers.pop(device_id, None)
+            if timer and not timer.task.done():
+                timer.task.cancel()
+                logger.debug(
+                    "Display grace timer cancelled for %s (display reconnected)",
+                    device_id,
+                )
+
+            # If we previously fired a "display off" notification, follow up
+            # with a "display reconnected" info-level notification.
+            if device_id in self._was_display_off:
+                self._was_display_off.discard(device_id)
+                asyncio.create_task(
+                    self._create_display_reconnected_notification(
+                        device_id, device_name, group_id, group_name,
+                    )
+                )
+            return
+
+        # Display went away — start (or restart) the grace timer.
+        existing = self._display_timers.pop(device_id, None)
+        if existing and not existing.task.done():
+            existing.task.cancel()
+
+        task = asyncio.create_task(
+            self._display_grace_expired(device_id, device_name, group_id, group_name)
+        )
+        self._display_timers[device_id] = _DisplayTimer(
+            task=task, device_name=device_name,
+            group_id=group_id, group_name=group_name,
+        )
+        logger.debug(
+            "Display grace timer started for %s (%ds)",
+            device_id, self._display_grace_seconds,
+        )
+
+    async def _display_grace_expired(
+        self,
+        device_id: str,
+        device_name: str,
+        group_id: str,
+        group_name: str,
+    ):
+        """Fires after the display grace period — creates a notification."""
+        try:
+            await asyncio.sleep(self._display_grace_seconds)
+        except asyncio.CancelledError:
+            return
+
+        # Clean up timer reference
+        self._display_timers.pop(device_id, None)
+
+        # Double-check the display hasn't reconnected during the sleep,
+        # and that the device itself is still online (if the device went
+        # fully offline during grace, the offline-alert handler covers it
+        # — no need to also fire a display-disconnected notification).
+        from cms.services.device_manager import device_manager
+        conn = device_manager.get(device_id)
+        if conn is None:
+            return
+        if conn.display_connected:
+            return
+
+        self._was_display_off.add(device_id)
+        logger.info(
+            "Device %s (%s) display disconnected — grace period expired, sending notification",
+            device_id, device_name,
+        )
+
+        try:
+            from cms.database import get_db
+            async for db in get_db():
+                gid = _to_uuid(group_id)
+                notification = Notification(
+                    scope="group",
+                    level="warning",
+                    title=f"Display disconnected: {device_name}",
+                    message=(
+                        f"Device '{device_name}' in group '{group_name}' has had "
+                        f"its HDMI display disconnected for over "
+                        f"{self._display_grace_seconds} seconds."
+                    ),
+                    group_id=gid,
+                    details={
+                        "device_id": device_id,
+                        "event_type": DeviceEventType.DISPLAY_DISCONNECTED.value,
+                    },
+                )
+                db.add(notification)
+                await db.commit()
+                logger.info("Display-disconnected notification created for device %s", device_id)
+                break
+        except Exception:
+            logger.exception(
+                "Failed to create display-disconnected notification for device %s",
+                device_id,
+            )
+
+    async def _create_display_reconnected_notification(
+        self,
+        device_id: str,
+        device_name: str,
+        group_id: str,
+        group_name: str,
+    ):
+        """Create a "display reconnected" follow-up notification."""
+        try:
+            from cms.database import get_db
+            gid = _to_uuid(group_id)
+            async for db in get_db():
+                notification = Notification(
+                    scope="group",
+                    level="info",
+                    title=f"Display reconnected: {device_name}",
+                    message=(
+                        f"Device '{device_name}' in group '{group_name}' "
+                        f"HDMI display is connected again."
+                    ),
+                    group_id=gid,
+                    details={
+                        "device_id": device_id,
+                        "event_type": DeviceEventType.DISPLAY_CONNECTED.value,
+                    },
+                )
+                db.add(notification)
+                await db.commit()
+                logger.info("Display-reconnected notification created for device %s", device_id)
+                break
+        except Exception:
+            logger.exception(
+                "Failed to create display-reconnected notification for device %s",
+                device_id,
+            )
+
     # ── Cleanup ──
 
     def cleanup_device(self, device_id: str):
@@ -443,8 +633,12 @@ class AlertService:
         timer = self._offline_timers.pop(device_id, None)
         if timer and not timer.task.done():
             timer.task.cancel()
+        d_timer = self._display_timers.pop(device_id, None)
+        if d_timer and not d_timer.task.done():
+            d_timer.task.cancel()
         self._temp_states.pop(device_id, None)
         self._was_offline.discard(device_id)
+        self._was_display_off.discard(device_id)
 
 
 # Singleton

--- a/cms/templates/event_log.html
+++ b/cms/templates/event_log.html
@@ -20,6 +20,10 @@
                     <option value="offline" {% if filter_event_type == 'offline' %}selected{% endif %}>Offline</option>
                     <option value="temp_high" {% if filter_event_type == 'temp_high' %}selected{% endif %}>Temperature High</option>
                     <option value="temp_cleared" {% if filter_event_type == 'temp_cleared' %}selected{% endif %}>Temperature Cleared</option>
+                    <option value="display_disconnected" {% if filter_event_type == 'display_disconnected' %}selected{% endif %}>Display Disconnected</option>
+                    <option value="display_connected" {% if filter_event_type == 'display_connected' %}selected{% endif %}>Display Connected</option>
+                    <option value="error" {% if filter_event_type == 'error' %}selected{% endif %}>Error</option>
+                    <option value="error_cleared" {% if filter_event_type == 'error_cleared' %}selected{% endif %}>Error Cleared</option>
                     <option value="cms_started" {% if filter_event_type == 'cms_started' %}selected{% endif %}>CMS Started</option>
                     <option value="cms_stopped" {% if filter_event_type == 'cms_stopped' %}selected{% endif %}>CMS Stopped</option>
                 </select>
@@ -88,6 +92,14 @@
                     <span class="badge badge-warning">Temp High</span>
                     {% elif event.event_type == 'temp_cleared' %}
                     <span class="badge badge-success">Temp Cleared</span>
+                    {% elif event.event_type == 'display_disconnected' %}
+                    <span class="badge badge-warning">Display Disconnected</span>
+                    {% elif event.event_type == 'display_connected' %}
+                    <span class="badge badge-success">Display Connected</span>
+                    {% elif event.event_type == 'error' %}
+                    <span class="badge badge-offline">Error</span>
+                    {% elif event.event_type == 'error_cleared' %}
+                    <span class="badge badge-success">Error Cleared</span>
                     {% elif event.event_type == 'cms_started' %}
                     <span class="badge badge-online">CMS Started</span>
                     {% elif event.event_type == 'cms_stopped' %}
@@ -107,6 +119,14 @@
                     Grace period: {{ event.details.grace_period }}s
                     {% elif event.event_type == 'online' %}
                     Back online
+                    {% elif event.event_type == 'display_disconnected' %}
+                    HDMI display disconnected
+                    {% elif event.event_type == 'display_connected' %}
+                    HDMI display connected
+                    {% elif event.event_type == 'error' and event.details and event.details.error %}
+                    {{ event.details.error }}
+                    {% elif event.event_type == 'error_cleared' %}
+                    Error cleared
                     {% elif event.event_type in ['cms_started', 'cms_stopped'] and event.details and event.details.version %}
                     Version {{ event.details.version }}
                     {% else %}
@@ -197,6 +217,10 @@
             offline: ["badge-offline", "Offline"],
             temp_high: ["badge-warning", "Temp High"],
             temp_cleared: ["badge-success", "Temp Cleared"],
+            display_disconnected: ["badge-warning", "Display Disconnected"],
+            display_connected: ["badge-success", "Display Connected"],
+            error: ["badge-offline", "Error"],
+            error_cleared: ["badge-success", "Error Cleared"],
             cms_started: ["badge-online", "CMS Started"],
             cms_stopped: ["badge-offline", "CMS Stopped"],
         };
@@ -213,6 +237,10 @@
             return `Grace period: ${d.grace_period}s`;
         }
         if (ev.event_type === "online") return "Back online";
+        if (ev.event_type === "display_disconnected") return "HDMI display disconnected";
+        if (ev.event_type === "display_connected") return "HDMI display connected";
+        if (ev.event_type === "error" && d.error) return d.error;
+        if (ev.event_type === "error_cleared") return "Error cleared";
         if ((ev.event_type === "cms_started" || ev.event_type === "cms_stopped") && d.version) {
             return `Version ${d.version}`;
         }

--- a/cms/templates/profile.html
+++ b/cms/templates/profile.html
@@ -265,6 +265,8 @@
         "online": { label: "Device Online", desc: "When a previously-offline device comes back online" },
         "temp_high": { label: "Temperature High", desc: "When a device exceeds temperature warning or critical thresholds" },
         "temp_cleared": { label: "Temperature Cleared", desc: "When a device temperature returns to normal" },
+        "display_disconnected": { label: "Display Disconnected", desc: "When a device's HDMI display has been disconnected for the grace period" },
+        "display_connected": { label: "Display Connected", desc: "When a previously-disconnected HDMI display reconnects" },
     };
 
     let prefs = [];

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -258,6 +258,16 @@ async function testSmtp() {
                 <input type="number" id="alert-temp-cooldown" min="60" max="3600" value="{{ alert_temp_cooldown }}" style="max-width: 150px;">
             </div>
         </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="alert-display-grace">Display Disconnect Grace Period (seconds)</label>
+                <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+                    How long the HDMI display must stay disconnected before creating a notification.
+                    The event log records the moment of disconnect regardless of this setting.
+                </p>
+                <input type="number" id="alert-display-grace" min="10" max="3600" value="{{ alert_display_grace }}" style="max-width: 150px;">
+            </div>
+        </div>
 
         <label style="display: flex; align-items: center; gap: 0.5rem; margin: 1rem 0; cursor: pointer;">
             <input type="checkbox" id="alert-email-enabled" {% if alert_email_enabled %}checked{% endif %} style="width: auto; margin: 0;">
@@ -279,6 +289,7 @@ async function saveAlertSettings() {
         temp_warning_c: parseFloat(document.getElementById("alert-temp-warning").value) || 70,
         temp_critical_c: parseFloat(document.getElementById("alert-temp-critical").value) || 80,
         temp_cooldown_seconds: parseInt(document.getElementById("alert-temp-cooldown").value) || 300,
+        display_grace_seconds: parseInt(document.getElementById("alert-display-grace").value) || 120,
         email_notifications_enabled: document.getElementById("alert-email-enabled").checked,
     };
     try {

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1537,6 +1537,7 @@ async def settings_page(
     alert_temp_warning = await get_setting(db, "alert_temp_warning_c") or "70"
     alert_temp_critical = await get_setting(db, "alert_temp_critical_c") or "80"
     alert_temp_cooldown = await get_setting(db, "alert_temp_cooldown_seconds") or "300"
+    alert_display_grace = await get_setting(db, "alert_display_grace_seconds") or "120"
     alert_email_enabled = (await get_setting(db, "email_notifications_enabled")) == "true"
 
     return templates.TemplateResponse(request, "settings.html", {
@@ -1555,6 +1556,7 @@ async def settings_page(
         "alert_temp_warning": alert_temp_warning,
         "alert_temp_critical": alert_temp_critical,
         "alert_temp_cooldown": alert_temp_cooldown,
+        "alert_display_grace": alert_display_grace,
         "alert_email_enabled": alert_email_enabled,
         "success": None,
         "error": None,
@@ -1723,6 +1725,7 @@ async def save_alert_settings(
     await set_setting(db, "alert_temp_warning_c", str(float(body.get("temp_warning_c", 70))))
     await set_setting(db, "alert_temp_critical_c", str(float(body.get("temp_critical_c", 80))))
     await set_setting(db, "alert_temp_cooldown_seconds", str(int(body.get("temp_cooldown_seconds", 300))))
+    await set_setting(db, "alert_display_grace_seconds", str(int(body.get("display_grace_seconds", 120))))
     await set_setting(db, "email_notifications_enabled", "true" if body.get("email_notifications_enabled") else "false")
 
     await audit_log(
@@ -1733,6 +1736,7 @@ async def save_alert_settings(
             "temp_warning_c": body.get("temp_warning_c"),
             "temp_critical_c": body.get("temp_critical_c"),
             "temp_cooldown_seconds": body.get("temp_cooldown_seconds"),
+            "display_grace_seconds": body.get("display_grace_seconds"),
             "email_notifications_enabled": bool(body.get("email_notifications_enabled")),
         },
         request=request,

--- a/tests/nightly/test_13_display_disconnect_notifications.py
+++ b/tests/nightly/test_13_display_disconnect_notifications.py
@@ -1,0 +1,335 @@
+"""Phase 13: display-disconnected -> scoped notification round-trip.
+
+End-to-end coverage of the alert_service display-monitoring path:
+
+    sim display fault -> cms_client WS heartbeat -> alert_service grace
+        -> Notification (scope=group) + DeviceEvent
+            (display_disconnected | display_connected)
+        -> dashboard recent activity / notification bell / event log
+
+Mirrors the thermal smoke test (Phase 9 / test_08) but for the display
+state pipeline added in agora-cms (display badges + bell notifications)
+and the agora-device-simulator ``display_connected`` fault knob.
+
+Round-trip phases exercised in order:
+
+  01 - admin pins an adopted device to Group A.
+  02 - simulator sets ``display_connected=false`` via the fault API and
+       the CMS observes it within a few heartbeats.
+  03 - admin event log + dashboard "Recent Activity" pick up the
+       DISPLAY_DISCONNECTED row immediately (no grace period applies to
+       the event log, only to the bell notification).
+  04 - after the production grace period (~120 s) alert_service emits a
+       Notification (scope=group, level=warning, event=display_disconnected)
+       which admin and Operator A (Group A) both see; Operator B
+       (Group B) does NOT.
+  05 - reconnect: simulator clears the fault. ws.py writes the
+       DISPLAY_CONNECTED DeviceEvent and alert_service emits a
+       follow-up DISPLAY_CONNECTED notification (level=info).
+  99 - belt-and-braces cleanup: clear the simulator fault.
+
+Depends on Phases 0-7 having set up OOBE, adopted devices, and created
+the RBAC fixtures (Operator A / Viewer in Group A, Operator B in Group B).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from playwright.sync_api import BrowserContext, Page
+
+from tests.nightly.test_06_rbac import (
+    OPERATOR_A,
+    OPERATOR_B,
+    STATE as RBAC_STATE,
+    VIEWER,
+    _login_page,
+)
+
+
+# State propagation: heartbeat-driven, ~3 s rapid cadence on transition.
+DISPLAY_PROPAGATION_TIMEOUT_S = 60.0
+# Production grace (alert_service.DEFAULT_DISPLAY_GRACE_SECONDS = 120). We
+# poll for the notification past this window with a generous margin so a
+# slow CI runner doesn't flake the test.
+DISPLAY_GRACE_SECONDS = 120
+NOTIF_TIMEOUT_S = DISPLAY_GRACE_SECONDS + 60.0
+# DeviceEvent emission is fire-and-forget after the WS message is processed.
+EVENT_EMISSION_TIMEOUT_S = 15.0
+
+
+# Shared state populated by earlier tests in this module.
+DISPLAY_STATE: dict[str, Any] = {
+    "device_id": None,      # CMS UUID of the device we pinned to Group A
+    "device_serial": None,  # simulator serial used to trigger the fault
+}
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _list_notifications(page: Page) -> list[dict]:
+    resp = page.request.get("/api/notifications?limit=200")
+    assert resp.status == 200, f"list notifications -> {resp.status}: {resp.text()[:400]}"
+    return resp.json()
+
+
+def _list_device_events(
+    page: Page, *, device_id: str | None = None, event_type: str | None = None
+) -> list[dict]:
+    qs = []
+    if device_id:
+        qs.append(f"device_id={device_id}")
+    if event_type:
+        qs.append(f"event_type={event_type}")
+    qs.append("limit=200")
+    url = "/api/device-events?" + "&".join(qs)
+    resp = page.request.get(url)
+    assert resp.status == 200, f"list device-events -> {resp.status}: {resp.text()[:400]}"
+    return resp.json()
+
+
+def _notifs_for(notifs: list[dict], device_id: str, event_type: str) -> list[dict]:
+    """Filter notifications to ones emitted by alert_service for (device, event_type)."""
+    out: list[dict] = []
+    for n in notifs:
+        det = n.get("details") or {}
+        if str(det.get("device_id", "")) != str(device_id):
+            continue
+        if str(det.get("event_type", "")) != event_type:
+            continue
+        out.append(n)
+    return out
+
+
+def _has_notif_for(notifs: list[dict], device_id: str, event_type: str) -> bool:
+    return bool(_notifs_for(notifs, device_id, event_type))
+
+
+def _wait_for_event(
+    page: Page, device_id: str, event_type: str, *, timeout: float = EVENT_EMISSION_TIMEOUT_S
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        events = _list_device_events(page, device_id=device_id, event_type=event_type)
+        if events:
+            return events[0]
+        time.sleep(0.5)
+    pytest.fail(
+        f"no {event_type!r} device event for device {device_id} after {timeout}s"
+    )
+
+
+def _wait_for_notif(
+    page: Page, device_id: str, event_type: str, *, timeout: float
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        matches = _notifs_for(_list_notifications(page), device_id, event_type)
+        if matches:
+            return matches[0]
+        # Long-sleep loop — poll less often to keep server load low.
+        time.sleep(2.0)
+    pytest.fail(
+        f"no {event_type!r} notification for device {device_id} after {timeout}s"
+    )
+
+
+def _wait_for_display_state(
+    page: Page, device_id: str, *, expected: bool
+) -> bool:
+    """Poll GET /api/devices/{id} until display_connected matches the expected bool."""
+    deadline = time.monotonic() + DISPLAY_PROPAGATION_TIMEOUT_S
+    last: Any = "<unread>"
+    while time.monotonic() < deadline:
+        resp = page.request.get(f"/api/devices/{device_id}")
+        if resp.status == 200:
+            last = resp.json().get("display_connected")
+            if last is expected:
+                return last
+        time.sleep(0.5)
+    pytest.fail(
+        f"display_connected never reached {expected!r} for device {device_id} "
+        f"after {DISPLAY_PROPAGATION_TIMEOUT_S}s; last value = {last!r}"
+    )
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+def test_01_pin_device_to_group_a(authenticated_page: Page) -> None:
+    """Pin an adopted device into Group A so we can assert per-group RBAC later."""
+    group_a = RBAC_STATE.get("group_a_id")
+    assert group_a, "Phase 7 must have created Group A"
+
+    resp = authenticated_page.request.get("/api/devices")
+    assert resp.status == 200
+    devices = resp.json()
+    adopted = [d for d in devices if d.get("status") in (None, "adopted", "active")]
+    assert adopted, "expected at least one adopted device from Phase 3"
+    device = adopted[0]
+    device_id = device["id"]
+
+    patch = authenticated_page.request.patch(
+        f"/api/devices/{device_id}", data={"group_id": group_a}
+    )
+    assert patch.status == 200, (
+        f"pin device -> group A failed: {patch.status} {patch.text()[:400]}"
+    )
+    assert str(patch.json().get("group_id")) == str(group_a)
+
+    DISPLAY_STATE["device_id"] = device_id
+    # DeviceOut.id IS the serial for adopted Pis (see test_08 comment).
+    DISPLAY_STATE["device_serial"] = device_id
+
+
+def test_02_simulator_disconnects_display(simulator, authenticated_page: Page) -> None:
+    """Drive ``display_connected=false`` via the sim fault API; CMS observes it."""
+    device_id = DISPLAY_STATE["device_id"]
+    serial = DISPLAY_STATE["device_serial"]
+    assert device_id and serial
+
+    simulator.apply_fault(serial, display_connected=False)
+    try:
+        observed = _wait_for_display_state(
+            authenticated_page, device_id, expected=False
+        )
+        assert observed is False, f"expected display_connected=False; saw {observed!r}"
+    except Exception:
+        # Don't leave the device in a faulted state if we abort here.
+        try:
+            simulator.apply_fault(serial, display_connected=True)
+        except Exception:
+            pass
+        raise
+    # Leave the fault applied; later phases assert event log + notification
+    # round-trip while the device is still in the disconnected state.
+
+
+def test_03_event_log_and_recent_activity_show_disconnect(
+    authenticated_page: Page,
+) -> None:
+    """The event log + dashboard 'Recent Activity' pick up DISPLAY_DISCONNECTED.
+
+    Note: the bell notification is gated on a grace period (Phase 04).
+    The event log row is written immediately by ws.py on every transition,
+    independent of any grace timer.
+    """
+    device_id = DISPLAY_STATE["device_id"]
+    assert device_id
+
+    event = _wait_for_event(authenticated_page, device_id, "display_disconnected")
+    assert event["event_type"] == "display_disconnected"
+    assert str(event["device_id"]) == str(device_id)
+
+    # Dashboard "Recent Activity" panel renders this event class. Friendly
+    # labels were added when display badges shipped — accept either spelling
+    # so a future copy tweak doesn't flake the smoke test.
+    resp = authenticated_page.request.get("/")
+    assert resp.status == 200
+    html = resp.text().lower()
+    assert (
+        "display off" in html
+        or "display disconnected" in html
+        or "display_disconnected" in html
+    ), "dashboard recent activity does not reference the display-disconnect event"
+
+
+def test_04_notification_fires_after_grace_period(
+    authenticated_page: Page, browser_context: BrowserContext
+) -> None:
+    """After the grace window, alert_service emits a scoped notification.
+
+    Admin + Operator A (member of Group A) both see it. Viewer (also Group A,
+    read-only) sees it too. Operator B (Group B) does NOT — negative RBAC.
+
+    This phase deliberately waits the production grace period (~2 minutes)
+    so the test reflects what users actually experience.
+    """
+    device_id = DISPLAY_STATE["device_id"]
+    assert device_id
+
+    notif = _wait_for_notif(
+        authenticated_page, device_id, "display_disconnected",
+        timeout=NOTIF_TIMEOUT_S,
+    )
+    assert notif["scope"] == "group", notif
+    assert str(notif["group_id"]) == str(RBAC_STATE["group_a_id"]), notif
+    assert notif["level"] == "warning", (
+        f"display-disconnect notif must be warning, got {notif['level']}"
+    )
+
+    # Operator A (same group) sees it.
+    op_a_page = _login_page(
+        browser_context, OPERATOR_A["email"], OPERATOR_A["password"]
+    )
+    assert _has_notif_for(
+        _list_notifications(op_a_page), device_id, "display_disconnected"
+    ), "Operator A (Group A) should see the display-disconnect notification"
+
+    # Viewer (same group, read-only) sees it too.
+    v_page = _login_page(browser_context, VIEWER["email"], VIEWER["password"])
+    assert _has_notif_for(
+        _list_notifications(v_page), device_id, "display_disconnected"
+    ), "Viewer (Group A) should see the display-disconnect notification"
+
+    # NEGATIVE: Operator B (Group B) must NOT see it.
+    op_b_page = _login_page(
+        browser_context, OPERATOR_B["email"], OPERATOR_B["password"]
+    )
+    assert not _has_notif_for(
+        _list_notifications(op_b_page), device_id, "display_disconnected"
+    ), "Operator B (Group B) must not see Group A's display notification"
+
+    # And no display_disconnected event row in their event log either.
+    op_b_events = _list_device_events(
+        op_b_page, device_id=device_id, event_type="display_disconnected"
+    )
+    assert op_b_events == [], (
+        f"Operator B must not see DISPLAY_DISCONNECTED for a Group A device; "
+        f"got {op_b_events!r}"
+    )
+
+
+def test_05_reconnect_emits_recovery_notification_and_event(
+    simulator, authenticated_page: Page
+) -> None:
+    """Plug the display back in. CMS emits display_connected event + notif."""
+    device_id = DISPLAY_STATE["device_id"]
+    serial = DISPLAY_STATE["device_serial"]
+    assert device_id and serial
+
+    simulator.apply_fault(serial, display_connected=True)
+
+    observed = _wait_for_display_state(
+        authenticated_page, device_id, expected=True
+    )
+    assert observed is True
+
+    # Recovery DeviceEvent appears in the event log immediately.
+    event = _wait_for_event(authenticated_page, device_id, "display_connected")
+    assert event["event_type"] == "display_connected"
+    assert str(event["device_id"]) == str(device_id)
+
+    # alert_service follows up the disconnect alert with an info-level
+    # reconnect notification (no grace period — this fires immediately).
+    recovered = _wait_for_notif(
+        authenticated_page, device_id, "display_connected",
+        timeout=EVENT_EMISSION_TIMEOUT_S,
+    )
+    assert recovered["level"] == "info", recovered
+    assert recovered["scope"] == "group"
+    assert str(recovered["group_id"]) == str(RBAC_STATE["group_a_id"])
+
+
+def test_99_cleanup(simulator) -> None:
+    """Clear the simulator fault so the device is back in its baseline state."""
+    serial = DISPLAY_STATE.get("device_serial")
+    if not serial:
+        return
+    try:
+        simulator.clear_faults(serial)
+    except Exception:
+        pass

--- a/tests/test_device_alerts.py
+++ b/tests/test_device_alerts.py
@@ -526,9 +526,10 @@ class TestNotificationPrefsAPI:
         resp = await client.get("/api/notification-preferences")
         assert resp.status_code == 200
         prefs = resp.json()
-        assert len(prefs) == 4
+        assert len(prefs) == 6
         types = {p["event_type"] for p in prefs}
-        assert types == {"offline", "online", "temp_high", "temp_cleared"}
+        assert types == {"offline", "online", "temp_high", "temp_cleared",
+                         "display_disconnected", "display_connected"}
         assert all(p["email_enabled"] is False for p in prefs)
 
     @pytest.mark.asyncio

--- a/tests/test_display_alerts.py
+++ b/tests/test_display_alerts.py
@@ -1,0 +1,271 @@
+"""Tests for the display-disconnected alert path in alert_service."""
+
+import asyncio
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.notification import Notification
+from cms.services.alert_service import AlertService
+
+
+@pytest_asyncio.fixture
+async def seed_group_and_device(app):
+    """Create an adopted device in a group for display alert testing."""
+    from cms.database import get_db
+    factory = app.dependency_overrides[get_db]
+
+    async for db in factory():
+        group = DeviceGroup(name="Display Alert Group")
+        db.add(group)
+        await db.flush()
+
+        device = Device(
+            id="display-device-001",
+            name="Test Display Device",
+            status=DeviceStatus.ADOPTED,
+            group_id=group.id,
+        )
+        db.add(device)
+        await db.commit()
+        yield {
+            "device_id": device.id,
+            "device_name": device.name,
+            "group_id": str(group.id),
+            "group_name": group.name,
+        }
+        break
+
+
+@pytest_asyncio.fixture
+def fresh_alert_service():
+    """Fresh AlertService with short grace periods for fast tests."""
+    svc = AlertService()
+    svc._offline_grace_seconds = 1
+    svc._display_grace_seconds = 1
+    svc._temp_cooldown_seconds = 1
+    return svc
+
+
+class TestDisplayDisconnect:
+    """Display-disconnected grace period and notifications."""
+
+    @pytest.mark.asyncio
+    async def test_grace_period_fires_notification(self, app, seed_group_and_device, fresh_alert_service):
+        """After the display grace period expires, a warning notification is created.
+
+        Requires the device to still be marked display_disconnected in
+        device_manager when the grace timer fires.
+        """
+        info = seed_group_and_device
+        svc = fresh_alert_service
+
+        # Mark the device as connected via device_manager so the grace
+        # callback's "still disconnected?" check finds it. We set
+        # display_connected=False to indicate the display is off.
+        from cms.services.device_manager import device_manager
+        device_manager.register(info["device_id"], websocket=None)
+        device_manager.update_status(
+            info["device_id"], mode="idle", asset=None, display_connected=False,
+        )
+
+        try:
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=False,
+            )
+
+            await asyncio.sleep(1.5)
+
+            from cms.database import get_db
+            factory = app.dependency_overrides[get_db]
+            async for db in factory():
+                notifs = (await db.execute(
+                    select(Notification).where(
+                        Notification.group_id == uuid.UUID(info["group_id"]),
+                        Notification.level == "warning",
+                    )
+                )).scalars().all()
+                assert any("display disconnected" in n.title.lower() for n in notifs), \
+                    [n.title for n in notifs]
+                break
+        finally:
+            device_manager.disconnect(info["device_id"])
+
+    @pytest.mark.asyncio
+    async def test_reconnect_cancels_grace_period(self, app, seed_group_and_device, fresh_alert_service):
+        """A quick display-reconnect before grace expires suppresses the notification."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+
+        from cms.services.device_manager import device_manager
+        device_manager.register(info["device_id"], websocket=None)
+        device_manager.update_status(
+            info["device_id"], mode="idle", asset=None, display_connected=False,
+        )
+
+        try:
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=False,
+            )
+            # Reconnect immediately
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=True,
+            )
+
+            await asyncio.sleep(1.5)
+
+            from cms.database import get_db
+            factory = app.dependency_overrides[get_db]
+            async for db in factory():
+                notifs = (await db.execute(
+                    select(Notification).where(
+                        Notification.group_id == uuid.UUID(info["group_id"]),
+                    )
+                )).scalars().all()
+                assert not any("display disconnected" in n.title.lower() for n in notifs)
+                # Also: no "display reconnected" notification, since the warning
+                # never fired in the first place.
+                assert not any("display reconnected" in n.title.lower() for n in notifs)
+                break
+        finally:
+            device_manager.disconnect(info["device_id"])
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_warning_fires_recovery(self, app, seed_group_and_device, fresh_alert_service):
+        """A reconnect after the warning was sent fires a "display reconnected" info."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+
+        from cms.services.device_manager import device_manager
+        device_manager.register(info["device_id"], websocket=None)
+        device_manager.update_status(
+            info["device_id"], mode="idle", asset=None, display_connected=False,
+        )
+
+        try:
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=False,
+            )
+
+            # Wait long enough for the warning to fire
+            await asyncio.sleep(1.5)
+
+            # Now display comes back
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=True,
+            )
+
+            # Give the recovery notification a moment to commit
+            await asyncio.sleep(0.3)
+
+            from cms.database import get_db
+            factory = app.dependency_overrides[get_db]
+            async for db in factory():
+                notifs = (await db.execute(
+                    select(Notification).where(
+                        Notification.group_id == uuid.UUID(info["group_id"]),
+                    )
+                )).scalars().all()
+                titles = [n.title.lower() for n in notifs]
+                assert any("display disconnected" in t for t in titles), titles
+                assert any("display reconnected" in t for t in titles), titles
+                break
+        finally:
+            device_manager.disconnect(info["device_id"])
+
+    @pytest.mark.asyncio
+    async def test_pending_device_no_alert(self, fresh_alert_service):
+        """Pending (unadopted) devices don't trigger display alerts."""
+        svc = fresh_alert_service
+        svc.display_state_changed(
+            "pending-d", "Pending Display",
+            group_id=str(uuid.uuid4()), group_name="G",
+            status="pending", connected=False,
+        )
+        assert "pending-d" not in svc._display_timers
+
+    @pytest.mark.asyncio
+    async def test_ungrouped_device_no_alert(self, fresh_alert_service):
+        """Adopted devices without a group don't trigger display alerts."""
+        svc = fresh_alert_service
+        svc.display_state_changed(
+            "ungrouped-d", "Ungrouped Display",
+            group_id=None, group_name="",
+            status="adopted", connected=False,
+        )
+        assert "ungrouped-d" not in svc._display_timers
+
+    @pytest.mark.asyncio
+    async def test_device_offline_during_grace_suppresses_display_notif(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """If the device goes fully offline during the display grace period,
+        no display-disconnected notification fires (offline alert covers it)."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+
+        from cms.services.device_manager import device_manager
+        device_manager.register(info["device_id"], websocket=None)
+        device_manager.update_status(
+            info["device_id"], mode="idle", asset=None, display_connected=False,
+        )
+
+        try:
+            svc.display_state_changed(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted", connected=False,
+            )
+
+            # Simulate full WS disconnect mid-grace
+            device_manager.disconnect(info["device_id"])
+            svc.device_disconnected(
+                info["device_id"], info["device_name"],
+                info["group_id"], info["group_name"],
+                status="adopted",
+            )
+
+            await asyncio.sleep(1.5)
+
+            from cms.database import get_db
+            factory = app.dependency_overrides[get_db]
+            async for db in factory():
+                notifs = (await db.execute(
+                    select(Notification).where(
+                        Notification.group_id == uuid.UUID(info["group_id"]),
+                    )
+                )).scalars().all()
+                assert not any("display disconnected" in n.title.lower() for n in notifs)
+                break
+        finally:
+            # device already disconnected; safe to call again
+            device_manager.disconnect(info["device_id"])
+
+    @pytest.mark.asyncio
+    async def test_cleanup_cancels_display_timer(self, fresh_alert_service):
+        """cleanup_device cancels any pending display grace timer."""
+        svc = fresh_alert_service
+        gid = str(uuid.uuid4())
+        svc.display_state_changed(
+            "dev-d", "Display", gid, "G",
+            status="adopted", connected=False,
+        )
+        assert "dev-d" in svc._display_timers
+        svc._was_display_off.add("dev-d")
+
+        svc.cleanup_device("dev-d")
+        assert "dev-d" not in svc._display_timers
+        assert "dev-d" not in svc._was_display_off


### PR DESCRIPTION
## Summary

Two related fixes for the device-display state machine, plus a nightly smoke test that pins the whole pipeline down end-to-end.

### 1. Friendly badge label
Drop the underscore in the event-log badges:

| Before | After |
|---|---|
| `display_disconnected` | `display disconnected` |
| `display_connected` | `display connected` |

Matches the existing `temp_high` -> `temperature high` style.

### 2. Bell notification after a grace period

Mirrors the thermal alert flow.

* `alert_service` gets `handle_display_state_change()`, called from `ws.py` on every `display_connected` transition.
  * **Disconnect** -> kicks off a configurable grace timer (default **120 s**).
  * **Reconnect during grace** -> cancels the timer silently. (Momentary HDMI glitches don't spam users.)
  * **Grace expires while still disconnected** -> emit a `Notification(scope=group, level=warning, event=display_disconnected)`.
  * **Reconnect after the alert fired** -> follow-up `Notification(level=info, event=display_connected)`.
* Settings page exposes `alert_display_grace_seconds` (10-3600s, default 120). Per-tenant tuning.
* Per-user notification preferences gain a `display` channel so users can opt out (matches existing `temperature` + `offline`).
* `ws.py` still writes the `DISPLAY_DISCONNECTED` / `DISPLAY_CONNECTED` DeviceEvent on every transition immediately — the grace timer only gates the bell, never the event log.

### 3. RBAC

Notifications are scoped to the device's group. Admin sees everything; users in the same group see the alert; users in other groups do not.

### 4. Nightly smoke test
`tests/nightly/test_13_display_disconnect_notifications.py` walks the round-trip end-to-end:

1. Pin an adopted device to Group A.
2. Drive `display_connected=false` via the simulator's new fault API.
3. Assert the `DISPLAY_DISCONNECTED` event appears in the event log + dashboard "Recent Activity".
4. Wait the production grace (~2 minutes) and assert the scoped notification fires for admin + Operator A + Viewer, but NOT Operator B.
5. Reconnect, assert the recovery event + `info` notification.
6. Cleanup.

Depends on `display_connected` fault knob in **agora-device-simulator PR #3**.

## Tests

* Unit: `tests/test_display_alerts.py` (new, 7 tests) + `tests/test_device_alerts.py` (extended). **31 pass locally.**
* Nightly: collects to 6 tests cleanly; the full Docker stack run will land in CI.

## Backwards compatibility

* Default grace = 120 s = matches the in-memory default if the setting row is missing, so existing tenants get the new behaviour with no manual config.
* Notification preferences default to `true` for the new `display` channel (consistent with existing channels).
* No DB migration needed — preference channel is JSON-bag inside the existing `preferences` field.
