### PR TITLE
test: install pytest-timeout so CI hangs fail fast

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 asyncio_mode = strict
-timeout = 30
+timeout = 60
+timeout_method = thread

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ pytest-asyncio>=0.24,<1.0
 httpx>=0.27,<1.0
 aiosqlite>=0.20,<1.0
 pytest-cov>=5.0,<7.0
+pytest-timeout>=2.3,<3.0
 pyyaml>=6.0,<7.0


### PR DESCRIPTION
pytest.ini had `timeout = 30` set but pytest-timeout was never declared in requirements-test.txt, so the setting was a no-op. Test hangs ran until the 60-min GH Actions job timeout instead of failing fast.

- Add `pytest-timeout>=2.3,<3.0` to requirements-test.txt
- Bump timeout 30 -> 60 (unit suite has some legit slow paths)
- `timeout_method = thread` for clean interaction with pytest-asyncio + xdist