### PR TITLE
fix(nightly): #146 smoke uses kebab menu (post PR #351)

### DIFF
--- a/tests/nightly/test_04_groups.py
+++ b/tests/nightly/test_04_groups.py
@@ -293,18 +293,21 @@ def test_devices_page_moves_row_in_place_on_group_change(
         # No navigation happened.
         assert page.url == url_before, "page reloaded — fix #146 regressed"
 
-        # Moved row should now expose a Remove button.
-        assert group_row.locator('button:has-text("Remove")').count() == 1
+        # Moved row should now expose a kebab menu containing "Remove from group".
+        # (Per PR #351 row actions were consolidated into a kebab popover.)
+        assert group_row.locator("button.btn-kebab").count() == 1
 
-        # Expand the group panel so the Remove button is visible/clickable.
+        # Expand the group panel so the kebab is visible/clickable.
         # Group panels start collapsed; the compact table lives inside the
         # panel body which is hidden until the header is clicked.
         group_panel = page.locator(f'.group-panel[data-group-id="{group_id}"]')
         if not group_panel.evaluate("el => el.classList.contains('expanded')"):
             group_panel.locator(".group-header").click()
 
-        # Step 2: click Remove — row should move back to Ungrouped in place.
-        group_row.locator('button:has-text("Remove")').click()
+        # Step 2: open the kebab and click "Remove from group" — the row should
+        # move back to Ungrouped in place.
+        group_row.locator("button.btn-kebab").click()
+        page.locator('.kebab-menu [role="menuitem"]:has-text("Remove from group")').click()
         ungrouped_row.wait_for(state="attached", timeout=5000)
         assert group_row.count() == 0
         assert count_badge.inner_text().lower().startswith("0 device"), count_badge.inner_text()


### PR DESCRIPTION
PR #351 consolidated per-row actions into a kebab menu popover. The
inline `Remove` button my nightly #146 smoke (#357) was clicking no
longer exists, so post-merge Smoke Test on `main` is red with a
Playwright timeout at the `click()` call.

## Fix

Open the kebab in the group row first, then click the
`Remove from group` menu item:

- Assert presence of `button.btn-kebab` on the moved row (replaces
  the old `button:has-text("Remove")` check).
- `group_row.locator("button.btn-kebab").click()` to open the
  popover.
- `page.locator('.kebab-menu [role="menuitem"]:has-text("Remove from group")').click()`
  to trigger the ungroup.

All other assertions (row moved to ungrouped tbody, count badge to
`0 devices`, empty-state visible, no reload) remain.

## Risk

Test-only change. Skipped unless `--run-nightly` / `NIGHTLY=1`.
