### PR TITLE
fix(audit): include resource_id in free-text search

### DIFF
--- a/cms/routers/audit.py
+++ b/cms/routers/audit.py
@@ -52,6 +52,7 @@ async def list_audit_logs(
                 AuditLog.description.ilike(like_q),
                 AuditLog.action.ilike(like_q),
                 AuditLog.resource_type.ilike(like_q),
+                AuditLog.resource_id.ilike(like_q),
             )
         )
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -307,6 +307,23 @@ class TestAuditAPI:
         assert len(data) >= 1
 
     @pytest.mark.asyncio
+    async def test_search_q_resource_id(self, client, db_session):
+        """q should match resource_id so UI searches by UUID find hits."""
+        user = await _create_test_user(db_session, "ridsearch")
+        rid = "a1b2c3d4-dead-beef-cafe-f00dbaadf00d"
+        await audit_log(
+            db_session, user=user, action="asset.update",
+            resource_type="asset", resource_id=rid,
+            description="Modified asset 'x.mp4'",
+            details={"changes": {"url": {"old": "a", "new": "b"}}},
+        )
+        await db_session.commit()
+        resp = await client.get(f"/api/audit-log?q={rid}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(e.get("resource_id") == rid for e in data)
+
+    @pytest.mark.asyncio
     async def test_pagination_limit_offset(self, client, seeded_audit):
         resp = await client.get("/api/audit-log?limit=2&offset=0")
         assert resp.status_code == 200


### PR DESCRIPTION
The audit log list endpoint's `q` parameter searched description,
action, and resource_type — but not resource_id. Users searching by
the UUID of a specific asset, device, or role got no hits, even
though matching rows existed. The asset-page audit-log UI passes the
asset's UUID through as q, so edit events for a webpage asset
(PR #369) were invisible in the audit drawer and the nightly smoke
(test_webpage_asset_create_then_edit_url_roundtrip) correctly
flagged the gap.

Fix: extend the OR'd ilike search to also match resource_id.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
