### PR TITLE
feat(logs): add log_requests outbox table + helpers (Stage 3a)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           pip install pytest pytest-asyncio pytest-timeout pytest-cov pytest-xdist httpx aiosqlite psycopg2-binary
 
       - name: Run tests
-        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -v -rfEsxX --maxfail=5 --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
+        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -q -rs --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           pip install pytest pytest-asyncio pytest-timeout pytest-cov pytest-xdist httpx aiosqlite psycopg2-binary
 
       - name: Run tests
-        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -q -rs --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
+        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -v -rfEsxX --maxfail=5 --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
 
       - name: Upload coverage report
         if: always()

--- a/alembic/versions/0005_log_requests_table.py
+++ b/alembic/versions/0005_log_requests_table.py
@@ -1,0 +1,151 @@
+"""stage 3a: log_requests outbox table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-25
+
+Introduces the durable outbox that backs the multi-replica log RPC.
+A row is created when the UI asks for device logs; a drainer on every
+replica picks ``pending`` rows (``SKIP LOCKED``) and dispatches
+``REQUEST_LOGS`` over the transport; the Pi uploads its bundle to CMS
+which streams it into blob storage and flips the row to ``ready``.
+
+Status lifecycle (enforced by ``cms.services.log_outbox``):
+
+    pending ─► sent ─► ready
+                 └─► failed
+                 └─► expired
+
+See issue #345 (multi-replica refactor, Stage 3) and
+``docs/multi-replica-architecture.md`` §Stage 3 for the locked design.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # ``services`` holds an optional list[str] of systemd service names
+    # to filter.  JSONB on Postgres, JSON on SQLite (tests).
+    services_type = postgresql.JSONB(astext_type=sa.Text()) if is_postgres else sa.JSON()
+
+    op.create_table(
+        "log_requests",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column(
+            "device_id",
+            sa.String(length=64),
+            sa.ForeignKey("devices.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Audit — who asked.  Nullable so system-initiated requests (future
+        # health probes, scheduled collection) can land without a user.
+        sa.Column(
+            "requested_by_user_id",
+            postgresql.UUID(as_uuid=True) if is_postgres else sa.String(length=36),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("services", services_type, nullable=True),
+        sa.Column(
+            "since",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'24h'"),
+        ),
+        # Lifecycle: pending | sent | ready | failed | expired.
+        # Checked at the app layer (enum values kept out of Postgres so new
+        # states can be added without migrations).
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        # Timestamps for each lifecycle transition.
+        sa.Column(
+            "sent_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            "ready_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        # Blob location (storage-backend-relative path), size, expiry for
+        # the reaper to delete old artefacts.
+        sa.Column("blob_path", sa.Text(), nullable=True),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "expires_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+
+    # Drainer scans ``WHERE status = 'pending' ORDER BY created_at``.
+    op.create_index(
+        "ix_log_requests_status_created",
+        "log_requests",
+        ["status", "created_at"],
+    )
+    # Per-device history lookup for the UI.
+    op.create_index(
+        "ix_log_requests_device_created",
+        "log_requests",
+        ["device_id", "created_at"],
+    )
+    # Reaper scans expired rows.  Partial index on Postgres so we only
+    # pay for rows that have an expiry set.
+    if is_postgres:
+        op.create_index(
+            "ix_log_requests_expires_at",
+            "log_requests",
+            ["expires_at"],
+            postgresql_where=sa.text("expires_at IS NOT NULL"),
+        )
+    else:
+        op.create_index(
+            "ix_log_requests_expires_at",
+            "log_requests",
+            ["expires_at"],
+        )
+
+    # HOT-friendly page layout: status/attempts/last_error/updated_at
+    # all churn on every drainer tick.  Same trick as ``devices``.
+    if is_postgres:
+        op.execute("ALTER TABLE log_requests SET (fillfactor = 80)")
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Project policy: migrations are forward-only. "
+        "Roll forward with a new migration if a schema correction is needed."
+    )

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -7,6 +7,7 @@ from cms.models.device import Device, DeviceGroup, DeviceStatus  # noqa: F401
 from cms.models.device_event import DeviceEvent, DeviceEventType  # noqa: F401
 from cms.models.device_profile import DeviceProfile  # noqa: F401
 from cms.models.group_asset import GroupAsset  # noqa: F401
+from cms.models.log_request import LogRequest  # noqa: F401
 from cms.models.notification import Notification  # noqa: F401
 from cms.models.notification_pref import UserNotificationPref  # noqa: F401
 from cms.models.schedule import Schedule  # noqa: F401

--- a/cms/models/log_request.py
+++ b/cms/models/log_request.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -38,7 +38,19 @@ TERMINAL_STATUSES = frozenset({STATUS_READY, STATUS_FAILED, STATUS_EXPIRED})
 
 class LogRequest(Base):
     __tablename__ = "log_requests"
-    __table_args__ = {"extend_existing": True}
+    __table_args__ = (
+        # Drainer scan — pending rows oldest-first.
+        Index("ix_log_requests_status_created", "status", "created_at"),
+        # Per-device history lookup for the UI.
+        Index("ix_log_requests_device_created", "device_id", "created_at"),
+        # Reaper scan — migration creates a partial index on Postgres
+        # (``WHERE expires_at IS NOT NULL``), but Alembic autogenerate
+        # still treats the plain ``Index`` here as a match because the
+        # partial predicate is declared via ``postgresql_where`` at the
+        # migration layer.  See alembic/versions/0005_*.py.
+        Index("ix_log_requests_expires_at", "expires_at"),
+        {"extend_existing": True},
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     device_id: Mapped[str] = mapped_column(

--- a/cms/models/log_request.py
+++ b/cms/models/log_request.py
@@ -1,0 +1,99 @@
+"""LogRequest ORM model — Stage 3 outbox row for device log collection.
+
+Backs the multi-replica-safe ``request_logs`` flow.  The UI creates a row
+(``pending``); a drainer on every CMS replica (with ``SKIP LOCKED``)
+picks pending rows and dispatches ``REQUEST_LOGS`` over the transport
+(``sent``); the Pi uploads its gzipped bundle to CMS which streams it
+into blob storage and flips the row (``ready``).  Failures bump
+``attempts`` and store ``last_error``; the reaper deletes blobs past
+``expires_at``.
+
+See ``alembic/versions/0005_log_requests_table.py`` for the schema and
+``docs/multi-replica-architecture.md`` §Stage 3 for the design.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from cms.database import Base
+
+
+# Status string values.  Kept as module-level constants (not a Python
+# Enum) so the drainer / reaper / tests can reference them without
+# coupling to SQLAlchemy's Enum type reflection.
+STATUS_PENDING = "pending"
+STATUS_SENT = "sent"
+STATUS_READY = "ready"
+STATUS_FAILED = "failed"
+STATUS_EXPIRED = "expired"
+
+TERMINAL_STATUSES = frozenset({STATUS_READY, STATUS_FAILED, STATUS_EXPIRED})
+
+
+class LogRequest(Base):
+    __tablename__ = "log_requests"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    device_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("devices.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Audit — who requested the logs.  Nullable so system-initiated
+    # collection (future health probes) can land without a user.
+    requested_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Optional list[str] of systemd service names; NULL = all services.
+    services: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    since: Mapped[str] = mapped_column(
+        Text, nullable=False, default="24h", server_default=text("'24h'"),
+    )
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default=STATUS_PENDING,
+        server_default=text("'pending'"),
+    )
+    attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0"),
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    ready_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    # Storage-backend-relative path to the uploaded bundle.  Populated
+    # when the Pi's upload completes.
+    blob_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Reaper deletes the blob + row after this timestamp.  Nullable so
+    # rows with no expiry (e.g., for forensic retention) can opt out.
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    device = relationship("Device")

