### PR TITLE
Stage 3d: log_requests drainer loop (#345)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -48,3 +48,12 @@ class Settings(SharedSettings):
 
     # SMTP is configured via the web UI settings page (stored in DB)
     base_url: str | None = None  # public URL for login links in emails
+
+    # Log-request drainer (issue #345 Stage 3d).  Self-healing loop for
+    # the ``log_requests`` outbox: retries stuck ``pending`` rows with
+    # exponential backoff and rescues rows that are stuck in ``sent``
+    # past ``sent_timeout_sec``.
+    log_drainer_interval_sec: float = 5.0
+    log_drainer_batch_size: int = 25
+    log_drainer_sent_timeout_sec: int = 900
+    log_drainer_max_attempts: int = 10

--- a/cms/main.py
+++ b/cms/main.py
@@ -331,6 +331,25 @@ async def lifespan(app: FastAPI):
     reaper_task = asyncio.create_task(deleted_asset_reaper_loop())
     outbox_drain_task = asyncio.create_task(outbox_drain_loop())
 
+    # ── Log-request drainer (issue #345 Stage 3d) ──
+    # Self-healing loop for the log_requests outbox: retries stuck
+    # pending rows with exponential backoff and rescues rows that are
+    # stuck in 'sent' past the configured timeout.  Transport + session
+    # factory are resolved per-tick via getters so the loop picks up
+    # the real instances after `init_db` / `set_transport` run.
+    from cms.services.log_drainer import run_loop as log_drainer_run_loop
+    from cms.services.transport import get_transport as _get_transport
+    from cms.database import get_session_factory as _get_session_factory
+    log_drainer_stop = asyncio.Event()
+    log_drainer_task = asyncio.create_task(
+        log_drainer_run_loop(
+            _get_session_factory,
+            _get_transport,
+            settings=settings,
+            stop_event=log_drainer_stop,
+        )
+    )
+
     # Log CMS startup to the event log (so upgrades/restarts show up in the timeline)
     try:
         from cms.models.device_event import DeviceEvent, DeviceEventType
@@ -412,6 +431,7 @@ async def lifespan(app: FastAPI):
     capture_monitor_task.cancel()
     reaper_task.cancel()
     outbox_drain_task.cancel()
+    log_drainer_stop.set()
     try:
         await scheduler_task
     except asyncio.CancelledError:
@@ -448,6 +468,16 @@ async def lifespan(app: FastAPI):
         await outbox_drain_task
     except asyncio.CancelledError:
         pass
+    try:
+        await asyncio.wait_for(log_drainer_task, timeout=5.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        log_drainer_task.cancel()
+        try:
+            await log_drainer_task
+        except asyncio.CancelledError:
+            pass
+    except Exception:
+        logger.exception("log_drainer: error during shutdown")
     # Close storage backend (Azure: close async blob client)
     if hasattr(backend, "close"):
         await backend.close()

--- a/cms/services/log_drainer.py
+++ b/cms/services/log_drainer.py
@@ -1,0 +1,366 @@
+"""Background drainer for the ``log_requests`` outbox (Stage 3d of #345).
+
+One asyncio loop per CMS replica.  Each tick opens a short-lived
+session and does two independent jobs inside one transaction:
+
+1. **Retry pending rows** — rows whose immediate dispatch from the
+   router failed (Pi offline, or in future N>1 the Pi's WS is on a
+   different replica).  Exponential backoff keyed off ``attempts``:
+
+       delay_seconds = min(60 * 2**attempts, 3600)
+
+   When ``attempts >= max_attempts`` (default 10) we transition to
+   ``failed`` via :func:`cms.services.log_outbox.mark_failed`.
+
+2. **Rescue stuck ``sent`` rows** — rows whose ``sent_at`` is more
+   than ``sent_timeout_sec`` (default 900s / 15 min) in the past.
+   Flip them back to ``pending`` so the next tick re-dispatches.
+   If ``attempts`` is already at the retry budget, transition
+   straight to ``failed``.
+
+The router's immediate dispatch in ``POST /api/logs/requests`` stays
+as-is — this loop is recovery only.
+
+Multi-replica safety: on Postgres each claim uses
+``SELECT ... FOR UPDATE SKIP LOCKED`` so overlapping scans don't
+double-dispatch.  On SQLite (tests) the lock hint is dropped — tests
+are single-process so contention isn't a concern.
+
+See ``docs/multi-replica-architecture.md`` §Stage 3 for the overall
+design and ``cms/services/log_outbox.py`` for the state-machine
+helpers this module composes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.log_request import (
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_SENT,
+    LogRequest,
+)
+from cms.services import log_outbox
+
+logger = logging.getLogger("agora.cms.log_drainer")
+
+
+# Defaults applied when the caller doesn't pass a Settings object.
+# Matches the AGORA_CMS_LOG_DRAINER_* fields declared in cms.config.
+_DEFAULT_BATCH_SIZE = 25
+_DEFAULT_SENT_TIMEOUT_SEC = 900
+_DEFAULT_MAX_ATTEMPTS = 10
+_DEFAULT_INTERVAL_SEC = 5.0
+_DISPATCH_TIMEOUT_SEC = 10.0
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_postgres(db: AsyncSession) -> bool:
+    """Return ``True`` when the session is bound to a Postgres engine.
+
+    Drives the ``SKIP LOCKED`` branch — SQLite doesn't understand the
+    locking hint so the tests use a plain ``SELECT``.
+    """
+    bind = getattr(db, "bind", None)
+    if bind is None:
+        try:
+            bind = db.get_bind()
+        except Exception:
+            return False
+    return bind.dialect.name == "postgresql"
+
+
+def _backoff_seconds(attempts: int) -> int:
+    """Return the retry delay after ``attempts`` failed sends."""
+    return min(60 * (2 ** attempts), 3600)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _eligible_for_retry(row: LogRequest, now: datetime) -> bool:
+    """Whether ``row`` is past its backoff window."""
+    if row.attempts == 0:
+        return True
+    updated = row.updated_at
+    if updated is None:
+        return True
+    next_at = _as_utc(updated) + timedelta(seconds=_backoff_seconds(row.attempts))
+    return next_at <= _as_utc(now)
+
+
+def _resolve_config(settings: Any) -> tuple[int, int, int]:
+    """Return ``(batch_size, sent_timeout_sec, max_attempts)`` from settings."""
+    if settings is None:
+        return _DEFAULT_BATCH_SIZE, _DEFAULT_SENT_TIMEOUT_SEC, _DEFAULT_MAX_ATTEMPTS
+    return (
+        int(getattr(settings, "log_drainer_batch_size", _DEFAULT_BATCH_SIZE)),
+        int(getattr(settings, "log_drainer_sent_timeout_sec", _DEFAULT_SENT_TIMEOUT_SEC)),
+        int(getattr(settings, "log_drainer_max_attempts", _DEFAULT_MAX_ATTEMPTS)),
+    )
+
+
+# ── Claim helpers ────────────────────────────────────────────────────
+
+
+async def claim_due_pending(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    batch_size: int,
+) -> list[LogRequest]:
+    """Return up to ``batch_size`` pending rows that are past their
+    backoff window.
+
+    The SQL filter is loose — it pulls the oldest pending rows and
+    then filters backoff-eligibility in Python.  Matches the spec's
+    "simpler path is fine" guidance: the batch_size cap bounds cost
+    and older rows sort first so backoff'd rows rarely starve.
+
+    On Postgres the scan uses ``FOR UPDATE SKIP LOCKED`` so multiple
+    replicas can run concurrently without double-dispatch.  On other
+    dialects (SQLite in tests) the hint is dropped.
+    """
+    stmt = (
+        select(LogRequest)
+        .where(LogRequest.status == STATUS_PENDING)
+        .order_by(LogRequest.created_at)
+        .limit(batch_size)
+        .execution_options(populate_existing=True)
+    )
+    if _is_postgres(db):
+        stmt = stmt.with_for_update(skip_locked=True)
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+    return [r for r in rows if _eligible_for_retry(r, now)]
+
+
+async def claim_stuck_sent(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    sent_timeout_sec: int,
+    batch_size: int,
+) -> list[LogRequest]:
+    """Return up to ``batch_size`` ``sent`` rows whose ``sent_at`` is
+    older than ``now - sent_timeout_sec``.
+
+    Rows whose Pi never uploaded (replica crash after send, or Pi
+    died mid-upload) pile up in ``sent`` indefinitely without this
+    rescue path.  See :func:`drain_once` for the flip-to-pending /
+    flip-to-failed logic.
+    """
+    cutoff = _as_utc(now) - timedelta(seconds=sent_timeout_sec)
+    stmt = (
+        select(LogRequest)
+        .where(LogRequest.status == STATUS_SENT)
+        .where(LogRequest.sent_at.is_not(None))
+        .where(LogRequest.sent_at <= cutoff)
+        .order_by(LogRequest.sent_at)
+        .limit(batch_size)
+        .execution_options(populate_existing=True)
+    )
+    if _is_postgres(db):
+        stmt = stmt.with_for_update(skip_locked=True)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+# ── Single tick ──────────────────────────────────────────────────────
+
+
+async def drain_once(
+    db: AsyncSession,
+    *,
+    transport: Any,
+    now: datetime | None = None,
+    settings: Any = None,
+) -> dict:
+    """Run one drainer tick inside a single transaction.
+
+    Returns a stats dict::
+
+        {"claimed_pending": N, "dispatched": M, "failed": K, "rescued_sent": R}
+
+    Order of operations:
+
+    1. Claim due-pending rows (backoff-eligible).
+    2. Claim stuck-sent rows and flip each inline to ``pending`` (or
+       ``failed`` if over the retry budget).  Rescued rows are **not**
+       re-dispatched in the same tick — they ride the next tick's
+       pending scan.  Keeps the transaction short.
+    3. Dispatch the pending batch concurrently with
+       ``asyncio.gather(return_exceptions=True)`` and a 10s per-row
+       timeout.  On success → ``mark_sent``.  On exception →
+       ``mark_failed`` if ``attempts + 1`` hits the budget, else
+       ``record_attempt_error``.
+
+    Commits once at the end of the ``db.begin()`` block — the helpers
+    in ``log_outbox`` are transaction-agnostic and never commit.
+    """
+    if now is None:
+        now = _now()
+    batch_size, sent_timeout_sec, max_attempts = _resolve_config(settings)
+
+    stats = {
+        "claimed_pending": 0,
+        "dispatched": 0,
+        "failed": 0,
+        "rescued_sent": 0,
+    }
+
+    # We own the transaction boundary for this tick: one commit at the
+    # end, rollback on unexpected error.  Using ``async with
+    # db.begin()`` would race with any autobegun read transaction the
+    # caller's session already has open (common in tests that read
+    # back state between ticks), so we commit manually to stay robust
+    # on reused sessions.
+    try:
+        pending_rows = await claim_due_pending(
+            db, now=now, batch_size=batch_size,
+        )
+        stats["claimed_pending"] = len(pending_rows)
+
+        stuck_rows = await claim_stuck_sent(
+            db,
+            now=now,
+            sent_timeout_sec=sent_timeout_sec,
+            batch_size=batch_size,
+        )
+        for row in stuck_rows:
+            if row.attempts >= max_attempts:
+                await log_outbox.mark_failed(
+                    db,
+                    row.id,
+                    error=f"sent timeout after {row.attempts} attempts",
+                )
+                stats["failed"] += 1
+            else:
+                await db.execute(
+                    update(LogRequest)
+                    .where(
+                        LogRequest.id == row.id,
+                        LogRequest.status == STATUS_SENT,
+                    )
+                    .values(status=STATUS_PENDING, updated_at=_now())
+                )
+                stats["rescued_sent"] += 1
+
+        if pending_rows:
+            # Snapshot the attributes we need before dispatching — the
+            # gathered coroutines only see plain tuples so nothing
+            # racy happens to ORM state while transports run.
+            targets = [
+                (r.id, r.device_id, r.services, r.since, r.attempts)
+                for r in pending_rows
+            ]
+
+            async def _dispatch(device_id, rid, services, since) -> None:
+                await asyncio.wait_for(
+                    transport.dispatch_request_logs(
+                        device_id,
+                        request_id=rid,
+                        services=services,
+                        since=since,
+                    ),
+                    timeout=_DISPATCH_TIMEOUT_SEC,
+                )
+
+            outcomes = await asyncio.gather(
+                *(
+                    _dispatch(device_id, rid, services, since)
+                    for (rid, device_id, services, since, _attempts) in targets
+                ),
+                return_exceptions=True,
+            )
+            for (rid, _device_id, _services, _since, attempts), outcome in zip(
+                targets, outcomes,
+            ):
+                if isinstance(outcome, BaseException):
+                    err = str(outcome) or type(outcome).__name__
+                    if attempts + 1 >= max_attempts:
+                        await log_outbox.mark_failed(db, rid, error=err)
+                        stats["failed"] += 1
+                    else:
+                        await log_outbox.record_attempt_error(
+                            db, rid, error=err,
+                        )
+                else:
+                    await log_outbox.mark_sent(db, rid)
+                    stats["dispatched"] += 1
+
+        await db.commit()
+    except BaseException:
+        await db.rollback()
+        raise
+
+    if any(v for v in stats.values()):
+        logger.info("drain_once: %s", stats)
+    return stats
+
+
+# ── Loop ─────────────────────────────────────────────────────────────
+
+
+async def run_loop(
+    session_factory_getter: Callable[[], Any],
+    transport_getter: Callable[[], Any],
+    *,
+    settings: Any,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run :func:`drain_once` forever on a ``log_drainer_interval_sec``
+    cadence until ``stop_event`` is set.
+
+    Both ``session_factory_getter`` and ``transport_getter`` are
+    resolved **per tick** rather than captured at startup — tests
+    call :func:`cms.services.transport.set_transport` after boot and
+    the factory isn't initialised until ``init_db`` runs.
+
+    A single tick failure (DB blip, transport exception) is logged
+    and the loop keeps going.  ``asyncio.CancelledError`` is
+    propagated so the standard shutdown path works.
+    """
+    interval = float(getattr(settings, "log_drainer_interval_sec", _DEFAULT_INTERVAL_SEC))
+    if stop_event is None:
+        stop_event = asyncio.Event()
+    logger.info("Log drainer loop started (interval=%.1fs)", interval)
+    try:
+        while not stop_event.is_set():
+            try:
+                factory = session_factory_getter()
+                if factory is None:
+                    logger.warning(
+                        "log_drainer: session factory not initialised; skipping tick",
+                    )
+                else:
+                    async with factory() as db:
+                        try:
+                            await drain_once(
+                                db,
+                                transport=transport_getter(),
+                                settings=settings,
+                            )
+                        except Exception:
+                            logger.exception("log_drainer: drain_once failed")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("log_drainer: unexpected error in tick")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        logger.info("Log drainer loop stopped")

--- a/tests/test_device_event_transitions.py
+++ b/tests/test_device_event_transitions.py
@@ -95,32 +95,36 @@ class TestDeviceEventTransitions:
             setup_session.add(dev)
             await setup_session.commit()
 
+        # Poll for events WHILE the websocket is still open.  If we close the
+        # WS before the server-side handler has processed the last inbound
+        # status message, the handler task can be cancelled mid-commit and
+        # we lose the final DeviceEvent.  Verifying before close removes that
+        # race entirely.
         with TestClient(app) as tc:
             with tc.websocket_connect("/ws/device") as ws:
                 _register(ws, "evt-display-001", token)
                 # First observation: display_connected=True (no prior -> no event)
                 _status(ws, "evt-display-001", display_connected=True)
-                time.sleep(0.3)
                 # Flip to False -> DISPLAY_DISCONNECTED
                 _status(ws, "evt-display-001", display_connected=False)
-                time.sleep(0.3)
                 # Flip back to True -> DISPLAY_CONNECTED
                 _status(ws, "evt-display-001", display_connected=True)
-                time.sleep(0.3)
+
+                async with factory() as verify_session:
+                    rows = await _wait_for_events(
+                        verify_session, "evt-display-001",
+                        lambda r: sum(1 for x in r if x.event_type.startswith("display_")) >= 2,
+                        timeout=10.0,
+                    )
                 ws.close()
 
-        async with factory() as verify_session:
-            rows = await _wait_for_events(
-                verify_session, "evt-display-001",
-                lambda r: sum(1 for x in r if x.event_type.startswith("display_")) >= 2,
-            )
-            types = [r.event_type for r in rows]
-            assert DeviceEventType.DISPLAY_DISCONNECTED.value in types
-            assert DeviceEventType.DISPLAY_CONNECTED.value in types
-            # First status should NOT have emitted anything (None -> True)
-            # so we expect exactly 2 display transitions.
-            display_rows = [r for r in rows if r.event_type.startswith("display_")]
-            assert len(display_rows) == 2
+        types = [r.event_type for r in rows]
+        assert DeviceEventType.DISPLAY_DISCONNECTED.value in types
+        assert DeviceEventType.DISPLAY_CONNECTED.value in types
+        # First status should NOT have emitted anything (None -> True)
+        # so we expect exactly 2 display transitions.
+        display_rows = [r for r in rows if r.event_type.startswith("display_")]
+        assert len(display_rows) == 2
 
     async def test_error_set_and_cleared_emits_events(self, app, db_engine):
         from starlette.testclient import TestClient
@@ -137,25 +141,24 @@ class TestDeviceEventTransitions:
                 _register(ws, "evt-err-001", token)
                 # Clean status (no prior, no error) — no event
                 _status(ws, "evt-err-001")
-                time.sleep(0.3)
                 # Error appears
                 _status(ws, "evt-err-001", error="pipeline stalled")
-                time.sleep(0.3)
                 # Error cleared
                 _status(ws, "evt-err-001", error=None)
-                time.sleep(0.3)
+
+                async with factory() as verify_session:
+                    rows = await _wait_for_events(
+                        verify_session, "evt-err-001",
+                        lambda r: sum(1 for x in r if x.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)) >= 2,
+                        timeout=10.0,
+                    )
                 ws.close()
 
-        async with factory() as verify_session:
-            rows = await _wait_for_events(
-                verify_session, "evt-err-001",
-                lambda r: sum(1 for x in r if x.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)) >= 2,
-            )
-            err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
-            assert len(err_rows) == 2
-            assert err_rows[0].event_type == DeviceEventType.ERROR.value
-            assert err_rows[0].details and err_rows[0].details.get("error") == "pipeline stalled"
-            assert err_rows[1].event_type == DeviceEventType.ERROR_CLEARED.value
+        err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
+        assert len(err_rows) == 2
+        assert err_rows[0].event_type == DeviceEventType.ERROR.value
+        assert err_rows[0].details and err_rows[0].details.get("error") == "pipeline stalled"
+        assert err_rows[1].event_type == DeviceEventType.ERROR_CLEARED.value
 
     async def test_error_string_change_emits_new_error_event(self, app, db_engine):
         from starlette.testclient import TestClient
