### PR TITLE
fix(infra): pin CMS container app to maxReplicas=1 (#344)

### DIFF
--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -226,7 +226,14 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
-        maxReplicas: 3
+        // Pinned to 1 until multi-replica architecture lands (issue #344).
+        // CMS is not multi-replica safe today: in-memory device manager,
+        // scheduler caches, singleton background loops, and the
+        // `_upgrading` guard all assume a single process. Scaling > 1
+        // silently drops device traffic and double-schedules work. See
+        // docs/multi-replica-architecture.md for the staged plan to
+        // lift this restriction.
+        maxReplicas: 1
       }
     }
   }


### PR DESCRIPTION
# Pin CMS Container App to maxReplicas=1 (issue #344)

## Summary

Pins the CMS Container App to `maxReplicas: 1` in
`infra/modules/containerApps.bicep` until the multi-replica architecture
work lands. Closes the acute prod risk while the rest of the work in
issue #344 is implemented.

## Why

CMS is not multi-replica safe today. The in-memory `device_manager`,
scheduler caches, nine singleton background loops, and the `_upgrading`
guard all assume a single process. Scaling `> 1` silently drops device
traffic and double-schedules work — this is the root cause of the
PR-244 / hot-fix class of bugs.

The full fix is a staged architecture change tracked in issue #344 and
documented in `docs/multi-replica-architecture.md`. This PR is the
Stage 0 immediate mitigation: one-line bicep change, no code changes,
closes the risk today.

## Changes

- `infra/modules/containerApps.bicep` — `maxReplicas: 3 → 1` on the CMS
  Container App, with an explanatory comment pointing at issue #344 and
  the architecture doc.

## Impact

- No functional change for users at current fleet size — we were only
  ever spinning up 2nd / 3rd replicas under bursty load, and the bugs
  that caused were the problem we're eliminating here.
- Once Stage 4 lands we revert this pin back to `maxReplicas: 3`.

## Testing

- `az bicep build` validates the template.
- Infra deploy is the verification — Container App will re-deploy
  pinned at 1 replica.

Refs issue #344.
