### PR TITLE
feat(ui): remove location.reload() from group handlers + cross-session sync (#87)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -814,6 +814,92 @@ async def delete_group(group_id: uuid.UUID, request: Request, db: AsyncSession =
     return {"deleted": str(group_id)}
 
 
+@router.get("/groups/{group_id}/panel", dependencies=[Depends(require_permission(GROUPS_READ))])
+async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
+    """Return the rendered <div class='group-panel'> HTML for one group.
+
+    Mirrors the pattern established by GET /api/assets/{id}/row and
+    /api/profiles/{id}/row so the cross-session poller on /devices and the
+    createGroup handler can insert server-rendered markup instead of
+    synthesizing HTML in JS or issuing a full page reload. See issue #87.
+    """
+    from fastapi.responses import HTMLResponse
+    from cms.ui import templates
+    from cms.services.variant_view import is_asset_ready as _is_asset_ready
+    from cms.models.schedule import Schedule as ScheduleModel
+
+    user = getattr(request.state, "user", None)
+    if user:
+        await verify_resource_group_access(user, db, group_id)
+
+    result = await db.execute(
+        select(DeviceGroup)
+        .where(DeviceGroup.id == group_id)
+        .options(selectinload(DeviceGroup.devices))
+    )
+    group = result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    # Annotate the same fields the /devices page template expects.
+    group.device_count = len(group.devices)
+    group.schedule_count = await db.scalar(
+        select(func.count()).select_from(ScheduleModel).where(ScheduleModel.group_id == group_id)
+    ) or 0
+
+    from cms.services.version_checker import is_update_available
+    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
+    for d in group.devices:
+        d.is_online = get_transport().is_connected(d.id)
+        state = live_states.get(d.id)
+        d.cpu_temp_c = state["cpu_temp_c"] if state else None
+        d.ip_address = state["ip_address"] if state else None
+        d.playback_mode = state["mode"] if state else None
+        d.playback_asset = state["asset"] if state else None
+        d.pipeline_state = state["pipeline_state"] if state else None
+        d.started_at = state["started_at"] if state else None
+        d.playback_position_ms = state["playback_position_ms"] if state else None
+        d.ssh_enabled = state["ssh_enabled"] if state else None
+        d.local_api_enabled = state["local_api_enabled"] if state else None
+        d.update_available = is_update_available(d.firmware_version)
+        d.has_active_schedule = False  # poller will flip this via updateLiveFields
+
+    # Splash-screen dropdown options need the same ready annotations ui.py
+    # applies on the full page render.
+    assets_q = await db.execute(
+        select(Asset)
+        .options(selectinload(Asset.variants))
+        .where(Asset.deleted_at.is_(None))
+        .order_by(Asset.filename)
+    )
+    assets = assets_q.scalars().all()
+    for a in assets:
+        ready, reason = _is_asset_ready(a.variants)
+        a.ready_for_selection = ready
+        a.not_ready_reason = reason
+
+    # All groups the user can see — populates each device row's group-select.
+    group_ids = await get_user_group_ids(user, db) if user else []
+    is_admin = group_ids is None
+    if is_admin:
+        visible_groups = (await db.execute(
+            select(DeviceGroup).order_by(DeviceGroup.name)
+        )).scalars().all()
+    elif group_ids:
+        visible_groups = (await db.execute(
+            select(DeviceGroup).where(DeviceGroup.id.in_(group_ids)).order_by(DeviceGroup.name)
+        )).scalars().all()
+    else:
+        visible_groups = []
+
+    user_perms = list(user.role.permissions) if user and user.role else []
+    pending_ttl_hours = get_settings().pending_device_ttl_hours
+
+    macros = templates.env.get_template("_macros.html").module
+    html = macros.group_panel(group, user_perms, assets, visible_groups, pending_ttl_hours)
+    return HTMLResponse(str(html))
+
+
 # ── Device-originated: WPS connect token ────────────────────────────
 #
 # A device authenticates with its API key and asks the CMS to mint a

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -604,59 +604,48 @@ function _deleteGroupFromDom(groupId) {
     return true;
 }
 
-// Build (and insert) the DOM for a newly-created empty group-panel so the
-// user sees their group immediately. Matches the jinja-rendered structure
-// closely enough that subsequent moveDeviceRowInDom() calls Just Work.
-function _renderNewGroupPanel(group) {
-    // Anchor the insert so the new panel slots in right before the
-    // "Add Group" form. If we can't find the form, we can't reliably place
-    // the panel and must fall back to a reload.
+// Fetch the server-rendered <div class="group-panel"> for a group and
+// insert it into the #device-groups card before the "Add Group" form. Used
+// by createGroup (same-session) and the cross-session poller. Mirrors the
+// _insertAssetRow / _insertProfileRow pattern from the #87 reload-hunt.
+async function _insertGroupPanel(groupId) {
+    const resp = await fetch(`/api/devices/groups/${groupId}/panel`);
+    if (!resp.ok) return false;
+    const html = (await resp.text()).trim();
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    const panel = tpl.content.querySelector(`.group-panel[data-group-id="${groupId}"]`);
+    if (!panel) return false;
+
+    // Anchor to the "Add Group" form's row so the new panel slots in right
+    // before it (matches the jinja render order).
     const addBtn = document.getElementById('add-group-btn');
     const formRow = addBtn ? addBtn.closest('div') : null;
     const container = formRow ? formRow.parentElement : null;
     if (!container || !formRow) return false;
+
     // First-group bookkeeping: hide the "No groups created yet" placeholder.
     container.querySelectorAll('p.empty-state').forEach(p => {
         if (/No groups created/i.test(p.textContent)) p.remove();
     });
-    const panel = document.createElement('div');
-    panel.className = 'group-panel';
-    panel.setAttribute('data-group-id', group.id);
-    panel.setAttribute('ondragover', "event.preventDefault(); this.classList.add('drag-over')");
-    panel.setAttribute('ondragleave', "this.classList.remove('drag-over')");
-    panel.setAttribute('ondrop', `dropDevice(event, '${group.id}'); this.classList.remove('drag-over')`);
-    const escName = _escHtmlLocal(group.name || '');
-    const escDesc = _escHtmlLocal(group.description || '');
-    panel.innerHTML =
-        `<div class="group-header" onclick="toggleGroup(this)">` +
-            `<span class="expand-toggle">▶</span>` +
-            `<strong><span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="${group.id}" data-field="name">${escName}</span></strong> ` +
-            `<span class="text-muted">— <span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="${group.id}" data-field="description" data-placeholder="No description">${escDesc || 'No description'}</span></span> ` +
-            `<span class="badge badge-count" data-group-count="${group.id}">0 devices</span>` +
-        `</div>` +
-        `<div class="group-body" style="display: none;">` +
-            `<table data-group-table="${group.id}" style="display: none;"><tbody data-group-tbody="${group.id}"></tbody></table>` +
-            `<p class="text-muted empty-state" data-group-empty="${group.id}">No devices in this group. Drag a device here to add it.</p>` +
-        `</div>`;
     container.insertBefore(panel, formRow);
+
     // Append a new <option> to every inline group-select on the main table
     // so the user can immediately assign a device to the freshly-made group.
+    const gName = panel.querySelector('.editable-name[data-field="name"]')?.textContent
+                || panel.querySelector('strong')?.textContent
+                || '';
     const opt = document.createElement('option');
-    opt.value = group.id;
-    opt.textContent = group.name;
+    opt.value = groupId;
+    opt.textContent = gName;
     document.querySelectorAll('select[data-device-group-select]').forEach(sel => {
-        sel.appendChild(opt.cloneNode(true));
+        if (!sel.querySelector(`option[value="${groupId}"]`)) {
+            sel.appendChild(opt.cloneNode(true));
+        }
     });
     return true;
 }
-
-// Minimal HTML escaper used by the group-panel synth. Scoped local so we
-// don't collide with any page-specific _escHtml in the templates.
-function _escHtmlLocal(s) {
-    return String(s).replace(/[&<>"']/g, c => (
-        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
-    ));
-}
+window._insertGroupPanel = _insertGroupPanel;
 
 async function adoptDevice(deviceId, deviceName) {
     // Show adoption modal with name + optional location + optional group + required profile
@@ -923,16 +912,14 @@ async function createGroup() {
         return;
     }
     const group = await resp.json().catch(() => null);
-    if (!group || !_renderNewGroupPanel(group)) {
-        // We couldn't synth the panel (unknown page layout); fall back so the
-        // user still sees the new group.
-        location.reload();
+    if (!group || !(await _insertGroupPanel(group.id))) {
+        showToast("Group created — refresh to see it", true);
         return;
     }
     showToast("Group created");
+    if (window._rememberGroup) window._rememberGroup(group.id);
     nameInput.value = "";
     descInput.value = "";
-    // Re-disable the Add button since the name field is now empty.
     const addBtn = document.getElementById("add-group-btn");
     if (addBtn) addBtn.disabled = true;
 }
@@ -948,7 +935,8 @@ async function deleteGroup(groupId) {
         return;
     }
     showToast("Group deleted");
-    if (!_deleteGroupFromDom(groupId)) location.reload();
+    if (window._forgetGroup) window._forgetGroup(groupId);
+    _deleteGroupFromDom(groupId);
 }
 
 // ── Asset actions ──

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -418,3 +418,137 @@
                 </td>
             </tr>
 {%- endmacro %}
+
+
+{#
+  Header row for the compact device table used inside group panels and
+  the "Ungrouped Devices" table on the /devices page. Moved here (from
+  devices.html) so the group-panel fragment endpoint can render it
+  without depending on page-scope {% set %} blocks. See issue #87.
+#}
+{% macro th_row_compact() -%}
+<tr>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Group</th>
+    <th>Actions</th>
+</tr>
+{%- endmacro %}
+
+
+{#
+  Compact device row — used inside each group panel and the "Ungrouped"
+  table. Moved from devices.html so that both the full-page render and
+  the GET /api/devices/groups/{id}/panel fragment endpoint can emit
+  identical markup. See issue #87.
+
+  `pending_ttl_hours` is passed in explicitly (it lives on the page
+  template context, not on `d`) so the macro stays self-contained.
+#}
+{% macro device_row_compact(d, groups, user_perms, pending_ttl_hours, draggable=false) -%}
+<tr class="device-row device-row-compact{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
+    <td>
+        {% if 'devices:write' in user_perms %}
+        <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
+        {% else %}
+        {{ d.name or d.id }}
+        {% endif %}
+    </td>
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}">
+        {% if d.status.value == 'orphaned' %}
+        <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">Re-flashed device — needs re-adoption</span></span>
+        {% elif d.status.value == 'pending' %}
+        {% if d.is_online %}
+        <span class="badge badge-pending">Pending</span>
+        {% else %}
+        <span class="has-tooltip"><span class="badge badge-offline">Pending (Offline)</span><span class="tooltip">This device registered but hasn't been seen recently. Stale pending devices are automatically removed after {{ pending_ttl_hours }} hours.</span></span>
+        {% endif %}
+        {% elif d.is_online %}
+        <span class="badge badge-online">Online</span>
+        {% else %}
+        <span class="badge badge-offline">Offline</span>
+        {% endif %}
+    </td>
+    <td>
+        {% if 'devices:write' in user_perms %}
+        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
+            <option value="">None</option>
+            {% for g in groups %}
+            <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
+            {% endfor %}
+        </select>
+        {% else %}
+        {{ d.group.name if d.group else '—' }}
+        {% endif %}
+    </td>
+    <td class="actions" onclick="event.stopPropagation()">
+        {% if d.group_id and 'devices:write' in user_perms %}
+        {% call kebab_menu() %}
+            <button type="button" role="menuitem" onclick="assignGroup('{{ d.id }}', '')" title="Remove this device from the group">Remove from group</button>
+        {% endcall %}
+        {% endif %}
+    </td>
+</tr>
+{%- endmacro %}
+
+
+{#
+  Device group panel — renders a single expandable <div class="group-panel">
+  with header (name, description, device count, group-actions kebab) and
+  body (compact device table).
+
+  Shared between the /devices full-page render and the
+  GET /api/devices/groups/{id}/panel fragment endpoint so the cross-session
+  poller and the createGroup handler insert identical markup. See issue #87.
+#}
+{% macro group_panel(g, user_perms, assets, groups, pending_ttl_hours) -%}
+<div class="group-panel" data-group-id="{{ g.id }}"
+     ondragover="event.preventDefault(); this.classList.add('drag-over')"
+     ondragleave="this.classList.remove('drag-over')"
+     ondrop="dropDevice(event, '{{ g.id }}'); this.classList.remove('drag-over')">
+    <div class="group-header" onclick="toggleGroup(this)">
+        <span class="expand-toggle">▶</span>
+        {% if 'groups:write' in user_perms %}
+        <strong><span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="{{ g.id }}" data-field="name">{{ g.name }}</span></strong>
+        <span class="text-muted">— <span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="{{ g.id }}" data-field="description" data-placeholder="No description">{{ g.description or 'No description' }}</span></span>
+        {% else %}
+        <strong>{{ g.name }}</strong>
+        <span class="text-muted">— {{ g.description or 'No description' }}</span>
+        {% endif %}
+        <span class="badge badge-count" data-group-count="{{ g.id }}">{{ g.device_count }} device{{ 's' if g.device_count != 1 }}</span>
+        <span class="group-actions" onclick="event.stopPropagation()">
+            <span class="has-tooltip inline-label">Group Splash Screen<span class="tooltip">Default splash screen shown when no schedule is active</span></span>
+            {% if 'groups:write' in user_perms %}
+            <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
+                <option value="">No default asset</option>
+                {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
+                <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+                {% endfor %}
+            </select>
+            {% if g.schedule_count %}
+            {% call kebab_menu() %}
+                <button type="button" role="menuitem" class="kebab-item-danger" disabled title="Cannot delete — used by {{ g.schedule_count }} schedule{{ 's' if g.schedule_count != 1 }}. Remove from all schedules first.">Delete</button>
+            {% endcall %}
+            {% else %}
+            {% call kebab_menu() %}
+                <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteGroup('{{ g.id }}')" title="Delete this group — devices will be ungrouped">Delete</button>
+            {% endcall %}
+            {% endif %}
+            {% else %}
+            <span class="text-muted">{% if g.default_asset_id %}{% set da = (assets | selectattr('id', 'equalto', g.default_asset_id) | first) %}{{ da.display_name or da.original_filename or da.filename }}{% else %}No default asset{% endif %}</span>
+            {% endif %}
+        </span>
+    </div>
+    <div class="group-body" style="display: none;">
+        <table data-group-table="{{ g.id }}"{% if not g.devices %} style="display: none;"{% endif %}>
+            <thead>{{ th_row_compact() }}</thead>
+            <tbody data-group-tbody="{{ g.id }}">
+                {% for d in g.devices | sort(attribute='name') %}
+                {{ device_row_compact(d, groups, user_perms, pending_ttl_hours) }}
+                {% endfor %}
+            </tbody>
+        </table>
+        <p class="text-muted empty-state" data-group-empty="{{ g.id }}"{% if g.devices %} style="display: none;"{% endif %}>No devices in this group. Drag a device here to add it.</p>
+    </div>
+</div>
+{%- endmacro %}

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -246,49 +246,7 @@
    row can move between grouped (not draggable) and ungrouped (draggable)
    sections without re-rendering. assignGroup() / dropDevice() handle this. #}
 {% macro device_row_compact(d, groups, draggable=false) %}
-<tr class="device-row device-row-compact{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
-    <td>
-        {% if 'devices:write' in user_perms %}
-        <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
-        {% else %}
-        {{ d.name or d.id }}
-        {% endif %}
-    </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}">
-        {% if d.status.value == 'orphaned' %}
-        <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">Re-flashed device — needs re-adoption</span></span>
-        {% elif d.status.value == 'pending' %}
-        {% if d.is_online %}
-        <span class="badge badge-pending">Pending</span>
-        {% else %}
-        <span class="has-tooltip"><span class="badge badge-offline">Pending (Offline)</span><span class="tooltip">This device registered but hasn't been seen recently. Stale pending devices are automatically removed after {{ pending_ttl_hours }} hours.</span></span>
-        {% endif %}
-        {% elif d.is_online %}
-        <span class="badge badge-online">Online</span>
-        {% else %}
-        <span class="badge badge-offline">Offline</span>
-        {% endif %}
-    </td>
-    <td>
-        {% if 'devices:write' in user_perms %}
-        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
-            <option value="">None</option>
-            {% for g in groups %}
-            <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
-            {% endfor %}
-        </select>
-        {% else %}
-        {{ d.group.name if d.group else '—' }}
-        {% endif %}
-    </td>
-    <td class="actions" onclick="event.stopPropagation()">
-        {% if d.group_id and 'devices:write' in user_perms %}
-        {% call macros.kebab_menu() %}
-            <button type="button" role="menuitem" onclick="assignGroup('{{ d.id }}', '')" title="Remove this device from the group">Remove from group</button>
-        {% endcall %}
-        {% endif %}
-    </td>
-</tr>
+{{ macros.device_row_compact(d, groups, user_perms, pending_ttl_hours, draggable=draggable) }}
 {% endmacro %}
 
 {% set th_row %}
@@ -304,14 +262,7 @@
 </tr>
 {% endset %}
 
-{% set th_row_compact %}
-<tr>
-    <th>Name</th>
-    <th>Status</th>
-    <th>Group</th>
-    <th>Actions</th>
-</tr>
-{% endset %}
+{% set th_row_compact %}{{ macros.th_row_compact() }}{% endset %}
 
 {# ── All Devices ── #}
 <div class="card">
@@ -342,55 +293,7 @@
 <div class="card">
     <h2>Device Groups</h2>
     {% for g in groups %}
-    <div class="group-panel" data-group-id="{{ g.id }}"
-         ondragover="event.preventDefault(); this.classList.add('drag-over')"
-         ondragleave="this.classList.remove('drag-over')"
-         ondrop="dropDevice(event, '{{ g.id }}'); this.classList.remove('drag-over')">
-        <div class="group-header" onclick="toggleGroup(this)">
-            <span class="expand-toggle">▶</span>
-            {% if 'groups:write' in user_perms %}
-            <strong><span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="{{ g.id }}" data-field="name">{{ g.name }}</span></strong>
-            <span class="text-muted">— <span class="editable-name" onclick="event.stopPropagation(); editGroupField(this)" data-group-id="{{ g.id }}" data-field="description" data-placeholder="No description">{{ g.description or 'No description' }}</span></span>
-            {% else %}
-            <strong>{{ g.name }}</strong>
-            <span class="text-muted">— {{ g.description or 'No description' }}</span>
-            {% endif %}
-            <span class="badge badge-count" data-group-count="{{ g.id }}">{{ g.device_count }} device{{ 's' if g.device_count != 1 }}</span>
-            <span class="group-actions" onclick="event.stopPropagation()">
-                <span class="has-tooltip inline-label">Group Splash Screen<span class="tooltip">Default splash screen shown when no schedule is active</span></span>
-                {% if 'groups:write' in user_perms %}
-                <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
-                    <option value="">No default asset</option>
-                    {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
-                    <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
-                    {% endfor %}
-                </select>
-                {% if g.schedule_count %}
-                {% call macros.kebab_menu() %}
-                    <button type="button" role="menuitem" class="kebab-item-danger" disabled title="Cannot delete — used by {{ g.schedule_count }} schedule{{ 's' if g.schedule_count != 1 }}. Remove from all schedules first.">Delete</button>
-                {% endcall %}
-                {% else %}
-                {% call macros.kebab_menu() %}
-                    <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteGroup('{{ g.id }}')" title="Delete this group — devices will be ungrouped">Delete</button>
-                {% endcall %}
-                {% endif %}
-                {% else %}
-                <span class="text-muted">{% if g.default_asset_id %}{% set da = (assets | selectattr('id', 'equalto', g.default_asset_id) | first) %}{{ da.display_name or da.original_filename or da.filename }}{% else %}No default asset{% endif %}</span>
-                {% endif %}
-            </span>
-        </div>
-        <div class="group-body" style="display: none;">
-            <table data-group-table="{{ g.id }}"{% if not g.devices %} style="display: none;"{% endif %}>
-                <thead>{{ th_row_compact }}</thead>
-                <tbody data-group-tbody="{{ g.id }}">
-                    {% for d in g.devices | sort(attribute='name') %}
-                    {{ device_row_compact(d, groups) }}
-                    {% endfor %}
-                </tbody>
-            </table>
-            <p class="text-muted empty-state" data-group-empty="{{ g.id }}"{% if g.devices %} style="display: none;"{% endif %}>No devices in this group. Drag a device here to add it.</p>
-        </div>
-    </div>
+    {{ macros.group_panel(g, user_perms, assets, groups, pending_ttl_hours) }}
     {% else %}
     <p class="text-muted empty-state">No groups created yet.</p>
     {% endfor %}
@@ -491,6 +394,7 @@ window._adoptionProfiles = [
 (function() {
     const __canManage = {{ 'true' if 'devices:manage' in user_perms else 'false' }};
     let knownDeviceIds = new Set({{ devices | map(attribute='id') | list | tojson }});
+    let knownGroupIds = new Set({{ groups | map(attribute='id') | map('string') | list | tojson }});
 
     function buildPipelineBadge(device) {
         if (device.pipeline_state === "PLAYING") return '<span class="badge badge-online">Playing</span>';
@@ -670,6 +574,45 @@ window._adoptionProfiles = [
     }
 
     setInterval(pollDevicesOnce, 5000);
+    setInterval(pollGroupsOnce, 5000);
+
+    // Keep the /devices Device Groups card in sync across replicas without
+    // a full page reload. Added as part of #87: when session A creates or
+    // deletes a group, session B inserts/removes the panel within ~5s.
+    async function pollGroupsOnce() {
+        if (isModalOpen()) return;
+        if (document.querySelector('.kebab-menu:popover-open')) return;
+        // Don't swap while the user is typing in a group-related field.
+        const el = document.activeElement;
+        if (el && (el.id === 'group-name' || el.id === 'group-desc')) return;
+        try {
+            const resp = await fetch("/api/devices/groups/");
+            if (!resp.ok) return;
+            const groups = await resp.json();
+            const serverIds = new Set(groups.map(g => String(g.id)));
+
+            // Insert any group we don't yet have a panel for.
+            for (const gid of serverIds) {
+                if (!knownGroupIds.has(gid) &&
+                    !document.querySelector(`.group-panel[data-group-id="${gid}"]`) &&
+                    typeof window._insertGroupPanel === 'function') {
+                    const ok = await window._insertGroupPanel(gid);
+                    if (ok) knownGroupIds.add(gid);
+                }
+            }
+            // Remove panels whose group was deleted on another replica.
+            for (const gid of Array.from(knownGroupIds)) {
+                if (!serverIds.has(gid)) {
+                    // Skip if the user is expanded into this panel — they'd
+                    // lose their context. The next poll cycle will retry.
+                    const panel = document.querySelector(`.group-panel[data-group-id="${gid}"]`);
+                    if (panel && panel.classList.contains('expanded')) continue;
+                    if (typeof _deleteGroupFromDom === 'function') _deleteGroupFromDom(gid);
+                    knownGroupIds.delete(gid);
+                }
+            }
+        } catch (e) { /* ignore */ }
+    }
 
     // Expose a lightweight re-poll hook so action handlers in app.js can
     // request an immediate refresh after mutating device state (SSH/Local
@@ -681,6 +624,11 @@ window._adoptionProfiles = [
     // client-side so the next poll doesn't see the set shrink and trigger
     // an unnecessary structural reload.
     window._forgetDevice = (id) => { knownDeviceIds.delete(id); };
+    // Same contract for groups: action handlers in app.js call these after
+    // mutating a group so the next poll doesn't treat it as a cross-session
+    // change and try to re-insert / re-delete the panel.
+    window._forgetGroup = (id) => { knownGroupIds.delete(String(id)); };
+    window._rememberGroup = (id) => { knownGroupIds.add(String(id)); };
 
     async function pollDevicesOnce(force) {
         if (!force) {

--- a/tests/test_asset_icons.py
+++ b/tests/test_asset_icons.py
@@ -223,6 +223,10 @@ def test_option_templates_prefix_icon_before_name(
     a suffix, this catches it.
     """
     body = _read(template_file)
+    # The group-default dropdown was extracted to macros.group_panel as part
+    # of the #87 no-reload work, so also scan _macros.html for devices.html.
+    if template_file == "devices.html":
+        body += _read("_macros.html")
     pattern = "{{ a | asset_icon }} {{ a.display_name"
     count = body.count(pattern)
     assert count >= must_contain_before_name, (

--- a/tests/test_group_panel_endpoint.py
+++ b/tests/test_group_panel_endpoint.py
@@ -1,0 +1,35 @@
+"""Unit test for GET /api/devices/groups/{id}/panel — the HTML fragment
+endpoint used by the /devices page's cross-session poller and createGroup
+handler to insert a group panel without a full page reload (issue #87)."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestGroupPanelEndpoint:
+    async def test_panel_returns_html_fragment(self, client):
+        resp = await client.post(
+            "/api/devices/groups/",
+            json={"name": "Fragment Test Group", "description": "fragment desc"},
+        )
+        assert resp.status_code == 201, resp.text
+        group_id = resp.json()["id"]
+
+        panel = await client.get(f"/api/devices/groups/{group_id}/panel")
+        assert panel.status_code == 200
+        body = panel.text
+        # The root element carries the group id so the client can locate it.
+        assert f'data-group-id="{group_id}"' in body
+        # Header renders the name + description.
+        assert "Fragment Test Group" in body
+        assert "fragment desc" in body
+        # Empty group renders the "No devices in this group" empty-state.
+        assert "No devices in this group" in body
+        # Body table gets a data-group-tbody anchor the poller looks for.
+        assert f'data-group-tbody="{group_id}"' in body
+
+    async def test_panel_unknown_id_404(self, client):
+        resp = await client.get(
+            "/api/devices/groups/00000000-0000-0000-0000-000000000000/panel"
+        )
+        assert resp.status_code == 404

--- a/tests_e2e/test_ui_cross_session.py
+++ b/tests_e2e/test_ui_cross_session.py
@@ -477,3 +477,55 @@ class TestAssetsInSessionNoReload:
         # Small settle so any (buggy) reload path would have fired by now.
         page.wait_for_timeout(500)
         assert page.evaluate("window.__noReloadSentinel") == "keep-me"
+
+class TestGroupsCrossSession:
+    """Cross-session visibility for the Device Groups card on /devices.
+
+    Added as part of the #87 no-reload rework (see PR following assets):
+    session A creating/deleting a group used to require session B to
+    reload. Now session B's 5s group poller inserts the panel via the
+    GET /api/devices/groups/{id}/panel fragment and removes it on delete.
+    """
+
+    def test_create_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A creates a group → session B inserts the panel inline."""
+        page.goto("/devices")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/devices")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        resp = api.post("/api/devices/groups/", json={
+            "name": "xsess-group-create", "description": "cross-session test",
+        })
+        assert resp.status_code == 201, resp.text
+        group_id = resp.json()["id"]
+
+        expect(
+            second_page.locator(f'.group-panel[data-group-id="{group_id}"]')
+        ).to_be_visible(timeout=POLL_TIMEOUT_MS)
+
+    def test_delete_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A deletes a group → session B removes the panel."""
+        resp = api.post("/api/devices/groups/", json={
+            "name": "xsess-group-delete", "description": "",
+        })
+        assert resp.status_code == 201, resp.text
+        group_id = resp.json()["id"]
+
+        page.goto("/devices")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/devices")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        expect(
+            second_page.locator(f'.group-panel[data-group-id="{group_id}"]')
+        ).to_be_visible(timeout=5000)
+
+        del_resp = api.delete(f"/api/devices/groups/{group_id}")
+        assert del_resp.status_code in (200, 204), del_resp.text
+
+        # Same CI-jitter headroom as the assets delete test (one 5s poll
+        # cycle can be consumed by the pre-delete to_be_visible check).
+        expect(
+            second_page.locator(f'.group-panel[data-group-id="{group_id}"]')
+        ).to_have_count(0, timeout=POLL_TIMEOUT_MS + 8000)


### PR DESCRIPTION
# feat(ui): remove location.reload() from group handlers + add cross-session group sync (#87)

Continues the #87 reload-hunt. Same pattern as #376 (assets) and #380
(asset handlers): server-rendered fragment endpoint + cross-session poller.

## What changed

**New fragment endpoint**
- `GET /api/devices/groups/{id}/panel` returns the rendered
  `<div class="group-panel">` for one group.

**Shared macros in `_macros.html`**
- Extracted `device_row_compact`, `th_row_compact`, and `group_panel`
  from `devices.html` so the full-page render and the panel fragment
  emit identical markup. `devices.html` keeps a thin local
  `device_row_compact` wrapper so the existing callsite signature stays
  stable.

**`app.js` group handlers**
- `createGroup` → fetches the server fragment via new
  `_insertGroupPanel(id)` helper instead of hand-synthesizing the panel
  DOM. Deleted the old `_renderNewGroupPanel` / `_escHtmlLocal` helpers.
- `deleteGroup` → drops the `location.reload()` fallback (the
  `_deleteGroupFromDom` path always works for groups it finds).
- Both now inform the devices-page poller of local mutations via new
  `window._rememberGroup(id)` / `window._forgetGroup(id)` hooks so the
  next cross-session poll doesn't flag the change as remote.

**Cross-session group sync**
- `devices.html` now runs a `pollGroupsOnce()` at 5 s alongside
  `pollDevicesOnce()`. It hits `/api/devices/groups/`, inserts panels
  for unknown ids (via the new fragment endpoint) and removes panels
  whose group was deleted on another replica. Skips any expanded panel
  to avoid yanking context from a user who's reading it.

## Why this matters

Two independent benefits:
1. Same-session flow no longer reloads — the user keeps their scroll /
   expanded panels / open dropdowns when creating or deleting a group.
2. Group create/delete now propagates across replicas within one 5 s
   poll cycle, matching the bar set by schedules / assets / profiles.

## Tests

- `tests/test_group_panel_endpoint.py` — new unit tests (endpoint
  returns the rendered panel; 404 for unknown ids).
- `tests_e2e/test_ui_cross_session.py::TestGroupsCrossSession` — new
  cross-session tests for create + delete propagation. Delete uses the
  same `POLL_TIMEOUT_MS + 8000` headroom that the assets delete test
  settled on for CI jitter.
- `tests/test_asset_icons.py` — scans `_macros.html` too now that the
  group-default-asset dropdown lives there.
- Local: 259/259 passed across the previously-affected test files.

## Scope notes

- The devices poller still has a `location.reload()` (line ~613 of
  `devices.html`) in its device-set structural-diff branch. That's the
  in-memory transport state you flagged as a larger rework and is
  **intentionally left alone**.
- Remaining reload-hunt slices: users / roles pages (admin-only,
  smallest), schedules fallbacks (1762+), devices structural-reload
  (blocked on WSS redesign).

**Do not merge yet** — other agent is still rewriting multi-CMS WSS;
this shouldn't collide (it's pure HTTP/template territory) but hold per
your prior instruction.
