### PR TITLE
feat(ui): distinct icons for every asset type

### DIFF
--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -181,7 +181,7 @@
                         <span class="tooltip">{{ a.display_name or a.original_filename or a.filename }}</span>
                     </span>
                 </td>
-                <td><span class="badge badge-{{ a.asset_type.value }}">{% if a.asset_type.value == 'saved_stream' %}Saved Stream{% else %}{{ a.asset_type.value | capitalize }}{% endif %}</span></td>
+                <td><span class="badge badge-{{ a.asset_type.value }}"><span aria-hidden="true">{{ a | asset_icon }}</span> {% if a.asset_type.value == 'saved_stream' %}Saved Stream{% else %}{{ a.asset_type.value | capitalize }}{% endif %}</span></td>
                 <td>
                     {% if a.is_global %}
                     <span class="badge badge-ready">Global</span>

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -130,7 +130,7 @@
             {% for s in schedules %}
             <tr>
                 <td class="cell-truncate"><span class="cell-text">{{ s.name }}</span></td>
-                <td class="cell-truncate"><span class="cell-text">{{ (s.asset.display_name or s.asset.original_filename or s.asset.filename) if s.asset else '—' }}</span></td>
+                <td class="cell-truncate"><span class="cell-text">{% if s.asset %}<span aria-hidden="true">{{ s.asset | asset_icon }}</span> {% endif %}{{ (s.asset.display_name or s.asset.original_filename or s.asset.filename) if s.asset else '—' }}</span></td>
                 <td>
                     {{ s.group.name if s.group else '—' }}
                 </td>
@@ -189,7 +189,7 @@
             {% for s in expired_schedules %}
             <tr>
                 <td class="cell-truncate"><span class="cell-text">{{ s.name }}</span></td>
-                <td class="cell-truncate"><span class="cell-text">{{ (s.asset.display_name or s.asset.original_filename or s.asset.filename) if s.asset else '—' }}</span></td>
+                <td class="cell-truncate"><span class="cell-text">{% if s.asset %}<span aria-hidden="true">{{ s.asset | asset_icon }}</span> {% endif %}{{ (s.asset.display_name or s.asset.original_filename or s.asset.filename) if s.asset else '—' }}</span></td>
                 <td>
                     {{ s.group.name if s.group else '—' }}
                 </td>
@@ -216,6 +216,7 @@
 <input type="hidden" id="_tz" value="{{ current_timezone }}">
 <input type="hidden" id="_tzOptions" value='{{ tz_options | tojson }}'>
 <script>
