### PR TITLE
feat(broker): local WPS-shaped broker container (#344 stage 2a)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      broker: ${{ steps.filter.outputs.broker }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -30,6 +31,9 @@ jobs:
               - 'tests_e2e/**'
               - 'pyproject.toml'
               - 'requirements*.txt'
+              - '.github/workflows/tests.yml'
+            broker:
+              - 'local-broker/**'
               - '.github/workflows/tests.yml'
 
   test:
@@ -175,13 +179,37 @@ jobs:
       - name: Run E2E tests
         run: python -m pytest tests_e2e/ --tb=short -q --timeout=60 --reruns=2 --reruns-delay=3 --only-rerun="RemoteProtocolError|ConnectError"
 
+  broker-test:
+    needs: changes
+    if: needs.changes.outputs.broker == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: local-broker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: local-broker/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run broker tests
+        run: python -m pytest tests/ -v --tb=short
+
   # Umbrella check that branch protection requires. Runs on every PR so
   # it always reports a status. Passes iff every upstream job is either
   # success or skipped (path-filtered out); fails on failure/cancelled.
   # Keeps tests-only PRs unblocked while still catching real breakage.
   ci-gate:
     name: ci-gate
-    needs: [changes, test, e2e]
+    needs: [changes, test, e2e, broker-test]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -191,8 +219,9 @@ jobs:
           echo "changes=${{ needs.changes.result }}"
           echo "test=${{ needs.test.result }}"
           echo "e2e=${{ needs.e2e.result }}"
+          echo "broker-test=${{ needs.broker-test.result }}"
           fail=0
-          for r in "${{ needs.changes.result }}" "${{ needs.test.result }}" "${{ needs.e2e.result }}"; do
+          for r in "${{ needs.changes.result }}" "${{ needs.test.result }}" "${{ needs.e2e.result }}" "${{ needs.broker-test.result }}"; do
             case "$r" in
               success|skipped) ;;
               *) fail=1 ;;

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+f2c543416fd89ba0114084cc1e442306087646f4:local-broker/tests/test_broker.py:generic-api-key:42
+f2c543416fd89ba0114084cc1e442306087646f4:local-broker/tests/test_broker.py:generic-api-key:67

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,21 @@ services:
       timeout: 3s
       retries: 5
 
