### PR TITLE
fix(devices): await async transport calls in get_group_panel

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -894,9 +894,10 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     ) or 0
 
     from cms.services.version_checker import is_update_available
-    live_states = {s["device_id"]: s for s in get_transport().get_all_states()}
+    transport = get_transport()
+    live_states = {s["device_id"]: s for s in await transport.get_all_states()}
     for d in group.devices:
-        d.is_online = get_transport().is_connected(d.id)
+        d.is_online = await transport.is_connected(d.id)
         state = live_states.get(d.id)
         d.cpu_temp_c = state["cpu_temp_c"] if state else None
         d.ip_address = state["ip_address"] if state else None


### PR DESCRIPTION
The `/api/devices/groups/{id}/panel` endpoint added in #383 calls `get_transport().get_all_states()` and `is_connected()` synchronously. Stage 2c (#382) converted both to async (DB-backed), but #383 was authored and CI'd before 2c merged, so the breakage slipped in.

`main`'s push workflow only runs Secrets/Smoke/Deploy (no e2e/unit tests), so the regression wasn't caught until the next PR. It makes 3 group-create e2e tests fail deterministically:
- `test_ui_devices.py::TestDevicesPage::test_create_device_group`
- `test_ui_devices_no_reload.py::TestDevicesNoReload::test_create_group_no_reload`
- `test_ui_cross_session.py::TestGroupsCrossSession::test_create_propagates`

All three fail the same way: panel fetch blows up server-side (`coroutine object is not iterable`), `createGroup` can't insert the panel, UI never renders the new group.

**Fix:** add the missing `await`s and cache `get_transport()` in a local. All other call sites in the repo already await these methods correctly (verified via grep).

Stage 3a PR #384 was blocked by this; rebasing it will be trivial once this lands.