+const ASSET_ICONS = {"video": "🎬", "image": "🖼️", "webpage": "🌐", "stream": "📡", "saved_stream": "📼"};
 const _scheduleData = {
     assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.duration_seconds else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
     groups: [{% for g in groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}],
@@ -274,9 +275,9 @@ function filterAssetsByTarget() {
             opt.value = a.id;
             opt.dataset.assetType = a.type || '';
             let label = a.name;
-            if (a.type === 'webpage') label += ' 🌐';
-            else if (a.type === 'stream') label += ' 📡';
-            else if (a.duration) label += ` (${Math.floor(a.duration/60)}:${String(Math.round(a.duration%60)).padStart(2,'0')})`;
+            const icon = ASSET_ICONS[a.type];
+            if (icon) label += ' ' + icon;
+            if (a.duration) label += ` (${Math.floor(a.duration/60)}:${String(Math.round(a.duration%60)).padStart(2,'0')})`;
             opt.textContent = label;
             if (a.id === currentVal) opt.selected = true;
             assetSel.appendChild(opt);
@@ -783,9 +784,9 @@ function editSchedule(s) {
 
     const assetOpts = _scheduleData.assets.map(a => {
         let label = a.name;
-        if (a.type === 'webpage') label += ' 🌐';
-        else if (a.type === 'stream') label += ' 📡';
-        else if (a.duration) {
+        const icon = ASSET_ICONS[a.type];
+        if (icon) label += ' ' + icon;
+        if (a.duration) {
             const m = Math.floor(a.duration / 60), s = Math.round(a.duration % 60);
             label += ` (${m}:${String(s).padStart(2,'0')})`;
         }

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -82,25 +82,52 @@ def select_days(day_names, day_numbers):
 templates.env.filters["select_days"] = select_days
 
 
+_ASSET_ICONS = {
+    "video": "🎬",
+    "image": "🖼️",
+    "webpage": "🌐",
+    "stream": "📡",
+    "saved_stream": "📼",
+}
+
+
+def _asset_type_value(asset_or_type):
+    """Resolve an asset-type string from either a string or an Asset/enum."""
+    if asset_or_type is None:
+        return None
+    if isinstance(asset_or_type, str):
+        return asset_or_type
+    asset_type = getattr(asset_or_type, "asset_type", asset_or_type)
+    return getattr(asset_type, "value", asset_type)
+
+
+def asset_icon(asset_or_type):
+    """Return the emoji icon for an asset type, or empty string if unknown.
+
+    Accepts an Asset ORM object, an AssetType enum/string, or None.
+    Used across templates to give each asset type a distinct visual
+    identity (🎬 video, 🖼️ image, 🌐 webpage, 📡 stream, 📼 saved stream).
+    """
+    return _ASSET_ICONS.get(_asset_type_value(asset_or_type), "")
+
+
+templates.env.filters["asset_icon"] = asset_icon
+
+
 def asset_label_suffix(asset):
     """Return a human-readable suffix for asset labels in dropdowns.
 
-    Shows duration `(mm:ss)` for any asset with a duration (video or
-    saved stream), a 🌐 globe for webpages, and a 📡 antenna for live
-    streams. Returns an empty string for assets with no meaningful
-    suffix (e.g. images). See issue #316.
+    Always includes the type icon, plus a `(mm:ss)` duration when the
+    asset has one (video or saved stream). Returns an empty string for
+    untyped assets. See issue #316.
     """
+    icon = asset_icon(asset)
     duration = getattr(asset, "duration_seconds", None)
     if duration:
         total = int(duration)
-        return f" ({total // 60}:{total % 60:02d})"
-    asset_type = getattr(asset, "asset_type", None)
-    type_val = getattr(asset_type, "value", asset_type)
-    if type_val == "webpage":
-        return " 🌐"
-    if type_val == "stream":
-        return " 📡"
-    return ""
+        dur = f"({total // 60}:{total % 60:02d})"
+        return f" {icon} {dur}" if icon else f" {dur}"
+    return f" {icon}" if icon else ""
 
 templates.env.filters["asset_label_suffix"] = asset_label_suffix
 

--- a/tests/test_asset_icons.py
+++ b/tests/test_asset_icons.py
@@ -1,0 +1,154 @@
+"""Smoke tests for asset-type icons.
+
+Each AssetType has a distinct emoji icon (🎬 video, 🖼️ image, 🌐 webpage,
+📡 stream, 📼 saved stream) so users can tell asset types apart at a glance
+in the library, schedule list, and device dropdowns.
+
+This file guards the feature end-to-end:
+
+1. The ``asset_icon`` Jinja filter returns the right emoji for every
+   AssetType (this has regressed before — see PR that added this file).
+2. The filter is registered on the Jinja environment so templates can
+   actually use it.
+3. Every asset type in ``AssetType`` has an icon — adding a new type
+   without an icon will fail here instead of silently shipping blanks.
+4. User-facing templates (assets list, schedules list, schedules JS
+   dropdown) actually reference the icons. If someone deletes the
+   ``asset_icon`` usage or reverts the JS mapping, this catches it.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cms.models.asset import AssetType
+from cms.ui import _ASSET_ICONS, asset_icon, templates
+
+
+EXPECTED_ICONS = {
+    "video": "🎬",
+    "image": "🖼️",
+    "webpage": "🌐",
+    "stream": "📡",
+    "saved_stream": "📼",
+}
+
+
+# ---------------------------------------------------------------------------
+# Filter behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("type_value,expected_icon", list(EXPECTED_ICONS.items()))
+def test_asset_icon_filter_returns_expected_emoji_for_string(type_value, expected_icon):
+    assert asset_icon(type_value) == expected_icon
+
+
+@pytest.mark.parametrize("asset_type", list(AssetType))
+def test_asset_icon_filter_accepts_enum_members(asset_type):
+    # Every enum member must resolve to a non-empty icon.
+    assert asset_icon(asset_type) != ""
+    assert asset_icon(asset_type) == EXPECTED_ICONS[asset_type.value]
+
+
+@pytest.mark.parametrize("asset_type", list(AssetType))
+def test_asset_icon_filter_accepts_asset_like_objects(asset_type):
+    asset = SimpleNamespace(asset_type=asset_type, duration_seconds=None)
+    assert asset_icon(asset) == EXPECTED_ICONS[asset_type.value]
+
+
+def test_asset_icon_filter_handles_none():
+    assert asset_icon(None) == ""
+
+
+def test_asset_icon_filter_handles_unknown_type():
+    # Unknown types must not raise — they just get no icon.
+    assert asset_icon("something_new") == ""
+
+
+def test_every_asset_type_has_an_icon():
+    """If a new AssetType ships without an icon mapping, fail loudly."""
+    missing = [t.value for t in AssetType if t.value not in _ASSET_ICONS]
+    assert not missing, (
+        f"AssetType(s) without an icon mapping in cms.ui._ASSET_ICONS: {missing}. "
+        "Add an entry or confirm the icon is intentionally blank."
+    )
+
+
+def test_asset_icon_mapping_matches_expected_set():
+    """Lock the icon set so accidental deletions/renames fail here."""
+    assert _ASSET_ICONS == EXPECTED_ICONS
+
+
+# ---------------------------------------------------------------------------
+# Jinja environment wiring
+# ---------------------------------------------------------------------------
+
+
+def test_asset_icon_filter_is_registered():
+    assert "asset_icon" in templates.env.filters
+    assert templates.env.filters["asset_icon"] is asset_icon
+
+
+def test_asset_label_suffix_filter_is_registered():
+    # The dropdown-suffix filter (which calls asset_icon under the hood)
+    # must stay registered too — templates that rely on it would otherwise
+    # render nothing.
+    assert "asset_label_suffix" in templates.env.filters
+
+
+def test_asset_icon_renders_via_jinja_filter_syntax():
+    """End-to-end: a template using ``{{ asset | asset_icon }}`` works."""
+    tpl = templates.env.from_string("{{ a | asset_icon }}")
+    asset = SimpleNamespace(asset_type=AssetType.WEBPAGE, duration_seconds=None)
+    assert tpl.render(a=asset) == "🌐"
+
+
+# ---------------------------------------------------------------------------
+# Template usage (regression guard — the feature existed before and was removed)
+# ---------------------------------------------------------------------------
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "cms" / "templates"
+
+
+def _read(name: str) -> str:
+    return (TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def test_assets_table_badge_uses_asset_icon_filter():
+    """The Type column in the assets library must render the icon."""
+    body = _read("assets.html")
+    assert "a | asset_icon" in body, (
+        "assets.html must use the asset_icon filter on each row's type badge. "
+        "If you moved it, update this test accordingly."
+    )
+
+
+def test_schedules_list_uses_asset_icon_filter():
+    """Both active + expired schedule lists must render the asset icon."""
+    body = _read("schedules.html")
+    # We expect the filter to be used at least twice (active + expired tables).
+    assert body.count("s.asset | asset_icon") >= 2, (
+        "schedules.html must render the asset icon for each schedule row "
+        "(active and expired tables)."
+    )
+
+
+def test_schedules_js_asset_icons_map_is_defined():
+    """The inline JS ASSET_ICONS map must cover all five asset types so
+    option labels in the asset dropdowns show icons — and the mapping must
+    stay in sync with the Python side.
+    """
+    body = _read("schedules.html")
+    assert "const ASSET_ICONS" in body, (
+        "schedules.html must define a shared ASSET_ICONS JS map so dropdown "
+        "option labels can render icons for every asset type."
+    )
+    # Each icon must appear in the JS block so we don't silently drop one.
+    for type_value, emoji in EXPECTED_ICONS.items():
+        assert emoji in body, (
+            f"schedules.html is missing the icon {emoji!r} for asset type "
+            f"{type_value!r}. Keep the JS ASSET_ICONS map in sync with "
+            "cms.ui._ASSET_ICONS."
+        )

--- a/tests/test_asset_label_suffix.py
+++ b/tests/test_asset_label_suffix.py
@@ -18,19 +18,20 @@ def _asset(asset_type, duration_seconds=None):
     )
 
 
-def test_video_with_duration_shows_mmss():
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 332)) == " (5:32)"
+def test_video_with_duration_shows_icon_and_mmss():
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 332)) == " 🎬 (5:32)"
 
 
-def test_saved_stream_with_duration_shows_mmss():
+def test_saved_stream_with_duration_shows_icon_and_mmss():
     # The bug this is protecting: saved streams were falling through
     # because the template only rendered duration for VIDEO.
-    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, 125)) == " (2:05)"
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, 125)) == " 📼 (2:05)"
 
 
-def test_saved_stream_without_duration_no_suffix():
-    # Capture still in progress — don't render "(None)" or similar.
-    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, None)) == ""
+def test_saved_stream_without_duration_shows_icon_only():
+    # Capture still in progress — don't render "(None)"; icon is still
+    # shown so the asset's type is identifiable.
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, None)) == " 📼"
 
 
 def test_webpage_shows_globe():
@@ -41,17 +42,18 @@ def test_live_stream_shows_antenna():
     assert asset_label_suffix(_asset(AssetType.STREAM)) == " 📡"
 
 
-def test_image_no_suffix():
-    assert asset_label_suffix(_asset(AssetType.IMAGE)) == ""
+def test_image_shows_frame_icon():
+    assert asset_label_suffix(_asset(AssetType.IMAGE)) == " 🖼️"
 
 
 def test_duration_pads_seconds():
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 65)) == " (1:05)"
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 65)) == " 🎬 (1:05)"
 
 
-def test_duration_zero_falsy_no_suffix():
-    # A zero-duration asset is effectively unknown — don't render "(0:00)".
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 0)) == ""
+def test_duration_zero_falsy_icon_only():
+    # A zero-duration asset is effectively unknown — don't render "(0:00)",
+    # but still show the video icon.
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 0)) == " 🎬"
 
 
 def test_accepts_string_type_value():


### PR DESCRIPTION
## What

Each AssetType now has a distinct emoji so users can tell types apart at a glance, everywhere assets are listed — not just in dropdowns.

| Type | Icon |
|---|---|
| video | 🎬 |
| image | 🖼️ |
| webpage | 🌐 |
| stream | 📡 |
| saved_stream | 📼 |

## Why

We had this feature and it was silently removed at some point — only webpage/stream had icons left, and only inside dropdowns. The smoke tests added here make sure it doesn't happen again.

## Where

- **Assets library** — Type badge on every row now leads with the icon.
- **Schedules page** — active + expired schedule lists show the icon before the asset name; the asset dropdown option labels use a shared ASSET_ICONS JS map that replaces the duplicated `webpage` / `stream` if/else chains (two copies, now one).
- **Device default-asset dropdowns** and anywhere else `asset_label_suffix` is used — the filter now always includes the type icon, plus `(mm:ss)` when the asset has a duration.

## How

- New `asset_icon` Jinja filter backed by a single source of truth (`cms.ui._ASSET_ICONS`).
- `asset_label_suffix` reuses the same mapping.
- Shared `ASSET_ICONS` JS const injected into `schedules.html` once, consumed by both dynamic dropdown builders.

## Tests

`tests/test_asset_icons.py` (new, 34 assertions):

- Every AssetType has an icon (fails loudly if a new type ships without one)
- Filter is registered on the Jinja environment and renders via {{ a | asset_icon }}
- `assets.html`, `schedules.html` list rows, and the schedules JS map actually reference the icons — **regression guard** because this feature has gone missing before.

`tests/test_asset_label_suffix.py` updated for the new behaviour (icon is always included; image no longer returns empty).

All 34 pass locally in ~1s.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
