### PR TITLE
feat(ui): remove location.reload() from users & roles handlers (#87)

### DIFF
--- a/cms/routers/roles.py
+++ b/cms/routers/roles.py
@@ -38,6 +38,37 @@ async def get_role(
     return role
 
 
+@router.get("/{role_id}/card", dependencies=[Depends(require_permission(ROLES_READ))])
+async def get_role_card(
+    role_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the rendered <div class="role-card"> HTML for a single role.
+
+    Used by the no-reload flows on the /users page Roles tab (create,
+    update, and the cross-session poller) so the client never has to
+    synthesize card markup in JS. See issue #87.
+    """
+    from fastapi.responses import HTMLResponse
+    from cms.permissions import PERMISSION_DESCRIPTIONS
+    from cms.ui import templates
+
+    result = await db.execute(select(Role).where(Role.id == role_id))
+    role = result.scalar_one_or_none()
+    if not role:
+        raise HTTPException(status_code=404, detail="Role not found")
+
+    actor = getattr(request.state, "user", None)
+    can_write_roles = bool(
+        actor and actor.role and ROLES_WRITE in actor.role.permissions
+    )
+
+    macros = templates.env.get_template("_macros.html").module
+    html = macros.role_card(role, PERMISSION_DESCRIPTIONS, can_write_roles)
+    return HTMLResponse(str(html))
+
+
 @router.post("", response_model=RoleRead, status_code=201)
 async def create_role(
     data: RoleCreate,

--- a/cms/routers/users.py
+++ b/cms/routers/users.py
@@ -110,6 +110,37 @@ async def get_user(
     return _user_to_read(user, gids)
 
 
+@router.get("/{user_id}/row", dependencies=[Depends(require_permission(USERS_READ))])
+async def get_user_row(
+    user_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the rendered <tr> HTML for a single user.
+
+    Used by the no-reload flows on the /users page (create, update,
+    toggle-active, and the cross-session poller) so the client never
+    has to synthesize row markup in JS. See issue #87.
+    """
+    from fastapi.responses import HTMLResponse
+    from cms.ui import templates
+
+    result = await db.execute(
+        select(User).options(selectinload(User.role)).where(User.id == user_id)
+    )
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    actor = getattr(request.state, "user", None)
+    can_write = bool(actor and actor.role and USERS_WRITE in actor.role.permissions)
+    current_user_id = str(actor.id) if actor else ""
+
+    macros = templates.env.get_template("_macros.html").module
+    html = macros.user_row(user, current_user_id, can_write)
+    return HTMLResponse(str(html))
+
+
 @router.post("", response_model=UserRead, status_code=201)
 async def create_user(
     data: UserCreate,

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1925,6 +1925,72 @@ function closeModal(id) {
     document.getElementById(id).style.display = 'none';
 }
 
+// ── Users/Roles fragment helpers (issue #87 no-reload) ──
+// Fetch the server-rendered <tr> / .role-card HTML for a single
+// entity and insert or replace it in-place. Mirrors the
+// _insertAssetRow / _replaceAssetDetailRow / _insertGroupPanel
+// pattern used for the other pages.
+
+async function _insertUserRow(userId) {
+    const resp = await fetch(`/api/users/${userId}/row`);
+    if (!resp.ok) return false;
+    const html = (await resp.text()).trim();
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    const newRow = tpl.content.querySelector(`tr[data-user-id="${userId}"]`);
+    if (!newRow) return false;
+    const existing = document.querySelector(`tr[data-user-id="${userId}"]`);
+    if (existing) {
+        existing.replaceWith(newRow);
+    } else {
+        const tbody = document.querySelector('[data-users-tbody]');
+        if (!tbody) return false;
+        tbody.appendChild(newRow);
+    }
+    return true;
+}
+window._insertUserRow = _insertUserRow;
+
+async function _insertRoleCard(roleId) {
+    const resp = await fetch(`/api/roles/${roleId}/card`);
+    if (!resp.ok) return false;
+    const html = (await resp.text()).trim();
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    const newCard = tpl.content.querySelector(`.role-card[data-role-id="${roleId}"]`);
+    if (!newCard) return false;
+    const existing = document.querySelector(`.role-card[data-role-id="${roleId}"]`);
+    if (existing) {
+        existing.replaceWith(newCard);
+    } else {
+        const list = document.querySelector('[data-roles-list]');
+        if (!list) return false;
+        list.appendChild(newCard);
+    }
+    return true;
+}
+window._insertRoleCard = _insertRoleCard;
+
+function _updateUsersCount(delta) {
+    const el = document.querySelector('[data-users-count]');
+    if (!el) return;
+    const n = parseInt(el.textContent, 10) || 0;
+    el.textContent = Math.max(0, n + delta);
+}
+
+function _updateRolesCount(delta) {
+    const el = document.querySelector('[data-roles-count]');
+    if (!el) return;
+    const n = parseInt(el.textContent, 10) || 0;
+    el.textContent = Math.max(0, n + delta);
+}
+
+function _resetForm(form) {
+    if (!form) return;
+    form.reset();
+    form.querySelectorAll('button[type="submit"]').forEach(b => { b.disabled = true; });
+}
+
 async function createUser(form) {
     const data = new FormData(form);
     const groupIds = data.getAll("group_ids");
@@ -1937,7 +2003,21 @@ async function createUser(form) {
     const resp = await apiCall("POST", "/api/users", body);
     if (resp && resp.ok) {
         showToast("User created — welcome email sent (if SMTP configured)");
-        location.reload();
+        const created = await resp.json().catch(() => null);
+        if (created && created.id) {
+            const uid = String(created.id);
+            usersData[uid] = {
+                email: created.email,
+                display_name: created.display_name || '',
+                role_id: created.role_id,
+                is_active: created.is_active,
+                group_ids: (created.group_ids || []).map(String),
+            };
+            if (window._rememberUser) window._rememberUser(uid);
+            const ok = await _insertUserRow(uid);
+            if (ok) _updateUsersCount(+1);
+        }
+        _resetForm(form);
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);
@@ -2010,7 +2090,19 @@ async function updateUser(form) {
         const resp = await apiCall("PATCH", `/api/users/${userId}`, body);
         if (resp && resp.ok) {
             showToast("User updated");
-            location.reload();
+            const updated = await resp.json().catch(() => null);
+            if (updated) {
+                const uid = String(userId);
+                usersData[uid] = {
+                    email: updated.email,
+                    display_name: updated.display_name || '',
+                    role_id: updated.role_id,
+                    is_active: updated.is_active,
+                    group_ids: (updated.group_ids || []).map(String),
+                };
+            }
+            await _insertUserRow(userId);
+            closeModal('edit-user-modal');
         } else if (resp) {
             const err = await resp.json().catch(() => ({}));
             showToast(err.detail || `Error: ${resp.status}`, true);
@@ -2025,7 +2117,12 @@ async function deleteUser(userId, email) {
     const resp = await apiCall("DELETE", `/api/users/${userId}`);
     if (resp && resp.ok) {
         showToast("User deleted");
-        location.reload();
+        const uid = String(userId);
+        const row = document.querySelector(`tr[data-user-id="${uid}"]`);
+        if (row) row.remove();
+        delete usersData[uid];
+        if (window._forgetUser) window._forgetUser(uid);
+        _updateUsersCount(-1);
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);
@@ -2036,7 +2133,9 @@ async function toggleUserActive(userId, active) {
     const resp = await apiCall("PATCH", `/api/users/${userId}`, { is_active: active });
     if (resp && resp.ok) {
         showToast(active ? "User enabled" : "User disabled");
-        location.reload();
+        const uid = String(userId);
+        if (usersData[uid]) usersData[uid].is_active = active;
+        await _insertUserRow(userId);
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);
@@ -2054,7 +2153,29 @@ async function createRole(form) {
     const resp = await apiCall("POST", "/api/roles", body);
     if (resp && resp.ok) {
         showToast("Role created");
-        location.reload();
+        const created = await resp.json().catch(() => null);
+        if (created && created.id) {
+            const rid = String(created.id);
+            rolesData[rid] = {
+                name: created.name,
+                description: created.description || '',
+                permissions: created.permissions,
+            };
+            if (window._rememberRole) window._rememberRole(rid);
+            const ok = await _insertRoleCard(rid);
+            if (ok) _updateRolesCount(+1);
+            // Also append a new <option> to every role <select> so the
+            // just-created role is usable immediately without a reload.
+            document.querySelectorAll('select[name="role_id"]').forEach(sel => {
+                if (!sel.querySelector(`option[value="${rid}"]`)) {
+                    const opt = document.createElement('option');
+                    opt.value = rid;
+                    opt.textContent = created.name;
+                    sel.appendChild(opt);
+                }
+            });
+        }
+        _resetForm(form);
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);
@@ -2086,7 +2207,22 @@ async function updateRole(form) {
     const resp = await apiCall("PATCH", `/api/roles/${roleId}`, body);
     if (resp && resp.ok) {
         showToast("Role updated");
-        location.reload();
+        const updated = await resp.json().catch(() => null);
+        if (updated) {
+            const rid = String(roleId);
+            rolesData[rid] = {
+                name: updated.name,
+                description: updated.description || '',
+                permissions: updated.permissions,
+            };
+            // Update the role's label in every role <select> so changes
+            // propagate without a reload.
+            document.querySelectorAll(`select[name="role_id"] option[value="${rid}"]`).forEach(opt => {
+                opt.textContent = updated.name;
+            });
+        }
+        await _insertRoleCard(roleId);
+        closeModal('edit-role-modal');
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);
@@ -2098,7 +2234,13 @@ async function deleteRole(roleId, roleName) {
     const resp = await apiCall("DELETE", `/api/roles/${roleId}`);
     if (resp && resp.ok) {
         showToast("Role deleted");
-        location.reload();
+        const rid = String(roleId);
+        const card = document.querySelector(`.role-card[data-role-id="${rid}"]`);
+        if (card) card.remove();
+        delete rolesData[rid];
+        if (window._forgetRole) window._forgetRole(rid);
+        _updateRolesCount(-1);
+        document.querySelectorAll(`select[name="role_id"] option[value="${rid}"]`).forEach(opt => opt.remove());
     } else if (resp) {
         const err = await resp.json();
         showToast(extractErrorMsg(err), true);

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -552,3 +552,88 @@
     </div>
 </div>
 {%- endmacro %}
+
+
+{#
+  User row (users page, Users tab). Shared between the full page render
+  and the GET /api/users/{id}/row fragment endpoint so both paths emit
+  identical markup — see issue #87. Row carries data-user-id so the
+  poller and action handlers can locate/swap/remove it.
+#}
+{% macro user_row(u, current_user_id, can_write) -%}
+<tr data-user-id="{{ u.id }}" class="{% if not u.is_active %}row-inactive{% endif %}">
+    <td><strong>{{ u.email }}</strong></td>
+    <td>{{ u.display_name or '—' }}</td>
+    <td>
+        {% if u.role %}
+        <span class="badge badge-role {% if u.role.name == 'Admin' %}badge-role-admin{% elif u.role.name == 'Operator' %}badge-role-operator{% elif u.role.name == 'Viewer' %}badge-role-viewer{% endif %}">{{ u.role.name }}</span>
+        {% else %}
+        <span class="badge badge-offline">No role</span>
+        {% endif %}
+    </td>
+    <td>
+        {% if u.is_active %}
+        <span class="badge badge-online">Active</span>
+        {% else %}
+        <span class="badge badge-offline">Inactive</span>
+        {% endif %}
+    </td>
+    <td>
+        {% if u.last_login_at %}
+        <span data-utc="{{ u.last_login_at.isoformat() }}">{{ u.last_login_at.strftime('%Y-%m-%d %H:%M') }}</span>
+        {% else %}
+        <span class="text-muted">Never</span>
+        {% endif %}
+    </td>
+    {% if can_write %}
+    <td class="actions-cell">
+        {% call kebab_menu() %}
+            <button type="button" role="menuitem" onclick="openEditUser('{{ u.id }}')">Edit</button>
+            {% if u.must_change_password %}
+            <button type="button" role="menuitem" onclick="resendInvite('{{ u.id }}', '{{ u.email }}')">Resend Invite</button>
+            {% endif %}
+            {% if u.id | string != current_user_id %}
+                {% if u.is_active %}
+                <button type="button" role="menuitem" onclick="toggleUserActive('{{ u.id }}', false)">Disable</button>
+                {% else %}
+                <button type="button" role="menuitem" onclick="toggleUserActive('{{ u.id }}', true)">Enable</button>
+                {% endif %}
+                <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteUser('{{ u.id }}', '{{ u.email }}')">Delete</button>
+            {% endif %}
+        {% endcall %}
+    </td>
+    {% endif %}
+</tr>
+{%- endmacro %}
+
+
+{#
+  Role card (users page, Roles tab). Shared between the full page render
+  and the GET /api/roles/{id}/card fragment endpoint — see issue #87.
+  Card carries data-role-id so the poller and action handlers can
+  locate/swap/remove it.
+#}
+{% macro role_card(role, perm_descriptions, can_write_roles) -%}
+<div class="role-card" data-role-id="{{ role.id }}">
+    <div class="role-header">
+        <div>
+            <strong>{{ role.name }}</strong>
+            {% if role.is_builtin %}<span class="badge badge-builtin">Built-in</span>{% endif %}
+            <span class="text-muted"> — {{ role.description }}</span>
+        </div>
+        {% if can_write_roles and not role.is_builtin %}
+        <div class="role-actions">
+            {% call kebab_menu() %}
+                <button type="button" role="menuitem" onclick="openEditRole('{{ role.id }}')">Edit</button>
+                <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteRole('{{ role.id }}', '{{ role.name }}')">Delete</button>
+            {% endcall %}
+        </div>
+        {% endif %}
+    </div>
+    <div class="role-permissions">
+        {% for perm in role.permissions %}
+        <span class="perm-tag has-tooltip">{{ perm }}<span class="tooltip">{{ perm_descriptions.get(perm, perm) }}</span></span>
+        {% endfor %}
+    </div>
+</div>
+{%- endmacro %}

--- a/cms/templates/users.html
+++ b/cms/templates/users.html
@@ -57,7 +57,7 @@
 {% endif %}
 
 <div class="card">
-    <h3>Users ({{ users | length }})</h3>
+    <h3 data-users-count-container>Users (<span data-users-count>{{ users | length }}</span>)</h3>
     {% if users %}
     <table>
         <thead>
@@ -70,56 +70,14 @@
                 {% if can_write %}<th>Actions</th>{% endif %}
             </tr>
         </thead>
-        <tbody>
+        <tbody data-users-tbody>
             {% for u in users %}
-            <tr class="{% if not u.is_active %}row-inactive{% endif %}">
-                <td><strong>{{ u.email }}</strong></td>
-                <td>{{ u.display_name or '—' }}</td>
-                <td>
-                    {% if u.role %}
-                    <span class="badge badge-role {% if u.role.name == 'Admin' %}badge-role-admin{% elif u.role.name == 'Operator' %}badge-role-operator{% elif u.role.name == 'Viewer' %}badge-role-viewer{% endif %}">{{ u.role.name }}</span>
-                    {% else %}
-                    <span class="badge badge-offline">No role</span>
-                    {% endif %}
-                </td>
-                <td>
-                    {% if u.is_active %}
-                    <span class="badge badge-online">Active</span>
-                    {% else %}
-                    <span class="badge badge-offline">Inactive</span>
-                    {% endif %}
-                </td>
-                <td>
-                    {% if u.last_login_at %}
-                    <span data-utc="{{ u.last_login_at.isoformat() }}">{{ u.last_login_at.strftime('%Y-%m-%d %H:%M') }}</span>
-                    {% else %}
-                    <span class="text-muted">Never</span>
-                    {% endif %}
-                </td>
-                {% if can_write %}
-                <td class="actions-cell">
-                    {% call macros.kebab_menu() %}
-                        <button type="button" role="menuitem" onclick="openEditUser('{{ u.id }}')">Edit</button>
-                        {% if u.must_change_password %}
-                        <button type="button" role="menuitem" onclick="resendInvite('{{ u.id }}', '{{ u.email }}')">Resend Invite</button>
-                        {% endif %}
-                        {% if u.id | string != current_user_id %}
-                            {% if u.is_active %}
-                            <button type="button" role="menuitem" onclick="toggleUserActive('{{ u.id }}', false)">Disable</button>
-                            {% else %}
-                            <button type="button" role="menuitem" onclick="toggleUserActive('{{ u.id }}', true)">Enable</button>
-                            {% endif %}
-                            <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteUser('{{ u.id }}', '{{ u.email }}')">Delete</button>
-                        {% endif %}
-                    {% endcall %}
-                </td>
-                {% endif %}
-            </tr>
+            {{ macros.user_row(u, current_user_id, can_write) }}
             {% endfor %}
         </tbody>
     </table>
     {% else %}
-    <p class="text-muted">No users found.</p>
+    <p class="text-muted" data-users-empty>No users found.</p>
     {% endif %}
 </div>
 </div>
@@ -175,34 +133,15 @@
 {% endif %}
 
 <div class="card">
-    <h3>Roles ({{ roles | length }})</h3>
+    <h3 data-roles-count-container>Roles (<span data-roles-count>{{ roles | length }}</span>)</h3>
     {% if roles %}
+    <div data-roles-list>
     {% for role in roles %}
-    <div class="role-card">
-        <div class="role-header">
-            <div>
-                <strong>{{ role.name }}</strong>
-                {% if role.is_builtin %}<span class="badge badge-builtin">Built-in</span>{% endif %}
-                <span class="text-muted"> — {{ role.description }}</span>
-            </div>
-            {% if can_write_roles and not role.is_builtin %}
-            <div class="role-actions">
-                {% call macros.kebab_menu() %}
-                    <button type="button" role="menuitem" onclick="openEditRole('{{ role.id }}')">Edit</button>
-                    <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteRole('{{ role.id }}', '{{ role.name }}')">Delete</button>
-                {% endcall %}
-            </div>
-            {% endif %}
-        </div>
-        <div class="role-permissions">
-            {% for perm in role.permissions %}
-            <span class="perm-tag has-tooltip">{{ perm }}<span class="tooltip">{{ perm_descriptions.get(perm, perm) }}</span></span>
-            {% endfor %}
-        </div>
-    </div>
+    {{ macros.role_card(role, perm_descriptions, can_write_roles) }}
     {% endfor %}
+    </div>
     {% else %}
-    <p class="text-muted">No roles defined.</p>
+    <p class="text-muted" data-roles-empty>No roles defined.</p>
     {% endif %}
 </div>
 </div>
@@ -490,5 +429,102 @@ async function resendInvite(userId, email) {
         showToast('Failed to resend invite', 'error');
     }
 }
+
+// ── Cross-session pollers ──
+// 5s poll on both tabs so a user/role added or removed in another
+// session (or CMS replica) becomes visible without a full reload.
+// See issue #87.
+(function() {
+    const CURRENT_USER_ID = {{ current_user_id | tojson }};
+    const knownUserIds = new Set({{ users | map(attribute='id') | map('string') | list | tojson }});
+    const knownRoleIds = new Set({{ roles | map(attribute='id') | map('string') | list | tojson }});
+
+    window._rememberUser = function(id) { knownUserIds.add(String(id)); };
+    window._forgetUser = function(id) { knownUserIds.delete(String(id)); };
+    window._rememberRole = function(id) { knownRoleIds.add(String(id)); };
+    window._forgetRole = function(id) { knownRoleIds.delete(String(id)); };
+
+    function _setUsersCount(n) {
+        const el = document.querySelector('[data-users-count]');
+        if (el) el.textContent = n;
+    }
+    function _setRolesCount(n) {
+        const el = document.querySelector('[data-roles-count]');
+        if (el) el.textContent = n;
+    }
+
+    async function pollUsersOnce() {
+        let remote;
+        try {
+            const resp = await fetch('/api/users');
+            if (!resp.ok) return;
+            remote = await resp.json();
+        } catch (e) { return; }
+
+        const remoteIds = new Set(remote.map(u => String(u.id)));
+
+        // Additions → fetch row fragment + hydrate usersData.
+        for (const u of remote) {
+            const uid = String(u.id);
+            if (knownUserIds.has(uid)) continue;
+            knownUserIds.add(uid);
+            usersData[uid] = {
+                email: u.email,
+                display_name: u.display_name || '',
+                role_id: u.role_id,
+                is_active: u.is_active,
+                group_ids: (u.group_ids || []).map(String),
+            };
+            await window._insertUserRow(uid);
+        }
+
+        // Deletions → remove row (skip the current user's own row).
+        for (const uid of Array.from(knownUserIds)) {
+            if (remoteIds.has(uid) || uid === CURRENT_USER_ID) continue;
+            knownUserIds.delete(uid);
+            delete usersData[uid];
+            const row = document.querySelector(`tr[data-user-id="${uid}"]`);
+            if (row) row.remove();
+        }
+
+        _setUsersCount(knownUserIds.size);
+    }
+
+    async function pollRolesOnce() {
+        let remote;
+        try {
+            const resp = await fetch('/api/roles');
+            if (!resp.ok) return;
+            remote = await resp.json();
+        } catch (e) { return; }
+
+        const remoteIds = new Set(remote.map(r => String(r.id)));
+
+        for (const r of remote) {
+            const rid = String(r.id);
+            if (knownRoleIds.has(rid)) continue;
+            knownRoleIds.add(rid);
+            rolesData[rid] = {
+                name: r.name,
+                description: r.description || '',
+                permissions: r.permissions,
+            };
+            await window._insertRoleCard(rid);
+        }
+
+        for (const rid of Array.from(knownRoleIds)) {
+            if (remoteIds.has(rid)) continue;
+            knownRoleIds.delete(rid);
+            delete rolesData[rid];
+            const card = document.querySelector(`.role-card[data-role-id="${rid}"]`);
+            if (card) card.remove();
+        }
+
+        _setRolesCount(knownRoleIds.size);
+    }
+
+    setInterval(pollUsersOnce, 5000);
+    setInterval(pollRolesOnce, 5000);
+})();
 </script>
 {% endblock %}

--- a/pr_body_users_roles.md
+++ b/pr_body_users_roles.md
@@ -1,0 +1,49 @@
+## Summary
+
+Removes the last 7 `location.reload()` calls on the Users & Roles admin page (`/users`) as part of the issue #87 reload hunt. The page now uses the same server-rendered fragment + cross-session poller pattern we already applied to assets, profiles, schedules, and groups.
+
+## What changed
+
+**Fragment endpoints (new):**
+- `GET /api/users/{id}/row` — returns the rendered `<tr>` for a single user.
+- `GET /api/roles/{id}/card` — returns the rendered `<div class="role-card">` for a single role.
+
+Both scope permissions to `users:read` / `roles:read` and re-use the same macros the full page renders with, so HTML stays byte-identical.
+
+**Macros (`cms/templates/_macros.html`):**
+- Extracted the user-table `<tr>` into `user_row(u, current_user_id, can_write)`.
+- Extracted the role-list card into `role_card(role, perm_descriptions, can_write_roles)`.
+- Both add `data-user-id` / `data-role-id` anchors the poller and action handlers use.
+
+**`users.html`:**
+- Replaced inline row / card markup with macro calls.
+- Added `data-users-tbody`, `data-roles-list`, `data-users-count`, `data-roles-count` anchors.
+- Added two 5s pollers (`pollUsersOnce` / `pollRolesOnce`) that diff `/api/users` and `/api/roles` against the known-id sets and insert/remove via the fragment endpoints.
+
+**`app.js`:**
+- `createUser`, `updateUser`, `deleteUser`, `toggleUserActive` — no reload. Patch `usersData`, DOM-insert / replace / remove the row via `_insertUserRow`, close the modal, update the count.
+- `createRole`, `updateRole`, `deleteRole` — no reload. Patch `rolesData`, DOM-insert / replace / remove the card via `_insertRoleCard`, keep every `<select name="role_id">` in sync so a just-created role is immediately assignable.
+- New helpers: `_insertUserRow`, `_insertRoleCard`, `_updateUsersCount`, `_updateRolesCount`, `_resetForm`.
+
+## Why
+
+Before this PR, any admin-side user or role change full-page-reloaded the `/users` tab. That wiped open kebab menus, scroll position, and any other session state. It also meant changes from a second admin session or a second CMS replica weren't visible until the user manually refreshed. Both issues are fixed by the same fragment-endpoint + cross-session-poller pattern established by the earlier reload-hunt slices.
+
+## Tests
+
+**New unit tests:**
+- `tests/test_user_row_endpoint.py` — 2 tests: happy-path fragment rendering + 404.
+- `tests/test_role_card_endpoint.py` — 3 tests: happy-path, built-in role (no edit/delete), 404.
+
+**New cross-session e2e tests (`tests_e2e/test_ui_cross_session.py`):**
+- `TestUsersCrossSession::test_create_propagates` / `test_delete_propagates`.
+- `TestRolesCrossSession::test_create_propagates` / `test_delete_propagates`.
+
+Local subset (`tests/test_user_row_endpoint.py`, `tests/test_role_card_endpoint.py`, `tests/test_rbac.py -k "user_create or user_update or user_delete or role"`) all green; relying on CI for the full suite.
+
+## Not in scope
+
+- `dashboard.html` and `devices.html` still have `location.reload()` calls — both are blocked on the in-flight multi-CMS WSS / in-memory transport rewrite.
+- `schedules.html` / `app.js` schedules helpers, `profiles.html` fallbacks, and a couple of `app.js` device/asset defensive fallbacks still have reloads — planned follow-up slices.
+
+Closes part of #87.

--- a/tests/test_role_card_endpoint.py
+++ b/tests/test_role_card_endpoint.py
@@ -1,0 +1,48 @@
+"""Unit test for GET /api/roles/{id}/card — the HTML fragment endpoint
+used by the /users page Roles tab's no-reload flows (create, update)
+and the cross-session poller. See issue #87."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestRoleCardEndpoint:
+    async def test_card_returns_html_fragment(self, client):
+        create = await client.post("/api/roles", json={
+            "name": "CardFragmentRole",
+            "description": "role card fragment test",
+            "permissions": ["devices:read"],
+        })
+        assert create.status_code == 201, create.text
+        role_id = create.json()["id"]
+
+        resp = await client.get(f"/api/roles/{role_id}/card")
+        assert resp.status_code == 200
+        body = resp.text
+        # The card carries the role id so the poller can locate it.
+        assert f'data-role-id="{role_id}"' in body
+        # Name + description + permission tag render verbatim.
+        assert "CardFragmentRole" in body
+        assert "role card fragment test" in body
+        assert "devices:read" in body
+
+    async def test_card_builtin_role(self, client, db_session):
+        # Built-in roles must render without the kebab menu actions.
+        from sqlalchemy import select
+        from cms.models.user import Role
+        r = await db_session.execute(select(Role).where(Role.name == "Admin"))
+        role = r.scalar_one()
+
+        resp = await client.get(f"/api/roles/{role.id}/card")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Built-in" in body
+        # The kebab menu's Edit/Delete buttons shouldn't render for builtins.
+        assert 'onclick="openEditRole' not in body
+        assert 'onclick="deleteRole' not in body
+
+    async def test_card_unknown_id_404(self, client):
+        resp = await client.get(
+            "/api/roles/00000000-0000-0000-0000-000000000000/card"
+        )
+        assert resp.status_code == 404

--- a/tests/test_user_row_endpoint.py
+++ b/tests/test_user_row_endpoint.py
@@ -1,0 +1,57 @@
+"""Unit test for GET /api/users/{id}/row — the HTML fragment endpoint
+used by the /users page's no-reload flows (create, update, toggle
+active) and the cross-session poller. See issue #87."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.user import Role
+
+
+async def _get_role_id(db: AsyncSession, name: str) -> uuid.UUID:
+    r = await db.execute(select(Role).where(Role.name == name))
+    return r.scalar_one().id
+
+
+async def _seed_smtp(db: AsyncSession):
+    # create_user requires SMTP to be configured.
+    from cms.auth import set_setting
+    await set_setting(db, "smtp_host", "smtp.example.com")
+    await set_setting(db, "smtp_from_email", "noreply@example.com")
+    await db.commit()
+
+
+@pytest.mark.asyncio
+class TestUserRowEndpoint:
+    async def test_row_returns_html_fragment(self, client, db_session):
+        await _seed_smtp(db_session)
+        role_id = str(await _get_role_id(db_session, "Viewer"))
+
+        create = await client.post("/api/users", json={
+            "email": "rowfrag@test.com",
+            "display_name": "Row Fragment",
+            "role_id": role_id,
+            "group_ids": [],
+        })
+        assert create.status_code == 201, create.text
+        user_id = create.json()["id"]
+
+        resp = await client.get(f"/api/users/{user_id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        # The <tr> carries the user id so the poller can locate it.
+        assert f'data-user-id="{user_id}"' in body
+        # Email and display name are rendered verbatim.
+        assert "rowfrag@test.com" in body
+        assert "Row Fragment" in body
+        # Role badge appears.
+        assert "Viewer" in body
+
+    async def test_row_unknown_id_404(self, client):
+        resp = await client.get(
+            "/api/users/00000000-0000-0000-0000-000000000000/row"
+        )
+        assert resp.status_code == 404

--- a/tests_e2e/test_ui_cross_session.py
+++ b/tests_e2e/test_ui_cross_session.py
@@ -529,3 +529,139 @@ class TestGroupsCrossSession:
         expect(
             second_page.locator(f'.group-panel[data-group-id="{group_id}"]')
         ).to_have_count(0, timeout=POLL_TIMEOUT_MS + 8000)
+
+
+# ─────────────────────────── Users & Roles ────────────────────────────
+
+
+def _seed_smtp_via_api(api):
+    """Configure SMTP so /api/users POSTs don't hit the pre-flight gate."""
+    api.post("/api/settings/smtp", json={
+        "host": "smtp.example.com",
+        "port": 587,
+        "from_email": "noreply@example.com",
+        "username": "",
+    })
+
+
+def _get_role_id(api, name: str) -> str:
+    roles = api.get("/api/roles").json()
+    return next(r["id"] for r in roles if r["name"] == name)
+
+
+class TestUsersCrossSession:
+    """Cross-session visibility for the /users page Users tab.
+
+    Added as part of the #87 no-reload rework (users & roles slice):
+    session A creating/deleting a user used to require session B to
+    reload. Now session B's 5s user poller inserts the row via the
+    GET /api/users/{id}/row fragment and removes it on delete.
+    """
+
+    def test_create_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A creates a user → session B inserts the row inline."""
+        _seed_smtp_via_api(api)
+        viewer_id = _get_role_id(api, "Viewer")
+
+        page.goto("/users")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/users")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        resp = api.post("/api/users", json={
+            "email": "xsess-user-create@test.com",
+            "display_name": "Cross Session Create",
+            "role_id": viewer_id,
+            "group_ids": [],
+        })
+        assert resp.status_code == 201, resp.text
+        user_id = resp.json()["id"]
+
+        expect(
+            second_page.locator(f'tr[data-user-id="{user_id}"]')
+        ).to_be_visible(timeout=POLL_TIMEOUT_MS)
+
+    def test_delete_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A deletes a user → session B removes the row."""
+        _seed_smtp_via_api(api)
+        viewer_id = _get_role_id(api, "Viewer")
+
+        resp = api.post("/api/users", json={
+            "email": "xsess-user-delete@test.com",
+            "display_name": "Cross Session Delete",
+            "role_id": viewer_id,
+            "group_ids": [],
+        })
+        assert resp.status_code == 201, resp.text
+        user_id = resp.json()["id"]
+
+        page.goto("/users")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/users")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        expect(
+            second_page.locator(f'tr[data-user-id="{user_id}"]')
+        ).to_be_visible(timeout=5000)
+
+        del_resp = api.delete(f"/api/users/{user_id}")
+        assert del_resp.status_code in (200, 204), del_resp.text
+
+        expect(
+            second_page.locator(f'tr[data-user-id="{user_id}"]')
+        ).to_have_count(0, timeout=POLL_TIMEOUT_MS + 8000)
+
+
+class TestRolesCrossSession:
+    """Cross-session visibility for the /users page Roles tab.
+
+    Added as part of the #87 no-reload rework: session A creating or
+    deleting a role used to require session B to reload. Now session
+    B's 5s role poller inserts the card via the
+    GET /api/roles/{id}/card fragment and removes it on delete.
+    """
+
+    def test_create_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A creates a role → session B inserts the card inline."""
+        page.goto("/users")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/users")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        resp = api.post("/api/roles", json={
+            "name": "xsess-role-create",
+            "description": "cross-session test",
+            "permissions": ["devices:read"],
+        })
+        assert resp.status_code == 201, resp.text
+        role_id = resp.json()["id"]
+
+        expect(
+            second_page.locator(f'.role-card[data-role-id="{role_id}"]')
+        ).to_be_visible(timeout=POLL_TIMEOUT_MS)
+
+    def test_delete_propagates(self, page: Page, second_page: Page, api, e2e_server):
+        """Session A deletes a role → session B removes the card."""
+        resp = api.post("/api/roles", json={
+            "name": "xsess-role-delete",
+            "description": "",
+            "permissions": ["devices:read"],
+        })
+        assert resp.status_code == 201, resp.text
+        role_id = resp.json()["id"]
+
+        page.goto("/users")
+        page.wait_for_load_state("domcontentloaded")
+        second_page.goto("/users")
+        second_page.wait_for_load_state("domcontentloaded")
+
+        expect(
+            second_page.locator(f'.role-card[data-role-id="{role_id}"]')
+        ).to_be_visible(timeout=5000)
+
+        del_resp = api.delete(f"/api/roles/{role_id}")
+        assert del_resp.status_code in (200, 204), del_resp.text
+
+        expect(
+            second_page.locator(f'.role-card[data-role-id="{role_id}"]')
+        ).to_have_count(0, timeout=POLL_TIMEOUT_MS + 8000)

--- a/tests_e2e/test_ui_cross_session.py
+++ b/tests_e2e/test_ui_cross_session.py
@@ -636,9 +636,13 @@ class TestRolesCrossSession:
         assert resp.status_code == 201, resp.text
         role_id = resp.json()["id"]
 
+        # The Roles tab starts hidden (display:none) until clicked, so we
+        # assert the card was attached to the DOM rather than visible.
+        # Propagation is what this test cares about; visibility is a tab
+        # state concern.
         expect(
             second_page.locator(f'.role-card[data-role-id="{role_id}"]')
-        ).to_be_visible(timeout=POLL_TIMEOUT_MS)
+        ).to_have_count(1, timeout=POLL_TIMEOUT_MS)
 
     def test_delete_propagates(self, page: Page, second_page: Page, api, e2e_server):
         """Session A deletes a role → session B removes the card."""
@@ -655,9 +659,11 @@ class TestRolesCrossSession:
         second_page.goto("/users")
         second_page.wait_for_load_state("domcontentloaded")
 
+        # Same reasoning as test_create_propagates: the Roles tab is hidden
+        # by default; we care about DOM attachment, not visibility.
         expect(
             second_page.locator(f'.role-card[data-role-id="{role_id}"]')
-        ).to_be_visible(timeout=5000)
+        ).to_have_count(1, timeout=POLL_TIMEOUT_MS)
 
         del_resp = api.delete(f"/api/roles/{role_id}")
         assert del_resp.status_code in (200, 204), del_resp.text


### PR DESCRIPTION
## Summary

Removes the last 7 `location.reload()` calls on the Users & Roles admin page (`/users`) as part of the issue #87 reload hunt. The page now uses the same server-rendered fragment + cross-session poller pattern we already applied to assets, profiles, schedules, and groups.

## What changed

**Fragment endpoints (new):**
- `GET /api/users/{id}/row` — returns the rendered `<tr>` for a single user.
- `GET /api/roles/{id}/card` — returns the rendered `<div class="role-card">` for a single role.

Both scope permissions to `users:read` / `roles:read` and re-use the same macros the full page renders with, so HTML stays byte-identical.

**Macros (`cms/templates/_macros.html`):**
- Extracted the user-table `<tr>` into `user_row(u, current_user_id, can_write)`.
- Extracted the role-list card into `role_card(role, perm_descriptions, can_write_roles)`.
- Both add `data-user-id` / `data-role-id` anchors the poller and action handlers use.

**`users.html`:**
- Replaced inline row / card markup with macro calls.
- Added `data-users-tbody`, `data-roles-list`, `data-users-count`, `data-roles-count` anchors.
- Added two 5s pollers (`pollUsersOnce` / `pollRolesOnce`) that diff `/api/users` and `/api/roles` against the known-id sets and insert/remove via the fragment endpoints.

**`app.js`:**
- `createUser`, `updateUser`, `deleteUser`, `toggleUserActive` — no reload. Patch `usersData`, DOM-insert / replace / remove the row via `_insertUserRow`, close the modal, update the count.
- `createRole`, `updateRole`, `deleteRole` — no reload. Patch `rolesData`, DOM-insert / replace / remove the card via `_insertRoleCard`, keep every `<select name="role_id">` in sync so a just-created role is immediately assignable.
- New helpers: `_insertUserRow`, `_insertRoleCard`, `_updateUsersCount`, `_updateRolesCount`, `_resetForm`.

## Why

Before this PR, any admin-side user or role change full-page-reloaded the `/users` tab. That wiped open kebab menus, scroll position, and any other session state. It also meant changes from a second admin session or a second CMS replica weren't visible until the user manually refreshed. Both issues are fixed by the same fragment-endpoint + cross-session-poller pattern established by the earlier reload-hunt slices.

## Tests

**New unit tests:**
- `tests/test_user_row_endpoint.py` — 2 tests: happy-path fragment rendering + 404.
- `tests/test_role_card_endpoint.py` — 3 tests: happy-path, built-in role (no edit/delete), 404.

**New cross-session e2e tests (`tests_e2e/test_ui_cross_session.py`):**
- `TestUsersCrossSession::test_create_propagates` / `test_delete_propagates`.
- `TestRolesCrossSession::test_create_propagates` / `test_delete_propagates`.

Local subset (`tests/test_user_row_endpoint.py`, `tests/test_role_card_endpoint.py`, `tests/test_rbac.py -k "user_create or user_update or user_delete or role"`) all green; relying on CI for the full suite.

## Not in scope

- `dashboard.html` and `devices.html` still have `location.reload()` calls — both are blocked on the in-flight multi-CMS WSS / in-memory transport rewrite.
- `schedules.html` / `app.js` schedules helpers, `profiles.html` fallbacks, and a couple of `app.js` device/asset defensive fallbacks still have reloads — planned follow-up slices.

Closes part of #87.