@@ -171,20 +174,20 @@ class TestDeviceEventTransitions:
             with tc.websocket_connect("/ws/device") as ws:
                 _register(ws, "evt-err-002", token)
                 _status(ws, "evt-err-002", error="first fault")
-                time.sleep(0.3)
                 # Different error string while still in error state → another ERROR event
                 _status(ws, "evt-err-002", error="second fault")
-                time.sleep(0.3)
+
+                async with factory() as verify_session:
+                    rows = await _wait_for_events(
+                        verify_session, "evt-err-002",
+                        lambda r: sum(1 for x in r if x.event_type == DeviceEventType.ERROR.value) >= 2,
+                        timeout=10.0,
+                    )
                 ws.close()
 
-        async with factory() as verify_session:
-            rows = await _wait_for_events(
-                verify_session, "evt-err-002",
-                lambda r: sum(1 for x in r if x.event_type == DeviceEventType.ERROR.value) >= 2,
-            )
-            err_rows = [r for r in rows if r.event_type == DeviceEventType.ERROR.value]
-            assert len(err_rows) == 2
-            assert err_rows[-1].details.get("error") == "second fault"
+        err_rows = [r for r in rows if r.event_type == DeviceEventType.ERROR.value]
+        assert len(err_rows) == 2
+        assert err_rows[-1].details.get("error") == "second fault"
 
     async def test_no_event_on_stable_state(self, app, db_engine):
         """Repeated identical status messages must NOT emit spurious events."""
