### PR TITLE
Polish asset library: icon prefix, camera icon, Shared badge placement, popover positioning

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1920,7 +1920,14 @@ window.addEventListener("pageshow", _rerunAllGates);
 // opts.align:     "right" (default — right-edge to right-edge of anchor)
 //                 or "left" (left-edge to left-edge of anchor)
 function positionPopover(popover, opts = {}) {
-    const btn = document.querySelector(`[popovertarget="${popover.id}"]`);
+    let btn = document.querySelector(`[popovertarget="${popover.id}"]`);
+    if (!btn) {
+        // Fallback for popovers opened via onclick (e.g. group-popup, whose
+        // `+` button lives as a sibling inside a .group-picker-wrap and does
+        // not use the native popovertarget attribute).
+        const wrap = popover.closest(".group-picker-wrap");
+        if (wrap) btn = wrap.querySelector(".btn-add-group");
+    }
     if (!btn) return;
     const placement = opts.placement || "below";
     const align = opts.align || "right";

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -989,6 +989,10 @@ tr.highlight-new td {
     position: fixed;
     margin: 0;
     inset: auto;
+    /* Park off-screen by default so the first paint after :popover-open
+       doesn't flash at (0,0) before JS positions the popover. */
+    top: -9999px;
+    left: -9999px;
     /* Visual styling — matches old .group-popup. */
     background: var(--surface-alt);
     border: 1px solid var(--primary);
@@ -1470,6 +1474,10 @@ textarea:not(:-webkit-autofill) {
     margin: 0;
     inset: auto;
     position: fixed;
+    /* Park off-screen so the first paint after :popover-open doesn't flash
+       at (0,0) before positionKebab() sets the real top/left. */
+    top: -9999px;
+    left: -9999px;
     min-width: 12rem;
     max-width: 18rem;
     background: var(--surface);

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -173,6 +173,8 @@
         </thead>
         <tbody>
             {% for a in assets %}
+            {% set is_owner = (request.state.user is defined and request.state.user and a.uploaded_by_user_id == request.state.user.id) or is_admin %}
+            {% set shared_badge = ('assets:write' in user_perms) and (not is_owner) %}
             <tr class="asset-row" onclick="toggleAsset(this)" data-asset-id="{{ a.id }}">
                 <td class="expand-toggle">▶</td>
                 <td class="wrap asset-filename-cell">
@@ -180,6 +182,9 @@
                         <span class="asset-filename-truncate editable-name" data-asset-id="{{ a.id }}" onclick="event.stopPropagation(); editAssetName(this)" title="Click to rename">{{ a.display_name or a.original_filename or a.filename }}</span>
                         <span class="tooltip">{{ a.display_name or a.original_filename or a.filename }}</span>
                     </span>
+                    {% if shared_badge %}
+                    <span class="has-tooltip" style="margin-left:0.4rem"><span class="badge badge-processing" style="font-size:0.75rem">Shared</span><span class="tooltip">Shared with you via a group. Only the owner can delete this asset.</span></span>
+                    {% endif %}
                 </td>
                 <td><span class="badge badge-{{ a.asset_type.value }}"><span aria-hidden="true">{{ a | asset_icon }}</span> {% if a.asset_type.value == 'saved_stream' %}Saved Stream{% else %}{{ a.asset_type.value | capitalize }}{% endif %}</span></td>
                 <td>
@@ -248,11 +253,6 @@
                     {% endif %}
                 </td>
                 <td class="actions" onclick="event.stopPropagation()">
-                    {% set is_owner = (request.state.user is defined and request.state.user and a.uploaded_by_user_id == request.state.user.id) or is_admin %}
-                    {% set shared_badge = ('assets:write' in user_perms) and (not is_owner) %}
-                    {% if shared_badge %}
-                    <span class="has-tooltip" style="display:inline-block;margin-right:0.4rem"><span class="badge badge-processing" style="font-size:0.75rem">Shared</span><span class="tooltip">Shared with you via a group. Only the owner can delete this asset.</span></span>
-                    {% endif %}
                     {% call macros.kebab_menu() %}
                     {% if a.asset_type.value == 'webpage' %}
                         <a role="menuitem" href="{{ a.url }}" target="_blank" rel="noopener">Open URL</a>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -49,7 +49,7 @@
         <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
             <option value="">None (use group)</option>
             {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
             {% endfor %}
         </select>
         {% else %}
@@ -358,7 +358,7 @@
                 <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
                     <option value="">No default asset</option>
                     {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
                 {% if g.schedule_count %}

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -29,7 +29,7 @@
                 <select name="asset_id" required onchange="onAssetTypeChange(this)">
                     <option value="">Select asset...</option>
                     {% for a in assets %}
-                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}"{% if not a.ready_for_selection %} disabled{% endif %}>{{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+                    <option value="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}"{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -216,7 +216,7 @@
 <input type="hidden" id="_tz" value="{{ current_timezone }}">
 <input type="hidden" id="_tzOptions" value='{{ tz_options | tojson }}'>
 <script>
-const ASSET_ICONS = {"video": "🎬", "image": "🖼️", "webpage": "🌐", "stream": "📡", "saved_stream": "📼"};
+const ASSET_ICONS = {"video": "🎬", "image": "📷", "webpage": "🌐", "stream": "📡", "saved_stream": "📼"};
 const _scheduleData = {
     assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.duration_seconds else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
     groups: [{% for g in groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}],
@@ -274,9 +274,8 @@ function filterAssetsByTarget() {
             const opt = document.createElement('option');
             opt.value = a.id;
             opt.dataset.assetType = a.type || '';
-            let label = a.name;
             const icon = ASSET_ICONS[a.type];
-            if (icon) label += ' ' + icon;
+            let label = icon ? icon + ' ' + a.name : a.name;
             if (a.duration) label += ` (${Math.floor(a.duration/60)}:${String(Math.round(a.duration%60)).padStart(2,'0')})`;
             opt.textContent = label;
             if (a.id === currentVal) opt.selected = true;
@@ -783,9 +782,8 @@ function editSchedule(s) {
     }).join(" ");
 
     const assetOpts = _scheduleData.assets.map(a => {
-        let label = a.name;
         const icon = ASSET_ICONS[a.type];
-        if (icon) label += ' ' + icon;
+        let label = icon ? icon + ' ' + a.name : a.name;
         if (a.duration) {
             const m = Math.floor(a.duration / 60), s = Math.round(a.duration % 60);
             label += ` (${m}:${String(s).padStart(2,'0')})`;

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -84,7 +84,7 @@ templates.env.filters["select_days"] = select_days
 
 _ASSET_ICONS = {
     "video": "🎬",
-    "image": "🖼️",
+    "image": "📷",
     "webpage": "🌐",
     "stream": "📡",
     "saved_stream": "📼",
@@ -115,19 +115,18 @@ templates.env.filters["asset_icon"] = asset_icon
 
 
 def asset_label_suffix(asset):
-    """Return a human-readable suffix for asset labels in dropdowns.
+    """Return a trailing ``(mm:ss)`` duration for asset labels in dropdowns.
 
-    Always includes the type icon, plus a `(mm:ss)` duration when the
-    asset has one (video or saved stream). Returns an empty string for
-    untyped assets. See issue #316.
+    Returns `` (m:ss)`` when the asset has a duration (video or saved
+    stream) and an empty string otherwise. Type icons are rendered as a
+    *prefix* via the ``asset_icon`` filter instead of being appended here
+    (see issue #316 / asset-icon placement fix).
     """
-    icon = asset_icon(asset)
     duration = getattr(asset, "duration_seconds", None)
     if duration:
         total = int(duration)
-        dur = f"({total // 60}:{total % 60:02d})"
-        return f" {icon} {dur}" if icon else f" {dur}"
-    return f" {icon}" if icon else ""
+        return f" ({total // 60}:{total % 60:02d})"
+    return ""
 
 templates.env.filters["asset_label_suffix"] = asset_label_suffix
 

--- a/tests/test_asset_icons.py
+++ b/tests/test_asset_icons.py
@@ -28,7 +28,7 @@ from cms.ui import _ASSET_ICONS, asset_icon, templates
 
 EXPECTED_ICONS = {
     "video": "🎬",
-    "image": "🖼️",
+    "image": "📷",
     "webpage": "🌐",
     "stream": "📡",
     "saved_stream": "📼",
@@ -152,3 +152,98 @@ def test_schedules_js_asset_icons_map_is_defined():
             f"{type_value!r}. Keep the JS ASSET_ICONS map in sync with "
             "cms.ui._ASSET_ICONS."
         )
+
+
+# ---------------------------------------------------------------------------
+# Dropdown icon placement (must be a PREFIX, not suffix)
+# ---------------------------------------------------------------------------
+
+
+def _render(source: str, **ctx) -> str:
+    return templates.env.from_string(source).render(**ctx)
+
+
+def test_asset_label_suffix_returns_only_duration():
+    """After the prefix fix, asset_label_suffix is duration-only. No emoji.
+
+    The icon is rendered separately as a prefix via ``asset_icon`` so it
+    appears *in front of* the asset name in dropdown options.
+    """
+    for t in AssetType:
+        suffix = templates.env.filters["asset_label_suffix"](
+            SimpleNamespace(asset_type=t, duration_seconds=None)
+        )
+        for emoji in EXPECTED_ICONS.values():
+            assert emoji not in suffix, (
+                f"asset_label_suffix({t.value}) unexpectedly contains icon "
+                f"{emoji!r} — icons must be rendered as a prefix via "
+                "asset_icon, not appended in the suffix."
+            )
+
+
+def test_dropdown_option_renders_icon_before_name():
+    """End-to-end: `{{ a | asset_icon }} {{ name }}{{ a | asset_label_suffix }}`
+    must produce `🎬 name (5:32)` — icon first, duration last."""
+    asset = SimpleNamespace(asset_type=AssetType.VIDEO, duration_seconds=332)
+    tpl = "{{ a | asset_icon }} {{ name }}{{ a | asset_label_suffix }}"
+    out = _render(tpl, a=asset, name="birthday.mp4")
+    assert out == "🎬 birthday.mp4 (5:32)"
+    # And specifically: icon must come before the name.
+    assert out.index("🎬") < out.index("birthday.mp4")
+
+
+def test_dropdown_option_webpage_renders_icon_only_as_prefix():
+    asset = SimpleNamespace(asset_type=AssetType.WEBPAGE, duration_seconds=None)
+    tpl = "{{ a | asset_icon }} {{ name }}{{ a | asset_label_suffix }}"
+    out = _render(tpl, a=asset, name="status-page")
+    assert out == "🌐 status-page"
+
+
+@pytest.mark.parametrize(
+    "template_file,must_contain_before_name",
+    [
+        # devices.html has 2 option blocks (per-device + per-group defaults);
+        # both must prefix the icon.
+        ("devices.html", 2),
+        # schedules.html server-rendered asset dropdown.
+        ("schedules.html", 1),
+    ],
+)
+def test_option_templates_prefix_icon_before_name(
+    template_file, must_contain_before_name
+):
+    """Guard the placement: ``{{ a | asset_icon }} {{ a.display_name ...`` must
+    appear for every asset dropdown. If someone reverts the prefix back to
+    a suffix, this catches it.
+    """
+    body = _read(template_file)
+    pattern = "{{ a | asset_icon }} {{ a.display_name"
+    count = body.count(pattern)
+    assert count >= must_contain_before_name, (
+        f"{template_file}: expected at least {must_contain_before_name} "
+        f"dropdown option(s) to prefix the asset name with the icon "
+        f"(pattern: '{{{{ a | asset_icon }}}} {{{{ a.display_name ...'), "
+        f"found {count}."
+    )
+
+
+def test_schedules_js_prefixes_icon_before_name():
+    """Both inline-JS dropdown builders must prepend the icon to ``a.name``
+    (the label string), not append it.
+    """
+    body = _read("schedules.html")
+    # The icon must be composed in front of a.name in both builders.
+    assert body.count("icon + ' ' + a.name") >= 2, (
+        "schedules.html inline JS must prefix ASSET_ICONS[a.type] before "
+        "a.name (expected two dropdown builders to use "
+        "`icon + ' ' + a.name`)."
+    )
+    # Regression guard: no builder should be appending the icon after the name.
+    assert "a.name + ' ' + icon" not in body, (
+        "schedules.html inline JS is appending the icon after the name — "
+        "icons must be a prefix."
+    )
+    assert "label += ' ' + icon" not in body, (
+        "schedules.html inline JS still has a 'label += icon' suffix style; "
+        "icons must be prepended to the label instead."
+    )

--- a/tests/test_asset_label_suffix.py
+++ b/tests/test_asset_label_suffix.py
@@ -1,8 +1,9 @@
 """Unit tests for the ``asset_label_suffix`` Jinja filter.
 
-Ensures saved-stream assets surface their duration in asset dropdowns
-the same way videos do, and that webpage/live-stream icons and
-empty-suffix cases still render correctly (issue #316).
+After asset-icons landed, the type emoji moved to a *prefix* (via
+``asset_icon``) and this filter now only carries the trailing
+``(mm:ss)`` duration for video / saved-stream assets. These tests
+lock that behaviour in.
 """
 
 from types import SimpleNamespace
@@ -18,46 +19,46 @@ def _asset(asset_type, duration_seconds=None):
     )
 
 
-def test_video_with_duration_shows_icon_and_mmss():
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 332)) == " 🎬 (5:32)"
+def test_video_with_duration_shows_mmss_only():
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 332)) == " (5:32)"
 
 
-def test_saved_stream_with_duration_shows_icon_and_mmss():
-    # The bug this is protecting: saved streams were falling through
-    # because the template only rendered duration for VIDEO.
-    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, 125)) == " 📼 (2:05)"
+def test_saved_stream_with_duration_shows_mmss_only():
+    # Saved streams must surface their duration too (this was the
+    # original #316 bug — the template only did it for VIDEO).
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, 125)) == " (2:05)"
 
 
-def test_saved_stream_without_duration_shows_icon_only():
-    # Capture still in progress — don't render "(None)"; icon is still
-    # shown so the asset's type is identifiable.
-    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, None)) == " 📼"
+def test_saved_stream_without_duration_empty():
+    # Capture still in progress — don't render "(None)".
+    # The icon is rendered separately as a prefix by `asset_icon`.
+    assert asset_label_suffix(_asset(AssetType.SAVED_STREAM, None)) == ""
 
 
-def test_webpage_shows_globe():
-    assert asset_label_suffix(_asset(AssetType.WEBPAGE)) == " 🌐"
+def test_webpage_has_no_suffix():
+    # Icon is a prefix now; no duration for webpages → empty suffix.
+    assert asset_label_suffix(_asset(AssetType.WEBPAGE)) == ""
 
 
-def test_live_stream_shows_antenna():
-    assert asset_label_suffix(_asset(AssetType.STREAM)) == " 📡"
+def test_live_stream_has_no_suffix():
+    assert asset_label_suffix(_asset(AssetType.STREAM)) == ""
 
 
-def test_image_shows_frame_icon():
-    assert asset_label_suffix(_asset(AssetType.IMAGE)) == " 🖼️"
+def test_image_has_no_suffix():
+    assert asset_label_suffix(_asset(AssetType.IMAGE)) == ""
 
 
 def test_duration_pads_seconds():
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 65)) == " 🎬 (1:05)"
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 65)) == " (1:05)"
 
 
-def test_duration_zero_falsy_icon_only():
-    # A zero-duration asset is effectively unknown — don't render "(0:00)",
-    # but still show the video icon.
-    assert asset_label_suffix(_asset(AssetType.VIDEO, 0)) == " 🎬"
+def test_duration_zero_falsy_empty():
+    # A zero-duration asset is effectively unknown — don't render "(0:00)".
+    assert asset_label_suffix(_asset(AssetType.VIDEO, 0)) == ""
 
 
 def test_accepts_string_type_value():
     # Filter is also used on dict-like objects in some paths; tolerate
     # a raw string type (as emitted via `asset_type.value`).
     asset = SimpleNamespace(asset_type="webpage", duration_seconds=None)
-    assert asset_label_suffix(asset) == " 🌐"
+    assert asset_label_suffix(asset) == ""

--- a/tests/test_assets_table_layout.py
+++ b/tests/test_assets_table_layout.py
@@ -1,0 +1,74 @@
+"""Smoke tests for the assets library table layout.
+
+Guards the structure of ``cms/templates/assets.html`` so regressions to
+column placement fail loudly. Current columns:
+
+    [▶] | Name | Type | Scope | Size | Status | Duration | Actions
+
+The "Shared" badge (displayed for assets shared with the current user
+via a group, where the user isn't the owner) lives in the **Name**
+column next to the filename — it's an ownership indicator, not an
+action, so it doesn't belong in Actions. This matches the conventions
+of Google Drive / Dropbox / OneDrive.
+"""
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "cms" / "templates"
+ASSETS_HTML = (TEMPLATES_DIR / "assets.html").read_text(encoding="utf-8")
+
+
+def test_shared_badge_is_in_name_column_not_actions():
+    """The Shared badge must render inside the Name cell, not Actions."""
+    # There must be exactly one Shared badge markup in the file (we used
+    # to have it in the Actions column — that placement is gone).
+    shared_markers = ASSETS_HTML.count('class="badge badge-processing" style="font-size:0.75rem">Shared<')
+    assert shared_markers == 1, (
+        f"Expected exactly one 'Shared' badge in assets.html (in the Name "
+        f"column). Found {shared_markers}. If you moved it, update this test."
+    )
+
+    # The actions cell must not contain the Shared badge anymore. Find the
+    # `<td class="actions"` block and verify "Shared" doesn't appear in it
+    # until the next `</td>`.
+    idx = ASSETS_HTML.find('<td class="actions"')
+    assert idx >= 0, "actions column <td> not found"
+    end = ASSETS_HTML.find("</td>", idx)
+    actions_block = ASSETS_HTML[idx:end]
+    assert ">Shared<" not in actions_block, (
+        "The Shared badge must not live in the Actions column — it's an "
+        "ownership indicator, not an action. Move it to the Name column."
+    )
+
+
+def test_shared_badge_set_is_row_scoped():
+    """``is_owner`` / ``shared_badge`` must be defined on the row (outside
+    the Name cell) so they're still in scope for the Actions column,
+    which uses ``is_owner`` to gate delete/recapture buttons.
+    """
+    # The {% set is_owner %} must appear before the <tr ... asset-row> that
+    # starts each row so the variable is in scope for the whole row.
+    is_owner_idx = ASSETS_HTML.find("{% set is_owner = ")
+    tr_idx = ASSETS_HTML.find('<tr class="asset-row"')
+    assert is_owner_idx >= 0 and tr_idx >= 0, (
+        "Expected `{% set is_owner %}` and `<tr class=\"asset-row\">` in "
+        "assets.html."
+    )
+    assert is_owner_idx < tr_idx, (
+        "`is_owner` must be defined before the `<tr class=\"asset-row\">` "
+        "opens, so it's in scope for every cell in the row (including the "
+        "Actions column, which uses it to gate owner-only controls)."
+    )
+
+
+def test_name_cell_renders_shared_badge():
+    """The Name cell (`asset-filename-cell`) must include the Shared badge."""
+    # Isolate the Name cell's <td> block and verify the badge lives inside.
+    idx = ASSETS_HTML.find('<td class="wrap asset-filename-cell">')
+    assert idx >= 0, "Name column <td> not found in assets.html"
+    end = ASSETS_HTML.find("</td>", idx)
+    name_block = ASSETS_HTML[idx:end]
+    assert "shared_badge" in name_block and ">Shared<" in name_block, (
+        "The Shared badge must be rendered inside the Name column "
+        "(`asset-filename-cell`), next to the filename."
+    )

--- a/tests_e2e/test_ui_popover_positioning.py
+++ b/tests_e2e/test_ui_popover_positioning.py
@@ -1,0 +1,141 @@
+"""E2E regression tests for popover positioning (PR #362).
+
+Both the kebab (⋮) action menu and the group-picker `+` popup use the
+native HTML popover API. Bugs we're guarding against:
+
+1. The `+` popup never moved off (0,0) because ``positionPopover()``
+   couldn't find the invoker via ``[popovertarget]`` (the `+` buttons
+   open via ``onclick="openGroupPopup(...)"`` and have no
+   ``popovertarget`` attribute). Fixed with a ``.group-picker-wrap``
+   sibling-lookup fallback.
+
+2. The kebab flashed at (0,0) for one frame on every open because the
+   browser paints the popover at its CSS default position before the
+   ``toggle`` event fires. Fixed by parking both popovers off-screen
+   (``top: -9999px; left: -9999px``) by default — the pre-positioned
+   frame is now invisible.
+
+These tests assert the popover ends up *near its invoker button*
+after opening, which catches both the "stuck at (0,0)" failure
+mode and any future positioning regressions.
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+def _create_group(api, name: str = "popover-position-test"):
+    resp = api.post("/api/devices/groups/", json={"name": name})
+    if resp.status_code not in (200, 201, 409):  # 409 = already exists from prior run
+        raise AssertionError(f"Failed to create group: {resp.status_code} {resp.text}")
+
+
+@pytest.mark.e2e
+class TestPopoverPositioning:
+    """Popovers must anchor near their invoker — never at viewport (0,0)."""
+
+    def test_kebab_menu_opens_near_invoker_button(self, page: Page, e2e_server):
+        """Kebab popover top/left must be within ~200px of its ⋮ button.
+
+        Regression: before the fix, the kebab briefly painted at (0,0)
+        on every open because the toggle event handler runs *after* the
+        first paint. We park the popover off-screen by default so that
+        first paint is invisible — but more importantly, this test
+        catches a future regression where positionKebab() stops running
+        entirely (popover would then stay at -9999px).
+        """
+        page.goto("/profiles")
+        page.wait_for_load_state("domcontentloaded")
+
+        row = page.locator("tr", has=page.locator(".badge-builtin")).first
+        kebab_btn = row.locator(".btn-kebab")
+
+        kebab_btn.click()
+        menu = page.locator(".kebab-menu:popover-open")
+        expect(menu).to_have_count(1)
+
+        btn_box = kebab_btn.bounding_box()
+        menu_box = menu.bounding_box()
+        assert btn_box is not None and menu_box is not None
+
+        # Menu should be on-screen (not parked at -9999px) — the off-screen
+        # default is the "before positioning" state. If positionKebab()
+        # silently fails, this catches it.
+        assert menu_box["x"] >= 0, (
+            f"Kebab menu left={menu_box['x']} is off-screen. "
+            f"positionKebab() likely didn't run — see app.js positionPopover()."
+        )
+        assert menu_box["y"] >= 0, (
+            f"Kebab menu top={menu_box['y']} is off-screen."
+        )
+
+        # Menu should be reasonably close to its invoker button (within
+        # 250px both axes — generous to avoid layout-flake while still
+        # catching the (0,0) bug, where distance from a typical row
+        # kebab is hundreds of px).
+        dx = abs(menu_box["x"] - btn_box["x"])
+        dy = abs(menu_box["y"] - btn_box["y"])
+        assert dx < 250 and dy < 250, (
+            f"Kebab menu at ({menu_box['x']}, {menu_box['y']}) is too far from "
+            f"its invoker at ({btn_box['x']}, {btn_box['y']}) — "
+            f"dx={dx}, dy={dy}. Likely positioning regression."
+        )
+
+    def test_group_plus_popup_opens_near_invoker_button(
+        self, page: Page, api, e2e_server,
+    ):
+        """Group `+` popup must position near its invoker button.
+
+        Regression (PR #362 root cause): ``positionPopover()`` looked up
+        the invoker via ``[popovertarget="X"]`` only, but `+` buttons
+        use ``onclick="openGroupPopup('X')"`` instead — so the lookup
+        returned null and the popup was glued to (0,0). The fix adds
+        a ``.group-picker-wrap`` sibling fallback. If that fallback
+        ever breaks, this test fails.
+        """
+        # Need at least one group so the upload `+` button is enabled.
+        _create_group(api)
+
+        page.goto("/assets")
+        page.wait_for_selector("#upload-form")
+
+        plus_btn = page.locator("#upload-groups-badges .btn-add-group")
+        expect(plus_btn).to_be_visible()
+        expect(plus_btn).to_be_enabled()
+
+        plus_btn.click()
+        popup = page.locator("#upload-group-popup")
+        # Wait for popover-open state; CSS toggles display:flex via :popover-open.
+        page.wait_for_function(
+            "el => el.matches(':popover-open')",
+            arg=popup.element_handle(),
+            timeout=2000,
+        )
+
+        btn_box = plus_btn.bounding_box()
+        popup_box = popup.bounding_box()
+        assert btn_box is not None and popup_box is not None
+
+        # Catch the original bug: popup stuck at top-left of viewport.
+        assert popup_box["x"] >= 0, (
+            f"Group popup left={popup_box['x']} is off-screen. "
+            f"positionGroupPopup() didn't run — see the .group-picker-wrap "
+            f"fallback in app.js positionPopover()."
+        )
+        # The original bug parked the popup at (0,0); button typically
+        # sits hundreds of px down/right of that on /assets.
+        assert popup_box["y"] >= 0
+        assert not (popup_box["x"] < 5 and popup_box["y"] < 5), (
+            f"Group popup is glued to viewport (0,0) — this is the exact "
+            f"failure mode of the [popovertarget] lookup bug. Verify the "
+            f".group-picker-wrap fallback in positionPopover() is intact."
+        )
+
+        # Popup should be reasonably close to the `+` button.
+        dx = abs(popup_box["x"] - btn_box["x"])
+        dy = abs(popup_box["y"] - btn_box["y"])
+        assert dx < 250 and dy < 250, (
+            f"Group popup at ({popup_box['x']}, {popup_box['y']}) is too far "
+            f"from its `+` button at ({btn_box['x']}, {btn_box['y']}) — "
+            f"dx={dx}, dy={dy}. Likely positioning regression."
+        )


### PR DESCRIPTION
## Summary

Three small UX polish nits in the assets library:

1. **Asset icons prefix dropdowns** — emoji icons now precede the asset
   name in `<option>` and JS-rendered dropdowns (was suffix). Reads
   more naturally and matches the `Type` column badge pattern.
2. **Image icon swap** 🖼️ → 📷 — old icon contrasted poorly with the
   blue `image` badge. Camera reads cleanly on every theme.
3. **"Shared" badge moved to Name column** — was incorrectly rendered
   in the `Actions` column. It's an ownership indicator, not an
   action, so it now sits next to the filename (matching Google
   Drive / Dropbox / OneDrive conventions).

### Bonus fixes (popovers)

While testing locally I noticed two popover-positioning bugs:

4. **`+` group-popup stuck in top-left** — `positionPopover()` looks
   up the invoker via `[popovertarget="..."]`, but `+` buttons use
   `onclick="openGroupPopup(...)"` and have no `popovertarget` attr,
   so the function early-returned and the popup never moved off its
   CSS default `(0,0)`. Added a fallback that finds the
   `.btn-add-group` inside the popup's nearest `.group-picker-wrap`.
5. **Kebab `⋮` action menu flash at top-left** — the browser paints
   the popover at its CSS default for one frame before the `toggle`
   event handler computes the real position. Parked both
   `.kebab-menu[popover]` and `.group-popup[popover]` at
   `top:-9999px; left:-9999px` by default so the pre-positioning
   frame is invisible.

## Tests

- `tests/test_asset_icons.py` — `EXPECTED_ICONS` updated for 📷;
  prefix-placement regressions guarded
- `tests/test_asset_label_suffix.py` — duration-only suffix locked in
- `tests/test_assets_table_layout.py` (new) — Shared badge must live
  in the Name column, not Actions; `is_owner` set must remain
  row-scoped so Actions-column owner gates still work

`43 passed` locally. Verified all five fixes in Docker before
opening this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
