### PR TITLE
refactor(cms): DeviceTransport abstraction (#344 stage 1)

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -297,6 +297,26 @@ async def lifespan(app: FastAPI):
         await fix_image_variant_extensions(db)
 
     # Start background tasks (transcoding is handled by the dedicated worker container)
+    #
+    # Multi-replica classification (issue #344, Stage 1 annotation —
+    # locking lands in Stage 4):
+    #
+    # | Loop                          | Class                | Notes |
+    # |-------------------------------|----------------------|-------|
+    # | scheduler_loop                | leader-only          | schedule dispatch, dedupe-critical |
+    # | _backfill_media_metadata      | leader-only          | one-shot; per-asset UPDATEs race |
+    # | version_check_loop            | replicated           | per-process cache warmer; dupes = extra GH hit |
+    # | device_purge_loop             | leader-only          | per-tick DELETEs; dupes waste work |
+    # | service_key_rotation_loop     | leader-only          | rotation races corrupt shared key |
+    # | _alert_settings_refresh_loop  | replicated           | per-process settings cache |
+    # | stream_capture_monitor_loop   | leader-only          | may create variant rows; dupes = double-create |
+    # | deleted_asset_reaper_loop     | leader-only          | concurrent deletes waste work |
+    # | outbox_drain_loop             | replicated (safe)    | already idempotent; worker-side dedupes |
+    #
+    # Today (maxReplicas=1 per Stage 0) every CMS process runs every loop —
+    # the classification is purely informational until the Stage 4 leader
+    # election lands.  See docs/multi-replica-architecture.md on branch
+    # `docs/multi-replica-plan` for the full rollout plan.
     scheduler_task = asyncio.create_task(scheduler_loop())
     backfill_task = asyncio.create_task(_backfill_media_metadata(settings))
     version_check_task = asyncio.create_task(version_check_loop())

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -29,7 +29,7 @@ from cms.schemas.device import (
     ToggleRequest,
 )
 from cms.schemas.protocol import ConfigMessage, FactoryResetMessage, RebootMessage, SyncMessage, UpgradeMessage, WipeAssetsMessage
-from cms.services.device_manager import device_manager
+from cms.services.transport import transport
 from cms.services.scheduler import push_sync_to_device
 from cms.services.audit_service import audit_log, compute_diff
 from cms.services.asset_readiness import require_asset_ready
@@ -72,7 +72,7 @@ async def _push_default_asset(device_id: str, asset: Asset, base_url: str, db: A
 
     fetch = await _resolve_asset_for_device(asset, device, base_url, db)
     if fetch:
-        await device_manager.send_to_device(device_id, fetch.model_dump(mode="json"))
+        await transport.send_to_device(device_id, fetch.model_dump(mode="json"))
 
     # Push a fresh sync so the device learns the new default_asset and splash
     # immediately (instead of waiting up to 15s for the scheduler cycle).
@@ -121,7 +121,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(query)
     devices = result.scalars().all()
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Build URL→display name map for resolving URL-based asset names
@@ -144,7 +144,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
         DeviceOut(
             **{c.key: getattr(d, c.key) for c in Device.__table__.columns},
             group_name=d.group.name if d.group else None,
-            is_online=device_manager.is_connected(d.id),
+            is_online=transport.is_connected(d.id),
             is_upgrading=d.id in _upgrading,
             playback_mode=live_states[d.id]["mode"] if d.id in live_states else None,
             playback_asset=_resolve_asset_name(d.id),
@@ -177,7 +177,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
 
     device = await _get_device_with_access(device_id, request, db)
     await db.refresh(device, ["group"])
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Resolve URL-based asset names
@@ -195,7 +195,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
     return DeviceOut(
         **{c.key: getattr(device, c.key) for c in Device.__table__.columns},
         group_name=device.group.name if device.group else None,
-        is_online=device_manager.is_connected(device.id),
+        is_online=transport.is_connected(device.id),
         is_upgrading=device.id in _upgrading,
         playback_mode=live_states[device.id]["mode"] if device.id in live_states else None,
         playback_asset=raw_asset,
@@ -286,7 +286,7 @@ async def update_device(
     return DeviceOut(
         **{c.key: getattr(device, c.key) for c in Device.__table__.columns},
         group_name=device.group.name if device.group else None,
-        is_online=device_manager.is_connected(device.id),
+        is_online=transport.is_connected(device.id),
     )
 
 
@@ -305,11 +305,11 @@ async def set_device_password(
 
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(web_password=password)
-    sent = await device_manager.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -332,11 +332,11 @@ async def reboot_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     reboot_msg = RebootMessage()
-    sent = await device_manager.send_to_device(device_id, reboot_msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, reboot_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -359,7 +359,7 @@ async def upgrade_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         _upgrading.discard(device_id)
         raise HTTPException(status_code=409, detail="Device is not connected")
 
@@ -368,7 +368,7 @@ async def upgrade_device(
 
     _upgrading.add(device_id)
     upgrade_msg = UpgradeMessage()
-    sent = await device_manager.send_to_device(device_id, upgrade_msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, upgrade_msg.model_dump(mode="json"))
     if not sent:
         _upgrading.discard(device_id)
         raise HTTPException(status_code=502, detail="Failed to send to device")
@@ -394,18 +394,16 @@ async def toggle_device_ssh(
     enabled = body.enabled
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(ssh_enabled=enabled)
-    sent = await device_manager.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
     # Track the SSH state immediately so the UI reflects it
-    conn = device_manager.get(device_id)
-    if conn:
-        conn.ssh_enabled = enabled
+    transport.set_state_flags(device_id, ssh_enabled=enabled)
 
     await audit_log(
         db, user=getattr(request.state, "user", None),
@@ -427,11 +425,11 @@ async def factory_reset_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     msg = FactoryResetMessage()
-    sent = await device_manager.send_to_device(device_id, msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -456,17 +454,15 @@ async def toggle_device_local_api(
     enabled = body.enabled
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(local_api_enabled=enabled)
-    sent = await device_manager.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
-    conn = device_manager.get(device_id)
-    if conn:
-        conn.local_api_enabled = enabled
+    transport.set_state_flags(device_id, local_api_enabled=enabled)
 
     await audit_log(
         db, user=getattr(request.state, "user", None),
@@ -530,7 +526,7 @@ async def adopt_device(device_id: str, body: AdoptRequest, request: Request, db:
 
     # Tell the device to wipe cached assets so it starts clean
     wipe_msg = WipeAssetsMessage(reason="adopted")
-    await device_manager.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
+    await transport.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
 
     # Push a fresh sync so the device learns its new status immediately
     # (e.g. the OOBE screen advances from "waiting for adoption" to "adopted").
@@ -570,7 +566,7 @@ async def delete_device(device_id: str, request: Request, db: AsyncSession = Dep
 
     # Tell the device to wipe cached assets before we remove it from the DB
     wipe_msg = WipeAssetsMessage(reason="deleted")
-    await device_manager.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
+    await transport.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
 
     # Remove referencing rows before deleting the device
     from cms.models.asset import DeviceAsset
@@ -605,11 +601,11 @@ async def request_device_logs(
     """
     device = await _get_device_with_access(device_id, request, db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     try:
-        logs = await device_manager.request_logs(device_id, services=body.services, since=body.since)
+        logs = await transport.request_logs(device_id, services=body.services, since=body.since)
     except TimeoutError as e:
         raise HTTPException(status_code=504, detail=str(e))
     except ValueError as e:

--- a/cms/routers/logs.py
+++ b/cms/routers/logs.py
@@ -16,7 +16,7 @@ from cms.auth import require_auth, require_permission, get_user_group_ids
 from cms.database import get_db
 from cms.permissions import LOGS_READ
 from cms.models.device import Device
-from cms.services.device_manager import device_manager
+from cms.services.transport import transport
 from cms.services.audit_service import audit_log
 
 logger = logging.getLogger("agora.cms.logs")
@@ -59,8 +59,8 @@ async def download_logs(req: LogDownloadRequest, request: Request, db: AsyncSess
         # ── Device logs ──
         tasks = {}
         for device_id in req.device_ids:
-            if device_manager.is_connected(device_id):
-                tasks[device_id] = device_manager.request_logs(
+            if transport.is_connected(device_id):
+                tasks[device_id] = transport.request_logs(
                     device_id,
                     services=req.services,
                     since=req.since,

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -214,8 +214,8 @@ class AlertService:
         self._offline_timers.pop(device_id, None)
 
         # Double-check the device hasn't reconnected during the sleep
-        from cms.services.device_manager import device_manager
-        if device_manager.is_connected(device_id):
+        from cms.services.transport import transport
+        if transport.is_connected(device_id):
             return
 
         self._was_offline.add(device_id)

--- a/cms/services/device_purge.py
+++ b/cms/services/device_purge.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.models.device import Device, DeviceStatus
-from cms.services.device_manager import device_manager
+from cms.services.transport import transport
 
 logger = logging.getLogger("agora.cms.device_purge")
 
@@ -30,7 +30,7 @@ async def purge_stale_pending_devices(db: AsyncSession, ttl_hours: int) -> list[
 
     for device in candidates:
         # Skip devices that are currently connected
-        if device_manager.is_connected(device.id):
+        if transport.is_connected(device.id):
             continue
 
         # Use last_seen, fall back to registered_at

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -16,7 +16,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import ScheduleEntry, SyncMessage
-from cms.services.device_manager import device_manager
+from cms.services.transport import transport
 
 logger = logging.getLogger("agora.cms.scheduler")
 
@@ -250,7 +250,7 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
 
     # Resolve target devices for each active schedule (filter per-device skips)
     now_playing = []
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
 
     # Get device names
     all_device_ids = set()
@@ -826,7 +826,7 @@ async def push_sync_to_device(device_id: str, db) -> None:
     """Build and push a fresh sync to a single connected device."""
     await _ensure_skips_loaded(db)
 
-    if not device_manager.is_connected(device_id):
+    if not transport.is_connected(device_id):
         return
 
     # Only sync adopted devices — pending/orphaned devices should not receive content
@@ -843,7 +843,7 @@ async def push_sync_to_device(device_id: str, db) -> None:
     if _last_sync_hash.get(device_id) == h:
         return
 
-    await device_manager.send_to_device(device_id, sync.model_dump(mode="json"))
+    await transport.send_to_device(device_id, sync.model_dump(mode="json"))
     _last_sync_hash[device_id] = h
     logger.info("Pushed full sync to device %s (%d schedules)", device_id, len(sync.schedules))
 
@@ -857,7 +857,7 @@ async def push_sync_to_affected_devices(schedule: Schedule, db) -> None:
 
 async def evaluate_schedules() -> None:
     """Single evaluation pass: sync schedules to devices and detect MISSED playback."""
-    if not device_manager.connected_count:
+    if not transport.connected_count:
         return
 
     sf = _get_session_factory()
@@ -876,7 +876,7 @@ async def evaluate_schedules() -> None:
         tz_name = tz_result.scalar_one_or_none() or "UTC"
         local_now = now.astimezone(ZoneInfo(tz_name)).replace(tzinfo=None)
 
-        connected = set(device_manager.connected_ids)
+        connected = set(transport.connected_ids)
 
         # Push full sync to each connected device (dedup via hash)
         for did in connected:
@@ -999,7 +999,7 @@ async def evaluate_schedules() -> None:
 
         # Seed _confirmed_playing from live device state after CMS restart
         live_states = {
-            s["device_id"]: s for s in device_manager.get_all_states()
+            s["device_id"]: s for s in transport.get_all_states()
         }
         from shared.models.asset import AssetType
         for s in active:

--- a/cms/services/transport.py
+++ b/cms/services/transport.py
@@ -1,0 +1,143 @@
+"""Abstract device transport — hides WS-vs-WPS from app code.
+
+Stage 1 of the multi-replica refactor (see
+``docs/multi-replica-architecture.md`` on the ``docs/multi-replica-plan``
+branch, and issue #344).
+
+Today, all call sites that need to talk to devices or query presence
+import this module's ``transport`` singleton.  The current
+``LocalDeviceTransport`` implementation wraps the in-process
+``device_manager`` (WebSockets owned by this process) — behaviour is
+identical to what the call sites did before Stage 1.
+
+In Stage 2, a ``WPSTransport`` sibling will land that sends via Azure
+Web PubSub REST and tracks presence through webhook-updated DB rows;
+at that point the singleton will be chosen by config at startup.
+
+WS-lifecycle operations (``register``/``disconnect``/``update_status``/
+``resolve_log_request``) are intentionally NOT on this interface — they
+are implementation details of the local direct-WS connection registry
+and live on ``device_manager``.  Only ``cms/routers/ws.py`` (and unit
+tests that fabricate device connections) should import
+``device_manager`` directly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class DeviceTransport(ABC):
+    """Application-level surface for device send + presence + state.
+
+    Every method is expected to be safe to call from any CMS replica.
+    """
+
+    @abstractmethod
+    async def send_to_device(self, device_id: str, message: dict[str, Any]) -> bool:
+        """Send a JSON message to a single device.
+
+        Returns ``True`` if the message was handed off to the transport,
+        ``False`` if the device is not reachable from this replica (or,
+        in Stage 2, not currently connected to any replica)."""
+
+    @abstractmethod
+    def is_connected(self, device_id: str) -> bool:
+        """Whether the device has a live connection right now."""
+
+    @property
+    @abstractmethod
+    def connected_count(self) -> int:
+        """Total number of currently-connected devices."""
+
+    @property
+    @abstractmethod
+    def connected_ids(self) -> list[str]:
+        """IDs of all currently-connected devices."""
+
+    @abstractmethod
+    def get_all_states(self) -> list[dict[str, Any]]:
+        """Latest playback/health state for every connected device.
+
+        Stage 2 will replace the in-memory implementation with a DB read
+        so the data is visible across replicas."""
+
+    @abstractmethod
+    async def request_logs(
+        self,
+        device_id: str,
+        services: list[str] | None = None,
+        since: str = "24h",
+        timeout: float = 30.0,
+    ) -> dict[str, str]:
+        """Synchronous RPC to pull device logs.
+
+        Stage 3 replaces this with a blob-upload outbox; this method will
+        be removed from the interface at that point."""
+
+    @abstractmethod
+    def set_state_flags(self, device_id: str, **flags: Any) -> None:
+        """Optimistically update fields on the in-memory device state.
+
+        Used by toggle endpoints (SSH, local-api) so the UI reflects the
+        new value before the next STATUS heartbeat arrives.  No-op if
+        the device is not connected.  Stage 2 replaces the in-memory
+        cache with a DB UPDATE."""
+
+
+class LocalDeviceTransport(DeviceTransport):
+    """Direct-WebSocket transport backed by the in-process
+    ``device_manager``.  This is the behaviour the CMS had before
+    Stage 1 — the class exists to put a stable interface in front of it
+    so Stage 2 can introduce ``WPSTransport`` without touching call
+    sites."""
+
+    def __init__(self, manager: Any | None = None) -> None:
+        if manager is None:
+            from cms.services.device_manager import device_manager as _dm
+            manager = _dm
+        self._manager = manager
+
+    async def send_to_device(self, device_id: str, message: dict[str, Any]) -> bool:
+        return await self._manager.send_to_device(device_id, message)
+
+    def is_connected(self, device_id: str) -> bool:
+        return self._manager.is_connected(device_id)
+
+    @property
+    def connected_count(self) -> int:
+        return self._manager.connected_count
+
+    @property
+    def connected_ids(self) -> list[str]:
+        return list(self._manager.connected_ids)
+
+    def get_all_states(self) -> list[dict[str, Any]]:
+        return self._manager.get_all_states()
+
+    async def request_logs(
+        self,
+        device_id: str,
+        services: list[str] | None = None,
+        since: str = "24h",
+        timeout: float = 30.0,
+    ) -> dict[str, str]:
+        return await self._manager.request_logs(
+            device_id, services=services, since=since, timeout=timeout,
+        )
+
+    def set_state_flags(self, device_id: str, **flags: Any) -> None:
+        conn = self._manager.get(device_id)
+        if conn is None:
+            return
+        for key, value in flags.items():
+            setattr(conn, key, value)
+
+
+transport: DeviceTransport = LocalDeviceTransport()
+"""Process-wide device transport singleton.
+
+Import as ``from cms.services.transport import transport`` and use its
+methods directly.  Tests may replace this attribute with a stub
+implementation (e.g., ``cms.services.transport.transport = FakeT()``)."""

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -47,7 +47,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.group_asset import GroupAsset
 from cms.models.user import User, UserGroup
-from cms.services.device_manager import device_manager
+from cms.services.transport import transport
 from cms.services.audit_service import audit_log
 from cms.services.json_compat import json_as_text
 from cms.services.version_checker import get_latest_device_version, is_update_available
@@ -605,7 +605,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
         pending_q = await db.execute(pending_query)
         pending_devices = pending_q.scalars().all()
         for d in pending_devices:
-            d.is_online = device_manager.is_connected(d.id)
+            d.is_online = transport.is_connected(d.id)
     else:
         pending_devices = []
 
@@ -626,7 +626,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     devices_q = await db.execute(devices_query)
     all_devices = devices_q.scalars().all()
     for d in all_devices:
-        d.is_online = device_manager.is_connected(d.id)
+        d.is_online = transport.is_connected(d.id)
 
     # Offline devices (adopted but not connected)
     offline_devices = [d for d in all_devices if not d.is_online]
@@ -675,7 +675,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             if start_t and end_t <= start_t:
                 end_today += _td(days=1)
             np["remaining_seconds"] = max(0, int((end_today - local_now).total_seconds()))
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
     for np in now_playing:
         did = np["device_id"]
         live = live_states.get(did, {})
@@ -693,12 +693,12 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             if (now - since).total_seconds() < 45:
                 np["mismatch"] = False
                 if actual_mode != "play":
-                    if not device_manager.is_connected(did):
+                    if not transport.is_connected(did):
                         np["device_offline"] = True
                     else:
                         np["starting"] = True
         # Outside the grace period, flag offline devices distinctly
-        if np.get("mismatch") and not device_manager.is_connected(did):
+        if np.get("mismatch") and not transport.is_connected(did):
             np["mismatch"] = False
             np["device_offline"] = True
 
@@ -861,7 +861,7 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
         _scope_device_query(select(Device.id).where(Device.status == DeviceStatus.ADOPTED))
     )
     all_device_ids = [r[0] for r in devices_q.all()]
-    offline_ids = [did for did in all_device_ids if not device_manager.is_connected(did)]
+    offline_ids = [did for did in all_device_ids if not transport.is_connected(did)]
 
     now_playing = await compute_now_playing(db, tz, now)
     # Scope now_playing to user's visible devices
@@ -886,7 +886,7 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
                 end_today += _td(days=1)
             np["remaining_seconds"] = max(0, int((end_today - local_now).total_seconds()))
 
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
     for np in now_playing:
         did = np["device_id"]
         live = live_states.get(did, {})
@@ -992,7 +992,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(device_query)
     devices = result.scalars().all()
-    live_states = {s["device_id"]: s for s in device_manager.get_all_states()}
+    live_states = {s["device_id"]: s for s in transport.get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Build URL→display name map for resolving playback_asset on URL-based assets
@@ -1015,7 +1015,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         a.ready_for_selection = ready
         a.not_ready_reason = reason
     for d in devices:
-        d.is_online = device_manager.is_connected(d.id)
+        d.is_online = transport.is_connected(d.id)
         state = live_states.get(d.id)
         d.cpu_temp_c = state["cpu_temp_c"] if state else None
         d.ip_address = state["ip_address"] if state else None
@@ -1062,7 +1062,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         g.device_count = len(g.devices)
         g.schedule_count = group_sched_counts.get(g.id, 0)
         for d in g.devices:
-            d.is_online = device_manager.is_connected(d.id)
+            d.is_online = transport.is_connected(d.id)
             state = live_states.get(d.id)
             d.cpu_temp_c = state["cpu_temp_c"] if state else None
             d.ip_address = state["ip_address"] if state else None
@@ -1575,7 +1575,7 @@ async def settings_page(
     result = await db.execute(select(Device).order_by(Device.name))
     devices = result.scalars().all()
     device_list = [
-        {"id": d.id, "name": d.name, "connected": device_manager.is_connected(d.id)}
+        {"id": d.id, "name": d.name, "connected": transport.is_connected(d.id)}
         for d in devices
     ]
 
@@ -1888,7 +1888,7 @@ async def change_timezone(
     result = await db.execute(select(Device).order_by(Device.name))
     devices = result.scalars().all()
     device_list = [
-        {"id": d.id, "name": d.name, "connected": device_manager.is_connected(d.id)}
+        {"id": d.id, "name": d.name, "connected": transport.is_connected(d.id)}
         for d in devices
     ]
 

--- a/tests/test_device_transport_contract.py
+++ b/tests/test_device_transport_contract.py
@@ -1,0 +1,137 @@
+"""Contract tests for ``DeviceTransport`` implementations.
+
+Every implementation must satisfy this suite.  Today only
+``LocalDeviceTransport`` exists; Stage 2 will add ``WPSTransport`` and
+will re-use this module (parametrized over impls).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from cms.services.device_manager import DeviceManager
+from cms.services.transport import DeviceTransport, LocalDeviceTransport
+
+
+@dataclass
+class _FakeWS:
+    sent: list[dict] = field(default_factory=list)
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+def _fresh_local() -> tuple[LocalDeviceTransport, DeviceManager]:
+    """Local transport wired to a fresh DeviceManager (no shared state)."""
+    dm = DeviceManager()
+    return LocalDeviceTransport(manager=dm), dm
+
+
+class TestLocalDeviceTransportContract:
+    def test_empty_state(self):
+        t, _ = _fresh_local()
+        assert t.connected_count == 0
+        assert t.connected_ids == []
+        assert not t.is_connected("nope")
+        assert t.get_all_states() == []
+
+    def test_presence_after_register(self):
+        t, dm = _fresh_local()
+        dm.register("d1", _FakeWS())
+        dm.register("d2", _FakeWS())
+        assert t.connected_count == 2
+        assert t.is_connected("d1") and t.is_connected("d2")
+        assert set(t.connected_ids) == {"d1", "d2"}
+
+    def test_get_all_states_shape(self):
+        t, dm = _fresh_local()
+        dm.register("d1", _FakeWS(), ip_address="10.0.0.1")
+        dm.update_status("d1", mode="play", asset="a.mp4")
+        states = t.get_all_states()
+        assert len(states) == 1
+        s = states[0]
+        # Stable contract: keys the UI depends on
+        for key in ("device_id", "mode", "asset", "connected_at",
+                    "ip_address", "ssh_enabled", "local_api_enabled"):
+            assert key in s
+        assert s["device_id"] == "d1"
+        assert s["ip_address"] == "10.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_send_to_device_success(self):
+        t, dm = _fresh_local()
+        ws = _FakeWS()
+        dm.register("d1", ws)
+        ok = await t.send_to_device("d1", {"type": "ping"})
+        assert ok is True
+        assert ws.sent == [{"type": "ping"}]
+
+    @pytest.mark.asyncio
+    async def test_send_to_unknown_device_returns_false(self):
+        t, _ = _fresh_local()
+        assert await t.send_to_device("missing", {"type": "ping"}) is False
+
+    @pytest.mark.asyncio
+    async def test_send_disconnects_on_error(self):
+        t, dm = _fresh_local()
+
+        class BrokenWS:
+            async def send_json(self, data):
+                raise RuntimeError("pipe broken")
+
+        dm.register("d1", BrokenWS())
+        assert t.is_connected("d1")
+        ok = await t.send_to_device("d1", {"type": "ping"})
+        assert ok is False
+        # Transport surfaces the disconnection on failure.
+        assert not t.is_connected("d1")
+
+    def test_set_state_flags_updates_visible_state(self):
+        t, dm = _fresh_local()
+        dm.register("d1", _FakeWS())
+        t.set_state_flags("d1", ssh_enabled=True, local_api_enabled=False)
+        s = {x["device_id"]: x for x in t.get_all_states()}["d1"]
+        assert s["ssh_enabled"] is True
+        assert s["local_api_enabled"] is False
+
+    def test_set_state_flags_on_unknown_device_is_noop(self):
+        t, _ = _fresh_local()
+        # Must not raise
+        t.set_state_flags("ghost", ssh_enabled=True)
+
+    @pytest.mark.asyncio
+    async def test_request_logs_resolves_via_manager_hook(self):
+        t, dm = _fresh_local()
+
+        captured: list[dict] = []
+
+        class CaptureWS:
+            async def send_json(self, data):
+                captured.append(data)
+
+        dm.register("d1", CaptureWS())
+
+        # Fire request_logs; capture the request_id from the WS message and
+        # resolve it synchronously from the "device".
+        import asyncio
+        task = asyncio.create_task(t.request_logs("d1", services=["agora"]))
+        await asyncio.sleep(0)
+        # Spin briefly until the message hits CaptureWS.
+        for _ in range(100):
+            if captured:
+                break
+            await asyncio.sleep(0.01)
+        assert captured, "request_logs never dispatched"
+        rid = captured[0]["request_id"]
+
+        dm.resolve_log_request(rid, logs={"agora": "hello"})
+        result = await asyncio.wait_for(task, timeout=1.0)
+        assert result == {"agora": "hello"}
+
+    def test_transport_is_an_abc(self):
+        # Cannot instantiate the abstract base
+        with pytest.raises(TypeError):
+            DeviceTransport()  # type: ignore[abstract]


### PR DESCRIPTION
## Summary

Stage 1 of the multi-replica CMS refactor (issue #344). Pure
refactor — no behaviour change.

- New `cms/services/transport.py` defines `DeviceTransport` (ABC) and
  `LocalDeviceTransport` (wraps the existing in-process
  `device_manager`).
- All app-level call sites (routers, scheduler, alert service, purge
  service, UI) now import `transport` instead of `device_manager`.
- Two SSH/local-API toggle call sites that mutated the in-memory
  `ConnectedDevice` object in place now go through a new
  `transport.set_state_flags()` method.
- `cms/routers/ws.py` intentionally still imports `device_manager`
  directly — WS-lifecycle operations (`register`, `disconnect`,
  `update_status`, `resolve_log_request`) are internal to the
  direct-WebSocket implementation and will be replaced by webhook
  ingestion in Stage 2.
- Annotated the 9 singleton background loops in `cms/main.py` with
  their multi-replica classification (leader-only / replicated /
  replicated-safe) as a reference for Stage 4. Purely informational;
  actual leader election lands in Stage 4.

## Why

Stage 2 will introduce a `WPSTransport` sibling that routes sends via
Azure Web PubSub REST. Putting a stable interface in front of the
existing direct-WS path lets Stage 2 swap transports without touching
~37 call sites.

## Call sites migrated

~37 sites across:

- `cms/routers/devices.py` (16 sites — send_to_device, is_connected,
  get_all_states, request_logs, and two `conn.ssh_enabled=x` /
  `conn.local_api_enabled=x` mutations replaced by `set_state_flags`)
- `cms/routers/logs.py` (2)
- `cms/services/scheduler.py` (6)
- `cms/services/alert_service.py` (1)
- `cms/services/device_purge.py` (1)
- `cms/ui.py` (11)

Zero call-site changes in tests — tests that fabricate device
connections via `device_manager.register()` continue to work since
those are WS-lifecycle internals, not transport-layer operations.

## Loop classification (`cms/main.py`)

| Loop | Class | Rationale |
|---|---|---|
| `scheduler_loop` | leader-only | schedule dispatch, dedupe-critical |
| `_backfill_media_metadata` | leader-only | one-shot; per-asset UPDATEs race |
| `version_check_loop` | replicated | per-process cache warmer; dupes = extra GH hit |
| `device_purge_loop` | leader-only | per-tick DELETEs; dupes waste work |
| `service_key_rotation_loop` | leader-only | rotation races corrupt shared key |
| `_alert_settings_refresh_loop` | replicated | per-process settings cache |
| `stream_capture_monitor_loop` | leader-only | may create variant rows; dupes = double-create |
| `deleted_asset_reaper_loop` | leader-only | concurrent deletes waste work |
| `outbox_drain_loop` | replicated (safe) | already idempotent; worker-side dedupes |

## Tests

- New `tests/test_device_transport_contract.py` — 10 contract tests
  for any `DeviceTransport` impl. All green locally.
  Parametrizable in Stage 2 when `WPSTransport` lands.
- 238 device-adjacent tests (devices, scheduler_advanced, temperature,
  dashboard_mismatch, alert notifications, live updates, logs, etc.)
  all green locally.
- Import smoke on every touched module clean.

## Stage 0 context (already shipped)

Stage 0 (PR #375) pinned `maxReplicas=1` so the existing behaviour is
preserved. This PR doesn't change that — it's purely interface work
to prepare for Stage 2.

## Follow-ups (separate PRs)

- Stage 2: `WPSTransport`, broker container, webhook HMAC, OTel.
- Stage 3: device-logs blob outbox (removes `request_logs` from the
  interface).
- Stage 4: leader election + lift `maxReplicas` back to 3+.
- Stage 5 (optional): generic device-command outbox.

Refs: #344
