### PR TITLE
fix(devices): move device row in-place when group changes (closes #146)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -327,10 +327,134 @@ function editDeviceName(el) {
     input.addEventListener('click', e => e.stopPropagation());
 }
 
+// Find the compact row for a device (the one that lives inside a group/ungrouped
+// table — NOT the main "All Devices" row). Returns null if not found.
+function _findCompactRow(deviceId) {
+    const rows = document.querySelectorAll(
+        `tr.device-row-compact[data-device-id="${deviceId}"]`
+    );
+    return rows[0] || null;
+}
+
+// Determine which group the compact row currently lives under.
+// Returns the group id string, or "ungrouped".
+function _compactRowGroupKey(row) {
+    const tbody = row.closest('tbody[data-group-tbody]');
+    return tbody ? tbody.getAttribute('data-group-tbody') : null;
+}
+
+// Update the device-count badge for a group (or ungrouped) by `delta`.
+function _bumpGroupCount(groupKey, delta) {
+    if (groupKey === 'ungrouped' || !groupKey) return;
+    const badge = document.querySelector(`[data-group-count="${groupKey}"]`);
+    if (!badge) return;
+    const m = badge.textContent.match(/(\d+)/);
+    const next = Math.max(0, (m ? parseInt(m[1], 10) : 0) + delta);
+    badge.textContent = `${next} device${next === 1 ? '' : 's'}`;
+}
+
+// Show the "no devices in this group" placeholder when its tbody is empty,
+// hide it otherwise. No-op for the ungrouped section.
+function _refreshGroupEmptyState(groupKey) {
+    if (!groupKey || groupKey === 'ungrouped') return;
+    const tbody = document.querySelector(`tbody[data-group-tbody="${groupKey}"]`);
+    const table = document.querySelector(`table[data-group-table="${groupKey}"]`);
+    const empty = document.querySelector(`[data-group-empty="${groupKey}"]`);
+    if (!tbody || !table || !empty) return;
+    const isEmpty = tbody.children.length === 0;
+    table.style.display = isEmpty ? 'none' : '';
+    empty.style.display = isEmpty ? '' : 'none';
+}
+
+// Show/hide the entire ungrouped section based on whether it has rows.
+function _refreshUngroupedSection() {
+    const section = document.getElementById('ungrouped-section');
+    const tbody = document.querySelector('tbody[data-group-tbody="ungrouped"]');
+    if (!section || !tbody) return;
+    section.style.display = tbody.children.length === 0 ? 'none' : '';
+}
+
+// Sync every inline group <select> for this device (both the main "All Devices"
+// row and the compact row) so their values match the new group after a change
+// originating from any of them or from drag-and-drop.
+function _syncDeviceGroupSelects(deviceId, groupId) {
+    document.querySelectorAll(
+        `tr.device-row[data-device-id="${deviceId}"] select[data-device-group-select]`
+    ).forEach(sel => { sel.value = groupId || ''; });
+}
+
+// Move a device's compact row to its new group's tbody (or ungrouped).
+// Returns true if the row was moved client-side; false if a full reload is
+// required (e.g., row not present in any compact table because it's a Pending
+// device that only appears in the main "All Devices" table).
+function moveDeviceRowInDom(deviceId, newGroupId) {
+    const row = _findCompactRow(deviceId);
+    if (!row) return false;
+
+    const fromKey = _compactRowGroupKey(row);
+    const toKey = newGroupId ? String(newGroupId) : 'ungrouped';
+    if (fromKey === toKey) return true;  // no-op move
+
+    const destTbody = document.querySelector(`tbody[data-group-tbody="${toKey}"]`);
+    if (!destTbody) return false;  // destination missing, fall back to reload
+
+    // Toggle draggable affordance — only ungrouped rows are draggable.
+    if (toKey === 'ungrouped') {
+        row.classList.add('draggable-device');
+        row.setAttribute('draggable', 'true');
+        row.setAttribute('ondragstart', `dragDevice(event, '${deviceId}')`);
+    } else {
+        row.classList.remove('draggable-device');
+        row.removeAttribute('draggable');
+        row.removeAttribute('ondragstart');
+    }
+
+    // Insert sorted by visible name to match server-side ordering.
+    const newName = (row.querySelector('td:nth-child(1)')?.textContent || '').trim().toLowerCase();
+    const siblings = Array.from(destTbody.children);
+    const before = siblings.find(sib => {
+        const n = (sib.querySelector('td:nth-child(1)')?.textContent || '').trim().toLowerCase();
+        return n > newName;
+    });
+    if (before) destTbody.insertBefore(row, before);
+    else destTbody.appendChild(row);
+
+    // The "Remove" button (compact row, last cell) is only shown when the
+    // device belongs to a group. Toggle it based on the new destination.
+    const actionsCell = row.querySelector('td.actions');
+    if (actionsCell) {
+        if (toKey === 'ungrouped') {
+            actionsCell.innerHTML = '';
+        } else if (!actionsCell.querySelector('button')) {
+            actionsCell.innerHTML =
+                '<span class="has-tooltip"><button class="btn btn-secondary btn-sm" ' +
+                `onclick="assignGroup('${deviceId}', '')">Remove</button>` +
+                '<span class="tooltip">Remove this device from the group</span></span>';
+        }
+    }
+
+    _bumpGroupCount(fromKey, -1);
+    _bumpGroupCount(toKey, +1);
+    _refreshGroupEmptyState(fromKey);
+    _refreshGroupEmptyState(toKey);
+    _refreshUngroupedSection();
+    _syncDeviceGroupSelects(deviceId, newGroupId);
+    return true;
+}
+
 async function assignGroup(deviceId, groupId) {
     const resp = await apiCall("PATCH", `/api/devices/${deviceId}`, { group_id: groupId || null });
-    if (resp && resp.ok) showToast("Group updated");
-    else showToast("Group update failed", true);
+    if (!resp || !resp.ok) {
+        showToast("Group update failed", true);
+        return;
+    }
+    showToast("Group updated");
+    if (!moveDeviceRowInDom(deviceId, groupId)) {
+        // Could not update DOM in place (e.g., destination tbody missing for a
+        // freshly-created group); fall back to a refresh so the user still sees
+        // the correct state.
+        location.reload();
+    }
 }
 
 async function setDefaultAsset(deviceId, assetId, selectEl) {

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -33,7 +33,7 @@
     </td>
     <td>
         {% if 'devices:write' in user_perms %}
-        <select class="inline-edit" onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
+        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
             <option value="">None</option>
             {% for g in groups %}
             <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
@@ -224,8 +224,11 @@
 {% endmacro %}
 
 {# ── Compact device row for grouped/ungrouped tables ── #}
+{# Note: the row's draggable affordance is owned by JS (not the macro) so a
+   row can move between grouped (not draggable) and ungrouped (draggable)
+   sections without re-rendering. assignGroup() / dropDevice() handle this. #}
 {% macro device_row_compact(d, groups, draggable=false) %}
-<tr class="device-row{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
+<tr class="device-row device-row-compact{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
     <td>
         {% if 'devices:write' in user_perms %}
         <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
@@ -250,7 +253,7 @@
     </td>
     <td>
         {% if 'devices:write' in user_perms %}
-        <select class="inline-edit" onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
+        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
             <option value="">None</option>
             {% for g in groups %}
             <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
@@ -328,7 +331,7 @@
             <strong>{{ g.name }}</strong>
             <span class="text-muted">— {{ g.description or 'No description' }}</span>
             {% endif %}
-            <span class="badge badge-count">{{ g.device_count }} device{{ 's' if g.device_count != 1 }}</span>
+            <span class="badge badge-count" data-group-count="{{ g.id }}">{{ g.device_count }} device{{ 's' if g.device_count != 1 }}</span>
             <span class="group-actions" onclick="event.stopPropagation()">
                 <span class="has-tooltip inline-label">Group Splash Screen<span class="tooltip">Default splash screen shown when no schedule is active</span></span>
                 {% if 'groups:write' in user_perms %}
@@ -349,18 +352,15 @@
             </span>
         </div>
         <div class="group-body" style="display: none;">
-            {% if g.devices %}
-            <table>
+            <table data-group-table="{{ g.id }}"{% if not g.devices %} style="display: none;"{% endif %}>
                 <thead>{{ th_row_compact }}</thead>
-                <tbody>
+                <tbody data-group-tbody="{{ g.id }}">
                     {% for d in g.devices | sort(attribute='name') %}
                     {{ device_row_compact(d, groups) }}
                     {% endfor %}
                 </tbody>
             </table>
-            {% else %}
-            <p class="text-muted empty-state">No devices in this group. Drag a device here to add it.</p>
-            {% endif %}
+            <p class="text-muted empty-state" data-group-empty="{{ g.id }}"{% if g.devices %} style="display: none;"{% endif %}>No devices in this group. Drag a device here to add it.</p>
         </div>
     </div>
     {% else %}
@@ -380,20 +380,20 @@
 </div>
 
 {# ── Ungrouped Devices ── #}
-{% if ungrouped %}
-<div class="card">
+{# Always rendered (even when empty) so JS can drop rows here without a full
+   page refresh after a device is removed from its group. See issue #146. #}
+<div class="card" id="ungrouped-section"{% if not ungrouped %} style="display: none;"{% endif %}>
     <h2>Ungrouped Devices</h2>
     <p class="text-muted" style="margin-bottom: 0.75rem;">Drag a device onto a group above to assign it.</p>
     <table>
         <thead>{{ th_row_compact }}</thead>
-        <tbody>
+        <tbody data-group-tbody="ungrouped">
             {% for d in ungrouped %}
             {{ device_row_compact(d, groups, draggable=true) }}
             {% endfor %}
         </tbody>
     </table>
 </div>
-{% endif %}
 {% endif %}{# end groups:read #}
 {% endblock %}
 
@@ -417,11 +417,13 @@ async function dropDevice(e, groupId) {
     const deviceId = e.dataTransfer.getData('text/plain');
     if (!deviceId) return;
     const resp = await apiCall('PATCH', `/api/devices/${deviceId}`, { group_id: groupId });
-    if (resp && resp.ok) {
-        showToast('Device added to group');
-        location.reload();
-    } else {
+    if (!resp || !resp.ok) {
         showToast('Failed to assign device to group', true);
+        return;
+    }
+    showToast('Device added to group');
+    if (!moveDeviceRowInDom(deviceId, groupId)) {
+        location.reload();
     }
 }
 

--- a/tests_e2e/test_ui_group_remove.py
+++ b/tests_e2e/test_ui_group_remove.py
@@ -193,3 +193,115 @@ class TestGroupRemoveButtons:
         remove_btn = group_panel.locator(".group-actions button", has_text="Delete")
         expect(remove_btn).to_be_visible(timeout=3000)
         expect(remove_btn).to_be_enabled()
+
+
+class TestGroupRemoveInPlaceMove:
+    """Regression tests for #146 — the row should move between sections without
+    a full page reload after a group assignment changes."""
+
+    def _register_and_adopt(self, api, ws_url, device_id, name=None):
+        async def register():
+            async with FakeDevice(device_id, ws_url, device_name=name) as dev:
+                await dev.send_status()
+
+        run_async(register())
+        # Properly adopt with a profile so the device leaves PENDING and is
+        # eligible to appear in the Ungrouped section (per cms/ui.py).
+        profiles = api.get("/api/profiles").json()
+        profile_id = profiles[0]["id"] if profiles else None
+        body = {"name": name or device_id}
+        if profile_id:
+            body["profile_id"] = profile_id
+        api.post(f"/api/devices/{device_id}/adopt", json=body)
+
+    def test_remove_moves_row_to_ungrouped_without_reload(self, page: Page, api, ws_url, e2e_server):
+        """Clicking Remove inside a group should move the row to the Ungrouped
+        section in place (no page navigation), update the group count, and reveal
+        the 'no devices' placeholder when the group becomes empty."""
+        self._register_and_adopt(api, ws_url, "inplace-001", "Solo Device")
+
+        resp = api.post("/api/devices/groups/", json={"name": "Inplace Move Group"})
+        assert resp.status_code == 201
+        group_id = resp.json()["id"]
+        api.patch("/api/devices/inplace-001", json={"group_id": group_id})
+
+        page.goto("/devices")
+        page.wait_for_load_state("domcontentloaded")
+
+        # Capture the URL so we can assert later that we never navigated.
+        nav_url_before = page.url
+
+        # Sanity: row starts in the group tbody, not in the ungrouped tbody.
+        group_tbody = page.locator(f'tbody[data-group-tbody="{group_id}"]')
+        ungrouped_tbody = page.locator('tbody[data-group-tbody="ungrouped"]')
+        expect(group_tbody.locator('tr[data-device-id="inplace-001"]')).to_have_count(1)
+        expect(ungrouped_tbody.locator('tr[data-device-id="inplace-001"]')).to_have_count(0)
+
+        # Expand and click Remove.
+        group_panel = page.locator(f'div.group-panel[data-group-id="{group_id}"]')
+        group_panel.locator(".group-header").click()
+        device_row = group_panel.locator('tr[data-device-id="inplace-001"]')
+        expect(device_row).to_be_visible(timeout=3000)
+        device_row.locator("button", has_text="Remove").click()
+
+        # Wait for the in-place move (no reload) — row should appear in the
+        # ungrouped tbody and disappear from the group tbody.
+        expect(ungrouped_tbody.locator('tr[data-device-id="inplace-001"]')).to_have_count(1, timeout=3000)
+        expect(group_tbody.locator('tr[data-device-id="inplace-001"]')).to_have_count(0)
+
+        # The Ungrouped section should now be visible.
+        expect(page.locator('#ungrouped-section')).to_be_visible()
+
+        # The group's device count badge should decrement to 0.
+        count_badge = page.locator(f'[data-group-count="{group_id}"]')
+        expect(count_badge).to_have_text("0 devices")
+
+        # The empty-state placeholder for the group should be visible.
+        expect(page.locator(f'[data-group-empty="{group_id}"]')).to_be_visible()
+
+        # The page must not have navigated — confirms it was an in-place update.
+        assert page.url == nav_url_before, (
+            "Page should not reload when removing a device from a group"
+        )
+
+        # The Remove button should be gone from the moved row (now ungrouped).
+        moved_row = ungrouped_tbody.locator('tr[data-device-id="inplace-001"]')
+        expect(moved_row.locator("button", has_text="Remove")).to_have_count(0)
+
+    def test_assign_to_group_moves_row_from_ungrouped_in_place(self, page: Page, api, ws_url, e2e_server):
+        """Assigning an ungrouped device to a group via the inline dropdown
+        should move its row out of the Ungrouped section without a reload."""
+        self._register_and_adopt(api, ws_url, "inplace-002", "Migrating Device")
+        # Adopt a second device into the group so the group panel starts non-empty.
+        self._register_and_adopt(api, ws_url, "inplace-003", "Anchor Device")
+
+        resp = api.post("/api/devices/groups/", json={"name": "Inplace Assign Group"})
+        assert resp.status_code == 201
+        group_id = resp.json()["id"]
+        api.patch("/api/devices/inplace-003", json={"group_id": group_id})
+
+        page.goto("/devices")
+        page.wait_for_load_state("domcontentloaded")
+        nav_url_before = page.url
+
+        ungrouped_tbody = page.locator('tbody[data-group-tbody="ungrouped"]')
+        group_tbody = page.locator(f'tbody[data-group-tbody="{group_id}"]')
+        expect(ungrouped_tbody.locator('tr[data-device-id="inplace-002"]')).to_have_count(1)
+
+        # Use the inline group <select> in the ungrouped row to assign the group.
+        ungrouped_row = ungrouped_tbody.locator('tr[data-device-id="inplace-002"]')
+        ungrouped_row.locator('select[data-device-group-select]').select_option(group_id)
+
+        # Row should appear in the group tbody and vanish from ungrouped.
+        expect(group_tbody.locator('tr[data-device-id="inplace-002"]')).to_have_count(1, timeout=3000)
+        expect(ungrouped_tbody.locator('tr[data-device-id="inplace-002"]')).to_have_count(0)
+
+        # Group device-count badge should bump from 1 → 2.
+        expect(page.locator(f'[data-group-count="{group_id}"]')).to_have_text("2 devices")
+
+        # No reload happened.
+        assert page.url == nav_url_before
+
+        # The moved row should now have a Remove button.
+        moved_row = group_tbody.locator('tr[data-device-id="inplace-002"]')
+        expect(moved_row.locator("button", has_text="Remove")).to_have_count(1)


### PR DESCRIPTION
## Summary

Fixes #146 — when a device's group assignment changes, the row now moves to its new section in place, without requiring a page refresh.

## What was happening

`assignGroup()` and `dropDevice()` both PATCHed the device and showed a toast, but did nothing to the DOM. After clicking **Remove** on a device inside a group, the row stayed where it was; the user had to refresh to see it appear in the **Ungrouped Devices** section. Same problem when dragging into a group.

## What changed

**Template (`devices.html`)**
- Always render the **Ungrouped Devices** card and per-group tables (with empty-state placeholders), toggled via `display:none`. Previously, an empty section was simply omitted from the DOM, leaving JS no destination to move a row into.
- Add stable selectors so JS can find what it needs:
  - `data-group-tbody="<group_id>"` / `data-group-tbody="ungrouped"` on tbodies
  - `data-group-table="<id>"` and `data-group-empty="<id>"` for visibility toggling
  - `data-group-count="<id>"` on the device-count badge
  - `data-device-group-select` on the inline group `<select>`
  - `device-row-compact` class on compact rows (to disambiguate from the main "All Devices" row)

**JS (`app.js`)**
- New `moveDeviceRowInDom(deviceId, newGroupId)` helper that:
  - Finds the compact row, computes source/destination tbodies
  - Toggles `draggable` + `ondragstart` (only ungrouped rows are draggable)
  - Inserts into the destination tbody sorted by name to match server ordering
  - Swaps the **Remove** button on (entering a group) or off (entering ungrouped)
  - Decrements/increments the affected group device-count badges
  - Toggles the per-group "No devices in this group" placeholder and the entire Ungrouped section's visibility
  - Syncs the inline group `<select>` on both the main and compact rows
- `assignGroup()` and `dropDevice()` call the helper on success; they fall back to `location.reload()` only if the destination tbody is unexpectedly missing.

## Tests

Two new Playwright tests in `tests_e2e/test_ui_group_remove.py::TestGroupRemoveInPlaceMove`:

1. `test_remove_moves_row_to_ungrouped_without_reload` — clicks Remove on a device in a group; asserts the row moves to the ungrouped tbody, the count badge decrements, the empty-state placeholder appears, and the page URL never changed.
2. `test_assign_to_group_moves_row_from_ungrouped_in_place` — selects a group via the inline dropdown on an ungrouped row; asserts the row moves into the group tbody, the count badge increments, and the moved row gains a Remove button.

Both tests pass locally. The remaining failures in the broader Playwright run (`test_group_remove_*_schedule_*`, `test_delete_device_with_schedule`) are pre-existing on `main` (schedule-create returning 422) and are out of scope here.

Closes #146
