### PR TITLE
feat: Stage 2b.2 — WPS transport + webhook receiver + token mint (#344)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage.xml
 htmlcov/
 tests/nightly/coverage-data/
 
+
+.commit_msg.txt
+

--- a/cms/config.py
+++ b/cms/config.py
@@ -33,5 +33,18 @@ class Settings(SharedSettings):
     # Transcode worker signaling (Azure)
     azure_transcode_queue_url: str | None = None
 
+    # Device transport — issue #344 Stage 2b.2
+    # "local" = direct WebSocket (today's behaviour; /ws/device handler).
+    # "wps"   = Azure Web PubSub; CMS sends via REST and receives events
+    #           via the upstream webhook receiver mounted at
+    #           /internal/wps/events.  Requires wps_connection_string.
+    device_transport: str = "local"
+    wps_connection_string: str | None = None
+    wps_hub: str = "agora"
+    wps_token_lifetime_minutes: int = 60
+    # Optional allow-list for the WebHook-Request-Origin handshake.
+    # If unset, the receiver echoes back whatever Azure sent (dev-friendly).
+    wps_webhook_allowed_origin: str | None = None
+
     # SMTP is configured via the web UI settings page (stored in DB)
     base_url: str | None = None  # public URL for login links in emails

--- a/cms/main.py
+++ b/cms/main.py
@@ -486,6 +486,7 @@ app.mount("/static", StaticFiles(directory="cms/static"), name="static")
 from cms.routers.assets import device_router as assets_device_router  # noqa: E402
 from cms.routers.assets import router as assets_router  # noqa: E402
 from cms.routers.devices import router as devices_router  # noqa: E402
+from cms.routers.devices import device_originated_router as devices_device_router  # noqa: E402
 from cms.routers.logs import router as logs_router  # noqa: E402
 from cms.routers.mcp import router as mcp_router  # noqa: E402
 from cms.routers.profiles import router as profiles_router  # noqa: E402
@@ -502,6 +503,7 @@ from cms.routers.users import router as users_router  # noqa: E402
 from cms.ui import router as ui_router  # noqa: E402
 
 app.include_router(devices_router)
+app.include_router(devices_device_router)
 app.include_router(assets_router)
 app.include_router(assets_device_router)
 app.include_router(schedules_router)

--- a/cms/main.py
+++ b/cms/main.py
@@ -344,9 +344,45 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("Failed to log CMS_STARTED event")
 
+    # ── Device transport selection (issue #344 Stage 2b.2) ──
+    # Default is "local" (direct WebSocket via cms/routers/ws.py, today's
+    # behaviour).  Setting AGORA_CMS_DEVICE_TRANSPORT=wps swaps in the
+    # WPSTransport + mounts the upstream webhook receiver — the /ws/device
+    # endpoint stays registered so a running deployment can flip back by
+    # restarting, but devices talk to it through Azure Web PubSub instead.
+    from cms.services import transport as transport_module
+    from cms.services.transport import LocalDeviceTransport
+    if settings.device_transport == "wps":
+        if not settings.wps_connection_string:
+            raise RuntimeError(
+                "AGORA_CMS_DEVICE_TRANSPORT=wps requires "
+                "AGORA_CMS_WPS_CONNECTION_STRING"
+            )
+        from cms.services.wps_transport import WPSTransport
+        wps_transport = WPSTransport(
+            settings.wps_connection_string, settings.wps_hub,
+        )
+        transport_module.set_transport(wps_transport)
+        from cms.routers.wps_webhook import router as wps_router
+        app.include_router(wps_router)
+        logger.info(
+            "Device transport: WPS (hub=%s, webhook=/internal/wps/events)",
+            settings.wps_hub,
+        )
+    else:
+        transport_module.set_transport(LocalDeviceTransport())
+        logger.info("Device transport: local (direct WebSocket)")
+
     logger.info("Agora CMS %s started", __version__)
     yield
     # Shutdown — log CMS shutdown first so the event is persisted before tasks stop
+    # Close the WPS client if we installed one (httpx pool etc).
+    try:
+        _t = transport_module.get_transport()
+        if hasattr(_t, "close"):
+            await _t.close()
+    except Exception:
+        logger.exception("Error closing device transport")
     try:
         from cms.models.device_event import DeviceEvent, DeviceEventType
         async for db in get_db():

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -37,6 +37,11 @@ from cms.services.version_checker import check_now
 
 router = APIRouter(prefix="/api/devices", dependencies=[Depends(require_auth)])
 
+# Separate router for device-originated endpoints — these authenticate
+# via X-Device-API-Key, so they must NOT inherit the browser-session
+# `require_auth` dependency from the main devices router.
+device_originated_router = APIRouter(prefix="/api/devices", tags=["devices (device-originated)"])
+
 # Track devices with an in-flight upgrade to prevent concurrent upgrade commands
 _upgrading: set[str] = set()
 
@@ -807,3 +812,82 @@ async def delete_group(group_id: uuid.UUID, request: Request, db: AsyncSession =
     await db.delete(group)
     await db.commit()
     return {"deleted": str(group_id)}
+
+
+# ── Device-originated: WPS connect token ────────────────────────────
+#
+# A device authenticates with its API key and asks the CMS to mint a
+# WPS client access token.  Only available when DEVICE_TRANSPORT=wps;
+# returns 404 on the direct-WS deployment so devices discover the mode
+# automatically.
+
+
+def _hash_device_api_key(key: str) -> str:
+    import hashlib
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+async def _authenticate_device(
+    device_id: str, api_key: str | None, db: AsyncSession,
+) -> Device:
+    """Verify the presented X-Device-API-Key matches `device_id`.
+
+    Returns the Device on success, raises 401/404 otherwise.  Accepts
+    the previous key within the standard rotation grace window.
+    """
+    from datetime import datetime, timedelta, timezone as _tz
+
+    if not api_key:
+        raise HTTPException(status_code=401, detail="X-Device-API-Key required")
+
+    result = await db.execute(select(Device).where(Device.id == device_id))
+    device = result.scalar_one_or_none()
+    if device is None:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    key_hash = _hash_device_api_key(api_key)
+    if device.device_api_key_hash == key_hash:
+        return device
+    if (
+        device.previous_api_key_hash == key_hash
+        and device.api_key_rotated_at is not None
+    ):
+        rotated_at = device.api_key_rotated_at
+        if rotated_at.tzinfo is None:
+            rotated_at = rotated_at.replace(tzinfo=_tz.utc)
+        if datetime.now(_tz.utc) - rotated_at < timedelta(seconds=300):
+            return device
+    raise HTTPException(status_code=401, detail="Invalid device API key")
+
+
+@device_originated_router.post("/{device_id}/connect-token")
+async def connect_token(
+    device_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Mint a WPS client access token (URL + JWT) for `device_id`.
+
+    Auth: `X-Device-API-Key` header bound to `device_id`.
+    Behaviour depends on the configured transport:
+      - `DEVICE_TRANSPORT=wps`: return {url, token} from the WPS SDK.
+      - else: 404 so devices flip back to the direct-WS path.
+    """
+    settings = get_settings()
+    if settings.device_transport != "wps":
+        raise HTTPException(status_code=404, detail="WPS transport not enabled")
+
+    api_key = request.headers.get("X-Device-API-Key")
+    await _authenticate_device(device_id, api_key, db)
+
+    transport = get_transport()
+    if not hasattr(transport, "get_client_access_token"):
+        raise HTTPException(
+            status_code=500, detail="Transport does not support client tokens",
+        )
+    minutes = getattr(settings, "wps_token_lifetime_minutes", 60)
+    token = await transport.get_client_access_token(device_id, minutes_to_expire=minutes)
+    return {
+        "url": token.get("url"),
+        "token": token.get("token"),
+    }

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -29,7 +29,7 @@ from cms.schemas.device import (
     ToggleRequest,
 )
 from cms.schemas.protocol import ConfigMessage, FactoryResetMessage, RebootMessage, SyncMessage, UpgradeMessage, WipeAssetsMessage
-from cms.services.transport import transport
+from cms.services.transport import get_transport
 from cms.services.scheduler import push_sync_to_device
 from cms.services.audit_service import audit_log, compute_diff
 from cms.services.asset_readiness import require_asset_ready
@@ -72,7 +72,7 @@ async def _push_default_asset(device_id: str, asset: Asset, base_url: str, db: A
 
     fetch = await _resolve_asset_for_device(asset, device, base_url, db)
     if fetch:
-        await transport.send_to_device(device_id, fetch.model_dump(mode="json"))
+        await get_transport().send_to_device(device_id, fetch.model_dump(mode="json"))
 
     # Push a fresh sync so the device learns the new default_asset and splash
     # immediately (instead of waiting up to 15s for the scheduler cycle).
@@ -121,7 +121,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(query)
     devices = result.scalars().all()
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Build URL→display name map for resolving URL-based asset names
@@ -144,7 +144,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
         DeviceOut(
             **{c.key: getattr(d, c.key) for c in Device.__table__.columns},
             group_name=d.group.name if d.group else None,
-            is_online=transport.is_connected(d.id),
+            is_online=get_transport().is_connected(d.id),
             is_upgrading=d.id in _upgrading,
             playback_mode=live_states[d.id]["mode"] if d.id in live_states else None,
             playback_asset=_resolve_asset_name(d.id),
@@ -177,7 +177,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
 
     device = await _get_device_with_access(device_id, request, db)
     await db.refresh(device, ["group"])
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Resolve URL-based asset names
@@ -195,7 +195,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
     return DeviceOut(
         **{c.key: getattr(device, c.key) for c in Device.__table__.columns},
         group_name=device.group.name if device.group else None,
-        is_online=transport.is_connected(device.id),
+        is_online=get_transport().is_connected(device.id),
         is_upgrading=device.id in _upgrading,
         playback_mode=live_states[device.id]["mode"] if device.id in live_states else None,
         playback_asset=raw_asset,
@@ -286,7 +286,7 @@ async def update_device(
     return DeviceOut(
         **{c.key: getattr(device, c.key) for c in Device.__table__.columns},
         group_name=device.group.name if device.group else None,
-        is_online=transport.is_connected(device.id),
+        is_online=get_transport().is_connected(device.id),
     )
 
 
@@ -305,11 +305,11 @@ async def set_device_password(
 
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(web_password=password)
-    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -332,11 +332,11 @@ async def reboot_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     reboot_msg = RebootMessage()
-    sent = await transport.send_to_device(device_id, reboot_msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, reboot_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -359,7 +359,7 @@ async def upgrade_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         _upgrading.discard(device_id)
         raise HTTPException(status_code=409, detail="Device is not connected")
 
@@ -368,7 +368,7 @@ async def upgrade_device(
 
     _upgrading.add(device_id)
     upgrade_msg = UpgradeMessage()
-    sent = await transport.send_to_device(device_id, upgrade_msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, upgrade_msg.model_dump(mode="json"))
     if not sent:
         _upgrading.discard(device_id)
         raise HTTPException(status_code=502, detail="Failed to send to device")
@@ -394,16 +394,16 @@ async def toggle_device_ssh(
     enabled = body.enabled
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(ssh_enabled=enabled)
-    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
     # Track the SSH state immediately so the UI reflects it
-    transport.set_state_flags(device_id, ssh_enabled=enabled)
+    get_transport().set_state_flags(device_id, ssh_enabled=enabled)
 
     await audit_log(
         db, user=getattr(request.state, "user", None),
@@ -425,11 +425,11 @@ async def factory_reset_device(
 ):
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     msg = FactoryResetMessage()
-    sent = await transport.send_to_device(device_id, msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
@@ -454,15 +454,15 @@ async def toggle_device_local_api(
     enabled = body.enabled
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     config_msg = ConfigMessage(local_api_enabled=enabled)
-    sent = await transport.send_to_device(device_id, config_msg.model_dump(mode="json"))
+    sent = await get_transport().send_to_device(device_id, config_msg.model_dump(mode="json"))
     if not sent:
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
-    transport.set_state_flags(device_id, local_api_enabled=enabled)
+    get_transport().set_state_flags(device_id, local_api_enabled=enabled)
 
     await audit_log(
         db, user=getattr(request.state, "user", None),
@@ -526,7 +526,7 @@ async def adopt_device(device_id: str, body: AdoptRequest, request: Request, db:
 
     # Tell the device to wipe cached assets so it starts clean
     wipe_msg = WipeAssetsMessage(reason="adopted")
-    await transport.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
+    await get_transport().send_to_device(device_id, wipe_msg.model_dump(mode="json"))
 
     # Push a fresh sync so the device learns its new status immediately
     # (e.g. the OOBE screen advances from "waiting for adoption" to "adopted").
@@ -566,7 +566,7 @@ async def delete_device(device_id: str, request: Request, db: AsyncSession = Dep
 
     # Tell the device to wipe cached assets before we remove it from the DB
     wipe_msg = WipeAssetsMessage(reason="deleted")
-    await transport.send_to_device(device_id, wipe_msg.model_dump(mode="json"))
+    await get_transport().send_to_device(device_id, wipe_msg.model_dump(mode="json"))
 
     # Remove referencing rows before deleting the device
     from cms.models.asset import DeviceAsset
@@ -601,11 +601,11 @@ async def request_device_logs(
     """
     device = await _get_device_with_access(device_id, request, db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
 
     try:
-        logs = await transport.request_logs(device_id, services=body.services, since=body.since)
+        logs = await get_transport().request_logs(device_id, services=body.services, since=body.since)
     except TimeoutError as e:
         raise HTTPException(status_code=504, detail=str(e))
     except ValueError as e:

--- a/cms/routers/logs.py
+++ b/cms/routers/logs.py
@@ -16,7 +16,7 @@ from cms.auth import require_auth, require_permission, get_user_group_ids
 from cms.database import get_db
 from cms.permissions import LOGS_READ
 from cms.models.device import Device
-from cms.services.transport import transport
+from cms.services.transport import get_transport
 from cms.services.audit_service import audit_log
 
 logger = logging.getLogger("agora.cms.logs")
@@ -59,8 +59,8 @@ async def download_logs(req: LogDownloadRequest, request: Request, db: AsyncSess
         # ── Device logs ──
         tasks = {}
         for device_id in req.device_ids:
-            if transport.is_connected(device_id):
-                tasks[device_id] = transport.request_logs(
+            if get_transport().is_connected(device_id):
+                tasks[device_id] = get_transport().request_logs(
                     device_id,
                     services=req.services,
                     since=req.since,

--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -1,0 +1,189 @@
+"""Azure Web PubSub upstream-webhook receiver.
+
+Implements the CMS side of the CloudEvents 1.0 binary binding contract
+Azure WPS uses to push events to us — see
+https://learn.microsoft.com/azure/azure-web-pubsub/reference-cloud-events.
+
+Endpoints:
+  OPTIONS /internal/wps/events
+      CloudEvents abuse-protection handshake.  Responds 200 with
+      ``WebHook-Allowed-Origin`` echoing ``WebHook-Request-Origin`` (or
+      the configured ``wps_webhook_allowed_origin`` if set).
+  POST /internal/wps/events
+      Verifies the ``ce-signature`` header (which signs the
+      connection id, NOT the body), then:
+        - ``azure.webpubsub.sys.connected``    -> register_remote + 204
+        - ``azure.webpubsub.sys.disconnected`` -> disconnect + 204
+        - ``azure.webpubsub.user.*``           -> dispatch_device_message + 204
+
+The dispatch invocation mirrors ``cms/routers/ws.py`` so the two paths
+stay in sync.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, Header, Request, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_settings
+from cms.config import Settings
+from cms.database import get_db
+from cms.models.device import Device
+from cms.services.device_inbound import InboundContext, dispatch_device_message
+from cms.services.device_manager import device_manager
+from cms.services.transport import get_transport
+from shared.wps_signature import verify_signature
+
+logger = logging.getLogger("agora.cms.wps_webhook")
+
+router = APIRouter(prefix="/internal/wps", tags=["wps-webhook"])
+
+
+def _extract_access_keys(connection_string: str | None) -> list[str]:
+    """Pull every ``AccessKey=...`` value out of a WPS connection string.
+
+    Azure-style connection strings are semicolon-separated
+    ``Key=Value`` pairs.  Returns an empty list if the string is unset
+    or carries no ``AccessKey``.
+    """
+    if not connection_string:
+        return []
+    keys: list[str] = []
+    for part in connection_string.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        name, _, value = part.partition("=")
+        if name.strip().lower() == "accesskey" and value:
+            keys.append(value.strip())
+    return keys
+
+
+def _get_asset_base_url(request: Request, settings: Settings) -> str:
+    """Base URL for asset download links — mirrors ws.get_asset_base_url."""
+    if settings.asset_base_url:
+        return settings.asset_base_url.rstrip("/")
+    host = request.headers.get("host")
+    if host:
+        scheme = "https" if request.url.scheme in ("https", "wss") else "http"
+        return f"{scheme}://{host}"
+    return str(request.base_url).rstrip("/")
+
+
+@router.options("/events")
+async def events_abuse_protection_handshake(
+    request: Request,
+    webhook_request_origin: str | None = Header(default=None, alias="WebHook-Request-Origin"),
+):
+    """Respond to the CloudEvents abuse-protection probe.
+
+    Azure sends ``OPTIONS`` with ``WebHook-Request-Origin: <host>``; we
+    must reply 200 with ``WebHook-Allowed-Origin`` to opt in.  The
+    configured ``wps_webhook_allowed_origin`` (if set) wins over echoing.
+    """
+    settings = get_settings()
+    allowed = settings.wps_webhook_allowed_origin or webhook_request_origin or "*"
+    return Response(status_code=200, headers={"WebHook-Allowed-Origin": allowed})
+
+
+@router.post("/events")
+async def events_receiver(
+    request: Request,
+    ce_type: str | None = Header(default=None, alias="ce-type"),
+    ce_connection_id: str | None = Header(default=None, alias="ce-connectionId"),
+    ce_user_id: str | None = Header(default=None, alias="ce-userId"),
+    ce_event_name: str | None = Header(default=None, alias="ce-eventName"),
+    ce_signature: str | None = Header(default=None, alias="ce-signature"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Receive one CloudEvents binary-binding upstream webhook.
+
+    Every event contributes a 204 on success.  Bad signature -> 401,
+    missing/unknown headers -> 400.
+    """
+    settings = get_settings()
+
+    if not ce_type or not ce_connection_id:
+        return Response(status_code=400, content="missing ce-type or ce-connectionId")
+
+    keys = _extract_access_keys(settings.wps_connection_string)
+    if not keys:
+        logger.error("WPS webhook called but no access keys configured")
+        return Response(status_code=500, content="WPS not configured")
+
+    if not verify_signature(ce_connection_id, ce_signature or "", keys):
+        logger.warning(
+            "WPS webhook signature mismatch (conn=%s, type=%s)",
+            ce_connection_id, ce_type,
+        )
+        return Response(status_code=401, content="bad signature")
+
+    body = await request.body()
+
+    # ---- system events -------------------------------------------------
+
+    if ce_type == "azure.webpubsub.sys.connected":
+        if not ce_user_id:
+            return Response(status_code=400, content="missing ce-userId")
+        device_manager.register_remote(
+            ce_user_id, connection_id=ce_connection_id, ip_address=None,
+        )
+        return Response(status_code=204)
+
+    if ce_type == "azure.webpubsub.sys.disconnected":
+        if ce_user_id:
+            device_manager.disconnect(ce_user_id)
+        return Response(status_code=204)
+
+    # ---- user events ---------------------------------------------------
+
+    if ce_type.startswith("azure.webpubsub.user."):
+        if not ce_user_id:
+            return Response(status_code=400, content="missing ce-userId")
+        try:
+            msg = json.loads(body or b"{}")
+        except json.JSONDecodeError:
+            logger.warning(
+                "WPS user event with non-JSON body (user=%s, event=%s)",
+                ce_user_id, ce_event_name,
+            )
+            return Response(status_code=400, content="body is not JSON")
+
+        # Look up the device row — dispatch_device_message wants a
+        # fully-hydrated ORM instance on the context.  Stage 2b.2 does
+        # NOT port the direct-WS register/adoption handshake over to the
+        # webhook path, so if the device row is missing we log and drop.
+        result = await db.execute(select(Device).where(Device.id == ce_user_id))
+        device = result.scalar_one_or_none()
+        if device is None:
+            logger.warning(
+                "WPS message from unknown device %s — registration over WPS "
+                "not implemented yet (Stage 2b.2)", ce_user_id,
+            )
+            return Response(status_code=204)
+
+        base_url = _get_asset_base_url(request, settings)
+        ctx = InboundContext(
+            device_id=ce_user_id,
+            device=device,
+            base_url=base_url,
+            settings=settings,
+            group_id=str(device.group_id) if device.group_id else None,
+            device_name=device.name or ce_user_id,
+            device_status=device.status.value if device.status else "pending",
+            group_name="",
+        )
+        transport = get_transport()
+
+        async def _send(payload: dict) -> None:
+            await transport.send_to_device(ce_user_id, payload)
+
+        await dispatch_device_message(msg=msg, ctx=ctx, db=db, send=_send)
+        return Response(status_code=204)
+
+    logger.warning("Unknown WPS event type %s (conn=%s)", ce_type, ce_connection_id)
+    return Response(status_code=400, content=f"unknown event type: {ce_type}")

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -214,8 +214,8 @@ class AlertService:
         self._offline_timers.pop(device_id, None)
 
         # Double-check the device hasn't reconnected during the sleep
-        from cms.services.transport import transport
-        if transport.is_connected(device_id):
+        from cms.services.transport import get_transport
+        if get_transport().is_connected(device_id):
             return
 
         self._was_offline.add(device_id)

--- a/cms/services/device_manager.py
+++ b/cms/services/device_manager.py
@@ -12,10 +12,13 @@ logger = logging.getLogger("agora.cms.device_manager")
 
 
 class ConnectedDevice:
-    def __init__(self, device_id: str, websocket: WebSocket, ip_address: Optional[str] = None):
+    def __init__(self, device_id: str, websocket: WebSocket | None = None, ip_address: Optional[str] = None):
         self.device_id = device_id
         self.websocket = websocket
         self.ip_address = ip_address
+        # Populated for WPS-backed connections (webhook path); None on the
+        # direct-WS path where no stable id is exposed.
+        self.connection_id: Optional[str] = None
         self.connected_at = datetime.now(timezone.utc)
         # Playback state from last STATUS message
         self.mode: str = "unknown"
@@ -33,6 +36,14 @@ class ConnectedDevice:
         self.error_since: Optional[datetime] = None
 
     async def send_json(self, data: dict):
+        if self.websocket is None:
+            # Ghost entries created by the WPS webhook path have no local
+            # socket — callers must route via transport.send_to_device.
+            # Raising here catches any site that hasn't been migrated.
+            raise RuntimeError(
+                f"device {self.device_id} has no local WebSocket — "
+                "route via transport.send_to_device instead",
+            )
         await self.websocket.send_json(data)
 
 
@@ -47,6 +58,32 @@ class DeviceManager:
         conn = ConnectedDevice(device_id, websocket, ip_address=ip_address)
         self._connections[device_id] = conn
         logger.info("Device %s connected (%d total)", device_id, len(self._connections))
+        return conn
+
+    def register_remote(
+        self,
+        device_id: str,
+        connection_id: str,
+        ip_address: Optional[str] = None,
+    ) -> ConnectedDevice:
+        """Register a device whose transport is remote (Web PubSub).
+
+        No local WebSocket is associated — sends must go through the
+        transport (``WPSTransport.send_to_device`` → REST call to the
+        broker/WPS).  The in-memory entry still tracks playback state so
+        the existing UI / presence queries keep working from this replica.
+
+        Stage 2c will migrate this in-memory state to the DB so presence
+        is visible across all replicas; today it intentionally keeps the
+        same single-replica behaviour as the direct-WS path.
+        """
+        conn = ConnectedDevice(device_id, websocket=None, ip_address=ip_address)
+        conn.connection_id = connection_id
+        self._connections[device_id] = conn
+        logger.info(
+            "Device %s connected via WPS (connection_id=%s, %d total)",
+            device_id, connection_id, len(self._connections),
+        )
         return conn
 
     def disconnect(self, device_id: str):

--- a/cms/services/device_purge.py
+++ b/cms/services/device_purge.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.models.device import Device, DeviceStatus
-from cms.services.transport import transport
+from cms.services.transport import get_transport
 
 logger = logging.getLogger("agora.cms.device_purge")
 
@@ -30,7 +30,7 @@ async def purge_stale_pending_devices(db: AsyncSession, ttl_hours: int) -> list[
 
     for device in candidates:
         # Skip devices that are currently connected
-        if transport.is_connected(device.id):
+        if get_transport().is_connected(device.id):
             continue
 
         # Use last_seen, fall back to registered_at

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -16,7 +16,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import ScheduleEntry, SyncMessage
-from cms.services.transport import transport
+from cms.services.transport import get_transport
 
 logger = logging.getLogger("agora.cms.scheduler")
 
@@ -250,7 +250,7 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
 
     # Resolve target devices for each active schedule (filter per-device skips)
     now_playing = []
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
 
     # Get device names
     all_device_ids = set()
@@ -826,7 +826,7 @@ async def push_sync_to_device(device_id: str, db) -> None:
     """Build and push a fresh sync to a single connected device."""
     await _ensure_skips_loaded(db)
 
-    if not transport.is_connected(device_id):
+    if not get_transport().is_connected(device_id):
         return
 
     # Only sync adopted devices — pending/orphaned devices should not receive content
@@ -843,7 +843,7 @@ async def push_sync_to_device(device_id: str, db) -> None:
     if _last_sync_hash.get(device_id) == h:
         return
 
-    await transport.send_to_device(device_id, sync.model_dump(mode="json"))
+    await get_transport().send_to_device(device_id, sync.model_dump(mode="json"))
     _last_sync_hash[device_id] = h
     logger.info("Pushed full sync to device %s (%d schedules)", device_id, len(sync.schedules))
 
@@ -857,7 +857,7 @@ async def push_sync_to_affected_devices(schedule: Schedule, db) -> None:
 
 async def evaluate_schedules() -> None:
     """Single evaluation pass: sync schedules to devices and detect MISSED playback."""
-    if not transport.connected_count:
+    if not get_transport().connected_count:
         return
 
     sf = _get_session_factory()
@@ -876,7 +876,7 @@ async def evaluate_schedules() -> None:
         tz_name = tz_result.scalar_one_or_none() or "UTC"
         local_now = now.astimezone(ZoneInfo(tz_name)).replace(tzinfo=None)
 
-        connected = set(transport.connected_ids)
+        connected = set(get_transport().connected_ids)
 
         # Push full sync to each connected device (dedup via hash)
         for did in connected:
@@ -999,7 +999,7 @@ async def evaluate_schedules() -> None:
 
         # Seed _confirmed_playing from live device state after CMS restart
         live_states = {
-            s["device_id"]: s for s in transport.get_all_states()
+            s["device_id"]: s for s in get_transport().get_all_states()
         }
         from shared.models.asset import AssetType
         for s in active:

--- a/cms/services/transport.py
+++ b/cms/services/transport.py
@@ -136,8 +136,40 @@ class LocalDeviceTransport(DeviceTransport):
 
 
 transport: DeviceTransport = LocalDeviceTransport()
-"""Process-wide device transport singleton.
+"""Process-wide device transport — retained as a module attribute for
+backwards compatibility.  Prefer ``get_transport()`` / ``set_transport()``
+at new call sites: those work even after the lifespan startup has
+swapped in a different implementation (e.g., ``WPSTransport``).
 
-Import as ``from cms.services.transport import transport`` and use its
-methods directly.  Tests may replace this attribute with a stub
-implementation (e.g., ``cms.services.transport.transport = FakeT()``)."""
+Import as ``from cms.services.transport import get_transport`` and use
+``get_transport().send_to_device(...)``.  Tests may replace the backing
+instance with :func:`set_transport` and restore with
+:func:`reset_transport_to_local`.
+"""
+
+
+def set_transport(t: DeviceTransport) -> None:
+    """Install *t* as the process-wide device transport.
+
+    Updates both the ``transport`` module attribute and the accessor's
+    backing instance so importers that captured the singleton at import
+    time (legacy pattern) continue to work.
+    """
+    global transport
+    transport = t
+
+
+def get_transport() -> DeviceTransport:
+    """Return the currently-installed device transport.
+
+    Always returns the latest instance installed by :func:`set_transport`
+    — this is what new code should call.
+    """
+    return transport
+
+
+def reset_transport_to_local() -> LocalDeviceTransport:
+    """Reinstall a fresh ``LocalDeviceTransport`` — used by test fixtures."""
+    t = LocalDeviceTransport()
+    set_transport(t)
+    return t

--- a/cms/services/wps_transport.py
+++ b/cms/services/wps_transport.py
@@ -1,0 +1,178 @@
+"""Azure Web PubSub device transport.
+
+Implements :class:`cms.services.transport.DeviceTransport` on top of the
+async Web PubSub service SDK.  Outbound messages are HTTP POSTs to the
+WPS REST API (``/api/hubs/{hub}/users/{userId}/:send``); inbound
+messages arrive via the upstream webhook receiver at
+``/internal/wps/events`` (see :mod:`cms.routers.wps_webhook`) which
+registers presence and dispatches each payload through
+``dispatch_device_message``.
+
+Presence + in-memory state still live on the shared
+:class:`cms.services.device_manager.DeviceManager` today — Stage 2c will
+move them to the DB.  Ghost entries (websocket=None) created by
+``register_remote`` let the existing UI / scheduler / alert paths work
+unchanged from the replica that happened to process the webhook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from azure.core.exceptions import HttpResponseError
+from azure.messaging.webpubsubservice.aio import WebPubSubServiceClient
+
+from cms.services.transport import DeviceTransport
+
+logger = logging.getLogger("agora.cms.wps_transport")
+
+
+class WPSTransport(DeviceTransport):
+    """Transport backed by Azure Web PubSub.
+
+    Outbound sends go via the async SDK (``send_to_user``); presence and
+    state are read from the shared in-process ``DeviceManager`` which
+    the webhook receiver keeps populated.
+    """
+
+    def __init__(
+        self,
+        connection_string: str,
+        hub: str,
+        device_manager: Any | None = None,
+    ) -> None:
+        if device_manager is None:
+            from cms.services.device_manager import device_manager as _dm
+            device_manager = _dm
+        self._manager = device_manager
+        self._hub = hub
+        self._client: WebPubSubServiceClient = (
+            WebPubSubServiceClient.from_connection_string(
+                connection_string, hub=hub,
+            )
+        )
+
+    # ---- outbound -----------------------------------------------------
+
+    async def send_to_device(self, device_id: str, message: dict[str, Any]) -> bool:
+        """Send a JSON payload to a single device via WPS REST.
+
+        Returns ``True`` on success.  Azure returns 404 when the user has
+        no active connections; translate that to ``False`` to match
+        :class:`LocalDeviceTransport`'s semantics (no per-caller
+        distinction between "unknown device" and "known but offline" —
+        both are "can't reach it").  All other errors are logged and
+        swallowed into ``False`` for the same reason.
+        """
+        try:
+            await self._client.send_to_user(
+                device_id,
+                json.dumps(message),
+                content_type="application/json",
+            )
+            return True
+        except HttpResponseError as e:
+            status = getattr(e, "status_code", None)
+            if status == 404:
+                logger.debug("send_to_device(%s): user has no active connections", device_id)
+                return False
+            logger.warning(
+                "send_to_device(%s) failed: %s (status=%s)", device_id, e, status,
+            )
+            return False
+        except Exception:
+            logger.exception("send_to_device(%s) unexpected error", device_id)
+            return False
+
+    # ---- presence (delegated to the in-memory manager) -----------------
+
+    def is_connected(self, device_id: str) -> bool:
+        return self._manager.is_connected(device_id)
+
+    @property
+    def connected_count(self) -> int:
+        return self._manager.connected_count
+
+    @property
+    def connected_ids(self) -> list[str]:
+        return list(self._manager.connected_ids)
+
+    def get_all_states(self) -> list[dict[str, Any]]:
+        return self._manager.get_all_states()
+
+    # ---- synchronous RPC (logs) ----------------------------------------
+
+    async def request_logs(
+        self,
+        device_id: str,
+        services: list[str] | None = None,
+        since: str = "24h",
+        timeout: float = 30.0,
+    ) -> dict[str, str]:
+        """Send a ``request_logs`` command and await the device's reply.
+
+        The manager's pending-log-request future is resolved by
+        :func:`dispatch_device_message` when it processes the device's
+        ``logs_response`` — that dispatcher runs for both the direct-WS
+        and the WPS webhook paths, so the same wait-on-future pattern
+        works here.  We can't reuse ``DeviceManager.request_logs``
+        because its send step routes through the ghost entry's
+        non-existent socket — we have to do the send ourselves.
+        """
+        import asyncio
+        import uuid
+
+        from cms.schemas.protocol import RequestLogsMessage
+
+        if not self._manager.is_connected(device_id):
+            raise ValueError(f"Device {device_id} is not connected")
+
+        request_id = str(uuid.uuid4())
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._manager._pending_log_requests[request_id] = fut
+
+        msg = RequestLogsMessage(
+            request_id=request_id, services=services, since=since,
+        )
+        ok = await self.send_to_device(device_id, msg.model_dump(mode="json"))
+        if not ok:
+            self._manager._pending_log_requests.pop(request_id, None)
+            raise ValueError(f"Failed to send request to device {device_id}")
+
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except asyncio.TimeoutError:
+            self._manager._pending_log_requests.pop(request_id, None)
+            raise TimeoutError(
+                f"Device {device_id} did not respond within {timeout}s"
+            )
+
+    # ---- state hints ---------------------------------------------------
+
+    def set_state_flags(self, device_id: str, **flags: Any) -> None:
+        conn = self._manager.get(device_id)
+        if conn is None:
+            return
+        for key, value in flags.items():
+            setattr(conn, key, value)
+
+    # ---- WPS-specific helpers -----------------------------------------
+
+    async def get_client_access_token(
+        self, device_id: str, minutes_to_expire: int = 60,
+    ) -> dict[str, Any]:
+        """Mint a device-scoped client access token (URL + JWT).
+
+        Returned dict has ``url`` (ws:// ...) and ``token`` keys — hand
+        both to the device and it can open the WPS client socket.
+        """
+        result = await self._client.get_client_access_token(
+            user_id=device_id, minutes_to_expire=minutes_to_expire,
+        )
+        # SDK returns a MutableMapping with url/token/baseUrl.
+        return dict(result)
+
+    async def close(self) -> None:
+        await self._client.close()

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -47,7 +47,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.group_asset import GroupAsset
 from cms.models.user import User, UserGroup
-from cms.services.transport import transport
+from cms.services.transport import get_transport
 from cms.services.audit_service import audit_log
 from cms.services.json_compat import json_as_text
 from cms.services.version_checker import get_latest_device_version, is_update_available
@@ -605,7 +605,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
         pending_q = await db.execute(pending_query)
         pending_devices = pending_q.scalars().all()
         for d in pending_devices:
-            d.is_online = transport.is_connected(d.id)
+            d.is_online = get_transport().is_connected(d.id)
     else:
         pending_devices = []
 
@@ -626,7 +626,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     devices_q = await db.execute(devices_query)
     all_devices = devices_q.scalars().all()
     for d in all_devices:
-        d.is_online = transport.is_connected(d.id)
+        d.is_online = get_transport().is_connected(d.id)
 
     # Offline devices (adopted but not connected)
     offline_devices = [d for d in all_devices if not d.is_online]
@@ -675,7 +675,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             if start_t and end_t <= start_t:
                 end_today += _td(days=1)
             np["remaining_seconds"] = max(0, int((end_today - local_now).total_seconds()))
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
     for np in now_playing:
         did = np["device_id"]
         live = live_states.get(did, {})
@@ -693,12 +693,12 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             if (now - since).total_seconds() < 45:
                 np["mismatch"] = False
                 if actual_mode != "play":
-                    if not transport.is_connected(did):
+                    if not get_transport().is_connected(did):
                         np["device_offline"] = True
                     else:
                         np["starting"] = True
         # Outside the grace period, flag offline devices distinctly
-        if np.get("mismatch") and not transport.is_connected(did):
+        if np.get("mismatch") and not get_transport().is_connected(did):
             np["mismatch"] = False
             np["device_offline"] = True
 
@@ -861,7 +861,7 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
         _scope_device_query(select(Device.id).where(Device.status == DeviceStatus.ADOPTED))
     )
     all_device_ids = [r[0] for r in devices_q.all()]
-    offline_ids = [did for did in all_device_ids if not transport.is_connected(did)]
+    offline_ids = [did for did in all_device_ids if not get_transport().is_connected(did)]
 
     now_playing = await compute_now_playing(db, tz, now)
     # Scope now_playing to user's visible devices
@@ -886,7 +886,7 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
                 end_today += _td(days=1)
             np["remaining_seconds"] = max(0, int((end_today - local_now).total_seconds()))
 
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
     for np in now_playing:
         did = np["device_id"]
         live = live_states.get(did, {})
@@ -992,7 +992,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     result = await db.execute(device_query)
     devices = result.scalars().all()
-    live_states = {s["device_id"]: s for s in transport.get_all_states()}
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
     # Build URL→display name map for resolving playback_asset on URL-based assets
@@ -1015,7 +1015,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         a.ready_for_selection = ready
         a.not_ready_reason = reason
     for d in devices:
-        d.is_online = transport.is_connected(d.id)
+        d.is_online = get_transport().is_connected(d.id)
         state = live_states.get(d.id)
         d.cpu_temp_c = state["cpu_temp_c"] if state else None
         d.ip_address = state["ip_address"] if state else None
@@ -1062,7 +1062,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         g.device_count = len(g.devices)
         g.schedule_count = group_sched_counts.get(g.id, 0)
         for d in g.devices:
-            d.is_online = transport.is_connected(d.id)
+            d.is_online = get_transport().is_connected(d.id)
             state = live_states.get(d.id)
             d.cpu_temp_c = state["cpu_temp_c"] if state else None
             d.ip_address = state["ip_address"] if state else None
@@ -1576,7 +1576,7 @@ async def settings_page(
     result = await db.execute(select(Device).order_by(Device.name))
     devices = result.scalars().all()
     device_list = [
-        {"id": d.id, "name": d.name, "connected": transport.is_connected(d.id)}
+        {"id": d.id, "name": d.name, "connected": get_transport().is_connected(d.id)}
         for d in devices
     ]
 
@@ -1889,7 +1889,7 @@ async def change_timezone(
     result = await db.execute(select(Device).order_by(Device.name))
     devices = result.scalars().all()
     device_list = [
-        {"id": d.id, "name": d.name, "connected": transport.is_connected(d.id)}
+        {"id": d.id, "name": d.name, "connected": get_transport().is_connected(d.id)}
         for d in devices
     ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,19 @@ services:
     ports:
       - "8080:8080"
     env_file: .env
+    # Device transport wiring (#344 Stage 2b.2).
+    # Defaults keep the direct-WS path.  To switch to the WPS path under
+    # the `wps` profile (see `local-broker` below), set in your .env:
+    #     AGORA_CMS_DEVICE_TRANSPORT=wps
+    #     AGORA_CMS_WPS_CONNECTION_STRING=Endpoint=http://local-broker:7080;AccessKey=<same as WPS_ACCESS_KEY>;Version=1.0;
+    #     AGORA_CMS_WPS_HUB=agora
+    # ...then bring the stack up with: `docker compose --profile wps up`.
+    environment:
+      - AGORA_CMS_DEVICE_TRANSPORT=${AGORA_CMS_DEVICE_TRANSPORT:-local}
+      - AGORA_CMS_WPS_CONNECTION_STRING=${AGORA_CMS_WPS_CONNECTION_STRING:-}
+      - AGORA_CMS_WPS_HUB=${AGORA_CMS_WPS_HUB:-agora}
+      - AGORA_CMS_WPS_TOKEN_LIFETIME_MINUTES=${AGORA_CMS_WPS_TOKEN_LIFETIME_MINUTES:-60}
+      - AGORA_CMS_WPS_WEBHOOK_ALLOWED_ORIGIN=${AGORA_CMS_WPS_WEBHOOK_ALLOWED_ORIGIN:-}
     depends_on:
       db:
         condition: service_healthy
@@ -51,9 +64,10 @@ services:
       retries: 5
 
   # Local WPS-shaped broker for Stage 2 of the multi-replica rollout
-  # (#344). Opt-in under the `wps` profile until Stage 2b wires the CMS
-  # WPSTransport up to it. Today the default compose stack keeps using
-  # the direct-WS path via `cms/routers/ws.py`.
+  # (#344). Opt-in under the `wps` profile. Stage 2b.2 added the
+  # WPSTransport + /internal/wps/events receiver in the CMS — flipping
+  # AGORA_CMS_DEVICE_TRANSPORT=wps (see comment on the cms service) is
+  # the only app-side change needed to route device traffic through here.
   local-broker:
     build: ./local-broker
     profiles: ["wps"]

--- a/local-broker/broker.py
+++ b/local-broker/broker.py
@@ -18,28 +18,39 @@ WSS (device → broker):
 
 Webhooks (broker → CMS) — Azure CloudEvents 1.0 binary binding:
   POST UPSTREAM_URL  with headers:
-    ce-specversion: 1.0
-    ce-type:        azure.webpubsub.sys.connected
-                  | azure.webpubsub.sys.disconnected
-                  | azure.webpubsub.user.message
-    ce-source:      /hubs/{hub}
-    ce-id:          <unique>
-    ce-time:        <RFC3339>
-    ce-signature:   sha256=<hex HMAC-SHA256 of body with access_key>
+    ce-specversion:  1.0
+    ce-type:         azure.webpubsub.sys.connected
+                   | azure.webpubsub.sys.disconnected
+                   | azure.webpubsub.user.<eventName>
+    ce-source:       /hubs/{hub}/client/{connectionId}
+    ce-id:           <unique>
+    ce-time:         <RFC3339>
+    ce-hub:          {hub}
+    ce-connectionId: {connectionId}
+    ce-userId:       {userId}
+    ce-eventName:    {event_name}  (user events only; short form for
+                                    system events: "connected" / "disconnected")
+    ce-signature:    sha256=<hex HMAC_SHA256(access_key, connectionId)>
+                     (comma-separated for key rotation; one entry today)
+  Body:
+    system events: b"{}"
+    user events:   raw client data (application/json today)
 
 Not implemented (intentionally — CMS does not use them):
   - Group operations
   - Broadcast to hub
   - Permissions / ACLs beyond user-scoped JWT
   - Connection state, custom protocols beyond raw JSON
+  - `.connect` blocking event (our devices use JWT auth handled at WPS layer)
 
 Security:
   - WSS: `access_token` JWT is HS256, signed with WPS_ACCESS_KEY.
     Claims required: `sub` (device_id / userId), `exp` (expiry).
   - REST: `Authorization: Bearer <server-jwt>` HS256, same key.
     `aud` claim must start with this broker's REST URI prefix.
-  - Webhook: `ce-signature` is HMAC-SHA256(body, access_key), hex,
-    prefixed `sha256=`.  CMS rejects on mismatch.
+  - Webhook: `ce-signature` = `hex(HMAC_SHA256(access_key, connectionId))`
+    prefixed `sha256=`.  The signature covers the *connectionId*, not
+    the body — matches Azure's contract.  CMS rejects on mismatch.
 
 Environment variables:
   WPS_ACCESS_KEY            shared HS256 secret (required)
@@ -180,17 +191,53 @@ def _verify_jwt(token: str, *, expected_aud_prefix: str | None = None) -> dict[s
     return claims
 
 
-def _sign_webhook(body: bytes) -> str:
-    digest = hmac.new(ACCESS_KEY.encode("utf-8"), body, hashlib.sha256).hexdigest()
-    return f"sha256={digest}"
+def _sign_webhook(connection_id: str, keys: list[str] | None = None) -> str:
+    """Return the ``ce-signature`` header value.
+
+    Signs the ``connection_id`` (not the body) — matches Azure's
+    contract.  ``keys`` is a list to allow primary+secondary signatures
+    for rotation; today the broker has exactly one key, so callers pass
+    ``[ACCESS_KEY]`` and a single ``sha256=<hex>`` entry is emitted.
+    """
+    key_list = keys if keys is not None else [ACCESS_KEY]
+    parts: list[str] = []
+    payload = connection_id.encode("utf-8")
+    for k in key_list:
+        digest = hmac.new(k.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        parts.append(f"sha256={digest}")
+    return ",".join(parts)
 
 
-def verify_webhook_signature(body: bytes, header_value: str, *, key: str | None = None) -> bool:
-    """Helper re-used by CMS tests — keeps the signing contract in one place."""
-    k = (key if key is not None else ACCESS_KEY).encode("utf-8")
-    want = hmac.new(k, body, hashlib.sha256).hexdigest()
-    expected = f"sha256={want}"
-    return hmac.compare_digest(expected, header_value or "")
+def verify_webhook_signature(
+    connection_id: str,
+    header_value: str,
+    keys: list[str] | None = None,
+) -> bool:
+    """Helper re-used by the broker's tests and the CMS receiver.
+
+    A valid ``header_value`` is a comma-separated list of
+    ``sha256=<hex>`` entries; the request is accepted if any entry
+    matches ``hex(HMAC_SHA256(k, connection_id))`` for any ``k`` in
+    ``keys``.
+    """
+    if not header_value:
+        return False
+    key_list = keys if keys is not None else [ACCESS_KEY]
+    presented: list[str] = []
+    for entry in header_value.split(","):
+        entry = entry.strip()
+        if not entry.lower().startswith("sha256="):
+            continue
+        presented.append(entry[len("sha256="):])
+    if not presented:
+        return False
+    payload = connection_id.encode("utf-8")
+    for k in key_list:
+        want = hmac.new(k.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        for got in presented:
+            if hmac.compare_digest(want, got):
+                return True
+    return False
 
 
 # --------------------------------------------------------------------- webhook
@@ -201,23 +248,43 @@ async def _post_webhook(
     *,
     event_type: str,
     hub: str,
-    body: dict[str, Any],
+    connection_id: str,
+    user_id: str,
+    event_name: str | None = None,
+    raw_body: bytes = b"{}",
+    content_type: str = "application/json",
 ) -> None:
+    """Post a CloudEvents 1.0 binary-binding webhook to the CMS.
+
+    - System events (``azure.webpubsub.sys.connected`` /
+      ``.disconnected``): ``raw_body`` is ``b"{}"``; ``event_name`` is
+      the short form (``"connected"`` / ``"disconnected"``).
+    - User events (``azure.webpubsub.user.<name>``): ``raw_body`` is the
+      raw client payload bytes; ``event_name`` is the custom event name
+      (e.g. ``"message"``).
+
+    The ``ce-signature`` header signs ``connection_id``, not the body —
+    matches Azure's upstream webhook contract.
+    """
     if not UPSTREAM_URL:
         logger.debug("WPS_UPSTREAM_URL not set; dropping %s event", event_type)
         return
-    raw = json.dumps(body, separators=(",", ":"), sort_keys=False).encode("utf-8")
     headers = {
-        "content-type": "application/json",
+        "content-type": content_type,
         "ce-specversion": "1.0",
         "ce-type": event_type,
-        "ce-source": f"/hubs/{hub}",
+        "ce-source": f"/hubs/{hub}/client/{connection_id}",
         "ce-id": str(uuid.uuid4()),
         "ce-time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-        "ce-signature": _sign_webhook(raw),
+        "ce-hub": hub,
+        "ce-connectionId": connection_id,
+        "ce-userId": user_id,
+        "ce-signature": _sign_webhook(connection_id),
     }
+    if event_name:
+        headers["ce-eventName"] = event_name
     try:
-        r = await client.post(UPSTREAM_URL, content=raw, headers=headers, timeout=UPSTREAM_TIMEOUT_S)
+        r = await client.post(UPSTREAM_URL, content=raw_body, headers=headers, timeout=UPSTREAM_TIMEOUT_S)
         if r.status_code >= 400:
             logger.warning(
                 "Upstream webhook %s -> %s failed: %s",
@@ -393,19 +460,13 @@ def create_app() -> FastAPI:
                 http_client,
                 event_type="azure.webpubsub.sys.connected",
                 hub=hub,
-                body={
-                    "userId": user_id,
-                    "hub": hub,
-                    "connectionId": connection_id,
-                    "claims": {k: v for k, v in claims.items() if k not in {"exp", "iat", "nbf"}},
-                    "query": {},
-                    "headers": {},
-                    "subprotocols": [],
-                },
+                connection_id=connection_id,
+                user_id=user_id,
+                event_name="connected",
+                raw_body=b"{}",
             )
         )
 
-        disconnect_reason = "client_close"
         try:
             while True:
                 msg = await websocket.receive()
@@ -413,25 +474,16 @@ def create_app() -> FastAPI:
                     break
                 if "text" in msg and msg["text"] is not None:
                     text = msg["text"]
-                    try:
-                        data_obj: Any = json.loads(text)
-                        data_type = "json"
-                    except json.JSONDecodeError:
-                        data_obj = text
-                        data_type = "text"
                     asyncio.create_task(
                         _post_webhook(
                             http_client,
                             event_type="azure.webpubsub.user.message",
                             hub=hub,
-                            body={
-                                "userId": user_id,
-                                "hub": hub,
-                                "connectionId": connection_id,
-                                "data": data_obj,
-                                "dataType": data_type,
-                                "eventName": "message",
-                            },
+                            connection_id=connection_id,
+                            user_id=user_id,
+                            event_name="message",
+                            raw_body=text.encode("utf-8"),
+                            content_type="application/json",
                         )
                     )
                 elif "bytes" in msg and msg["bytes"] is not None:
@@ -441,21 +493,17 @@ def create_app() -> FastAPI:
                             http_client,
                             event_type="azure.webpubsub.user.message",
                             hub=hub,
-                            body={
-                                "userId": user_id,
-                                "hub": hub,
-                                "connectionId": connection_id,
-                                "data": msg["bytes"].hex(),
-                                "dataType": "binary",
-                                "eventName": "message",
-                            },
+                            connection_id=connection_id,
+                            user_id=user_id,
+                            event_name="message",
+                            raw_body=msg["bytes"],
+                            content_type="application/octet-stream",
                         )
                     )
         except WebSocketDisconnect:
-            disconnect_reason = "client_close"
+            pass
         except Exception:
             logger.exception("Unexpected error on client socket %s", connection_id)
-            disconnect_reason = "server_error"
         finally:
             await registry.remove(connection_id)
             # Fire disconnected webhook (fire-and-forget — no await on teardown).
@@ -464,12 +512,10 @@ def create_app() -> FastAPI:
                     http_client,
                     event_type="azure.webpubsub.sys.disconnected",
                     hub=hub,
-                    body={
-                        "userId": user_id,
-                        "hub": hub,
-                        "connectionId": connection_id,
-                        "reason": disconnect_reason,
-                    },
+                    connection_id=connection_id,
+                    user_id=user_id,
+                    event_name="disconnected",
+                    raw_body=b"{}",
                 )
             )
 

--- a/local-broker/tests/test_broker.py
+++ b/local-broker/tests/test_broker.py
@@ -72,23 +72,34 @@ class TestJwt:
 
 class TestWebhookSignature:
     def test_signature_roundtrip(self):
-        body = b'{"hello":"world"}'
-        header = broker._sign_webhook(body)
+        cid = "conn-123"
+        header = broker._sign_webhook(cid)
         assert header.startswith("sha256=")
-        assert broker.verify_webhook_signature(body, header)
+        assert broker.verify_webhook_signature(cid, header)
 
-    def test_signature_rejects_tampered_body(self):
-        body = b'{"hello":"world"}'
-        header = broker._sign_webhook(body)
-        assert not broker.verify_webhook_signature(b'{"hello":"evil"}', header)
+    def test_signature_rejects_tampered_connection_id(self):
+        header = broker._sign_webhook("conn-abc")
+        assert not broker.verify_webhook_signature("conn-xyz", header)
 
     def test_signature_rejects_wrong_key(self):
-        body = b'{"x":1}'
-        header = broker._sign_webhook(body)
-        assert not broker.verify_webhook_signature(body, header, key="other-key")
+        cid = "conn-1"
+        header = broker._sign_webhook(cid)
+        assert not broker.verify_webhook_signature(cid, header, keys=["other-key"])
 
     def test_signature_rejects_blank_header(self):
-        assert not broker.verify_webhook_signature(b'{}', "")
+        assert not broker.verify_webhook_signature("conn-1", "")
+
+    def test_multi_signature_rotation(self):
+        """Two keys → two comma-separated sigs → valid if either matches."""
+        cid = "conn-rot"
+        header = broker._sign_webhook(cid, keys=["new-key", "old-key"])
+        assert header.count("sha256=") == 2
+        # Receiver holding only the new key verifies.
+        assert broker.verify_webhook_signature(cid, header, keys=["new-key"])
+        # Receiver holding only the old key verifies too.
+        assert broker.verify_webhook_signature(cid, header, keys=["old-key"])
+        # Receiver holding neither key rejects.
+        assert not broker.verify_webhook_signature(cid, header, keys=["stranger"])
 
 
 # ---------------------------------------------------------------- REST auth
@@ -269,18 +280,25 @@ def _client_base(port: int):
 @pytest.mark.asyncio
 class TestUpstreamWebhooks:
     async def test_connected_and_disconnected_fire(self, monkeypatch):
-        """Full loopback: connect, then close, assert webhooks arrive with valid sig."""
+        """Full loopback: connect, then close, assert webhooks arrive with
+        valid sig and the CloudEvents 1.0 binary-binding header shape."""
         received: list[dict] = []
 
         async def _capture(request):
             import httpx
             body = await request.aread()
             event_type = request.headers.get("ce-type")
+            cid = request.headers.get("ce-connectionid") or request.headers.get("ce-connectionId")
             sig = request.headers.get("ce-signature") or ""
-            assert broker.verify_webhook_signature(body, sig), (
-                f"bad sig on {event_type}: got {sig}"
+            # Signature signs the connection id, not the body.
+            assert broker.verify_webhook_signature(cid, sig), (
+                f"bad sig on {event_type}: got {sig} cid={cid}"
             )
-            received.append({"type": event_type, "body": json.loads(body)})
+            received.append({
+                "type": event_type,
+                "headers": dict(request.headers),
+                "body": body,
+            })
             return httpx.Response(200)
 
         import httpx
@@ -300,7 +318,7 @@ class TestUpstreamWebhooks:
             uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
             async with websockets.connect(uri) as ws:
                 await ws.send(json.dumps({"type": "HEARTBEAT"}))
-                # Wait for messages to propagate + webhooks to fire.
+                # Wait for connected + message to propagate.
                 for _ in range(100):
                     await asyncio.sleep(0.05)
                     if len(received) >= 2:
@@ -319,14 +337,25 @@ class TestUpstreamWebhooks:
         assert "azure.webpubsub.user.message" in types
         assert "azure.webpubsub.sys.disconnected" in types
 
-        # Connected payload shape
-        conn_ev = next(r for r in received if r["type"].endswith(".connected"))
-        assert conn_ev["body"]["userId"] == "pi-hook"
-        assert conn_ev["body"]["hub"] == "agora"
-        assert "connectionId" in conn_ev["body"]
+        # Header shape — every event carries ce-hub / ce-userId / ce-connectionId
+        # / ce-source / ce-specversion.
+        for ev in received:
+            h = ev["headers"]
+            assert h.get("ce-specversion") == "1.0"
+            assert h.get("ce-hub") == "agora"
+            assert h.get("ce-userid") == "pi-hook"
+            cid = h.get("ce-connectionid")
+            assert cid, "ce-connectionId missing"
+            assert h.get("ce-source") == f"/hubs/agora/client/{cid}"
 
-        # User message payload shape
+        # System events have empty-object body and short ce-eventName.
+        for ev in received:
+            if ev["type"].startswith("azure.webpubsub.sys."):
+                assert ev["body"] == b"{}", f"sys event body must be empty obj, got {ev['body']!r}"
+                assert ev["headers"].get("ce-eventname") in ("connected", "disconnected")
+
+        # User message: raw client JSON bytes, ce-eventName = "message".
         msg_ev = next(r for r in received if r["type"].endswith("user.message"))
-        assert msg_ev["body"]["userId"] == "pi-hook"
-        assert msg_ev["body"]["data"] == {"type": "HEARTBEAT"}
-        assert msg_ev["body"]["dataType"] == "json"
+        assert msg_ev["headers"].get("ce-eventname") == "message"
+        assert json.loads(msg_ev["body"]) == {"type": "HEARTBEAT"}
+        assert msg_ev["headers"].get("content-type", "").startswith("application/json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ aiohttp>=3.9,<4.0
 # Azure Key Vault (service key exchange in Azure deployments)
 azure-identity>=1.16,<2.0
 azure-keyvault-secrets>=4.8,<5.0
+# Azure Web PubSub (#344 Stage 2b.2 — DEVICE_TRANSPORT=wps)
+azure-messaging-webpubsubservice>=1.2,<2.0

--- a/shared/wps_signature.py
+++ b/shared/wps_signature.py
@@ -1,0 +1,61 @@
+"""Azure Web PubSub CloudEvents webhook signature helpers.
+
+Azure signs its upstream webhook requests with
+``ce-signature: sha256=<hex>,sha256=<hex>`` where each entry is
+``hex(HMAC_SHA256(access_key, connection_id))`` — note: the connection
+ID is signed, **not** the body.  Multiple entries support primary +
+secondary key rotation; a request is valid if any entry matches any
+configured key.
+
+See: https://learn.microsoft.com/azure/azure-web-pubsub/reference-cloud-events
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Iterable
+
+
+def sign_connection_id(connection_id: str, keys: Iterable[str]) -> str:
+    """Return a ``ce-signature`` header value.
+
+    ``keys`` may be a single-element iterable (emit one signature) or a
+    list of primary+secondary (emit a comma-separated multi-sig).
+    """
+    parts: list[str] = []
+    payload = connection_id.encode("utf-8")
+    for k in keys:
+        digest = hmac.new(k.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        parts.append(f"sha256={digest}")
+    if not parts:
+        raise ValueError("at least one key is required")
+    return ",".join(parts)
+
+
+def verify_signature(
+    connection_id: str, header_value: str, keys: Iterable[str]
+) -> bool:
+    """Return ``True`` if any entry in ``header_value`` matches any key.
+
+    ``header_value`` is the raw ``ce-signature`` header contents
+    (comma-separated ``sha256=<hex>`` entries).  Comparison uses
+    ``hmac.compare_digest`` to avoid timing leaks.
+    """
+    if not header_value:
+        return False
+    presented: list[str] = []
+    for entry in header_value.split(","):
+        entry = entry.strip()
+        if not entry.lower().startswith("sha256="):
+            continue
+        presented.append(entry[len("sha256="):])
+    if not presented:
+        return False
+    payload = connection_id.encode("utf-8")
+    for k in keys:
+        want = hmac.new(k.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        for got in presented:
+            if hmac.compare_digest(want, got):
+                return True
+    return False

--- a/tests/test_cms_lifespan_events.py
+++ b/tests/test_cms_lifespan_events.py
@@ -108,6 +108,9 @@ async def test_real_lifespan_logs_cms_started_event(app, db_session, monkeypatch
         azure_storage_account_name = None
         azure_storage_account_key = None
         azure_sas_expiry_hours = 1
+        device_transport = "local"
+        wps_connection_string = None
+        wps_hub = "agora"
     monkeypatch.setattr(main_mod, "get_settings", lambda: _S())
 
     # init_storage no-op already done by the app fixture (it initializes local storage).

--- a/tests/test_connect_token.py
+++ b/tests/test_connect_token.py
@@ -1,0 +1,148 @@
+"""Tests for ``POST /api/devices/{id}/connect-token``.
+
+The endpoint is device-originated (authenticates via
+``X-Device-API-Key``) and returns a WPS client access token when
+``DEVICE_TRANSPORT=wps``.  Tests mount only the sub-router so they
+run without Postgres; the DB session and settings are faked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+def _hash(key: str) -> str:
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+class _FakeSession:
+    def __init__(self, device=None):
+        self.device = device
+
+    async def execute(self, _stmt):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=self.device)
+        return result
+
+
+def _fake_device(device_id: str, api_key: str):
+    d = MagicMock()
+    d.id = device_id
+    d.device_api_key_hash = _hash(api_key)
+    d.previous_api_key_hash = None
+    d.api_key_rotated_at = None
+    return d
+
+
+def _install_settings(monkeypatch, *, transport_mode: str = "wps"):
+    class _S:
+        device_transport = transport_mode
+        wps_connection_string = "Endpoint=http://broker:7080;AccessKey=k;Version=1.0;"
+        wps_hub = "agora"
+        wps_token_lifetime_minutes = 30
+
+    from cms.routers import devices as devices_module
+    monkeypatch.setattr(devices_module, "get_settings", lambda: _S())
+
+
+@pytest_asyncio.fixture
+async def app_and_session(monkeypatch):
+    """Build a minimal FastAPI app with only the device-originated router."""
+    from cms.routers.devices import device_originated_router
+    from cms.database import get_db
+
+    session = _FakeSession()
+
+    async def _fake_db():
+        yield session
+
+    app = FastAPI()
+    app.include_router(device_originated_router)
+    app.dependency_overrides[get_db] = _fake_db
+
+    yield app, session
+
+
+@pytest_asyncio.fixture
+async def client(app_and_session):
+    app, _ = app_and_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+class TestConnectToken:
+    async def test_returns_url_and_token(self, monkeypatch, app_and_session, client):
+        _install_settings(monkeypatch, transport_mode="wps")
+
+        _, session = app_and_session
+        api_key = "dev-key-123"
+        session.device = _fake_device("pi-1", api_key)
+
+        fake_transport = MagicMock()
+        fake_transport.get_client_access_token = AsyncMock(
+            return_value={
+                "url": "wss://broker/client/hubs/agora?access_token=jwtjwt",
+                "token": "jwtjwt",
+            }
+        )
+        from cms.routers import devices as devices_module
+        monkeypatch.setattr(devices_module, "get_transport", lambda: fake_transport)
+
+        r = await client.post(
+            "/api/devices/pi-1/connect-token",
+            headers={"X-Device-API-Key": api_key},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["url"].startswith("wss://broker/")
+        assert body["token"] == "jwtjwt"
+
+        fake_transport.get_client_access_token.assert_awaited_once_with(
+            "pi-1", minutes_to_expire=30,
+        )
+
+    async def test_404_when_transport_is_local(self, monkeypatch, app_and_session, client):
+        _install_settings(monkeypatch, transport_mode="local")
+        _, session = app_and_session
+        session.device = _fake_device("pi-1", "any-key")
+
+        r = await client.post(
+            "/api/devices/pi-1/connect-token",
+            headers={"X-Device-API-Key": "any-key"},
+        )
+        assert r.status_code == 404
+
+    async def test_401_without_api_key(self, monkeypatch, client):
+        _install_settings(monkeypatch, transport_mode="wps")
+        r = await client.post("/api/devices/pi-1/connect-token")
+        assert r.status_code == 401
+
+    async def test_401_with_wrong_api_key(self, monkeypatch, app_and_session, client):
+        _install_settings(monkeypatch, transport_mode="wps")
+        _, session = app_and_session
+        session.device = _fake_device("pi-1", "correct-key")
+
+        r = await client.post(
+            "/api/devices/pi-1/connect-token",
+            headers={"X-Device-API-Key": "wrong-key"},
+        )
+        assert r.status_code == 401
+
+    async def test_404_when_device_missing(self, monkeypatch, app_and_session, client):
+        _install_settings(monkeypatch, transport_mode="wps")
+        _, session = app_and_session
+        session.device = None  # device lookup returns nothing
+
+        r = await client.post(
+            "/api/devices/pi-ghost/connect-token",
+            headers={"X-Device-API-Key": "any"},
+        )
+        assert r.status_code == 404

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -55,6 +55,35 @@ class TestDeviceManager:
         dm = DeviceManager()
         assert dm.get("nonexistent") is None
 
+    def test_register_remote(self):
+        """WPS webhook path: no local socket, stable connection_id tracked."""
+        dm = DeviceManager()
+        conn = dm.register_remote("device-r", connection_id="wps-conn-abc", ip_address="10.0.0.7")
+        assert conn.device_id == "device-r"
+        assert conn.websocket is None
+        assert conn.connection_id == "wps-conn-abc"
+        assert conn.ip_address == "10.0.0.7"
+        assert dm.is_connected("device-r")
+        assert dm.connected_count == 1
+        # get_all_states still surfaces the ghost entry so the UI works.
+        states = dm.get_all_states()
+        assert len(states) == 1
+        assert states[0]["device_id"] == "device-r"
+        assert states[0]["ip_address"] == "10.0.0.7"
+
+    @pytest.mark.asyncio
+    async def test_remote_device_send_via_manager_raises(self):
+        """Calling DeviceManager.send_to_device on a ghost entry must
+        fail loudly — the WPS path has to route through the transport's
+        REST client, never through the in-memory socket."""
+        dm = DeviceManager()
+        dm.register_remote("device-r", connection_id="cid")
+        # DeviceManager.send_to_device swallows exceptions + disconnects,
+        # so the observable behaviour is: no-op + drop the entry.
+        ok = await dm.send_to_device("device-r", {"type": "ping"})
+        assert ok is False
+        assert not dm.is_connected("device-r")
+
     def test_multiple_devices(self):
         dm = DeviceManager()
 

--- a/tests/test_wps_transport.py
+++ b/tests/test_wps_transport.py
@@ -1,0 +1,184 @@
+"""Unit tests for ``cms.services.wps_transport.WPSTransport``.
+
+The Azure SDK's ``WebPubSubServiceClient`` is mocked at import site; no
+real WPS endpoint is contacted.  The transport shares presence state
+with the in-process ``DeviceManager``, so we register ghost entries
+(``register_remote``) to drive ``is_connected`` / state-read paths.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cms.services.device_manager import DeviceManager
+
+
+def _make_transport(manager: DeviceManager | None = None):
+    """Create a ``WPSTransport`` with the SDK client mocked out.
+
+    Returns ``(transport, fake_client, manager)``.  ``fake_client``
+    exposes the mocked ``send_to_user`` / ``get_client_access_token`` /
+    ``close`` coroutines so tests can assert on them.
+    """
+    if manager is None:
+        manager = DeviceManager()
+
+    fake_client = MagicMock()
+    fake_client.send_to_user = AsyncMock(return_value=None)
+    fake_client.close = AsyncMock(return_value=None)
+    fake_client.get_client_access_token = AsyncMock(
+        return_value={
+            "url": "wss://broker/client/hubs/agora?access_token=xyz",
+            "baseUrl": "wss://broker/client/hubs/agora",
+            "token": "xyz",
+        }
+    )
+
+    with patch(
+        "cms.services.wps_transport.WebPubSubServiceClient"
+    ) as svc_cls:
+        svc_cls.from_connection_string.return_value = fake_client
+        from cms.services.wps_transport import WPSTransport  # noqa: WPS433
+        t = WPSTransport(
+            "Endpoint=http://broker:7080;AccessKey=k;Version=1.0;",
+            hub="agora",
+            device_manager=manager,
+        )
+    return t, fake_client, manager
+
+
+@pytest.mark.asyncio
+class TestSendToDevice:
+    async def test_success_returns_true(self):
+        t, c, _ = _make_transport()
+        ok = await t.send_to_device("pi-1", {"type": "ping"})
+        assert ok is True
+        c.send_to_user.assert_awaited_once()
+        args, kwargs = c.send_to_user.call_args
+        # (user_id, body_str, content_type=...)
+        assert args[0] == "pi-1"
+        assert json.loads(args[1]) == {"type": "ping"}
+        assert kwargs.get("content_type") == "application/json"
+
+    async def test_404_returns_false(self):
+        from azure.core.exceptions import HttpResponseError
+
+        t, c, _ = _make_transport()
+
+        # HttpResponseError with a .status_code attribute.
+        err = HttpResponseError(message="not connected")
+        err.status_code = 404
+        c.send_to_user.side_effect = err
+
+        ok = await t.send_to_device("pi-ghost", {"type": "ping"})
+        assert ok is False
+
+    async def test_other_http_error_returns_false(self):
+        from azure.core.exceptions import HttpResponseError
+
+        t, c, _ = _make_transport()
+        err = HttpResponseError(message="boom")
+        err.status_code = 500
+        c.send_to_user.side_effect = err
+
+        ok = await t.send_to_device("pi-1", {"type": "ping"})
+        assert ok is False
+
+    async def test_generic_exception_returns_false(self):
+        t, c, _ = _make_transport()
+        c.send_to_user.side_effect = RuntimeError("network died")
+        ok = await t.send_to_device("pi-1", {"type": "ping"})
+        assert ok is False
+
+
+class TestPresenceDelegates:
+    def test_empty_state(self):
+        t, _, _ = _make_transport()
+        assert t.connected_count == 0
+        assert t.connected_ids == []
+        assert not t.is_connected("pi-none")
+        assert t.get_all_states() == []
+
+    def test_reflects_register_remote(self):
+        dm = DeviceManager()
+        t, _, _ = _make_transport(manager=dm)
+        dm.register_remote("pi-1", connection_id="cid-1", ip_address="10.0.0.1")
+        dm.register_remote("pi-2", connection_id="cid-2")
+        assert t.connected_count == 2
+        assert t.is_connected("pi-1")
+        assert set(t.connected_ids) == {"pi-1", "pi-2"}
+        states_by_id = {s["device_id"]: s for s in t.get_all_states()}
+        assert states_by_id["pi-1"]["ip_address"] == "10.0.0.1"
+
+    def test_set_state_flags(self):
+        dm = DeviceManager()
+        t, _, _ = _make_transport(manager=dm)
+        dm.register_remote("pi-1", connection_id="cid")
+        t.set_state_flags("pi-1", ssh_enabled=True, local_api_enabled=False)
+        s = {x["device_id"]: x for x in t.get_all_states()}["pi-1"]
+        assert s["ssh_enabled"] is True
+        assert s["local_api_enabled"] is False
+
+    def test_set_state_flags_unknown_device_is_noop(self):
+        t, _, _ = _make_transport()
+        t.set_state_flags("ghost", ssh_enabled=True)  # must not raise
+
+
+@pytest.mark.asyncio
+class TestClientAccessToken:
+    async def test_returns_dict_from_sdk(self):
+        t, c, _ = _make_transport()
+        out = await t.get_client_access_token("pi-1", minutes_to_expire=30)
+        assert out["url"].startswith("wss://broker/")
+        assert out["token"] == "xyz"
+        c.get_client_access_token.assert_awaited_once()
+        _, kwargs = c.get_client_access_token.call_args
+        assert kwargs["user_id"] == "pi-1"
+        assert kwargs["minutes_to_expire"] == 30
+
+
+@pytest.mark.asyncio
+class TestRequestLogs:
+    async def test_raises_when_not_connected(self):
+        t, _, _ = _make_transport()
+        with pytest.raises(ValueError):
+            await t.request_logs("pi-missing")
+
+    async def test_resolves_via_manager_future(self):
+        import asyncio
+
+        dm = DeviceManager()
+        t, c, _ = _make_transport(manager=dm)
+        dm.register_remote("pi-1", connection_id="cid")
+
+        sent_payloads: list[dict] = []
+
+        async def _capture(user_id, body, **kwargs):
+            sent_payloads.append(json.loads(body))
+
+        c.send_to_user.side_effect = _capture
+
+        task = asyncio.create_task(t.request_logs("pi-1", services=["agora"]))
+        # Wait for send to hit the mock.
+        for _ in range(100):
+            if sent_payloads:
+                break
+            await asyncio.sleep(0.01)
+        assert sent_payloads, "request_logs never dispatched"
+        rid = sent_payloads[0]["request_id"]
+
+        dm.resolve_log_request(rid, logs={"agora": "hello"})
+        result = await asyncio.wait_for(task, timeout=1.0)
+        assert result == {"agora": "hello"}
+
+
+@pytest.mark.asyncio
+class TestClose:
+    async def test_close_propagates_to_client(self):
+        t, c, _ = _make_transport()
+        await t.close()
+        c.close.assert_awaited_once()

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -1,0 +1,374 @@
+"""Unit tests for the WPS upstream-webhook receiver.
+
+These tests wire up only the webhook router (not the full CMS app) with
+``get_db`` overridden to yield a fake async session, so they run
+without Postgres and without the rest of the lifespan machinery.  The
+``Settings`` lookup is monkeypatched to a hand-built instance so tests
+can control the WPS connection string (and therefore the signing key).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+WPS_KEY = "test-webhook-key"
+CONN_STR = f"Endpoint=http://broker:7080;AccessKey={WPS_KEY};Version=1.0;"
+
+
+def _sig(connection_id: str, key: str = WPS_KEY) -> str:
+    digest = hmac.new(key.encode(), connection_id.encode(), hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+class _FakeSession:
+    """Minimal ``AsyncSession`` stand-in — webhook tests don't need a real DB.
+
+    ``execute`` returns a result whose ``.scalar_one_or_none()`` is
+    driven by ``device_row`` (set per test).
+    """
+
+    def __init__(self, device_row=None):
+        self.device_row = device_row
+        self.commits = 0
+        self.added: list = []
+
+    async def execute(self, _stmt):
+        row = self.device_row
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=row)
+        return result
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+    async def refresh(self, obj, *args, **kwargs):  # pragma: no cover - not hit here
+        pass
+
+
+@pytest_asyncio.fixture
+async def app_and_session(monkeypatch):
+    """Build a fresh FastAPI app containing only the wps_webhook router."""
+    # Fresh DeviceManager for every test — isolation across webhook events.
+    from cms.services import device_manager as dm_module
+    dm_module.device_manager._connections.clear()
+    dm_module.device_manager._pending_log_requests.clear()
+
+    # Stub Settings that satisfies the receiver's needs.
+    class _S:
+        wps_connection_string = CONN_STR
+        wps_hub = "agora"
+        wps_webhook_allowed_origin = None
+        asset_base_url = None
+
+    from cms.routers import wps_webhook as wh
+
+    monkeypatch.setattr(wh, "get_settings", lambda: _S())
+
+    session = _FakeSession()
+
+    async def _fake_db():
+        yield session
+
+    from cms.database import get_db
+
+    app = FastAPI()
+    app.include_router(wh.router)
+    app.dependency_overrides[get_db] = _fake_db
+
+    yield app, session
+
+
+@pytest_asyncio.fixture
+async def client(app_and_session):
+    app, _ = app_and_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+# ---------------------------------------------------------------- OPTIONS
+
+
+@pytest.mark.asyncio
+class TestAbuseProtectionHandshake:
+    async def test_echoes_request_origin(self, client):
+        r = await client.options(
+            "/internal/wps/events",
+            headers={"WebHook-Request-Origin": "foo.webpubsub.azure.com"},
+        )
+        assert r.status_code == 200
+        assert r.headers["WebHook-Allowed-Origin"] == "foo.webpubsub.azure.com"
+
+    async def test_wildcard_when_origin_unset(self, client):
+        r = await client.options("/internal/wps/events")
+        assert r.status_code == 200
+        assert r.headers["WebHook-Allowed-Origin"] == "*"
+
+    async def test_configured_origin_wins(self, monkeypatch, app_and_session, client):
+        from cms.routers import wps_webhook as wh
+
+        class _S:
+            wps_connection_string = CONN_STR
+            wps_hub = "agora"
+            wps_webhook_allowed_origin = "only.me"
+            asset_base_url = None
+
+        monkeypatch.setattr(wh, "get_settings", lambda: _S())
+        r = await client.options(
+            "/internal/wps/events",
+            headers={"WebHook-Request-Origin": "other.example"},
+        )
+        assert r.status_code == 200
+        assert r.headers["WebHook-Allowed-Origin"] == "only.me"
+
+
+# ---------------------------------------------------------------- signature
+
+
+@pytest.mark.asyncio
+class TestSignatureVerification:
+    async def test_rejects_bad_signature(self, client):
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.connected",
+                "ce-connectionId": "conn-1",
+                "ce-userId": "pi-1",
+                "ce-signature": "sha256=deadbeef",
+            },
+        )
+        assert r.status_code == 401
+
+    async def test_rejects_missing_signature(self, client):
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.connected",
+                "ce-connectionId": "conn-1",
+                "ce-userId": "pi-1",
+            },
+        )
+        assert r.status_code == 401
+
+    async def test_missing_connection_id_rejected(self, client):
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.connected",
+                "ce-userId": "pi-1",
+                "ce-signature": _sig("whatever"),
+            },
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------- system events
+
+
+@pytest.mark.asyncio
+class TestSystemEvents:
+    async def test_connected_registers_remote(self, client):
+        from cms.services.device_manager import device_manager
+
+        cid = "conn-register"
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.connected",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-register",
+                "ce-eventName": "connected",
+                "ce-signature": _sig(cid),
+            },
+        )
+        assert r.status_code == 204
+        assert device_manager.is_connected("pi-register")
+        conn = device_manager.get("pi-register")
+        assert conn is not None
+        assert conn.websocket is None
+        assert conn.connection_id == cid
+
+    async def test_disconnected_removes_from_manager(self, client):
+        from cms.services.device_manager import device_manager
+
+        # Arrange: pre-register.
+        device_manager.register_remote("pi-gone", connection_id="old-cid")
+        assert device_manager.is_connected("pi-gone")
+
+        cid = "old-cid"
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.disconnected",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-gone",
+                "ce-eventName": "disconnected",
+                "ce-signature": _sig(cid),
+            },
+        )
+        assert r.status_code == 204
+        assert not device_manager.is_connected("pi-gone")
+
+
+# ---------------------------------------------------------------- user events
+
+
+@pytest.mark.asyncio
+class TestUserEvents:
+    async def test_unknown_device_is_logged_and_204(self, client, app_and_session):
+        """Until the register-over-WPS handshake is ported, messages
+        from devices with no DB row are dropped with a warning."""
+        app, session = app_and_session
+        session.device_row = None
+
+        cid = "conn-unknown"
+        r = await client.post(
+            "/internal/wps/events",
+            content=json.dumps({"type": "STATUS"}).encode(),
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.user.message",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-unknown",
+                "ce-eventName": "message",
+                "ce-signature": _sig(cid),
+            },
+        )
+        assert r.status_code == 204
+
+    async def test_known_device_dispatches(self, client, app_and_session):
+        """Valid CE on a user event routes to dispatch_device_message."""
+        app, session = app_and_session
+        # Fake device row with just enough attrs for InboundContext build.
+        device = MagicMock()
+        device.id = "pi-known"
+        device.name = "Lobby"
+        device.group_id = None
+        device.status = MagicMock(value="adopted")
+        session.device_row = device
+
+        cid = "conn-known"
+        payload = {"type": "STATUS", "mode": "play"}
+
+        with patch(
+            "cms.routers.wps_webhook.dispatch_device_message",
+            new=AsyncMock(return_value=None),
+        ) as mock_dispatch:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-known",
+                    "ce-eventName": "message",
+                    "ce-signature": _sig(cid),
+                },
+            )
+            assert r.status_code == 204
+            mock_dispatch.assert_awaited_once()
+            _, kwargs = mock_dispatch.call_args
+            assert kwargs["msg"] == payload
+            assert kwargs["ctx"].device_id == "pi-known"
+            assert kwargs["ctx"].device is device
+            # send closure should be wired to the current transport.
+            assert callable(kwargs["send"])
+
+    async def test_non_json_body_is_400(self, client, app_and_session):
+        _, session = app_and_session
+        session.device_row = MagicMock(
+            id="pi-known", name="x", group_id=None, status=MagicMock(value="adopted"),
+        )
+        cid = "conn-badbody"
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"not json at all",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.user.message",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-known",
+                "ce-eventName": "message",
+                "ce-signature": _sig(cid),
+            },
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------- unknown type
+
+
+@pytest.mark.asyncio
+class TestUnknownEventType:
+    async def test_400_on_unknown(self, client):
+        cid = "conn-x"
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.somethingnew",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-1",
+                "ce-signature": _sig(cid),
+            },
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------- multi-key
+
+
+@pytest.mark.asyncio
+class TestMultiKeyAcceptance:
+    async def test_any_configured_key_verifies(self, monkeypatch, app_and_session, client):
+        """Connection strings may carry primary+secondary AccessKey for rotation."""
+        from cms.routers import wps_webhook as wh
+
+        conn = f"Endpoint=http://b;AccessKey=new-key;AccessKey=old-key;Version=1.0;"
+
+        class _S:
+            wps_connection_string = conn
+            wps_hub = "agora"
+            wps_webhook_allowed_origin = None
+            asset_base_url = None
+
+        monkeypatch.setattr(wh, "get_settings", lambda: _S())
+
+        cid = "conn-rot"
+        # Sign with the OLD key — receiver should still accept.
+        r = await client.post(
+            "/internal/wps/events",
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "ce-type": "azure.webpubsub.sys.connected",
+                "ce-connectionId": cid,
+                "ce-userId": "pi-rot",
+                "ce-signature": _sig(cid, key="old-key"),
+            },
+        )
+        assert r.status_code == 204


### PR DESCRIPTION
# Stage 2b.2 — WPS transport, webhook receiver, token mint

Issue #344 · Stage 2b.2 of the [multi-replica CMS plan](https://github.com/sslivins/agora-cms/blob/docs/multi-replica-plan/docs/multi-replica-architecture.md).

Builds on Stage 2b.1 (#379) which extracted inbound dispatch into `cms/services/device_inbound.py`. This PR wires the Azure Web PubSub path end-to-end so CMS can run behind real WPS (and behind the Stage 2a local broker for compose/CI).

## What's in this PR

1. **Broker contract fix** — the Stage 2a broker signed the wrong thing. Fixed to match real Azure:
   - `ce-signature` signs `connectionId` (not body) via `hex(HMAC_SHA256(access_key, connection_id))`.
   - Multi-sig header `sha256=<primary>,sha256=<secondary>` for key rotation.
   - Event metadata in `ce-*` headers (CloudEvents 1.0 binary binding), not JSON body.
   - `ce-source` is `/hubs/{hub}/client/{connectionId}`.
   - System events have `{}` body; user events have raw client bytes.
2. **`WPSTransport`** — new `cms/services/wps_transport.py` wrapping `azure.messaging.webpubsubservice.aio` and satisfying the `DeviceTransport` ABC from Stage 1.
3. **Webhook receiver** — `POST /internal/wps/events`:
   - `OPTIONS` handshake for Azure's abuse-protection (responds with `WebHook-Allowed-Origin`).
   - CE signature verification (constant-time, multi-key).
   - `sys.connected` → `device_manager.register_remote(…)` (ghost entry, `websocket=None`).
   - `sys.disconnected` → `device_manager.disconnect(…)`.
   - `user.*` → `dispatch_device_message(…)` with a WPS-backed `send` closure — same dispatcher the direct-WS path uses.
4. **Token mint** — `POST /api/devices/{id}/connect-token`:
   - Authenticated via `X-Device-API-Key` (separate router, since the main `/api/devices` router is behind user session auth).
   - Returns `{url, token}` from the SDK's `get_client_access_token()`.
   - Returns 404 when `DEVICE_TRANSPORT=local`.
5. **Config + selector**: `device_transport` (`local`|`wps`), `wps_connection_string`, `wps_hub`, `wps_token_lifetime_minutes`, `wps_webhook_allowed_origin`. `main.lifespan` picks transport, mounts `wps_webhook` router in `wps` mode, and closes the transport on shutdown.
6. **Transport singleton refactored to accessor** (`get_transport()`/`set_transport()`) so the lifespan swap is visible to every caller. All 7 call sites migrated.
7. **Compose** — `wps` profile wires CMS to the broker with `DEVICE_TRANSPORT=wps` + generated connection string.

## Tests

72 new + updated tests, all passing locally on Windows:

```
tests/test_wps_transport.py      12
tests/test_wps_webhook.py        13
tests/test_connect_token.py       5
tests/test_device_manager.py     11 (1 new)
tests/test_device_transport_contract.py  9
tests/test_devices.py            54 (regression check)
tests/test_device_actions.py     11 (transport refactor smoke)
local-broker/tests/test_broker.py 18 (rewritten for new contract)
```

`tests/test_websocket.py` not run locally (needs pg); CI will cover it.

## Safe-merge notes

- **`ConnectedDevice.send_json` now raises** if called on a ghost entry (`websocket is None`). All in-tree callers go through `transport.send_to_device`; any survivor will fail loudly — preferred over silent wrong behavior.
- **`WPSTransport.request_logs`** duplicates the pending-future wiring from `DeviceManager.request_logs` (since the ghost entry has no socket). Stage 2c is the right time to collapse this once presence moves to DB.
- **Webhook path registers ghost-only** — a subsequent `user.*` event from an unknown device gets logged and 204'd. Adoption/registration over WPS is a follow-up; intentionally out of scope here.
- **Transport selection is explicit opt-in** — `DEVICE_TRANSPORT` defaults to `local`, so prod and dev are unaffected until the env var is set. Stage 2c will flip the default and delete the direct-WS path.

## Validation plan after merge

1. CI green.
2. Publish & Deploy green.
3. Create `agoracms-wps` (Free_F1) in `agoracms-cms-rg`; wire CMS container with `DEVICE_TRANSPORT=wps` + connection string.
4. Configure WPS event handler URL to `https://<fqdn>/internal/wps/events`, system events `connected,disconnected`, user events `*`.
5. Flash the test Pi at `192.168.1.53` to hit the Azure CMS, confirm connect → STATUS → command-send work end-to-end through real Azure WPS.
