### PR TITLE
fix(alerts): disconnect = error (red), reconnect = success (green)

### DIFF
--- a/cms/models/notification.py
+++ b/cms/models/notification.py
@@ -22,7 +22,7 @@ class Notification(Base):
     )
     level: Mapped[str] = mapped_column(
         String(20), nullable=False, default="info",
-        doc="Severity: 'info', 'warning', or 'error'",
+        doc="Severity: 'info', 'success', 'warning', or 'error'",
     )
     title: Mapped[str] = mapped_column(String(200), nullable=False)
     message: Mapped[str] = mapped_column(Text, default="")

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -227,7 +227,7 @@ class AlertService:
                 gid = _to_uuid(group_id)
                 notification = Notification(
                     scope="group",
-                    level="warning",
+                    level="error",
                     title=f"Device offline: {device_name}",
                     message=(
                         f"Device '{device_name}' in group '{group_name}' has been "
@@ -286,7 +286,7 @@ class AlertService:
             async for db in get_db():
                 notification = Notification(
                     scope="group",
-                    level="info",
+                    level="success",
                     title=f"Device back online: {device_name}",
                     message=(
                         f"Device '{device_name}' in group '{group_name}' is back online."
@@ -407,7 +407,7 @@ class AlertService:
                         f"is at {cpu_temp_c:.1f}°C ({level})."
                     )
                 else:
-                    notif_level = "info"
+                    notif_level = "success"
                     title = f"Temperature normal: {device_name}"
                     message = (
                         f"Device '{device_name}' in group '{group_name}' "

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -200,6 +200,7 @@ header {
 .notification-item.unread { border-left: 3px solid var(--accent); }
 .notification-item.notif-error .notif-title { color: var(--danger); }
 .notification-item.notif-warning .notif-title { color: var(--warning); }
+.notification-item.notif-success .notif-title { color: var(--success); }
 .notification-item.notif-info .notif-title { color: var(--accent); }
 .notif-title { font-weight: 600; font-size: 0.85rem; margin-bottom: 0.25rem; padding-right: 1.2rem; }
 .notif-message { font-size: 0.8rem; color: var(--text-muted); line-height: 1.4; }

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -139,7 +139,7 @@
             }
             list.innerHTML = items.map(n => {
                 const isUnread = !n.read_at;
-                const levelClass = n.level === 'error' ? 'notif-error' : n.level === 'warning' ? 'notif-warning' : 'notif-info';
+                const levelClass = n.level === 'error' ? 'notif-error' : n.level === 'warning' ? 'notif-warning' : n.level === 'success' ? 'notif-success' : 'notif-info';
                 const age = _timeAgo(n.created_at);
                 return `<div class="notification-item ${isUnread ? 'unread' : ''} ${levelClass}" data-id="${n.id}" onclick="markNotifRead('${n.id}', this)">
                     <button class="notif-dismiss" onclick="event.stopPropagation(); dismissNotification('${n.id}', this)" aria-label="Dismiss">&times;</button>

--- a/tests/nightly/test_08_thermal_notifications.py
+++ b/tests/nightly/test_08_thermal_notifications.py
@@ -36,7 +36,7 @@ RBAC fixtures (Operator A / Viewer in Group A, Operator B in Group B).
 Default alert thresholds (``cms.services.alert_service``):
   WARNING  = 70.0 C   ->  Notification level="warning"
   CRITICAL = 80.0 C   ->  Notification level="error"
-  CLEAR    =  <WARNING ->  Notification level="info", event TEMP_CLEARED
+  CLEAR    =  <WARNING ->  Notification level="success", event TEMP_CLEARED
 """
 
 from __future__ import annotations
@@ -396,9 +396,9 @@ def test_08_clear_fault_emits_cleared_notification(
     observed = _wait_for_temp_below(authenticated_page, device_id, below=70.0)
     assert observed < 70.0
 
-    # alert_service emits the TEMP_CLEARED Notification (level=info) + event.
+    # alert_service emits the TEMP_CLEARED Notification (level=success) + event.
     cleared = _wait_for_thermal_notif(authenticated_page, device_id, "temp_cleared")
-    assert cleared["level"] == "info", cleared
+    assert cleared["level"] == "success", cleared
     assert cleared["scope"] == "group"
     assert str(cleared["group_id"]) == str(RBAC_STATE["group_a_id"])
     det = cleared.get("details") or {}

--- a/tests/test_device_alerts.py
+++ b/tests/test_device_alerts.py
@@ -134,7 +134,7 @@ class TestOfflineDetection:
             notifs = (await db.execute(
                 select(Notification).where(
                     Notification.group_id == uuid.UUID(info["group_id"]),
-                    Notification.level == "warning",
+                    Notification.level == "error",
                 )
             )).scalars().all()
             assert len(notifs) >= 1
@@ -220,7 +220,7 @@ class TestOfflineDetection:
             notifs = (await db.execute(
                 select(Notification).where(
                     Notification.group_id == uuid.UUID(info["group_id"]),
-                    Notification.level == "info",
+                    Notification.level == "success",
                 )
             )).scalars().all()
             assert any("back online" in n.title.lower() for n in notifs)
@@ -362,7 +362,7 @@ class TestTemperatureAlerts:
             notifs = (await db.execute(
                 select(Notification).where(
                     Notification.group_id == uuid.UUID(info["group_id"]),
-                    Notification.level == "info",
+                    Notification.level == "success",
                 )
             )).scalars().all()
             assert any("normal" in n.title.lower() for n in notifs)


### PR DESCRIPTION
Device-offline bell notifications were level=warning (yellow) and the
back-online notifications were level=info, which rendered red because
notif-info uses the --accent (pinkish-red) brand color. Wrong semantics:
red should mean bad, green should mean good.

- Offline notification: warning -> error (red). An offline device with a
  disconnected display is a serious/alerting state, not a soft warning.
- Back-online notification: info -> new success level (green).
- Temperature-cleared notification: info -> success (same rationale).
- Added notif-success CSS class (color: var(--success)) and routed
  level='success' through the bell render path in base.html.
- Updated Notification model doc, unit tests, nightly #08 thermal test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