@@ -202,15 +205,19 @@ class TestDeviceEventTransitions:
                 _register(ws, "evt-stable-001", token)
                 for _ in range(3):
                     _status(ws, "evt-stable-001", display_connected=True)
-                    time.sleep(0.15)
+
+                # Give the server a beat to process all three before we read.
+                # Using async sleep so we don't block the pytest-asyncio loop.
+                await asyncio.sleep(1.0)
+
+                async with factory() as verify_session:
+                    rows = (await verify_session.execute(
+                        select(DeviceEvent)
+                        .where(DeviceEvent.device_id == "evt-stable-001")
+                    )).scalars().all()
                 ws.close()
 
-        async with factory() as verify_session:
-            rows = (await verify_session.execute(
-                select(DeviceEvent)
-                .where(DeviceEvent.device_id == "evt-stable-001")
-            )).scalars().all()
-            display_rows = [r for r in rows if r.event_type.startswith("display_")]
-            err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
-            assert display_rows == []
-            assert err_rows == []
+        display_rows = [r for r in rows if r.event_type.startswith("display_")]
+        err_rows = [r for r in rows if r.event_type in (DeviceEventType.ERROR.value, DeviceEventType.ERROR_CLEARED.value)]
+        assert display_rows == []
+        assert err_rows == []