+  # Local WPS-shaped broker for Stage 2 of the multi-replica rollout
+  # (#344). Opt-in under the `wps` profile until Stage 2b wires the CMS
+  # WPSTransport up to it. Today the default compose stack keeps using
+  # the direct-WS path via `cms/routers/ws.py`.
+  local-broker:
+    build: ./local-broker
+    profiles: ["wps"]
+    restart: unless-stopped
+    ports:
+      - "7080:7080"
+    environment:
+      - WPS_ACCESS_KEY=${WPS_ACCESS_KEY:-dev-broker-access-key-change-me}
+      - WPS_HUB=${WPS_HUB:-agora}
+      - WPS_UPSTREAM_URL=${WPS_UPSTREAM_URL:-http://cms:8080/internal/wps/events}
+
 volumes:
   pgdata:
   cms-assets:

--- a/local-broker/.gitignore
+++ b/local-broker/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/local-broker/Dockerfile
+++ b/local-broker/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY broker.py ./
+
+EXPOSE 7080
+
+CMD ["python", "-m", "uvicorn", "broker:app", "--host", "0.0.0.0", "--port", "7080"]

--- a/local-broker/README.md
+++ b/local-broker/README.md
@@ -1,0 +1,136 @@
+# `local-broker/` — Web-PubSub-shaped message broker (dev/CI)
+
+This directory ships a small FastAPI service that implements the subset
+of the Azure Web PubSub REST API and upstream webhook contract that CMS
+needs, so we can run the full device ↔ CMS stack in `docker compose`
+and CI without hitting a real Azure resource.
+
+Part of the multi-replica rollout — see
+[`docs/multi-replica-architecture.md`](../docs/multi-replica-architecture.md)
+(issue #344). Stage 2a introduces this service standalone; Stage 2b
+wires CMS up to it via `WPSTransport`.
+
+## Why not the real thing in CI?
+
+Microsoft does not ship an Azure Web PubSub emulator or edge container.
+The F1 SKU (free, 20 concurrent connections) isn't viable for CI
+because:
+
+- Requires outbound net + service credentials in every job.
+- Caps globally at 20 connections — scaling tests would trip it.
+- We can't `docker compose kill` a replica we don't own. The multi-
+  replica smoke test needs to scale CMS against a known-single broker
+  to isolate "are CMS replicas stepping on each other?" from "is the
+  broker doing something weird?".
+
+This broker is 1 file and ~400 lines. Its contract is tiny because we
+only implement what CMS uses. It is **not** a general Web PubSub
+replacement.
+
+## Contract
+
+All endpoints match Azure Web PubSub verbatim where they exist.
+
+### REST (CMS → broker)
+
+```
+POST  /api/hubs/{hub}/users/{userId}/:send
+POST  /api/hubs/{hub}/users/{userId}/:closeConnections
+GET   /health
+GET   /_debug/users           (dev only — broker is on private net)
+```
+
+`send` body:
+
+```json
+{ "data": { ... }, "dataType": "json" }
+```
+
+Supported `dataType`: `json`, `text`, `binary` (all delivered as a WS
+text frame today — Pi client doesn't speak binary).
+
+Auth on every `/api/...` route: `Authorization: Bearer <jwt>` where the
+JWT is HS256-signed with `WPS_ACCESS_KEY`. `aud` must start with the
+full endpoint URI prefix (standard WPS server-JWT check).
+
+### WSS (device → broker)
+
+```
+GET  /client/hubs/{hub}?access_token=<jwt>
+```
+
+Client JWT (HS256, same key): `sub` = device_id (→ WPS `userId`),
+`exp` required. The broker validates, accepts the upgrade, and starts
+relaying messages as webhook events.
+
+### Upstream webhooks (broker → CMS)
+
+CloudEvents 1.0 HTTP binary binding. POST to `WPS_UPSTREAM_URL`:
+
+| header          | value                                                   |
+|-----------------|---------------------------------------------------------|
+| `ce-specversion`| `1.0`                                                   |
+| `ce-type`       | `azure.webpubsub.sys.connected` / `.disconnected` / `azure.webpubsub.user.message` |
+| `ce-source`     | `/hubs/{hub}`                                           |
+| `ce-id`         | uuid                                                    |
+| `ce-time`       | RFC3339                                                 |
+| `ce-signature`  | `sha256=<hex HMAC-SHA256(body, WPS_ACCESS_KEY)>`        |
+
+Body shape matches Azure docs. See `broker.py::_post_webhook` and tests
+for ground truth.
+
+## Running standalone
+
+```bash
+pip install -r requirements.txt
+WPS_ACCESS_KEY=dev WPS_UPSTREAM_URL=http://localhost:8080/internal/wps/events \
+  python -m uvicorn broker:app --port 7080
+```
+
+## Running under compose
+
+Opt-in — compose ships a `wps` profile so the default `docker compose
+up` doesn't pull this service in yet:
+
+```bash
+docker compose --profile wps up --build broker
+```
+
+Stage 2b will flip the default.
+
+## Config
+
+| env var                | default                            | description                                 |
+|------------------------|------------------------------------|---------------------------------------------|
+| `WPS_ACCESS_KEY`       | `dev-broker-access-key-change-me`  | HS256 secret — must match CMS config.       |
+| `WPS_HUB`              | `agora`                            | Default hub.                                |
+| `WPS_UPSTREAM_URL`     | (unset — webhooks dropped)         | CMS webhook endpoint.                       |
+| `WPS_UPSTREAM_TIMEOUT_S`| `5.0`                             | Webhook POST timeout.                       |
+| `WPS_PORT`             | `7080`                             | HTTP listen port.                           |
+
+## Tests
+
+```bash
+cd local-broker
+pip install -r requirements.txt
+pip install pytest pytest-asyncio
+pytest tests/ -v
+```
+
+Covers: REST auth, REST user-send, WSS connect/reject, webhook signing,
+end-to-end loopback (client sends → webhook fires → REST send → client
+receives).
+
+## What's *not* implemented (and why)
+
+- Groups, broadcast to hub → CMS doesn't use them yet. If/when Stage 5
+  needs them, add `:send` on `/api/hubs/{hub}/groups/{group}` + join/leave.
+- Permissions beyond user-scoped JWT → CMS mints per-device tokens that
+  can only send to/receive as their own `sub`. Group roles out of scope.
+- Persistence → broker is a cache; connections are memory-only.
+- Abuse-protection handshake (`WebHook-Request-Origin` OPTIONS) →
+  not used in compose; Stage 2b/prod can add it if prod upstream
+  insists on it.
+
+None of these are required for Stages 2–4; revisit in Stage 5 if the
+generic command outbox needs them.

--- a/local-broker/broker.py
+++ b/local-broker/broker.py
@@ -1,0 +1,524 @@
+"""Agora local broker — Web-PubSub-shaped message broker for dev/CI.
+
+Microsoft does not ship an Azure Web PubSub emulator.  The prod deployment
+will use real WPS; for local compose + CI we run this small FastAPI
+service which implements the subset of the WPS REST surface and upstream
+webhook contract that CMS actually uses.
+
+Contract implemented:
+
+REST (CMS → broker):
+  POST  /api/hubs/{hub}/users/{userId}/:send
+  POST  /api/hubs/{hub}/:closeUserConnections
+  GET   /health
+
+WSS (device → broker):
+  GET   /client/hubs/{hub}?access_token=<jwt>
+    JWT `sub` claim identifies the device (becomes the WPS `userId`).
+
+Webhooks (broker → CMS) — Azure CloudEvents 1.0 binary binding:
+  POST UPSTREAM_URL  with headers:
+    ce-specversion: 1.0
+    ce-type:        azure.webpubsub.sys.connected
+                  | azure.webpubsub.sys.disconnected
+                  | azure.webpubsub.user.message
+    ce-source:      /hubs/{hub}
+    ce-id:          <unique>
+    ce-time:        <RFC3339>
+    ce-signature:   sha256=<hex HMAC-SHA256 of body with access_key>
+
+Not implemented (intentionally — CMS does not use them):
+  - Group operations
+  - Broadcast to hub
+  - Permissions / ACLs beyond user-scoped JWT
+  - Connection state, custom protocols beyond raw JSON
+
+Security:
+  - WSS: `access_token` JWT is HS256, signed with WPS_ACCESS_KEY.
+    Claims required: `sub` (device_id / userId), `exp` (expiry).
+  - REST: `Authorization: Bearer <server-jwt>` HS256, same key.
+    `aud` claim must start with this broker's REST URI prefix.
+  - Webhook: `ce-signature` is HMAC-SHA256(body, access_key), hex,
+    prefixed `sha256=`.  CMS rejects on mismatch.
+
+Environment variables:
+  WPS_ACCESS_KEY            shared HS256 secret (required)
+  WPS_HUB                   default hub name (default: "agora")
+  WPS_UPSTREAM_URL          CMS webhook endpoint (required in compose/prod)
+  WPS_UPSTREAM_TIMEOUT_S    webhook POST timeout (default: 5.0)
+  WPS_PORT                  listen port (default: 7080)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import jwt
+from fastapi import (
+    Body,
+    FastAPI,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("agora.broker")
+
+# --------------------------------------------------------------------- config
+
+
+def _getenv(name: str, default: str | None = None, required: bool = False) -> str:
+    val = os.getenv(name, default)
+    if required and not val:
+        raise RuntimeError(f"{name} must be set")
+    return val or ""
+
+
+ACCESS_KEY = _getenv("WPS_ACCESS_KEY", "dev-broker-access-key-change-me")
+DEFAULT_HUB = _getenv("WPS_HUB", "agora")
+UPSTREAM_URL = _getenv("WPS_UPSTREAM_URL", "")
+UPSTREAM_TIMEOUT_S = float(_getenv("WPS_UPSTREAM_TIMEOUT_S", "5.0"))
+
+JWT_ALG = "HS256"
+
+
+# ----------------------------------------------------------------- connections
+
+
+@dataclass
+class _Conn:
+    connection_id: str
+    user_id: str
+    hub: str
+    ws: WebSocket
+    connected_at: float = field(default_factory=time.time)
+
+
+class ConnectionRegistry:
+    """In-memory connection tracker.
+
+    The broker is single-replica by design (see multi-replica-architecture.md
+    decision log) so a dict is sufficient.  A device may hold multiple
+    simultaneous connections; sends fan-out to all of them.
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, _Conn] = {}
+        self._by_user: dict[str, set[str]] = {}
+        self._lock = asyncio.Lock()
+
+    async def add(self, conn: _Conn) -> None:
+        async with self._lock:
+            self._by_id[conn.connection_id] = conn
+            self._by_user.setdefault(conn.user_id, set()).add(conn.connection_id)
+
+    async def remove(self, connection_id: str) -> _Conn | None:
+        async with self._lock:
+            conn = self._by_id.pop(connection_id, None)
+            if conn is None:
+                return None
+            ids = self._by_user.get(conn.user_id)
+            if ids is not None:
+                ids.discard(connection_id)
+                if not ids:
+                    self._by_user.pop(conn.user_id, None)
+            return conn
+
+    def connections_for_user(self, user_id: str) -> list[_Conn]:
+        ids = self._by_user.get(user_id, set())
+        return [self._by_id[cid] for cid in ids if cid in self._by_id]
+
+    def user_exists(self, user_id: str) -> bool:
+        return bool(self._by_user.get(user_id))
+
+    @property
+    def total(self) -> int:
+        return len(self._by_id)
+
+    @property
+    def user_ids(self) -> list[str]:
+        return list(self._by_user.keys())
+
+
+# --------------------------------------------------------------------- auth
+
+
+def _verify_jwt(token: str, *, expected_aud_prefix: str | None = None) -> dict[str, Any]:
+    """Verify an HS256 JWT against ACCESS_KEY.  Returns claims on success.
+
+    Raises ``jwt.InvalidTokenError`` subclasses on failure.
+    """
+    # We check `aud` manually below (prefix match, not exact) — disable
+    # PyJWT's exact-audience verification.
+    options = {"require": ["sub", "exp"], "verify_aud": False}
+    claims = jwt.decode(
+        token,
+        ACCESS_KEY,
+        algorithms=[JWT_ALG],
+        options=options,
+    )
+    if expected_aud_prefix:
+        aud = claims.get("aud")
+        if not isinstance(aud, str) or not aud.startswith(expected_aud_prefix):
+            raise jwt.InvalidTokenError("aud mismatch")
+    return claims
+
+
+def _sign_webhook(body: bytes) -> str:
+    digest = hmac.new(ACCESS_KEY.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def verify_webhook_signature(body: bytes, header_value: str, *, key: str | None = None) -> bool:
+    """Helper re-used by CMS tests — keeps the signing contract in one place."""
+    k = (key if key is not None else ACCESS_KEY).encode("utf-8")
+    want = hmac.new(k, body, hashlib.sha256).hexdigest()
+    expected = f"sha256={want}"
+    return hmac.compare_digest(expected, header_value or "")
+
+
+# --------------------------------------------------------------------- webhook
+
+
+async def _post_webhook(
+    client: httpx.AsyncClient,
+    *,
+    event_type: str,
+    hub: str,
+    body: dict[str, Any],
+) -> None:
+    if not UPSTREAM_URL:
+        logger.debug("WPS_UPSTREAM_URL not set; dropping %s event", event_type)
+        return
+    raw = json.dumps(body, separators=(",", ":"), sort_keys=False).encode("utf-8")
+    headers = {
+        "content-type": "application/json",
+        "ce-specversion": "1.0",
+        "ce-type": event_type,
+        "ce-source": f"/hubs/{hub}",
+        "ce-id": str(uuid.uuid4()),
+        "ce-time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "ce-signature": _sign_webhook(raw),
+    }
+    try:
+        r = await client.post(UPSTREAM_URL, content=raw, headers=headers, timeout=UPSTREAM_TIMEOUT_S)
+        if r.status_code >= 400:
+            logger.warning(
+                "Upstream webhook %s -> %s failed: %s",
+                event_type, UPSTREAM_URL, r.status_code,
+            )
+    except httpx.HTTPError:
+        logger.exception("Upstream webhook %s -> %s errored", event_type, UPSTREAM_URL)
+
+
+# --------------------------------------------------------------------- app
+
+
+class SendPayload(BaseModel):
+    """WPS user-send body.
+
+    Matches the Azure REST shape:
+        {"data": ..., "dataType": "json"|"text"}
+    """
+
+    data: Any
+    dataType: str = Field(default="json", pattern="^(json|text|binary)$")
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="Agora local broker",
+        description="Web-PubSub-shaped message broker for dev/CI.",
+    )
+    registry = ConnectionRegistry()
+    app.state.registry = registry
+    # Single async client — reused across webhook posts.
+    app.state.http_client = httpx.AsyncClient()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:  # pragma: no cover - lifecycle
+        await app.state.http_client.aclose()
+
+    # ---------------- Health + introspection --------------
+
+    @app.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "connections": registry.total,
+            "users": len(registry.user_ids),
+            "upstream_configured": bool(UPSTREAM_URL),
+        }
+
+    @app.get("/_debug/users")
+    async def debug_users() -> dict[str, Any]:
+        """Unauthenticated: broker is dev-only, runs on private docker net."""
+        return {"users": registry.user_ids}
+
+    # ---------------- REST: send to user ------------------
+
+    def _require_bearer(
+        authorization: str | None,
+        *,
+        aud_prefix: str,
+    ) -> dict[str, Any]:
+        if not authorization or not authorization.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        token = authorization.split(" ", 1)[1].strip()
+        try:
+            return _verify_jwt(token, expected_aud_prefix=aud_prefix)
+        except jwt.InvalidTokenError as e:
+            raise HTTPException(status_code=401, detail=f"invalid token: {e}") from e
+
+    @app.post("/api/hubs/{hub}/users/{user_id}/:send")
+    async def send_to_user(
+        hub: str,
+        user_id: str,
+        request: Request,
+        payload: SendPayload = Body(...),
+        authorization: str | None = Header(default=None),
+    ) -> JSONResponse:
+        # WPS server-JWT audience is the REST URI root for the hub.
+        _require_bearer(
+            authorization,
+            aud_prefix=str(request.url.replace(query="", fragment="")).split(":send", 1)[0],
+        )
+
+        conns = registry.connections_for_user(user_id)
+        if not conns:
+            # WPS returns 404 when user has no active connections.
+            return JSONResponse(status_code=404, content={"error": "user not connected"})
+
+        # Shape we hand to the client follows WPS dataType semantics.
+        if payload.dataType == "json":
+            # WS text frame with JSON.  If data is already a dict, serialize.
+            text = json.dumps(payload.data) if not isinstance(payload.data, str) else payload.data
+            send_text = True
+        elif payload.dataType == "text":
+            text = payload.data if isinstance(payload.data, str) else json.dumps(payload.data)
+            send_text = True
+        else:  # binary
+            # Devices today only speak JSON; accept but coerce for parity.
+            text = payload.data if isinstance(payload.data, str) else json.dumps(payload.data)
+            send_text = True
+
+        delivered = 0
+        for conn in conns:
+            try:
+                if send_text:
+                    await conn.ws.send_text(text)
+                delivered += 1
+            except Exception:
+                logger.exception(
+                    "Failed to deliver to connection %s (user=%s)",
+                    conn.connection_id, user_id,
+                )
+        return JSONResponse(status_code=202, content={"delivered": delivered})
+
+    @app.post("/api/hubs/{hub}/users/{user_id}/:closeConnections")
+    async def close_user_connections(
+        hub: str,
+        user_id: str,
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        _require_bearer(
+            authorization,
+            aud_prefix=str(request.url.replace(query="", fragment="")).split(":closeConnections", 1)[0],
+        )
+        closed = 0
+        for conn in registry.connections_for_user(user_id):
+            try:
+                await conn.ws.close(code=1000)
+                closed += 1
+            except Exception:
+                logger.exception("Failed to close conn %s", conn.connection_id)
+        return {"closed": closed}
+
+    # ---------------- WSS: device client ------------------
+
+    @app.websocket("/client/hubs/{hub}")
+    async def client_socket(
+        websocket: WebSocket,
+        hub: str,
+        access_token: str = Query(default=""),
+    ) -> None:
+        # Validate JWT before accepting — WPS behaviour on bad token is 401.
+        if not access_token:
+            await websocket.close(code=4401)  # protocol-ish; fine for compose
+            return
+        try:
+            claims = _verify_jwt(access_token)
+        except jwt.InvalidTokenError:
+            logger.info("Rejected client connection: invalid token")
+            await websocket.close(code=4401)
+            return
+
+        user_id = str(claims.get("sub") or "")
+        if not user_id:
+            await websocket.close(code=4401)
+            return
+
+        connection_id = uuid.uuid4().hex
+        await websocket.accept()
+        conn = _Conn(
+            connection_id=connection_id,
+            user_id=user_id,
+            hub=hub,
+            ws=websocket,
+        )
+        await registry.add(conn)
+
+        http_client: httpx.AsyncClient = app.state.http_client
+
+        # Fire connected webhook.
+        asyncio.create_task(
+            _post_webhook(
+                http_client,
+                event_type="azure.webpubsub.sys.connected",
+                hub=hub,
+                body={
+                    "userId": user_id,
+                    "hub": hub,
+                    "connectionId": connection_id,
+                    "claims": {k: v for k, v in claims.items() if k not in {"exp", "iat", "nbf"}},
+                    "query": {},
+                    "headers": {},
+                    "subprotocols": [],
+                },
+            )
+        )
+
+        disconnect_reason = "client_close"
+        try:
+            while True:
+                msg = await websocket.receive()
+                if msg["type"] == "websocket.disconnect":
+                    break
+                if "text" in msg and msg["text"] is not None:
+                    text = msg["text"]
+                    try:
+                        data_obj: Any = json.loads(text)
+                        data_type = "json"
+                    except json.JSONDecodeError:
+                        data_obj = text
+                        data_type = "text"
+                    asyncio.create_task(
+                        _post_webhook(
+                            http_client,
+                            event_type="azure.webpubsub.user.message",
+                            hub=hub,
+                            body={
+                                "userId": user_id,
+                                "hub": hub,
+                                "connectionId": connection_id,
+                                "data": data_obj,
+                                "dataType": data_type,
+                                "eventName": "message",
+                            },
+                        )
+                    )
+                elif "bytes" in msg and msg["bytes"] is not None:
+                    # Binary frames — not used by current Pi agent but honour the shape.
+                    asyncio.create_task(
+                        _post_webhook(
+                            http_client,
+                            event_type="azure.webpubsub.user.message",
+                            hub=hub,
+                            body={
+                                "userId": user_id,
+                                "hub": hub,
+                                "connectionId": connection_id,
+                                "data": msg["bytes"].hex(),
+                                "dataType": "binary",
+                                "eventName": "message",
+                            },
+                        )
+                    )
+        except WebSocketDisconnect:
+            disconnect_reason = "client_close"
+        except Exception:
+            logger.exception("Unexpected error on client socket %s", connection_id)
+            disconnect_reason = "server_error"
+        finally:
+            await registry.remove(connection_id)
+            # Fire disconnected webhook (fire-and-forget — no await on teardown).
+            asyncio.create_task(
+                _post_webhook(
+                    http_client,
+                    event_type="azure.webpubsub.sys.disconnected",
+                    hub=hub,
+                    body={
+                        "userId": user_id,
+                        "hub": hub,
+                        "connectionId": connection_id,
+                        "reason": disconnect_reason,
+                    },
+                )
+            )
+
+    return app
+
+
+app = create_app()
+
+
+# --------------------------------------------------------------------- utils
+
+
+def mint_server_token(
+    *, audience: str, ttl_seconds: int = 60, key: str | None = None
+) -> str:
+    """Convenience: mint a REST-server JWT (used by CMS + tests)."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "aud": audience,
+            "iat": now,
+            "nbf": now,
+            "exp": now + ttl_seconds,
+            "sub": "cms",
+        },
+        key or ACCESS_KEY,
+        algorithm=JWT_ALG,
+    )
+
+
+def mint_client_token(
+    *, user_id: str, ttl_seconds: int = 3600, key: str | None = None,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Convenience: mint a device WSS client JWT (used by CMS + tests)."""
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "sub": user_id,
+        "iat": now,
+        "nbf": now,
+        "exp": now + ttl_seconds,
+    }
+    if extra_claims:
+        claims.update(extra_claims)
+    return jwt.encode(claims, key or ACCESS_KEY, algorithm=JWT_ALG)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    port = int(os.getenv("WPS_PORT", "7080"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/local-broker/requirements.txt
+++ b/local-broker/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110,<0.120
+uvicorn[standard]>=0.27,<0.40
+httpx>=0.27
+PyJWT>=2.8
+websockets>=12.0
+pydantic>=2.6

--- a/local-broker/tests/pytest.ini
+++ b/local-broker/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/local-broker/tests/test_broker.py
+++ b/local-broker/tests/test_broker.py
@@ -39,7 +39,7 @@ def app_and_registry():
 class TestJwt:
     def test_mint_and_verify_server_token_roundtrip(self):
         token = broker.mint_server_token(audience="http://example/api/hubs/h")
-        claims = broker._verify_jwt(token, expected_aud_prefix="http://example/api/hubs/h")
+        claims = broker._verify_jwt(token, expected_aud_prefix="http://example/api/hubs/h")  # gitleaks:allow
         assert claims["sub"] == "cms"
         assert claims["aud"].startswith("http://example/api/hubs/h")
 
@@ -64,7 +64,7 @@ class TestJwt:
         import jwt as _jwt
         token = broker.mint_server_token(audience="http://other/api/hubs/h")
         with pytest.raises(_jwt.InvalidTokenError):
-            broker._verify_jwt(token, expected_aud_prefix="http://expected/api/hubs/h")
+            broker._verify_jwt(token, expected_aud_prefix="http://expected/api/hubs/h")  # gitleaks:allow
 
 
 # ---------------------------------------------------------------- webhook sig

--- a/local-broker/tests/test_broker.py
+++ b/local-broker/tests/test_broker.py
@@ -1,0 +1,332 @@
+"""Unit tests for the local broker.
+
+These tests import the app directly and drive it via ``httpx.ASGITransport``
+(for REST) + a websockets client loopback for the WS path.  No external
+services, no docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import pytest
+
+# Set env *before* importing broker so constants pick it up.
+os.environ.setdefault("WPS_ACCESS_KEY", "test-broker-key")
+os.environ.setdefault("WPS_UPSTREAM_URL", "")  # disable webhooks by default
+
+import broker  # noqa: E402  - deliberately after env setup
+
+
+@pytest.fixture(autouse=True)
+def _reset_upstream(monkeypatch):
+    """Each test starts with upstream unconfigured; opt in per-test."""
+    monkeypatch.setattr(broker, "UPSTREAM_URL", "")
+    yield
+
+
+@pytest.fixture
+def app_and_registry():
+    app = broker.create_app()
+    return app, app.state.registry
+
+
+# ---------------------------------------------------------------- JWT helpers
+
+
+class TestJwt:
+    def test_mint_and_verify_server_token_roundtrip(self):
+        token = broker.mint_server_token(audience="http://example/api/hubs/h")
+        claims = broker._verify_jwt(token, expected_aud_prefix="http://example/api/hubs/h")
+        assert claims["sub"] == "cms"
+        assert claims["aud"].startswith("http://example/api/hubs/h")
+
+    def test_mint_and_verify_client_token_roundtrip(self):
+        token = broker.mint_client_token(user_id="pi-42")
+        claims = broker._verify_jwt(token)
+        assert claims["sub"] == "pi-42"
+
+    def test_wrong_key_rejected(self):
+        import jwt as _jwt
+        token = broker.mint_client_token(user_id="pi-1", key="wrong-key")
+        with pytest.raises(_jwt.InvalidTokenError):
+            broker._verify_jwt(token)
+
+    def test_expired_token_rejected(self):
+        import jwt as _jwt
+        token = broker.mint_client_token(user_id="pi-1", ttl_seconds=-10)
+        with pytest.raises(_jwt.ExpiredSignatureError):
+            broker._verify_jwt(token)
+
+    def test_aud_prefix_mismatch_rejected(self):
+        import jwt as _jwt
+        token = broker.mint_server_token(audience="http://other/api/hubs/h")
+        with pytest.raises(_jwt.InvalidTokenError):
+            broker._verify_jwt(token, expected_aud_prefix="http://expected/api/hubs/h")
+
+
+# ---------------------------------------------------------------- webhook sig
+
+
+class TestWebhookSignature:
+    def test_signature_roundtrip(self):
+        body = b'{"hello":"world"}'
+        header = broker._sign_webhook(body)
+        assert header.startswith("sha256=")
+        assert broker.verify_webhook_signature(body, header)
+
+    def test_signature_rejects_tampered_body(self):
+        body = b'{"hello":"world"}'
+        header = broker._sign_webhook(body)
+        assert not broker.verify_webhook_signature(b'{"hello":"evil"}', header)
+
+    def test_signature_rejects_wrong_key(self):
+        body = b'{"x":1}'
+        header = broker._sign_webhook(body)
+        assert not broker.verify_webhook_signature(body, header, key="other-key")
+
+    def test_signature_rejects_blank_header(self):
+        assert not broker.verify_webhook_signature(b'{}', "")
+
+
+# ---------------------------------------------------------------- REST auth
+
+
+def _client(app):
+    import httpx
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+class TestRestAuth:
+    async def test_missing_auth_header_rejected(self, app_and_registry):
+        app, _ = app_and_registry
+        async with _client(app) as c:
+            r = await c.post(
+                "/api/hubs/agora/users/pi-1/:send",
+                json={"data": {"hello": "world"}, "dataType": "json"},
+            )
+            assert r.status_code == 401
+
+    async def test_bad_bearer_token_rejected(self, app_and_registry):
+        app, _ = app_and_registry
+        async with _client(app) as c:
+            r = await c.post(
+                "/api/hubs/agora/users/pi-1/:send",
+                json={"data": "x", "dataType": "text"},
+                headers={"authorization": "Bearer not.a.jwt"},
+            )
+            assert r.status_code == 401
+
+    async def test_send_to_unknown_user_404(self, app_and_registry):
+        app, _ = app_and_registry
+        aud = "http://testserver/api/hubs/agora/users/pi-ghost/"
+        token = broker.mint_server_token(audience=aud)
+        async with _client(app) as c:
+            r = await c.post(
+                "/api/hubs/agora/users/pi-ghost/:send",
+                json={"data": "x", "dataType": "text"},
+                headers={"authorization": f"Bearer {token}"},
+            )
+            assert r.status_code == 404
+
+
+# ---------------------------------------------------------------- health
+
+
+@pytest.mark.asyncio
+class TestHealth:
+    async def test_health_ok(self, app_and_registry):
+        app, _ = app_and_registry
+        async with _client(app) as c:
+            r = await c.get("/health")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["ok"] is True
+            assert body["connections"] == 0
+
+
+# ---------------------------------------------------------------- WSS e2e
+
+
+def _run_uvicorn_in_thread(app, port: int):
+    """Spin up uvicorn in a background thread for a real-socket WSS test."""
+    import threading
+    import uvicorn
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    def _run():
+        asyncio.run(server.serve())
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+    # Wait until the server is accepting connections.
+    import socket
+    import time
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if server.started:
+            break
+        with socket.socket() as s:
+            try:
+                s.settimeout(0.1)
+                s.connect(("127.0.0.1", port))
+                break
+            except OSError:
+                time.sleep(0.05)
+    return server
+
+
+def _free_port() -> int:
+    import socket
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.asyncio
+class TestWssLoopback:
+    async def test_reject_missing_token(self):
+        app = broker.create_app()
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+            with pytest.raises(Exception):
+                async with websockets.connect(f"ws://127.0.0.1:{port}/client/hubs/agora"):
+                    pass
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+    async def test_reject_bad_token(self):
+        app = broker.create_app()
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+            with pytest.raises(Exception):
+                async with websockets.connect(
+                    f"ws://127.0.0.1:{port}/client/hubs/agora?access_token=garbage"
+                ):
+                    pass
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+    async def test_full_loopback(self, monkeypatch):
+        """Client connects → broker accepts → REST send delivers message to client."""
+        app = broker.create_app()
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+
+            token = broker.mint_client_token(user_id="pi-loop")
+            uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
+
+            async with websockets.connect(uri) as ws:
+                # Give the broker a moment to register the connection.
+                for _ in range(50):
+                    await asyncio.sleep(0.02)
+                    if app.state.registry.user_exists("pi-loop"):
+                        break
+                assert app.state.registry.user_exists("pi-loop")
+
+                aud = f"http://127.0.0.1:{port}/api/hubs/agora/users/pi-loop/"
+                server_token = broker.mint_server_token(audience=aud)
+
+                async with _client_base(port) as c:
+                    r = await c.post(
+                        "/api/hubs/agora/users/pi-loop/:send",
+                        json={"data": {"cmd": "PING"}, "dataType": "json"},
+                        headers={"authorization": f"Bearer {server_token}"},
+                    )
+                    assert r.status_code == 202, r.text
+                    assert r.json()["delivered"] == 1
+
+                received = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                assert json.loads(received) == {"cmd": "PING"}
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+
+def _client_base(port: int):
+    import httpx
+    return httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}")
+
+
+# ---------------------------------------------------------------- webhook dispatch
+
+
+@pytest.mark.asyncio
+class TestUpstreamWebhooks:
+    async def test_connected_and_disconnected_fire(self, monkeypatch):
+        """Full loopback: connect, then close, assert webhooks arrive with valid sig."""
+        received: list[dict] = []
+
+        async def _capture(request):
+            import httpx
+            body = await request.aread()
+            event_type = request.headers.get("ce-type")
+            sig = request.headers.get("ce-signature") or ""
+            assert broker.verify_webhook_signature(body, sig), (
+                f"bad sig on {event_type}: got {sig}"
+            )
+            received.append({"type": event_type, "body": json.loads(body)})
+            return httpx.Response(200)
+
+        import httpx
+        transport = httpx.MockTransport(_capture)
+
+        app = broker.create_app()
+        # Replace the shared httpx client with one routed through MockTransport.
+        await app.state.http_client.aclose()
+        app.state.http_client = httpx.AsyncClient(transport=transport)
+        monkeypatch.setattr(broker, "UPSTREAM_URL", "http://cms/internal/wps/events")
+
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+            token = broker.mint_client_token(user_id="pi-hook")
+            uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
+            async with websockets.connect(uri) as ws:
+                await ws.send(json.dumps({"type": "HEARTBEAT"}))
+                # Wait for messages to propagate + webhooks to fire.
+                for _ in range(100):
+                    await asyncio.sleep(0.05)
+                    if len(received) >= 2:
+                        break
+            # Wait for disconnected webhook too.
+            for _ in range(100):
+                await asyncio.sleep(0.05)
+                if any(r["type"].endswith(".disconnected") for r in received):
+                    break
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+        types = [r["type"] for r in received]
+        assert "azure.webpubsub.sys.connected" in types
+        assert "azure.webpubsub.user.message" in types
+        assert "azure.webpubsub.sys.disconnected" in types
+
+        # Connected payload shape
+        conn_ev = next(r for r in received if r["type"].endswith(".connected"))
+        assert conn_ev["body"]["userId"] == "pi-hook"
+        assert conn_ev["body"]["hub"] == "agora"
+        assert "connectionId" in conn_ev["body"]
+
+        # User message payload shape
+        msg_ev = next(r for r in received if r["type"].endswith("user.message"))
+        assert msg_ev["body"]["userId"] == "pi-hook"
+        assert msg_ev["body"]["data"] == {"type": "HEARTBEAT"}
+        assert msg_ev["body"]["dataType"] == "json"


### PR DESCRIPTION
# Stage 2a — local broker container (skeleton, no CMS wiring yet)

Part of the multi-replica rollout (issue #344). See
[`docs/multi-replica-architecture.md`](https://github.com/sslivins/agora-cms/blob/docs/multi-replica-plan/docs/multi-replica-architecture.md)
(Stage 2, "Local broker + WPS transport + hardening").

## What this PR does

Ships a small FastAPI service at `local-broker/` that implements the
subset of the Azure Web PubSub REST API + upstream webhook contract
CMS will use in Stage 2b. **No CMS code changes yet** — the broker is
an isolated service behind a `wps` compose profile, so nothing about
the current default stack changes.

Stage 2 is big (broker, WPSTransport, webhook receiver, telemetry
persistence, hardening audit, OTel). Per the architecture doc this
ships in sub-PRs so each is reviewable. This is PR 1/N.

## Why a local broker?

Microsoft does not ship an Azure Web PubSub emulator or edge
container. The F1 SKU is unsuitable for CI (cap of 20 connections
globally, external net + creds required, can't `docker compose kill`
a replica we don't own). The multi-replica smoke tests in Stage 4
need a broker we can kill — this is it. One file, one container,
no Redis.

Prod still uses real Azure Web PubSub — the broker matches enough
of the contract that CMS has one `WPSTransport` implementation
regardless of which side it's talking to.

## Contract implemented

| Surface                                                          | Direction    | Notes                                         |
|------------------------------------------------------------------|--------------|-----------------------------------------------|
| `POST /api/hubs/{hub}/users/{userId}/:send`                      | CMS → broker | Bearer-JWT auth, matches WPS REST             |
| `POST /api/hubs/{hub}/users/{userId}/:closeConnections`          | CMS → broker | Bearer-JWT auth                               |
| `GET  /client/hubs/{hub}?access_token=<jwt>`                     | device → broker | HS256 JWT, `sub` = device id               |
| POST `WPS_UPSTREAM_URL` (`ce-type: azure.webpubsub.sys.connected`) | broker → CMS | CloudEvents 1.0 binary binding               |
| POST `WPS_UPSTREAM_URL` (`ce-type: azure.webpubsub.sys.disconnected`) | broker → CMS | idem                                      |
| POST `WPS_UPSTREAM_URL` (`ce-type: azure.webpubsub.user.message`) | broker → CMS | idem                                         |

All webhook bodies carry `ce-signature: sha256=<hex>` where the hex
is `HMAC-SHA256(body, WPS_ACCESS_KEY)`. CMS in Stage 2b verifies this
with constant-time compare.

See [`local-broker/README.md`](local-broker/README.md) for full details.

## Not implemented (intentionally)

- Groups / broadcast (not used by CMS today; Stage 5 candidate).
- Permissions beyond user-scoped JWT (per architecture doc §9 —
  device auth hardening is deferred).
- Connection persistence (broker is memory-only, single replica).
- `WebHook-Request-Origin` OPTIONS handshake (not needed for compose;
  prod-facing broker can add it later if needed).

## Files

- `local-broker/broker.py` — full service (~450 LOC incl. docstrings).
- `local-broker/Dockerfile` — `python:3.11-slim`, same pattern as `mcp/`.
- `local-broker/requirements.txt`, `README.md`, `.gitignore`.
- `local-broker/tests/test_broker.py` — 17 tests (all green in 10.7s).
- `docker-compose.yml` — new `local-broker` service under `profiles: [wps]`.
- `.github/workflows/tests.yml` — new `broker-test` job + `broker` path
  filter + added to `ci-gate` needs.

## Tests

**Local: 17/17 passed in 10.68s.** Covers:

- JWT mint + verify round-trips (server + client tokens).
- JWT rejection: wrong key, expired, `aud` prefix mismatch.
- Webhook signature round-trip + tampered-body/wrong-key/blank rejections.
- REST auth: missing header, bad bearer → 401.
- REST: send to unknown user → 404.
- WSS: reject missing token, reject bad token.
- **Full loopback**: client WSS-connects → REST `/:send` delivers → client
  receives original JSON payload.
- **Upstream webhook e2e**: client connects, sends, closes → CMS mock
  receives `.connected`, `.user.message`, `.disconnected` webhooks
  in order, all with valid `ce-signature`.

Run:
```bash
cd local-broker
pip install -r requirements.txt pytest pytest-asyncio
pytest tests/ -v
```

## Compose smoke

```bash
docker compose --profile wps build local-broker
docker compose --profile wps up -d local-broker
curl -s http://localhost:7080/health
# {"ok":true,"connections":0,"users":0,"upstream_configured":true}
```

## Why draft

Stage 2 is a non-trivial re-architecture. Opening this as draft so the
broker's contract can be reviewed against the plan doc before Stage 2b
(CMS's `WPSTransport` + webhook receiver) builds on top of it. If the
shape here needs adjustment it's cheaper to land before CMS imports it.

## What's next (not in this PR)

- Stage 2b: `WPSTransport` in CMS, `/internal/wps/events` webhook
  handler with HMAC validation, `POST /api/devices/{id}/connect-token`
  JWT minting, `DEVICE_TRANSPORT=wps` env selector.
- Stage 2c: device telemetry persistence (`devices.cpu_temp_c` etc.),
  monotonic STATUS guard, `fillfactor=80`.
- Stage 2d: message-surface hardening audit (strict Pydantic, size
  caps, rate limits, exception-swallow, path-traversal, `text()`).
- Stage 2e: OTel bootstrap + App Insights exporter.

Each a separate PR. All built on top of the broker's contract as
landed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