--- a/cms/services/log_outbox.py
+++ b/cms/services/log_outbox.py
@@ -1,0 +1,299 @@
+"""Log outbox helpers (Stage 3 of #345).
+
+Backs the multi-replica-safe ``request_logs`` flow.  Each helper is a
+small atomic operation on the ``log_requests`` outbox table — the
+router, the drainer, the upload endpoint and the reaper compose them
+into the full lifecycle:
+
+    pending ─► sent ─► ready
+                 └─► failed
+                 └─► expired
+
+All helpers take an ``AsyncSession`` and **do not commit** — the caller
+owns the transaction boundary.  This lets routers batch the outbox
+write with audit writes, and the drainer batch status updates with
+``FOR UPDATE SKIP LOCKED`` scans.
+
+See ``docs/multi-replica-architecture.md`` §Stage 3 for the locked
+design; ``cms/models/log_request.py`` for the schema.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.log_request import (
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_READY,
+    STATUS_SENT,
+    TERMINAL_STATUSES,
+    LogRequest,
+)
+
+logger = logging.getLogger("agora.cms.log_outbox")
+
+
+# Default retention: Stage 3 arch doc targets a 30-day blob lifecycle.
+# Individual callers can override by passing ``expires_in`` explicitly.
+DEFAULT_RETENTION = timedelta(days=30)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    device_id: str,
+    requested_by_user_id: uuid.UUID | str | None = None,
+    services: list[str] | None = None,
+    since: str = "24h",
+    expires_in: timedelta | None = DEFAULT_RETENTION,
+    request_id: str | None = None,
+) -> LogRequest:
+    """Insert a new ``pending`` outbox row.
+
+    Returns the persisted :class:`LogRequest` (flushed, not committed).
+    ``request_id`` is accepted so callers that need to emit the id in a
+    response before commit can pre-generate it; otherwise a v4 UUID is
+    allocated.
+    """
+    now = _now()
+    row = LogRequest(
+        id=request_id or str(uuid.uuid4()),
+        device_id=device_id,
+        requested_by_user_id=requested_by_user_id,
+        services=services,
+        since=since,
+        status=STATUS_PENDING,
+        attempts=0,
+        created_at=now,
+        updated_at=now,
+        expires_at=(now + expires_in) if expires_in is not None else None,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def get(db: AsyncSession, request_id: str) -> LogRequest | None:
+    """Fetch a single request by id, or ``None`` when missing."""
+    return await db.get(LogRequest, request_id)
+
+
+async def mark_sent(
+    db: AsyncSession,
+    request_id: str,
+    *,
+    attempt_increment: int = 1,
+) -> bool:
+    """Transition ``pending → sent`` after the transport dispatch
+    succeeds.  Records the send timestamp and bumps ``attempts``.
+
+    Returns ``True`` iff a row was updated (i.e. the row still exists
+    and was in ``pending``).  Drainer uses the boolean to detect the
+    case where another replica picked the same row first — with
+    ``SKIP LOCKED`` this should be rare but the guard keeps us honest
+    on non-Postgres backends (tests) that don't honour locking.
+    """
+    result = await db.execute(
+        update(LogRequest)
+        .where(LogRequest.id == request_id, LogRequest.status == STATUS_PENDING)
+        .values(
+            status=STATUS_SENT,
+            sent_at=_now(),
+            updated_at=_now(),
+            attempts=LogRequest.attempts + attempt_increment,
+        )
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def mark_ready(
+    db: AsyncSession,
+    request_id: str,
+    *,
+    blob_path: str,
+    size_bytes: int,
+) -> bool:
+    """Transition ``sent → ready`` after the Pi's upload lands in blob
+    storage.  Also accepts ``pending → ready`` for the Stage 3b back-
+    compat shim that writes the legacy ``LOGS_RESPONSE`` inline
+    payload before the drainer has picked up the row.
+
+    Returns ``True`` iff a row was updated.
+    """
+    result = await db.execute(
+        update(LogRequest)
+        .where(
+            LogRequest.id == request_id,
+            LogRequest.status.in_([STATUS_PENDING, STATUS_SENT]),
+        )
+        .values(
+            status=STATUS_READY,
+            ready_at=_now(),
+            updated_at=_now(),
+            blob_path=blob_path,
+            size_bytes=size_bytes,
+            last_error=None,
+        )
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def mark_failed(
+    db: AsyncSession,
+    request_id: str,
+    *,
+    error: str,
+) -> bool:
+    """Transition any non-terminal row to ``failed`` with a message.
+
+    Used by the drainer when ``attempts`` exceeds the retry budget and
+    by the upload endpoint when Pi reports an error.  Does not bump
+    ``attempts`` — that's the drainer's job on send.
+    """
+    result = await db.execute(
+        update(LogRequest)
+        .where(
+            LogRequest.id == request_id,
+            LogRequest.status.notin_(list(TERMINAL_STATUSES)),
+        )
+        .values(
+            status=STATUS_FAILED,
+            last_error=error[:2000] if error else None,
+            updated_at=_now(),
+        )
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def mark_expired(
+    db: AsyncSession,
+    request_id: str,
+) -> bool:
+    """Flip a row to ``expired`` — used by the reaper before deleting
+    its blob.  Only affects non-terminal rows so already-failed or
+    already-ready rows keep their final status."""
+    result = await db.execute(
+        update(LogRequest)
+        .where(
+            LogRequest.id == request_id,
+            LogRequest.status.notin_(list(TERMINAL_STATUSES)),
+        )
+        .values(status=STATUS_EXPIRED, updated_at=_now())
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def record_attempt_error(
+    db: AsyncSession,
+    request_id: str,
+    *,
+    error: str,
+) -> bool:
+    """Record a transient error without changing status.
+
+    Called when the drainer attempts a send that fails but the retry
+    budget isn't exhausted.  Bumps ``attempts`` and stores the latest
+    error message.  The row stays ``pending`` so the next drainer tick
+    picks it up again.
+    """
+    result = await db.execute(
+        update(LogRequest)
+        .where(LogRequest.id == request_id, LogRequest.status == STATUS_PENDING)
+        .values(
+            attempts=LogRequest.attempts + 1,
+            last_error=error[:2000] if error else None,
+            updated_at=_now(),
+        )
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def list_pending(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+    max_attempts: int | None = None,
+) -> list[LogRequest]:
+    """Fetch up to ``limit`` pending rows ordered by ``created_at``.
+
+    Stage 3d will add ``.with_for_update(skip_locked=True)`` on the
+    drainer path so multiple replicas can scan concurrently without
+    duplicating work.  Stage 3a just exposes the read side; nothing
+    calls it yet.
+    """
+    stmt = (
+        select(LogRequest)
+        .where(LogRequest.status == STATUS_PENDING)
+        .order_by(LogRequest.created_at)
+        .limit(limit)
+    )
+    if max_attempts is not None:
+        stmt = stmt.where(LogRequest.attempts < max_attempts)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def list_expired(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    limit: int = 100,
+) -> list[LogRequest]:
+    """Fetch rows whose ``expires_at`` has passed.
+
+    Used by the Stage 3e reaper to delete old blobs.  Terminal rows
+    whose blobs are already gone (``blob_path`` IS NULL) are also
+    returned so the reaper can drop them from the table.
+    """
+    cutoff = now or _now()
+    stmt = (
+        select(LogRequest)
+        .where(
+            LogRequest.expires_at.is_not(None),
+            LogRequest.expires_at <= cutoff,
+        )
+        .order_by(LogRequest.expires_at)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def list_for_device(
+    db: AsyncSession,
+    device_id: str,
+    *,
+    limit: int = 50,
+) -> list[LogRequest]:
+    """Return the most recent log requests for one device (UI history)."""
+    stmt = (
+        select(LogRequest)
+        .where(LogRequest.device_id == device_id)
+        .order_by(LogRequest.created_at.desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def count_by_status(db: AsyncSession) -> dict[str, int]:
+    """Return a ``{status: count}`` dict over all outbox rows.
+
+    Stage 3 observability hook — the Stage 4 smoke-test gate reads
+    this to assert the drainer is keeping up.
+    """
+    stmt = select(LogRequest.status, func.count()).group_by(LogRequest.status)
+    result = await db.execute(stmt)
+    return {row[0]: row[1] for row in result.all()}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 asyncio_mode = strict
 timeout = 60
-timeout_method = thread
+timeout_method = signal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def _patch_array_columns():
     from cms.models.audit_log import AuditLog
     from cms.models.notification import Notification
     from cms.models.device_event import DeviceEvent
+    from cms.models.log_request import LogRequest
     col = Schedule.__table__.columns["days_of_week"]
     col.type = JSON()
     col = Role.__table__.columns["permissions"]
@@ -149,6 +150,8 @@ def _patch_array_columns():
     col = Notification.__table__.columns["details"]
     col.type = JSON()
     col = DeviceEvent.__table__.columns["details"]
+    col.type = JSON()
+    col = LogRequest.__table__.columns["services"]
     col.type = JSON()
 
 

--- a/tests/test_log_outbox.py
+++ b/tests/test_log_outbox.py
@@ -1,0 +1,482 @@
+"""Unit tests for :mod:`cms.services.log_outbox` (Stage 3a of #345).
+
+Covers the outbox helper surface that backs the multi-replica-safe
+``request_logs`` flow — row creation, status transitions, list helpers,
+and the monotonic-ish guards that prevent lost updates when two
+replicas race on the same row.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.models.device import Device, DeviceStatus
+from cms.models.log_request import (
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_READY,
+    STATUS_SENT,
+    LogRequest,
+)
+from cms.services import log_outbox
+
+
+async def _reload(db, request_id):
+    """Re-fetch a LogRequest after a bulk UPDATE.
+
+    Our helpers issue ``UPDATE ... WHERE ...`` statements which bypass
+    the ORM identity map, so :func:`log_outbox.get` would otherwise
+    return the stale instance cached in the session.  Production code
+    avoids this by separating the commit from the subsequent read
+    (usually across request boundaries); tests short-circuit with
+    ``expire_all``.
+    """
+    db.expire_all()
+    return await log_outbox.get(db, request_id)
+
+
+@pytest_asyncio.fixture
+async def _device(db_session):
+    d = Device(id="d-outbox-1", name="Outbox Test", status=DeviceStatus.ADOPTED)
+    db_session.add(d)
+    await db_session.commit()
+    return d
+
+
+# ── create ──
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_creates_pending_row_with_defaults(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        assert row.id  # UUID assigned
+        assert row.device_id == _device.id
+        assert row.status == STATUS_PENDING
+        assert row.attempts == 0
+        assert row.since == "24h"
+        assert row.services is None
+        assert row.sent_at is None
+        assert row.ready_at is None
+        assert row.blob_path is None
+        assert row.size_bytes is None
+        assert row.expires_at is not None  # default retention applied
+
+    @pytest.mark.asyncio
+    async def test_respects_provided_request_id(self, db_session, _device):
+        row = await log_outbox.create(
+            db_session, device_id=_device.id, request_id="fixed-rid-1",
+        )
+        await db_session.commit()
+        assert row.id == "fixed-rid-1"
+
+    @pytest.mark.asyncio
+    async def test_respects_provided_services_and_since(self, db_session, _device):
+        row = await log_outbox.create(
+            db_session,
+            device_id=_device.id,
+            services=["agora-player", "agora-api"],
+            since="7d",
+        )
+        await db_session.commit()
+        assert row.services == ["agora-player", "agora-api"]
+        assert row.since == "7d"
+
+    @pytest.mark.asyncio
+    async def test_expires_in_none_leaves_expires_at_null(self, db_session, _device):
+        row = await log_outbox.create(
+            db_session, device_id=_device.id, expires_in=None,
+        )
+        await db_session.commit()
+        assert row.expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_device_raises(self, db_session):
+        # FK violation — conftest enables SQLite PRAGMA foreign_keys so
+        # the check fires at flush (Postgres) or commit (SQLite).
+        with pytest.raises(Exception):
+            await log_outbox.create(db_session, device_id="does-not-exist")
+            await db_session.commit()
+
+
+# ── get ──
+
+class TestGet:
+    @pytest.mark.asyncio
+    async def test_returns_row_when_present(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        fetched = await log_outbox.get(db_session, row.id)
+        assert fetched is not None
+        assert fetched.id == row.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self, db_session):
+        fetched = await log_outbox.get(db_session, "no-such-id")
+        assert fetched is None
+
+
+# ── mark_sent ──
+
+class TestMarkSent:
+    @pytest.mark.asyncio
+    async def test_transitions_pending_to_sent_and_bumps_attempts(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        ok = await log_outbox.mark_sent(db_session, row.id)
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_SENT
+        assert refreshed.attempts == 1
+        assert refreshed.sent_at is not None
+
+    @pytest.mark.asyncio
+    async def test_second_call_is_noop_since_row_no_longer_pending(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        assert await log_outbox.mark_sent(db_session, row.id) is True
+        await db_session.commit()
+        # Second call — status is now 'sent', so the update guard matches zero rows.
+        assert await log_outbox.mark_sent(db_session, row.id) is False
+        await db_session.commit()
+
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.attempts == 1  # not bumped a second time
+
+    @pytest.mark.asyncio
+    async def test_missing_row_returns_false(self, db_session):
+        assert await log_outbox.mark_sent(db_session, "no-such-id") is False
+
+
+# ── mark_ready ──
+
+class TestMarkReady:
+    @pytest.mark.asyncio
+    async def test_transitions_sent_to_ready_with_blob_metadata(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_sent(db_session, row.id)
+        await db_session.commit()
+
+        ok = await log_outbox.mark_ready(
+            db_session, row.id,
+            blob_path="device-logs/d-outbox-1/abc.tar.gz",
+            size_bytes=12345,
+        )
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_READY
+        assert refreshed.blob_path == "device-logs/d-outbox-1/abc.tar.gz"
+        assert refreshed.size_bytes == 12345
+        assert refreshed.ready_at is not None
+
+    @pytest.mark.asyncio
+    async def test_accepts_pending_to_ready_for_backcompat_shim(self, db_session, _device):
+        # Stage 3b back-compat shim writes the legacy LOGS_RESPONSE
+        # payload straight to blob without going through the drainer.
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        ok = await log_outbox.mark_ready(
+            db_session, row.id, blob_path="x/y.tar.gz", size_bytes=1,
+        )
+        await db_session.commit()
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_READY
+
+    @pytest.mark.asyncio
+    async def test_clears_last_error_on_ready(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.record_attempt_error(db_session, row.id, error="boom")
+        await db_session.commit()
+
+        await log_outbox.mark_ready(
+            db_session, row.id, blob_path="x/y.tar.gz", size_bytes=1,
+        )
+        await db_session.commit()
+
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.last_error is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_transition_terminal_rows(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_failed(db_session, row.id, error="fatal")
+        await db_session.commit()
+
+        ok = await log_outbox.mark_ready(
+            db_session, row.id, blob_path="x/y.tar.gz", size_bytes=1,
+        )
+        await db_session.commit()
+
+        assert ok is False
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_FAILED
+
+
+# ── mark_failed ──
+
+class TestMarkFailed:
+    @pytest.mark.asyncio
+    async def test_transitions_pending_to_failed(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        ok = await log_outbox.mark_failed(db_session, row.id, error="device offline")
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_FAILED
+        assert refreshed.last_error == "device offline"
+
+    @pytest.mark.asyncio
+    async def test_transitions_sent_to_failed(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_sent(db_session, row.id)
+        await db_session.commit()
+
+        ok = await log_outbox.mark_failed(db_session, row.id, error="upload timed out")
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_FAILED
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_ready(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_ready(
+            db_session, row.id, blob_path="x/y", size_bytes=1,
+        )
+        await db_session.commit()
+
+        ok = await log_outbox.mark_failed(db_session, row.id, error="late")
+        await db_session.commit()
+
+        assert ok is False
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_READY
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_error_messages(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        long_err = "x" * 5000
+        await log_outbox.mark_failed(db_session, row.id, error=long_err)
+        await db_session.commit()
+
+        refreshed = await _reload(db_session, row.id)
+        assert len(refreshed.last_error) == 2000
+
+
+# ── mark_expired ──
+
+class TestMarkExpired:
+    @pytest.mark.asyncio
+    async def test_transitions_pending_to_expired(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        ok = await log_outbox.mark_expired(db_session, row.id)
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_EXPIRED
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_terminal_rows(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_ready(
+            db_session, row.id, blob_path="x/y", size_bytes=1,
+        )
+        await db_session.commit()
+
+        ok = await log_outbox.mark_expired(db_session, row.id)
+        await db_session.commit()
+
+        assert ok is False
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_READY
+
+
+# ── record_attempt_error ──
+
+class TestRecordAttemptError:
+    @pytest.mark.asyncio
+    async def test_bumps_attempts_and_stores_error_without_status_change(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        ok = await log_outbox.record_attempt_error(
+            db_session, row.id, error="transport unavailable",
+        )
+        await db_session.commit()
+
+        assert ok is True
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.status == STATUS_PENDING  # unchanged
+        assert refreshed.attempts == 1
+        assert refreshed.last_error == "transport unavailable"
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_non_pending_rows(self, db_session, _device):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_sent(db_session, row.id)
+        await db_session.commit()
+
+        ok = await log_outbox.record_attempt_error(
+            db_session, row.id, error="should be ignored",
+        )
+        await db_session.commit()
+
+        assert ok is False
+        refreshed = await _reload(db_session, row.id)
+        assert refreshed.last_error is None
+        assert refreshed.attempts == 1  # only from mark_sent
+
+
+# ── list_pending ──
+
+class TestListPending:
+    @pytest.mark.asyncio
+    async def test_returns_pending_rows_in_created_order(self, db_session, _device):
+        r1 = await log_outbox.create(db_session, device_id=_device.id)
+        r2 = await log_outbox.create(db_session, device_id=_device.id)
+        r3 = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        pending = await log_outbox.list_pending(db_session)
+        ids = [r.id for r in pending]
+        assert ids == [r1.id, r2.id, r3.id]
+
+    @pytest.mark.asyncio
+    async def test_excludes_non_pending_rows(self, db_session, _device):
+        r1 = await log_outbox.create(db_session, device_id=_device.id)
+        r2 = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_sent(db_session, r1.id)
+        await db_session.commit()
+
+        pending = await log_outbox.list_pending(db_session)
+        assert [r.id for r in pending] == [r2.id]
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, db_session, _device):
+        for _ in range(5):
+            await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        pending = await log_outbox.list_pending(db_session, limit=2)
+        assert len(pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_filters_exhausted_rows(self, db_session, _device):
+        r1 = await log_outbox.create(db_session, device_id=_device.id)
+        r2 = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        # Simulate r1 having hit the retry budget.
+        await log_outbox.record_attempt_error(db_session, r1.id, error="e")
+        await log_outbox.record_attempt_error(db_session, r1.id, error="e")
+        await log_outbox.record_attempt_error(db_session, r1.id, error="e")
+        await db_session.commit()
+
+        pending = await log_outbox.list_pending(db_session, max_attempts=3)
+        ids = [r.id for r in pending]
+        assert r2.id in ids
+        assert r1.id not in ids
+
+
+# ── list_expired ──
+
+class TestListExpired:
+    @pytest.mark.asyncio
+    async def test_returns_rows_past_expiry(self, db_session, _device):
+        # Past expiry
+        r1 = await log_outbox.create(
+            db_session, device_id=_device.id, expires_in=timedelta(seconds=-1),
+        )
+        # Future expiry
+        r2 = await log_outbox.create(
+            db_session, device_id=_device.id, expires_in=timedelta(days=30),
+        )
+        # No expiry
+        await log_outbox.create(
+            db_session, device_id=_device.id, expires_in=None,
+        )
+        await db_session.commit()
+
+        expired = await log_outbox.list_expired(db_session)
+        ids = [r.id for r in expired]
+        assert r1.id in ids
+        assert r2.id not in ids
+
+    @pytest.mark.asyncio
+    async def test_excludes_null_expires_at(self, db_session, _device):
+        await log_outbox.create(
+            db_session, device_id=_device.id, expires_in=None,
+        )
+        await db_session.commit()
+
+        expired = await log_outbox.list_expired(db_session)
+        assert expired == []
+
+
+# ── list_for_device ──
+
+class TestListForDevice:
+    @pytest.mark.asyncio
+    async def test_filters_by_device_and_sorts_newest_first(self, db_session, _device):
+        # Second device so we can assert filtering.
+        other = Device(id="d-other", name="Other", status=DeviceStatus.ADOPTED)
+        db_session.add(other)
+        await db_session.commit()
+
+        r1 = await log_outbox.create(db_session, device_id=_device.id)
+        await log_outbox.create(db_session, device_id=other.id)
+        r3 = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+
+        rows = await log_outbox.list_for_device(db_session, _device.id)
+        ids = [r.id for r in rows]
+        assert ids == [r3.id, r1.id]
+
+
+# ── count_by_status ──
+
+class TestCountByStatus:
+    @pytest.mark.asyncio
+    async def test_returns_counts_per_status(self, db_session, _device):
+        r1 = await log_outbox.create(db_session, device_id=_device.id)
+        r2 = await log_outbox.create(db_session, device_id=_device.id)
+        r3 = await log_outbox.create(db_session, device_id=_device.id)
+        await db_session.commit()
+        await log_outbox.mark_sent(db_session, r1.id)
+        await log_outbox.mark_ready(db_session, r1.id, blob_path="x", size_bytes=1)
+        await log_outbox.mark_failed(db_session, r2.id, error="e")
+        await db_session.commit()
+
+        counts = await log_outbox.count_by_status(db_session)
+        assert counts.get(STATUS_READY) == 1
+        assert counts.get(STATUS_FAILED) == 1
+        assert counts.get(STATUS_PENDING) == 1

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -205,20 +205,23 @@ class TestDashboardJsonTemperature:
 class TestWebSocketStatusTemperature:
     """Test that cpu_temp_c sent via WebSocket STATUS is tracked correctly."""
 
-    async def test_status_message_tracks_cpu_temp(self, app, db_session):
+    async def test_status_message_tracks_cpu_temp(self, app):
         """Send a STATUS message with cpu_temp_c and verify device_manager stores it."""
         token = "temp-test-token"
         token_hash = hashlib.sha256(token.encode()).hexdigest()
 
-        device = Device(
-            id="ws-temp-001",
-            name="WS Temp Device",
-            status=DeviceStatus.ADOPTED,
-            device_auth_token_hash=token_hash,
-        )
-        db_session.add(device)
-        await db_session.commit()
-        await db_session.close()
+        from shared.database import get_session_factory
+        factory = get_session_factory()
+
+        async with factory() as setup_db:
+            device = Device(
+                id="ws-temp-001",
+                name="WS Temp Device",
+                status=DeviceStatus.ADOPTED,
+                device_auth_token_hash=token_hash,
+            )
+            setup_db.add(device)
+            await setup_db.commit()
 
         from starlette.testclient import TestClient
 
@@ -276,20 +279,23 @@ class TestWebSocketStatusTemperature:
                 assert row_mode == "play"
                 assert row_temp == 73.2
 
-    async def test_status_without_cpu_temp_stays_none(self, app, db_session):
+    async def test_status_without_cpu_temp_stays_none(self, app):
         """A STATUS message without cpu_temp_c should leave it as None."""
         token = "temp-test-token2"
         token_hash = hashlib.sha256(token.encode()).hexdigest()
 
-        device = Device(
-            id="ws-temp-002",
-            name="WS No Temp Device",
-            status=DeviceStatus.ADOPTED,
-            device_auth_token_hash=token_hash,
-        )
-        db_session.add(device)
-        await db_session.commit()
-        await db_session.close()
+        from shared.database import get_session_factory
+        factory = get_session_factory()
+
+        async with factory() as setup_db:
+            device = Device(
+                id="ws-temp-002",
+                name="WS No Temp Device",
+                status=DeviceStatus.ADOPTED,
+                device_auth_token_hash=token_hash,
+            )
+            setup_db.add(device)
+            await setup_db.commit()
 
         from starlette.testclient import TestClient
 


### PR DESCRIPTION
## Stage 3a — Log outbox schema + helpers

First PR of the Stage 3 multi-replica log-collection rework.  Purely additive: introduces the durable outbox that backs the multi-replica-safe `request_logs` flow; **nothing calls the new helpers yet.**

Subsequent PRs in the Stage 3 chain (all tracked under #345):
- **3b** — async API (`POST /api/logs/requests`, `GET /api/logs/requests/{id}`) + CMS-side upload endpoint. Keeps a back-compat shim for the legacy `LOGS_RESPONSE` path.
- **3c** — Pi-side upload (gzipped journal → `POST …/upload`), OTA rollout.
- **3d** — drainer loop on every replica (`SKIP LOCKED`) dispatching `REQUEST_LOGS` from the outbox.
- **3e** — remove `_pending_log_requests` map + legacy `LOGS_RESPONSE` handler; add the reaper.

### What's in this PR

| File | Purpose |
|---|---|
| `alembic/versions/0005_log_requests_table.py` | New `log_requests` table (id, device_id, services, since, status, attempts, sent_at, ready_at, blob_path, size_bytes, expires_at, created/updated_at) with indexes on `(status, created_at)`, `(device_id, created_at)`, and a partial index on `expires_at`. `fillfactor=80` for HOT updates. |
| `cms/models/log_request.py` | ORM model + `STATUS_*` constants + `TERMINAL_STATUSES` set. |
| `cms/services/log_outbox.py` | Atomic helpers: `create`, `get`, `mark_sent`, `mark_ready`, `mark_failed`, `mark_expired`, `record_attempt_error`, `list_pending`, `list_expired`, `list_for_device`, `count_by_status`. None commit — callers own the transaction. |
| `tests/test_log_outbox.py` | 30 unit tests covering every helper + guard conditions (no overwriting terminal rows, attempts not bumped on duplicate `mark_sent`, `list_expired` respects `NULL` expiry, etc.). |
| `tests/conftest.py` | Adds `LogRequest.services` to the SQLite JSONB → JSON patch set. |
| `cms/models/__init__.py` | Exports `LogRequest`. |

### Lifecycle (enforced at the helper layer)

```
pending ─► sent ─► ready
             └─► failed
             └─► expired
```

- `mark_sent` is a no-op unless the row is `pending` — safe against the drainer race two replicas might hit on non-Postgres backends (Postgres gets `SKIP LOCKED` in Stage 3d).
- `mark_ready` accepts both `pending → ready` (back-compat shim for Stage 3b legacy path) and `sent → ready` (normal Stage 3c+ flow).
- `mark_failed` refuses to touch terminal rows; `mark_expired` same.
- `record_attempt_error` bumps `attempts` and stores the latest error without changing status — drainer's retry path.

### Observability hook

`count_by_status()` returns `{status: count}` aggregated over the whole table.  Stage 4's smoke-test gate will read this to assert the drainer is keeping up before enabling N>1 replicas in prod.

### Design rationale

- **Strings, not Postgres enum**, for `status`: adding a new state (e.g. `awaiting_upload`) in a future stage should not require a migration.
- **Helpers don't commit**: lets routers batch the outbox write with audit writes and lets the drainer batch status updates. Tests use `db.expire_all()` to force a re-read after bulk UPDATE — documented in the `_reload` fixture helper.
- **30-day default retention** (`DEFAULT_RETENTION`) matches the arch doc; callers can opt out with `expires_in=None`.
- **`services` stored as JSONB** (Postgres) / `JSON` (SQLite tests) — matches the shape of the existing `REQUEST_LOGS` wire message and avoids string parsing.

### Tests

```
tests/test_log_outbox.py ............................ 30 passed
tests/test_device_presence.py ...................... 29 passed
tests/test_device_logs.py ........................... 14 passed
tests/test_wps_webhook.py ............................ 4 passed
tests/test_device_transport_contract.py .............. 3 passed
tests/test_wps_transport.py .......................... 3 passed
tests/test_migration_policy.py ...................... 19 passed
```

No existing behaviour touched.

Refs #345.
