### PR TITLE
feat(ui): drop full-page reload on asset delete/recapture

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1086,7 +1086,16 @@ async function editAssetName(el) {
 async function deleteAsset(assetId, filename) {
     if (!await showConfirm("Delete \"" + (filename || "this asset") + "\"?")) return;
     const resp = await apiCall("DELETE", `/api/assets/${assetId}`);
-    if (resp && resp.ok) location.reload();
+    if (resp && resp.ok) {
+        // Remove both the main asset row and its (possibly present) expanded
+        // detail row. Falling back to a reload is unnecessary: the row's own
+        // identity is enough to clean up the DOM without dropping any other
+        // state the user may have (scroll position, other expanded rows).
+        const row = document.querySelector(`tr.asset-row[data-asset-id="${assetId}"]`);
+        const detail = document.querySelector(`tr.asset-detail[data-detail-for="${assetId}"]`);
+        if (row) row.remove();
+        if (detail) detail.remove();
+    }
     else if (resp) {
         const err = await resp.json().catch(() => null);
         showToast(err?.detail || "Delete failed", true);
@@ -1125,7 +1134,9 @@ async function recaptureStream(assetId, displayName) {
     const resp = await apiCall("POST", `/api/assets/${assetId}/recapture`);
     if (resp && resp.ok) {
         showToast("Re-capture started — variants will be re-transcoded.");
-        location.reload();
+        // No reload needed — the assets page polls /api/assets/status every
+        // ~5s and updateLiveAssets() will flip variant badges to "Transcoding"
+        // and tick the progress meter as the recapture runs.
     } else if (resp) {
         const err = await resp.json().catch(() => null);
         showToast(extractErrorMsg(err), true);

--- a/tests_e2e/test_ui_asset_delete.py
+++ b/tests_e2e/test_ui_asset_delete.py
@@ -1,0 +1,75 @@
+"""E2E regression for issue #87 — no full-page reload on asset delete.
+
+Guards the UX win from PR #367: clicking Delete in an asset's kebab
+menu removes just that asset's row (and its expanded-detail row)
+without navigating away, so scroll position and any other expanded
+rows stay intact.
+
+If someone re-introduces a ``location.reload()`` in ``deleteAsset``,
+the ``page.url`` and ``framenavigated`` assertions here will catch it.
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests_e2e.conftest import click_row_action
+
+
+@pytest.mark.e2e
+class TestAssetDeleteNoReload:
+    def test_delete_asset_removes_row_without_navigation(
+        self, page: Page, api, e2e_server
+    ):
+        # Create two assets so we can tell the "remove one row" change from a
+        # "reload the whole table" change — after the delete, the other row
+        # should still be present (and it demonstrably came from the original
+        # page load, not a re-fetch).
+        keep = api.create_asset(filename="e2e-keep-reload.mp4").json()
+        target = api.create_asset(filename="e2e-delete-me.mp4").json()
+
+        page.goto("/assets")
+        page.wait_for_load_state("domcontentloaded")
+
+        target_row = page.locator(f'tr.asset-row[data-asset-id="{target["id"]}"]')
+        keep_row = page.locator(f'tr.asset-row[data-asset-id="{keep["id"]}"]')
+        expect(target_row).to_have_count(1)
+        expect(keep_row).to_have_count(1)
+
+        # Stamp the page so we can verify after the delete that no reload
+        # happened. If the DOM was re-rendered by a full navigation this
+        # custom property would be gone.
+        page.evaluate("window.__reloadSentinel = 'before-delete';")
+
+        # Also watch for any framenavigated event during the delete — a
+        # belt-and-suspenders check alongside the sentinel.
+        navigations: list[str] = []
+        page.on("framenavigated", lambda frame: navigations.append(frame.url))
+
+        url_before = page.url
+
+        click_row_action(target_row, "Delete")
+
+        # The confirm modal from showConfirm() — click "Confirm" to proceed.
+        page.get_by_role("button", name="Confirm").click()
+
+        # Target row disappears, kept row is still there.
+        expect(target_row).to_have_count(0, timeout=5000)
+        expect(keep_row).to_have_count(1)
+
+        # Detail row (if any) for the deleted asset is also gone.
+        expect(
+            page.locator(f'tr.asset-detail[data-detail-for="{target["id"]}"]')
+        ).to_have_count(0)
+
+        # No navigation happened — URL is unchanged, the sentinel still
+        # lives on window, and no framenavigated event fired to this page's
+        # frame during the delete.
+        assert page.url == url_before, (
+            f"asset delete must not navigate; url changed to {page.url!r}"
+        )
+        assert page.evaluate("window.__reloadSentinel") == "before-delete", (
+            "__reloadSentinel was cleared — looks like a full-page reload happened"
+        )
+        assert navigations == [], (
+            f"asset delete fired navigation event(s): {navigations!r}"
+        )


### PR DESCRIPTION
Small first slice of #87 / #160 (reduce `location.reload()` usage).

### Scope — assets page only

| Action | Before | After |
| --- | --- | --- |
| `deleteAsset` | Full page reload | Remove `tr.asset-row` + `tr.asset-detail` for the deleted asset |
| `recaptureStream` | Toast + full reload | Toast only — the 5s poller already flips variant badges to "Transcoding" and ticks the progress meter via `updateLiveAssets` |

### Why this is safe
- `deleteAsset` is called from one place (the kebab menu `onclick` in `assets.html`). No other code paths rely on the reload side-effect.
- `recaptureStream` is the same. The existing poller handles variant state transitions — the reload was redundant.
- The three callers that use `location.reload()` as a *fallback* when their target element isn't found (`app.js:458`, `assets.html:606`, etc.) are left alone — that's a legitimate pattern.

### Out of scope (follow-up)
- Upload / webpage / stream **create** flows still reload. Rendering the new row inline needs either a server-rendered row partial or duplicating the jinja template in JS — too much for a nit PR.
- Poll-driven fallbacks in `assets.html` (`hasNew → reload`, saved_stream variant transitions) — these are guard rails, not primary paths.

### Testing
Manual: delete an asset → row disappears, scroll/expand state preserved. Recapture a saved_stream → variant badge flips to Transcoding within ~5s without any navigation.

CI: existing `DELETE /api/assets/{id}` backend tests still cover the API contract.

Tracking inventory for the remaining pages posted in https://github.com/sslivins/agora-cms/issues/87#issuecomment-4283710987.