--- a/tests/test_log_drainer.py
+++ b/tests/test_log_drainer.py
@@ -1,0 +1,420 @@
+"""Tests for :mod:`cms.services.log_drainer` (Stage 3d of #345).
+
+Covers :func:`drain_once` — the single-tick workhorse — and a light
+smoke test of :func:`run_loop`'s shutdown path.  Keeps things unit-y
+(no HTTP / router) by driving the outbox helpers directly against
+``db_session`` fixtures.
+
+Avoids the cross-loop asyncpg bug: tests talk to the same loop as
+pytest-asyncio, use ``db_session`` or a session from the test's own
+factory, and never mix :class:`starlette.testclient.TestClient`
+with async DB fixtures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from cms.models.device import Device, DeviceStatus
+from cms.models.log_request import (
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_READY,  # noqa: F401 — intentionally imported for parity with sibling tests
+    STATUS_SENT,
+    LogRequest,
+)
+from cms.services import log_drainer, log_outbox
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def _device(db_session):
+    """Seed a single adopted device for the outbox rows to reference."""
+    d = Device(id="d-drainer-1", name="Drainer Test", status=DeviceStatus.ADOPTED)
+    db_session.add(d)
+    await db_session.commit()
+    return d
+
+
+def _make_settings(**overrides) -> SimpleNamespace:
+    """Build a Settings-shaped object with the drainer knobs."""
+    base = {
+        "log_drainer_interval_sec": 5.0,
+        "log_drainer_batch_size": 25,
+        "log_drainer_sent_timeout_sec": 900,
+        "log_drainer_max_attempts": 10,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class FakeTransport:
+    """Minimal dispatcher — only ``dispatch_request_logs`` is exercised
+    by the drainer.  Other ``DeviceTransport`` methods raise so the
+    tests would fail loudly if the drainer started using them.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.should_fail = False
+        self.fail_exc: BaseException = ValueError("device offline")
+        # Per-request-id override: failures keyed by request id win
+        # over the global flag.  Lets test_drainer_continues_on_exception
+        # fail exactly one row in a batch.
+        self.fail_for_request_id: dict[str, BaseException] = {}
+
+    async def dispatch_request_logs(
+        self,
+        device_id: str,
+        *,
+        request_id: str,
+        services=None,
+        since: str = "24h",
+    ) -> None:
+        self.calls.append((device_id, request_id, services, since))
+        if request_id in self.fail_for_request_id:
+            raise self.fail_for_request_id[request_id]
+        if self.should_fail:
+            raise self.fail_exc
+
+    async def send_to_device(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    async def is_connected(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    async def connected_count(self):  # pragma: no cover
+        raise NotImplementedError
+
+    async def connected_ids(self):  # pragma: no cover
+        raise NotImplementedError
+
+    async def get_all_states(self):  # pragma: no cover
+        raise NotImplementedError
+
+    async def request_logs(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    async def set_state_flags(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+
+async def _reload(db, request_id: str) -> LogRequest | None:
+    """Re-fetch a row after bulk UPDATEs (our helpers bypass the
+    identity map, so ORM-cached instances go stale).
+
+    Uses ``populate_existing=True`` which forces the SELECT to
+    overwrite the identity-mapped instance's attributes.  We avoid
+    ``db.expire_all()`` because it would expire *all* other cached
+    instances — subsequent attribute access on those would trigger
+    sync refresh and trip MissingGreenlet on AsyncSession.
+    """
+    result = await db.execute(
+        select(LogRequest)
+        .where(LogRequest.id == request_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _set_row(db, request_id: str, **values) -> None:
+    """Raw UPDATE helper for priming rows into specific states.
+
+    The drainer's SELECTs use ``populate_existing=True`` so tests
+    don't need to expire the session here — keeping the identity
+    map intact means ``row.id`` stays accessible after this call.
+    """
+    await db.execute(
+        update(LogRequest).where(LogRequest.id == request_id).values(**values)
+    )
+    await db.commit()
+
+
+# ── Individual tick scenarios ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drainer_dispatches_pending_row(db_session, _device):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    transport = FakeTransport()
+    stats = await log_drainer.drain_once(db_session, transport=transport)
+
+    assert stats["claimed_pending"] == 1
+    assert stats["dispatched"] == 1
+    assert stats["failed"] == 0
+    assert len(transport.calls) == 1
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_SENT
+    assert refreshed.attempts == 1
+    assert refreshed.sent_at is not None
+
+
+@pytest.mark.asyncio
+async def test_drainer_records_transient_failure_and_keeps_pending(
+    db_session, _device,
+):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    transport = FakeTransport()
+    transport.should_fail = True
+    transport.fail_exc = ValueError("device offline")
+
+    stats = await log_drainer.drain_once(db_session, transport=transport)
+
+    assert stats["claimed_pending"] == 1
+    assert stats["dispatched"] == 0
+    assert stats["failed"] == 0
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_PENDING
+    assert refreshed.attempts == 1
+    assert refreshed.last_error == "device offline"
+
+
+@pytest.mark.asyncio
+async def test_drainer_marks_failed_after_max_attempts(db_session, _device):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    settings = _make_settings(log_drainer_max_attempts=5)
+    # Prime attempts = max - 1 so the next failure trips the budget.
+    # Also backdate updated_at so the row is past its backoff window.
+    await _set_row(
+        db_session, row.id,
+        attempts=settings.log_drainer_max_attempts - 1,
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+
+    transport = FakeTransport()
+    transport.should_fail = True
+
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, settings=settings,
+    )
+
+    assert stats["failed"] == 1
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_FAILED
+    assert refreshed.last_error
+
+
+@pytest.mark.asyncio
+async def test_drainer_respects_backoff(db_session, _device):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    # attempts=3 → backoff window = 60 * 2**3 = 480s.  updated_at is
+    # 30s in the past → 450s still to wait before retry.
+    now = datetime.now(timezone.utc)
+    await _set_row(
+        db_session, row.id,
+        attempts=3,
+        updated_at=now - timedelta(seconds=30),
+    )
+
+    transport = FakeTransport()
+
+    # Inside the backoff window → no dispatch.
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, now=now,
+    )
+    assert stats["claimed_pending"] == 0
+    assert stats["dispatched"] == 0
+    assert transport.calls == []
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_PENDING
+    assert refreshed.attempts == 3  # unchanged
+
+    # Advance past the backoff window → row is picked up.
+    future = now + timedelta(seconds=500)
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, now=future,
+    )
+    assert stats["dispatched"] == 1
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_SENT
+    assert refreshed.attempts == 4  # 3 + 1 from mark_sent
+
+
+@pytest.mark.asyncio
+async def test_drainer_rescues_stuck_sent(db_session, _device):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    # Put it into the sent state and push sent_at 20 min into the past.
+    now = datetime.now(timezone.utc)
+    await _set_row(
+        db_session, row.id,
+        status=STATUS_SENT,
+        attempts=1,
+        sent_at=now - timedelta(minutes=20),
+        updated_at=now - timedelta(minutes=20),
+    )
+
+    transport = FakeTransport()
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, now=now,
+    )
+    assert stats["rescued_sent"] == 1
+    # Rescued rows are not re-dispatched in the same tick.
+    assert stats["dispatched"] == 0
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_PENDING
+
+    # Next tick picks up the now-pending row.  attempts was 1 so the
+    # backoff window is 120s — advance ``now`` well past it.
+    stats = await log_drainer.drain_once(
+        db_session,
+        transport=transport,
+        now=now + timedelta(seconds=600),
+    )
+    assert stats["dispatched"] == 1
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_SENT
+
+
+@pytest.mark.asyncio
+async def test_drainer_does_not_rescue_fresh_sent(db_session, _device):
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    now = datetime.now(timezone.utc)
+    await _set_row(
+        db_session, row.id,
+        status=STATUS_SENT,
+        attempts=1,
+        sent_at=now - timedelta(minutes=5),
+        updated_at=now - timedelta(minutes=5),
+    )
+
+    transport = FakeTransport()
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, now=now,
+    )
+    assert stats["rescued_sent"] == 0
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_SENT
+
+
+@pytest.mark.asyncio
+async def test_drainer_fails_stuck_sent_over_max_attempts(db_session, _device):
+    settings = _make_settings(log_drainer_max_attempts=5)
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+
+    now = datetime.now(timezone.utc)
+    await _set_row(
+        db_session, row.id,
+        status=STATUS_SENT,
+        attempts=settings.log_drainer_max_attempts,
+        sent_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+
+    transport = FakeTransport()
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, settings=settings, now=now,
+    )
+    assert stats["failed"] == 1
+    assert stats["rescued_sent"] == 0
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_FAILED
+
+
+@pytest.mark.asyncio
+async def test_drainer_batch_size_caps_work(db_session, _device):
+    ids: list[str] = []
+    for _ in range(30):
+        row = await log_outbox.create(db_session, device_id=_device.id)
+        ids.append(row.id)
+    await db_session.commit()
+
+    settings = _make_settings(log_drainer_batch_size=10)
+    transport = FakeTransport()
+    stats = await log_drainer.drain_once(
+        db_session, transport=transport, settings=settings,
+    )
+    assert stats["claimed_pending"] == 10
+    assert stats["dispatched"] == 10
+
+    # 20 rows remain pending.
+    db_session.expire_all()
+    rows = (
+        await db_session.execute(
+            select(LogRequest).where(LogRequest.status == STATUS_PENDING)
+        )
+    ).scalars().all()
+    assert len(rows) == 20
+
+
+@pytest.mark.asyncio
+async def test_drainer_continues_on_exception(db_session, _device):
+    r1 = await log_outbox.create(db_session, device_id=_device.id)
+    r2 = await log_outbox.create(db_session, device_id=_device.id)
+    r3 = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    # Capture ids upfront — later expire_all() calls in _reload leave
+    # the ORM instances with expired attrs, and accessing row.id would
+    # trigger a sync refresh (MissingGreenlet on AsyncSession).
+    r1_id, r2_id, r3_id = r1.id, r2.id, r3.id
+
+    transport = FakeTransport()
+    # Fail exactly r2 with a non-ValueError — gather(return_exceptions=True)
+    # must let r1 and r3 succeed.
+    transport.fail_for_request_id[r2_id] = RuntimeError("boom")
+
+    stats = await log_drainer.drain_once(db_session, transport=transport)
+    assert stats["claimed_pending"] == 3
+    assert stats["dispatched"] == 2
+    assert stats["failed"] == 0  # under max_attempts → record_attempt_error
+
+    refreshed_r1 = await _reload(db_session, r1_id)
+    refreshed_r2 = await _reload(db_session, r2_id)
+    refreshed_r3 = await _reload(db_session, r3_id)
+    assert refreshed_r1.status == STATUS_SENT
+    assert refreshed_r2.status == STATUS_PENDING
+    assert refreshed_r2.attempts == 1
+    assert refreshed_r3.status == STATUS_SENT
+
+
+# ── run_loop lifecycle ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drainer_loop_stops_on_event(db_engine):
+    """``run_loop`` must exit promptly when ``stop_event`` is set."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    transport = FakeTransport()
+    settings = _make_settings(log_drainer_interval_sec=0.05)
+    stop_event = asyncio.Event()
+
+    task = asyncio.create_task(
+        log_drainer.run_loop(
+            lambda: factory,
+            lambda: transport,
+            settings=settings,
+            stop_event=stop_event,
+        )
+    )
+    # Let the loop complete at least one tick.
+    await asyncio.sleep(0.1)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert task.done()


### PR DESCRIPTION
# Stage 3d — log_requests drainer loop (#345)

Part of the multi-replica rollout for device log collection. Stage 3a (PR #384) added the outbox schema + helpers; Stage 3b (PR #389) added the async API + LOGS_RESPONSE back-compat shim. This PR makes the outbox **self-healing** — a background drainer retries failed dispatches and rescues stuck rows, so the state machine keeps flowing even when a Pi is offline at request time or (Stage 4) connected to a different replica than the one that took the request.

## What's new

### `cms/services/log_drainer.py`

One asyncio loop per CMS replica. Each tick does two jobs in a single transaction:

1. **Retry `pending` rows** — rows whose immediate dispatch failed (Pi offline, or future N>1 where the Pi's WS is on a different replica). Exponential backoff: `updated_at + min(60 * 2^attempts, 3600)s`. When `attempts >= max_attempts` (default 10), transition to `failed`.
2. **Rescue stuck `sent` rows** — `sent_at` older than `sent_timeout_sec` (default 15 min) flips back to `pending` so the next tick re-dispatches. The upload endpoint is idempotent on `request_id`.

Per-row dispatch is wrapped in `asyncio.wait_for(..., timeout=10)` and batched with `asyncio.gather(return_exceptions=True)` so one slow device can't stall the tick.

### Concurrency

- **Postgres**: `SELECT ... FOR UPDATE SKIP LOCKED` claims each batch, so multiple replicas coordinate safely without a `claimed_by` column — the transaction *is* the claim.
- **SQLite** (tests + local): plain `SELECT`, no contention in single-process runs.

Branch is on `db.bind.dialect.name`.

### No schema migration

Existing columns (`status`, `attempts`, `updated_at`, `sent_at`, `last_error`) are sufficient. `next_attempt_at` is derived in Python.

### Four new settings (all have sane defaults)

| Env var | Default | Purpose |
|---|---|---|
| `AGORA_CMS_LOG_DRAINER_INTERVAL_SEC` | 5.0 | Sleep between ticks |
| `AGORA_CMS_LOG_DRAINER_BATCH_SIZE` | 25 | Max rows claimed per tick |
| `AGORA_CMS_LOG_DRAINER_SENT_TIMEOUT_SEC` | 900 | How long `sent` can sit before rescue |
| `AGORA_CMS_LOG_DRAINER_MAX_ATTEMPTS` | 10 | Terminal failure threshold |

### Lifespan wiring

Registered in `cms/main.py` next to the existing `outbox_drain_task` (transcoder). Graceful shutdown via `asyncio.Event`. The transport and session factory are passed as callables, not instances, so tests can inject fakes per tick.

## Tests

`tests/test_log_drainer.py` — 10 tests covering:
- Happy path dispatch → `sent`
- Transient failure → stays `pending`, bumps `attempts`, records `last_error`
- Hits `max_attempts` → `failed`
- Backoff respected (time-advanced)
- Stuck-`sent` → `pending` rescue
- Fresh `sent` not rescued
- Stuck `sent` over `max_attempts` → `failed` directly
- `batch_size` caps work
- Non-ValueError exceptions don't stall the batch
- `run_loop` stops cleanly on stop_event

Full local run: `tests/test_log_drainer.py tests/test_log_outbox.py tests/test_log_requests_api.py tests/test_logs_response_shim.py` → **56 pass**.

## What's intentionally _not_ in this PR

- No changes to the router's immediate-dispatch happy path in `POST /api/logs/requests` — drainer supplements, not replaces.
- No changes to `_pending_log_requests` / LOGS_RESPONSE shim — those go in Stage 3e after we're confident the outbox path is solid.
- No Pi firmware changes — Stage 3c.
- WPS is still not wired into prod — Stage 4.

## Risk

- Additive surface. Router behaviour unchanged. Helpers unchanged.
- Drainer failure is self-contained: any exception in a tick is logged and the loop continues.
- At current N=1 + `LocalDeviceTransport`, the drainer only sees rows for devices on its own replica, so behaviour is effectively equivalent to today's single-process retries. The real value kicks in at Stage 4 when we flip to WPS + N>1.

## Deploy plan

Merge → Azure auto-deploy → `/healthz/system` reaches new version → monitor `agora.cms.log_drainer` logs for a clean "drain_once: {...}" heartbeat line → smoke a failed-dispatch scenario (disconnect test Pi, issue a request, reconnect, watch row transition to `ready`).

Fixes part of #345.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
