### PR TITLE
test(ws): poll device_manager before closing status-update test

### DIFF
--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -164,7 +164,15 @@ class TestWebSocket:
                     "storage_used_mb": 200,
                 })
 
-                time.sleep(0.5)  # Allow server to process status before disconnect
+                # Poll device_manager until the status message is processed,
+                # so we don't close the WS mid-commit and hang pool teardown.
+                from cms.services.device_manager import device_manager
+                deadline = time.time() + 5.0
+                while time.time() < deadline:
+                    states = {s["device_id"]: s for s in device_manager.get_all_states()}
+                    if states.get("ws-test-status", {}).get("mode") == "splash":
+                        break
+                    time.sleep(0.05)
 
                 ws.close()
 


### PR DESCRIPTION
## Problem

`tests/test_websocket.py::TestWebSocket::test_status_message_updates_device` flakes on CI with:

```
ERROR at teardown of TestWebSocket.test_status_message_updates_device
E   Failed: Timeout (>30.0s) from pytest-timeout.
```

The test sends a status message over the WS, sleeps 0.5s, then closes. The server-side handler processes the status via `await db.commit()` — when the WS is closed mid-commit the asyncpg connection hangs during pool teardown.

Second flake (same class) hitting PR #369 and PR #367. PR #370 fixed the temperature variant; this follow-up fixes the one in `test_websocket.py`.

## Fix

Replace the fixed 0.5s sleep with a 5s poll (50ms cadence) on `device_manager.get_all_states()` — waits for `mode == 'splash'` to land before closing the WS, so the server is quiescent.

## Verify

```
pytest tests/test_websocket.py::TestWebSocket::test_status_message_updates_device -x
# 1 passed in 2.78s
```