### PR TITLE
feat: Stage 3c chunked LOGS_RESPONSE over WSS (#345)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -57,3 +57,15 @@ class Settings(SharedSettings):
     log_drainer_batch_size: int = 25
     log_drainer_sent_timeout_sec: int = 900
     log_drainer_max_attempts: int = 10
+
+    # Log chunk assembler (issue #345 Stage 3c).  Pi firmware splits
+    # large log bundles into sequential binary WS frames tagged with
+    # the ``LGCK`` magic.  The assembler buffers frames in-process
+    # keyed by ``(device_id, request_id)`` until the ``is_final`` bit
+    # arrives, then writes the reassembled tar.gz to blob storage.
+    # ``max_count`` and ``max_bytes`` bound memory use per request;
+    # ``buffer_ttl_sec`` lets the TTL reaper evict stalled transfers.
+    log_chunk_max_count: int = 30
+    log_chunk_max_bytes: int = 22_020_096  # 21 MiB
+    log_chunk_buffer_ttl_sec: int = 300
+    log_chunk_reaper_interval_sec: float = 5.0

--- a/cms/main.py
+++ b/cms/main.py
@@ -262,6 +262,12 @@ async def lifespan(app: FastAPI):
     # Initialize log-blob backend (separate from asset storage — Stage 3b).
     await init_log_storage(settings)
 
+    # Initialize the log chunk assembler (Stage 3c): process-local
+    # buffer for binary ``LGCK`` frames from Pi firmware advertising
+    # ``logs_chunk_v1``.  Must run before the reaper task starts.
+    from cms.services.log_chunk_assembler import init_assembler as _init_chunk_assembler
+    _init_chunk_assembler(settings)
+
     # Seed built-in RBAC roles (Admin, Operator, Viewer)
     async for db in get_db():
         await _seed_roles(db)
@@ -350,6 +356,21 @@ async def lifespan(app: FastAPI):
         )
     )
 
+    # ── Log chunk reaper (issue #345 Stage 3c) ──
+    # Evicts stalled chunked-upload buffers past the configured TTL and
+    # flips the matching outbox rows to ``failed`` so the user sees the
+    # transfer timed out.  Cheap tick — a no-op when no transfers are
+    # in flight.
+    from cms.services.log_chunk_assembler import run_reaper_loop as log_chunk_reaper_run_loop
+    log_chunk_reaper_stop = asyncio.Event()
+    log_chunk_reaper_task = asyncio.create_task(
+        log_chunk_reaper_run_loop(
+            _get_session_factory,
+            settings=settings,
+            stop_event=log_chunk_reaper_stop,
+        )
+    )
+
     # Log CMS startup to the event log (so upgrades/restarts show up in the timeline)
     try:
         from cms.models.device_event import DeviceEvent, DeviceEventType
@@ -432,6 +453,7 @@ async def lifespan(app: FastAPI):
     reaper_task.cancel()
     outbox_drain_task.cancel()
     log_drainer_stop.set()
+    log_chunk_reaper_stop.set()
     try:
         await scheduler_task
     except asyncio.CancelledError:
@@ -478,6 +500,16 @@ async def lifespan(app: FastAPI):
             pass
     except Exception:
         logger.exception("log_drainer: error during shutdown")
+    try:
+        await asyncio.wait_for(log_chunk_reaper_task, timeout=5.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        log_chunk_reaper_task.cancel()
+        try:
+            await log_chunk_reaper_task
+        except asyncio.CancelledError:
+            pass
+    except Exception:
+        logger.exception("log_chunk_reaper: error during shutdown")
     # Close storage backend (Azure: close async blob client)
     if hasattr(backend, "close"):
         await backend.close()

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -16,6 +16,7 @@ from cms.models.device import Device, DeviceStatus
 from cms.models.device_profile import DeviceProfile
 from cms.schemas.protocol import (
     PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
     AuthAssignedMessage,
     MessageType,
 )
@@ -27,6 +28,10 @@ from cms.services.device_inbound import (
 )
 from cms.services.device_manager import device_manager
 from cms.services.alert_service import alert_service
+from cms.services.log_chunk_assembler import (
+    handle_frame as handle_log_chunk_frame,
+    is_chunk_frame,
+)
 from cms.services.scheduler import build_device_sync
 
 logger = logging.getLogger("agora.cms.ws")
@@ -124,9 +129,12 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
             return
 
         protocol = raw.get("protocol_version", 0)
-        if protocol != PROTOCOL_VERSION:
+        if protocol not in SUPPORTED_PROTOCOL_VERSIONS:
             await websocket.send_json({
-                "error": f"Protocol mismatch: expected {PROTOCOL_VERSION}, got {protocol}"
+                "error": (
+                    f"Protocol mismatch: supported {sorted(SUPPORTED_PROTOCOL_VERSIONS)}, "
+                    f"got {protocol}"
+                )
             })
             await websocket.close(code=4003)
             return
@@ -303,10 +311,52 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
         # ── 8. Message loop ──
         while True:
             try:
-                msg = await asyncio.wait_for(websocket.receive_json(), timeout=WS_RECEIVE_TIMEOUT)
+                event = await asyncio.wait_for(websocket.receive(), timeout=WS_RECEIVE_TIMEOUT)
             except asyncio.TimeoutError:
                 logger.info("Device %s timed out (no message in %ds)", device_id, WS_RECEIVE_TIMEOUT)
                 break
+
+            # Starlette surfaces disconnects as dicts with type=websocket.disconnect.
+            event_type = event.get("type")
+            if event_type == "websocket.disconnect":
+                raise WebSocketDisconnect(code=event.get("code", 1005))
+            if event_type != "websocket.receive":
+                logger.warning("Device %s sent unknown event type %s", device_id, event_type)
+                continue
+
+            # Stage 3c (#345): binary frames tagged with the LGCK magic
+            # carry chunked LOGS_RESPONSE payloads too large for a single
+            # WPS message (~1 MiB cap).  Dispatch them to the assembler
+            # and skip JSON parsing.
+            binary = event.get("bytes")
+            if binary is not None:
+                if is_chunk_frame(binary):
+                    try:
+                        await handle_log_chunk_frame(
+                            db, device_id=device_id, frame_bytes=binary,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Log chunk handling failed for device %s", device_id,
+                        )
+                    continue
+                logger.warning(
+                    "Device %s sent unknown binary frame (%d bytes)",
+                    device_id, len(binary),
+                )
+                continue
+
+            text = event.get("text")
+            if text is None:
+                continue
+            import json
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "Device %s sent malformed JSON: %s", device_id, exc,
+                )
+                continue
             await dispatch_device_message(msg=msg, ctx=ctx, db=db, send=_ws_send)
 
     except WebSocketDisconnect:

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -1,6 +1,6 @@
 """WebSocket protocol message types — shared contract with device repo (sslivins/agora).
 
-Protocol version: 1
+Protocol version: 2
 
 Any changes to this file MUST be mirrored in the device-side implementation.
 """
@@ -11,7 +11,26 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-PROTOCOL_VERSION = 1
+# Protocol versioning
+#
+# ``PROTOCOL_VERSION`` is the canonical current version.  ``SUPPORTED_PROTOCOL_VERSIONS``
+# is the set the CMS accepts on the REGISTER handshake.  Keep older versions
+# here during fleet OTA rollouts so devices running previous firmware don't
+# get kicked when the CMS bumps its version.
+#
+#   v1 — original text-only JSON protocol.
+#   v2 — adds binary ``LGCK`` frames carrying chunked ``LOGS_RESPONSE``
+#        payloads so log bundles larger than the 1 MiB WPS message cap
+#        can be delivered over the device WebSocket.  Small payloads
+#        still use the original JSON ``LOGS_RESPONSE`` path.
+PROTOCOL_VERSION = 2
+SUPPORTED_PROTOCOL_VERSIONS = frozenset({1, 2})
+
+# Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
+# firmware advertising the ``logs_chunk_v1`` capability sends these as
+# WS binary frames when a log bundle exceeds the single-message cap.
+LOGS_CHUNK_MAGIC = b"LGCK"
+LOGS_CHUNK_HEADER_VERSION = 1
 
 
 # ── Base ──

--- a/cms/services/log_chunk_assembler.py
+++ b/cms/services/log_chunk_assembler.py
@@ -1,0 +1,557 @@
+"""Chunked log-response assembler (Stage 3c of #345).
+
+Pi firmware advertising the ``logs_chunk_v1`` capability splits log
+bundles larger than the single-message WPS cap (~1 MiB) into a
+sequence of binary WebSocket frames.  Each frame is prefixed with
+the ``LGCK`` magic so the WS receive loop can route it apart from
+text (JSON) messages.
+
+This module owns the per-process reassembly buffer, concatenates
+chunks in ``seq`` order on the ``is_final`` flag, writes the combined
+tar.gz to blob storage, and flips the ``log_requests`` outbox row to
+``ready``.  A background reaper expires stalled transfers so a Pi
+that crashes mid-upload doesn't leak memory (and the matching outbox
+row flips to ``failed`` for the user to see).
+
+Multi-replica note: the buffer is process-local.  That's correct
+under today's transport (``device_transport=local``) and under WPS
+with sticky routing — all frames for a given device land on the
+same replica as the REGISTER.  If a device reconnects mid-stream to
+a different replica (rare), the orphaned buffer expires via the TTL
+reaper, the outbox row flips to ``failed``, and the Pi's drainer-
+driven retry re-requests cleanly.
+
+Wire format for ``LGCK`` frames (all integers little-endian)::
+
+    +----------+-------+-----------------+----------------+------+-------+-------+
+    | "LGCK"   | ver   | request_id_len  | request_id     | seq  | total | flags |
+    |  4 bytes | u8    |  u16            |  UTF-8 N bytes |  u16 |  u16  |  u8   |
+    +----------+-------+-----------------+----------------+------+-------+-------+
+    | chunk payload (rest of the frame, raw gzipped-tar bytes)                   |
+    +----------------------------------------------------------------------------+
+
+``flags`` bit 0 (``0x01``) indicates the final chunk in the sequence.
+``seq`` is 0-based and must satisfy ``seq < total``.  ``total`` is
+fixed for the lifetime of one ``request_id`` — a mismatch on a later
+frame aborts the transfer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import struct
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger("agora.cms.log_chunks")
+
+
+# ── Wire format constants ────────────────────────────────────────────
+
+MAGIC = b"LGCK"
+VERSION = 1
+_HEADER_PREFIX = struct.Struct("<4sB H")  # magic, version, request_id_len
+_TRAILER = struct.Struct("<HHB")  # seq, total, flags
+FLAG_FINAL = 0x01
+# Magic(4) + version(1) + rid_len(2) + seq(2) + total(2) + flags(1).
+# The request_id bytes live between rid_len and seq.
+_FIXED_HEADER_BYTES = 4 + 1 + 2 + 2 + 2 + 1
+
+
+# ── Errors ───────────────────────────────────────────────────────────
+
+class ChunkProtocolError(Exception):
+    """Frame violated the LGCK wire contract (bad magic, short, etc.)."""
+
+
+class ChunkStateError(Exception):
+    """Frame was well-formed but inconsistent with existing buffer state.
+
+    Examples: ``total`` changed between frames; ``seq`` out of range;
+    count/bytes cap exceeded; duplicate ``is_final`` with missing seqs.
+    """
+
+
+# ── Parsed frame ─────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ChunkFrame:
+    request_id: str
+    seq: int
+    total: int
+    is_final: bool
+    payload: bytes
+
+
+def is_chunk_frame(data: bytes) -> bool:
+    """Quick O(1) check — does ``data`` start with the LGCK magic?"""
+    return len(data) >= 4 and data[:4] == MAGIC
+
+
+def parse_frame(data: bytes) -> ChunkFrame:
+    """Parse one ``LGCK`` binary frame.
+
+    Raises :class:`ChunkProtocolError` on any wire-format violation.
+    Does not enforce buffer-level invariants — that's the assembler's
+    job (see :meth:`LogChunkAssembler.ingest`).
+    """
+    if len(data) < _FIXED_HEADER_BYTES:
+        raise ChunkProtocolError(
+            f"frame too short ({len(data)} < {_FIXED_HEADER_BYTES})"
+        )
+    magic, version, rid_len = _HEADER_PREFIX.unpack_from(data, 0)
+    if magic != MAGIC:
+        raise ChunkProtocolError(f"bad magic {magic!r}")
+    if version != VERSION:
+        raise ChunkProtocolError(f"unsupported version {version}")
+    rid_start = _HEADER_PREFIX.size
+    rid_end = rid_start + rid_len
+    if rid_end + _TRAILER.size > len(data):
+        raise ChunkProtocolError("truncated request_id or trailer")
+    try:
+        request_id = data[rid_start:rid_end].decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ChunkProtocolError(f"non-utf8 request_id: {exc}") from exc
+    seq, total, flags = _TRAILER.unpack_from(data, rid_end)
+    if total == 0:
+        raise ChunkProtocolError("total must be >= 1")
+    if seq >= total:
+        raise ChunkProtocolError(f"seq {seq} out of range for total {total}")
+    payload = data[rid_end + _TRAILER.size:]
+    return ChunkFrame(
+        request_id=request_id,
+        seq=seq,
+        total=total,
+        is_final=bool(flags & FLAG_FINAL),
+        payload=payload,
+    )
+
+
+def encode_frame(
+    request_id: str,
+    seq: int,
+    total: int,
+    payload: bytes,
+    *,
+    is_final: bool,
+) -> bytes:
+    """Produce a wire-format ``LGCK`` frame.  Used by tests; Pi firmware
+    has its own encoder in ``agora/cms_client/service.py`` that must
+    stay in lockstep with this one."""
+    rid_bytes = request_id.encode("utf-8")
+    if len(rid_bytes) > 0xFFFF:
+        raise ValueError("request_id too long")
+    if total < 1 or total > 0xFFFF:
+        raise ValueError("total out of range")
+    if seq < 0 or seq >= total:
+        raise ValueError("seq out of range")
+    header = _HEADER_PREFIX.pack(MAGIC, VERSION, len(rid_bytes)) + rid_bytes
+    trailer = _TRAILER.pack(seq, total, FLAG_FINAL if is_final else 0)
+    return header + trailer + payload
+
+
+# ── Assembly buffer ──────────────────────────────────────────────────
+
+@dataclass
+class _Buffer:
+    device_id: str
+    request_id: str
+    total: int
+    created_at: datetime
+    last_updated_at: datetime
+    chunks: dict[int, bytes] = field(default_factory=dict)
+    total_bytes: int = 0
+    saw_final: bool = False
+
+    def has_all(self) -> bool:
+        return len(self.chunks) == self.total
+
+    def assemble(self) -> bytes:
+        parts = [self.chunks[i] for i in range(self.total)]
+        return b"".join(parts)
+
+
+@dataclass(frozen=True)
+class AssembledBundle:
+    device_id: str
+    request_id: str
+    data: bytes
+
+
+@dataclass(frozen=True)
+class ReapedTransfer:
+    device_id: str
+    request_id: str
+    reason: str
+
+
+class LogChunkAssembler:
+    """Process-local buffer for partially-received chunked log uploads.
+
+    Methods are synchronous — the caller drives I/O (blob write,
+    outbox flip) after :meth:`ingest` returns an :class:`AssembledBundle`.
+
+    Thread-safety: guarded by an internal :class:`asyncio.Lock` so
+    concurrent frame arrivals from distinct tasks can't race.  In
+    practice the WS receive loop is single-tasked per connection, so
+    the lock is mostly belt-and-suspenders.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_count: int,
+        max_bytes: int,
+        buffer_ttl_sec: float,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if max_count < 1:
+            raise ValueError("max_count must be >= 1")
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+        if buffer_ttl_sec <= 0:
+            raise ValueError("buffer_ttl_sec must be > 0")
+        self._max_count = int(max_count)
+        self._max_bytes = int(max_bytes)
+        self._ttl = timedelta(seconds=buffer_ttl_sec)
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._buffers: dict[tuple[str, str], _Buffer] = {}
+        self._lock = asyncio.Lock()
+
+    # -- introspection ------------------------------------------------
+
+    def pending_count(self) -> int:
+        return len(self._buffers)
+
+    def has_buffer(self, device_id: str, request_id: str) -> bool:
+        return (device_id, request_id) in self._buffers
+
+    # -- ingest -------------------------------------------------------
+
+    async def ingest(
+        self, device_id: str, frame: ChunkFrame,
+    ) -> AssembledBundle | None:
+        """Add ``frame`` to the buffer for ``(device_id, request_id)``.
+
+        Returns an :class:`AssembledBundle` when ``is_final`` is set and
+        every sequence number has arrived.  Returns ``None`` for
+        intermediate frames or when waiting on a late ``is_final``.
+
+        Raises :class:`ChunkStateError` on buffer-level violations
+        (e.g. ``total`` exceeds cap, assembled size exceeds cap,
+        ``is_final`` with missing seqs).  The caller is expected to
+        catch and translate this into an outbox ``failed`` + drop the
+        buffer via :meth:`drop`.
+        """
+        async with self._lock:
+            key = (device_id, frame.request_id)
+            now = self._clock()
+            buf = self._buffers.get(key)
+            if buf is None:
+                if frame.total > self._max_count:
+                    raise ChunkStateError(
+                        f"chunks_exceeded: total {frame.total} > "
+                        f"max_count {self._max_count}"
+                    )
+                buf = _Buffer(
+                    device_id=device_id,
+                    request_id=frame.request_id,
+                    total=frame.total,
+                    created_at=now,
+                    last_updated_at=now,
+                )
+                self._buffers[key] = buf
+            elif buf.total != frame.total:
+                # Drop the buffer — the Pi's second pass can't recover.
+                self._buffers.pop(key, None)
+                raise ChunkStateError(
+                    f"total_changed: saw {buf.total}, frame has {frame.total}"
+                )
+
+            buf.last_updated_at = now
+
+            if frame.seq in buf.chunks:
+                # Duplicate — ignore.  Don't error: WPS can redeliver on
+                # transient network blips and the first copy is authoritative.
+                logger.debug(
+                    "log_chunks: duplicate seq %d for (%s, %s) — ignored",
+                    frame.seq, device_id, frame.request_id,
+                )
+                if frame.is_final:
+                    buf.saw_final = True
+                if buf.saw_final and buf.has_all():
+                    return self._finalise(key, buf)
+                return None
+
+            projected = buf.total_bytes + len(frame.payload)
+            if projected > self._max_bytes:
+                self._buffers.pop(key, None)
+                raise ChunkStateError(
+                    f"bytes_exceeded: assembled size would be {projected} "
+                    f"bytes > max_bytes {self._max_bytes}"
+                )
+
+            buf.chunks[frame.seq] = frame.payload
+            buf.total_bytes = projected
+
+            if frame.is_final:
+                buf.saw_final = True
+
+            if buf.saw_final:
+                if buf.has_all():
+                    return self._finalise(key, buf)
+                missing = sorted(set(range(buf.total)) - buf.chunks.keys())
+                # Only fail when the final frame *is* the latest — if
+                # ``is_final`` arrived out of order (seq < total-1) the
+                # remaining chunks may still be in flight.  That said,
+                # the Pi always sends the final chunk last in practice,
+                # so a missing-seq state on ``saw_final`` is terminal.
+                if frame.is_final:
+                    self._buffers.pop(key, None)
+                    raise ChunkStateError(
+                        f"chunks_missing: final frame received but seqs "
+                        f"{missing} still missing"
+                    )
+            return None
+
+    def _finalise(self, key: tuple[str, str], buf: _Buffer) -> AssembledBundle:
+        data = buf.assemble()
+        self._buffers.pop(key, None)
+        return AssembledBundle(
+            device_id=buf.device_id,
+            request_id=buf.request_id,
+            data=data,
+        )
+
+    # -- explicit drop ------------------------------------------------
+
+    async def drop(self, device_id: str, request_id: str) -> bool:
+        """Drop the buffer for the given pair without assembly.
+
+        Used when the caller decides the transfer is doomed (e.g. the
+        outbox flip to ``failed`` already ran)."""
+        async with self._lock:
+            return self._buffers.pop((device_id, request_id), None) is not None
+
+    # -- reaper -------------------------------------------------------
+
+    async def reap_expired(self, now: datetime | None = None) -> list[ReapedTransfer]:
+        """Remove buffers whose ``last_updated_at`` is older than the TTL.
+
+        Returns the list of reaped ``(device_id, request_id)`` pairs
+        so the caller can flip the matching outbox rows to ``failed``.
+        """
+        now = now or self._clock()
+        cutoff = now - self._ttl
+        expired: list[ReapedTransfer] = []
+        async with self._lock:
+            dead: list[tuple[str, str]] = []
+            for key, buf in self._buffers.items():
+                if buf.last_updated_at <= cutoff:
+                    dead.append(key)
+                    expired.append(
+                        ReapedTransfer(
+                            device_id=buf.device_id,
+                            request_id=buf.request_id,
+                            reason=(
+                                "chunk_buffer_timeout: last frame received at "
+                                f"{buf.last_updated_at.isoformat()} "
+                                f"(TTL {self._ttl.total_seconds():.0f}s)"
+                            ),
+                        )
+                    )
+            for key in dead:
+                self._buffers.pop(key, None)
+        return expired
+
+
+# ── Module-level singleton ───────────────────────────────────────────
+
+_assembler: LogChunkAssembler | None = None
+
+
+def init_assembler(settings: Any) -> LogChunkAssembler:
+    """Initialise the process-wide assembler singleton from settings."""
+    global _assembler
+    _assembler = LogChunkAssembler(
+        max_count=int(getattr(settings, "log_chunk_max_count", 30)),
+        max_bytes=int(getattr(settings, "log_chunk_max_bytes", 22_020_096)),
+        buffer_ttl_sec=float(getattr(settings, "log_chunk_buffer_ttl_sec", 300)),
+    )
+    logger.info(
+        "Log chunk assembler initialised (max_count=%d, max_bytes=%d, ttl=%.0fs)",
+        _assembler._max_count, _assembler._max_bytes, _assembler._ttl.total_seconds(),
+    )
+    return _assembler
+
+
+def get_assembler() -> LogChunkAssembler:
+    if _assembler is None:
+        raise RuntimeError(
+            "Log chunk assembler not initialised — call init_assembler() first"
+        )
+    return _assembler
+
+
+def set_assembler(assembler: LogChunkAssembler | None) -> None:
+    """Test helper — swap in a pre-built assembler."""
+    global _assembler
+    _assembler = assembler
+
+
+# ── Integration: frame → blob + outbox ───────────────────────────────
+
+async def handle_frame(
+    db,
+    *,
+    device_id: str,
+    frame_bytes: bytes,
+    assembler: LogChunkAssembler | None = None,
+) -> AssembledBundle | None:
+    """Parse ``frame_bytes``, feed it to the assembler, and — on the
+    final frame — write the reassembled tar.gz to blob storage and
+    flip the outbox row to ``ready``.
+
+    Returns the :class:`AssembledBundle` when assembly completed on
+    this call, ``None`` otherwise (intermediate frame, malformed, or
+    buffer-level failure).
+
+    All failures are caught here so a bad frame can't drop the WS
+    connection — worst case we log + mark the outbox row ``failed``
+    and the Pi retries via the drainer.
+    """
+    from cms.services import log_outbox
+    from cms.services.log_blob import write_log_blob
+
+    asm = assembler or get_assembler()
+
+    try:
+        frame = parse_frame(frame_bytes)
+    except ChunkProtocolError as exc:
+        logger.warning(
+            "log_chunks: protocol error from %s: %s", device_id, exc,
+        )
+        return None
+
+    try:
+        bundle = await asm.ingest(device_id, frame)
+    except ChunkStateError as exc:
+        logger.warning(
+            "log_chunks: state error on %s request %s: %s",
+            device_id, frame.request_id, exc,
+        )
+        try:
+            await log_outbox.mark_failed(db, frame.request_id, error=str(exc))
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "log_chunks: failed to mark outbox failed for %s/%s",
+                device_id, frame.request_id,
+            )
+        return None
+
+    if bundle is None:
+        return None
+
+    blob_path = f"{bundle.device_id}/{bundle.request_id}.tar.gz"
+    try:
+        await write_log_blob(blob_path, bundle.data)
+        await log_outbox.mark_ready(
+            db, bundle.request_id,
+            blob_path=blob_path, size_bytes=len(bundle.data),
+        )
+        await db.commit()
+    except Exception:
+        logger.exception(
+            "log_chunks: failed to persist assembled bundle for %s/%s",
+            bundle.device_id, bundle.request_id,
+        )
+        try:
+            await log_outbox.mark_failed(
+                db, bundle.request_id, error="chunk_persist_failed",
+            )
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "log_chunks: failed to mark outbox failed after persist error",
+            )
+        return None
+
+    logger.info(
+        "log_chunks: assembled %d bytes for %s/%s (%d chunks)",
+        len(bundle.data), bundle.device_id, bundle.request_id, frame.total,
+    )
+    return bundle
+
+
+# ── Reaper loop ──────────────────────────────────────────────────────
+
+async def run_reaper_loop(
+    session_factory_getter: Callable[[], Any],
+    *,
+    assembler_getter: Callable[[], LogChunkAssembler] = get_assembler,
+    settings: Any,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run the TTL reaper forever until ``stop_event`` is set.
+
+    Each tick pulls expired buffers out of the assembler and, for each
+    one, flips the matching ``log_requests`` row to ``failed`` so the
+    user can see the transfer timed out.  Rows are addressed by
+    ``request_id`` alone — device_id is only used for logging.
+    """
+    from cms.services import log_outbox
+
+    interval = float(getattr(settings, "log_chunk_reaper_interval_sec", 5.0))
+    if stop_event is None:
+        stop_event = asyncio.Event()
+    logger.info("Log chunk reaper loop started (interval=%.1fs)", interval)
+    try:
+        while not stop_event.is_set():
+            try:
+                asm = assembler_getter()
+                expired = await asm.reap_expired()
+                if expired:
+                    factory = session_factory_getter()
+                    if factory is None:
+                        logger.warning(
+                            "log_chunk_reaper: %d expired buffers but "
+                            "session factory not initialised",
+                            len(expired),
+                        )
+                    else:
+                        async with factory() as db:
+                            try:
+                                for item in expired:
+                                    try:
+                                        await log_outbox.mark_failed(
+                                            db, item.request_id, error=item.reason,
+                                        )
+                                    except Exception:
+                                        logger.exception(
+                                            "log_chunk_reaper: mark_failed "
+                                            "failed for %s/%s",
+                                            item.device_id, item.request_id,
+                                        )
+                                await db.commit()
+                            except BaseException:
+                                await db.rollback()
+                                raise
+                    for item in expired:
+                        logger.warning(
+                            "log_chunks: reaped stalled transfer %s/%s (%s)",
+                            item.device_id, item.request_id, item.reason,
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("log_chunk_reaper: unexpected tick error")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        logger.info("Log chunk reaper loop stopped")

--- a/tests/test_device_logs.py
+++ b/tests/test_device_logs.py
@@ -233,7 +233,7 @@ class TestProtocolMessages:
         assert data["request_id"] == "test-123"
         assert data["services"] == ["agora-player"]
         assert data["since"] == "6h"
-        assert data["protocol_version"] == 1
+        assert data["protocol_version"] == 2
 
     def test_logs_response_message(self):
         from cms.schemas.protocol import LogsResponseMessage

--- a/tests/test_log_chunk_assembler.py
+++ b/tests/test_log_chunk_assembler.py
@@ -1,0 +1,315 @@
+"""Unit tests for the chunked log-response assembler (Stage 3c of #345)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+
+from cms.services.log_chunk_assembler import (
+    ChunkProtocolError,
+    ChunkStateError,
+    FLAG_FINAL,
+    LogChunkAssembler,
+    MAGIC,
+    VERSION,
+    encode_frame,
+    is_chunk_frame,
+    parse_frame,
+)
+
+
+# ── Wire-format tests ────────────────────────────────────────────────
+
+
+def test_is_chunk_frame_detects_magic():
+    assert is_chunk_frame(encode_frame("r1", 0, 1, b"payload", is_final=True))
+    assert not is_chunk_frame(b"")
+    assert not is_chunk_frame(b"{\"type\":\"status\"}")
+    assert not is_chunk_frame(b"LGC")  # too short
+    assert not is_chunk_frame(b"ABCD" + b"rest")
+
+
+def test_parse_frame_roundtrip():
+    payload = b"\x00" * 500
+    raw = encode_frame("req-abc", seq=3, total=5, payload=payload, is_final=False)
+    parsed = parse_frame(raw)
+    assert parsed.request_id == "req-abc"
+    assert parsed.seq == 3
+    assert parsed.total == 5
+    assert parsed.is_final is False
+    assert parsed.payload == payload
+
+
+def test_parse_frame_final_flag():
+    raw = encode_frame("r", 0, 1, b"last", is_final=True)
+    parsed = parse_frame(raw)
+    assert parsed.is_final is True
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        b"",
+        b"XYZ!",
+        b"LGCK\x02\x00\x00",  # wrong version
+        b"LGCK\x01\xff\xff",  # claims a 65535-byte request_id, truncated
+    ],
+)
+def test_parse_frame_rejects_garbage(bad):
+    with pytest.raises(ChunkProtocolError):
+        parse_frame(bad)
+
+
+def test_parse_frame_rejects_bad_total():
+    # total = 0 is invalid
+    import struct
+    raw = b"LGCK\x01" + struct.pack("<H", 1) + b"r" + struct.pack("<HHB", 0, 0, 0)
+    with pytest.raises(ChunkProtocolError):
+        parse_frame(raw)
+
+
+def test_parse_frame_rejects_seq_out_of_range():
+    import struct
+    raw = b"LGCK\x01" + struct.pack("<H", 1) + b"r" + struct.pack("<HHB", 5, 3, 0)
+    with pytest.raises(ChunkProtocolError):
+        parse_frame(raw)
+
+
+def test_encode_frame_validations():
+    with pytest.raises(ValueError):
+        encode_frame("r", 5, 3, b"", is_final=False)
+    with pytest.raises(ValueError):
+        encode_frame("r", 0, 0, b"", is_final=False)
+    with pytest.raises(ValueError):
+        encode_frame("r" * 70000, 0, 1, b"", is_final=True)
+
+
+# ── Assembler tests ──────────────────────────────────────────────────
+
+
+def _assembler(**overrides) -> LogChunkAssembler:
+    kwargs = dict(max_count=30, max_bytes=22_020_096, buffer_ttl_sec=300)
+    kwargs.update(overrides)
+    return LogChunkAssembler(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_assembles_three_chunks():
+    asm = _assembler()
+    chunks = [b"aaa", b"bbb", b"ccc"]
+    frames = [
+        parse_frame(encode_frame("rid", i, 3, c, is_final=(i == 2)))
+        for i, c in enumerate(chunks)
+    ]
+
+    result = await asm.ingest("dev", frames[0])
+    assert result is None
+    result = await asm.ingest("dev", frames[1])
+    assert result is None
+    result = await asm.ingest("dev", frames[2])
+    assert result is not None
+    assert result.device_id == "dev"
+    assert result.request_id == "rid"
+    assert result.data == b"aaabbbccc"
+    # Buffer dropped after assembly.
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_assembles_correctly():
+    asm = _assembler()
+    # Middle and first frames arrive swapped; final frame (highest seq)
+    # arrives last — which matches real-world single-WS ordering but
+    # still exercises the "fill by seq index, not arrival order" code.
+    f0 = parse_frame(encode_frame("rid", 0, 3, b"111", is_final=False))
+    f1 = parse_frame(encode_frame("rid", 1, 3, b"222", is_final=False))
+    f2 = parse_frame(encode_frame("rid", 2, 3, b"333", is_final=True))
+
+    assert await asm.ingest("dev", f1) is None
+    assert await asm.ingest("dev", f0) is None
+    result = await asm.ingest("dev", f2)
+    assert result is not None
+    assert result.data == b"111222333"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_seq_ignored():
+    asm = _assembler()
+    f0a = parse_frame(encode_frame("rid", 0, 2, b"first", is_final=False))
+    f0b = parse_frame(encode_frame("rid", 0, 2, b"REDO!", is_final=False))
+    f1 = parse_frame(encode_frame("rid", 1, 2, b"tail", is_final=True))
+
+    assert await asm.ingest("dev", f0a) is None
+    # Duplicate ignored — first copy wins.
+    assert await asm.ingest("dev", f0b) is None
+    result = await asm.ingest("dev", f1)
+    assert result is not None
+    assert result.data == b"firsttail"
+
+
+@pytest.mark.asyncio
+async def test_missing_seq_on_final_fails():
+    asm = _assembler()
+    f0 = parse_frame(encode_frame("rid", 0, 3, b"a", is_final=False))
+    f2 = parse_frame(encode_frame("rid", 2, 3, b"c", is_final=True))
+
+    assert await asm.ingest("dev", f0) is None
+    with pytest.raises(ChunkStateError, match="chunks_missing"):
+        await asm.ingest("dev", f2)
+    # Buffer dropped after state error.
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_count_cap_rejected():
+    asm = _assembler(max_count=5)
+    over = parse_frame(encode_frame("rid", 0, 6, b"x", is_final=False))
+    with pytest.raises(ChunkStateError, match="chunks_exceeded"):
+        await asm.ingest("dev", over)
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_bytes_cap_rejected():
+    asm = _assembler(max_bytes=1000)
+    f0 = parse_frame(encode_frame("rid", 0, 2, b"x" * 600, is_final=False))
+    f1 = parse_frame(encode_frame("rid", 1, 2, b"x" * 600, is_final=True))
+    assert await asm.ingest("dev", f0) is None
+    with pytest.raises(ChunkStateError, match="bytes_exceeded"):
+        await asm.ingest("dev", f1)
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_total_mismatch_rejected():
+    asm = _assembler()
+    f0 = parse_frame(encode_frame("rid", 0, 3, b"a", is_final=False))
+    f1_bad = parse_frame(encode_frame("rid", 1, 5, b"b", is_final=False))
+    assert await asm.ingest("dev", f0) is None
+    with pytest.raises(ChunkStateError, match="total_changed"):
+        await asm.ingest("dev", f1_bad)
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_different_requests_isolated():
+    asm = _assembler()
+    rA = parse_frame(encode_frame("ridA", 0, 1, b"A", is_final=True))
+    rB = parse_frame(encode_frame("ridB", 0, 1, b"B", is_final=True))
+    resA = await asm.ingest("devA", rA)
+    resB = await asm.ingest("devB", rB)
+    assert resA.data == b"A"
+    assert resB.data == b"B"
+
+
+@pytest.mark.asyncio
+async def test_same_request_id_different_devices_isolated():
+    """Keyed by ``(device_id, request_id)`` — same request_id from two
+    devices can coexist (request ids are UUIDs in practice, but the
+    assembler shouldn't rely on global uniqueness)."""
+    asm = _assembler()
+    f_a = parse_frame(encode_frame("rid", 0, 1, b"hostA", is_final=True))
+    f_b = parse_frame(encode_frame("rid", 0, 1, b"hostB", is_final=True))
+    a = await asm.ingest("dev-a", f_a)
+    b = await asm.ingest("dev-b", f_b)
+    assert a.data == b"hostA"
+    assert b.data == b"hostB"
+    assert a.device_id == "dev-a"
+    assert b.device_id == "dev-b"
+
+
+# ── Reaper tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reap_expired_drops_stalled_and_returns_metadata():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    clock = {"t": now}
+    asm = LogChunkAssembler(
+        max_count=10, max_bytes=10_000, buffer_ttl_sec=60,
+        clock=lambda: clock["t"],
+    )
+
+    f0 = parse_frame(encode_frame("rid", 0, 2, b"first", is_final=False))
+    await asm.ingest("dev", f0)
+    assert asm.pending_count() == 1
+
+    # Before TTL: nothing reaped.
+    clock["t"] = now + timedelta(seconds=30)
+    assert await asm.reap_expired() == []
+    assert asm.pending_count() == 1
+
+    # Past TTL: reaped.
+    clock["t"] = now + timedelta(seconds=120)
+    reaped = await asm.reap_expired()
+    assert len(reaped) == 1
+    assert reaped[0].device_id == "dev"
+    assert reaped[0].request_id == "rid"
+    assert "chunk_buffer_timeout" in reaped[0].reason
+    assert asm.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_reap_preserves_active_buffers():
+    """A buffer that received a frame recently (after another one
+    stalled) should not be reaped."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    clock = {"t": now}
+    asm = LogChunkAssembler(
+        max_count=10, max_bytes=10_000, buffer_ttl_sec=60,
+        clock=lambda: clock["t"],
+    )
+
+    # Stalled buffer.
+    await asm.ingest("dev", parse_frame(
+        encode_frame("old", 0, 2, b"x", is_final=False),
+    ))
+
+    # Active buffer — added much later.
+    clock["t"] = now + timedelta(seconds=90)
+    await asm.ingest("dev", parse_frame(
+        encode_frame("new", 0, 2, b"y", is_final=False),
+    ))
+
+    reaped = await asm.reap_expired()
+    assert [r.request_id for r in reaped] == ["old"]
+    assert asm.pending_count() == 1
+    assert asm.has_buffer("dev", "new")
+
+
+# ── drop() helper ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drop_removes_buffer():
+    asm = _assembler()
+    await asm.ingest(
+        "dev", parse_frame(encode_frame("rid", 0, 2, b"x", is_final=False)),
+    )
+    assert asm.has_buffer("dev", "rid")
+    assert await asm.drop("dev", "rid") is True
+    assert asm.has_buffer("dev", "rid") is False
+    assert await asm.drop("dev", "rid") is False
+
+
+# ── Large-ish payload smoke ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_assembles_many_chunks_preserving_bytes():
+    asm = _assembler(max_count=30, max_bytes=30 * 100_000)
+    total = 20
+    chunks = [bytes([i % 256]) * 1000 for i in range(total)]
+    for i, c in enumerate(chunks):
+        frame = parse_frame(
+            encode_frame("big", i, total, c, is_final=(i == total - 1))
+        )
+        res = await asm.ingest("dev", frame)
+        if i < total - 1:
+            assert res is None
+        else:
+            assert res is not None
+            assert res.data == b"".join(chunks)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,7 +19,7 @@ class TestProtocolMessages:
         )
         data = msg.model_dump()
         assert data["type"] == "register"
-        assert data["protocol_version"] == 1
+        assert data["protocol_version"] == 2
         assert data["device_id"] == "pi-001"
 
     def test_sync_message_defaults(self):
@@ -28,7 +28,7 @@ class TestProtocolMessages:
         msg = SyncMessage()
         data = msg.model_dump(mode="json")
         assert data["type"] == "sync"
-        assert data["protocol_version"] == 1
+        assert data["protocol_version"] == 2
 
     def test_auth_assigned_message(self):
         from cms.schemas.protocol import AuthAssignedMessage


### PR DESCRIPTION
# Stage 3c — Chunked LOGS_RESPONSE over WSS (CMS side)

Part of the multi-replica rollout: #345.

## Why

Today, logs come back from the Pi as a single `LOGS_RESPONSE` JSON message.
WPS caps a single WebSocket message at ~1 MiB, so the current path silently
bottoms out for noisy devices or wider time ranges. This PR adds a
chunked binary path on the WS channel so large gzipped journal bundles
still work without introducing an HTTP upload path on the Pi (no new
auth surface, no new network stack, no schema change).

The small-payload `LOGS_RESPONSE` shim is untouched — legacy firmware
keeps working.

## What

- **Protocol**
  - `cms/schemas/protocol.py`
  - `PROTOCOL_VERSION` → `2`; `SUPPORTED_PROTOCOL_VERSIONS = {1, 2}` so
    legacy firmware is still accepted during rollout.
  - New `LOGS_CHUNK_MAGIC = b"LGCK"` + `LOGS_CHUNK_HEADER_VERSION = 1`.

- **Wire format** (little-endian binary WS frame):
  ```
  +--------+-----+---------+------------+-----+-------+-------+---------+
  | "LGCK" | ver | rid_len | request_id | seq | total | flags | payload |
  |  4b    | u8  |  u16    | utf8 Nb    | u16 | u16   | u8    | rest    |
  +--------+-----+---------+------------+-----+-------+-------+---------+
  ```
  - `flags` bit 0 = `is_final`.
  - `seq < total`; `total > 0`.

- **Assembler** — `cms/services/log_chunk_assembler.py` (new, ~430
  lines):
  - Process-local buffer keyed `(device_id, request_id)`.
  - Duplicate `seq` ignored (first copy wins — WPS can redeliver on
    transient blips).
  - `total` mismatch between frames, `total > max_count`, or projected
    `sum(bytes) > max_bytes` → terminal error, buffer dropped, outbox
    `failed`.
  - `is_final` with missing seqs → terminal error.
  - On complete set: concat in `seq` order, write blob at
    `device-logs/{device_id}/{request_id}.tar.gz`, mark outbox `ready`.
  - TTL reaper (`buffer_ttl_sec`, default 300 s; interval 5 s) prunes
    stale buffers and flips their outbox rows to `failed`.

- **Router** — `cms/routers/ws.py`
  - Switched message loop from `receive_json()` to `receive()` so
    binary frames surface alongside text.
  - Binary frames with `LGCK` magic → `handle_log_chunk_frame`.
  - Non-magic binary frames are logged and dropped (forward-compat).
  - Text frames go through the existing JSON dispatch unchanged.
  - Register-time version check relaxed from strict-equality to
    `in SUPPORTED_PROTOCOL_VERSIONS`.

- **Lifespan** — `cms/main.py`
  - `init_assembler(settings)` after `init_log_storage(settings)`.
  - `log_chunk_reaper_task` alongside `log_drainer_task`, with matching
    5 s bounded shutdown wait.

- **Config** — `cms/config.py` (Stage 3c settings):
  - `log_chunk_max_count = 30`
  - `log_chunk_max_bytes = 22_020_096` (21 MiB assembled cap)
  - `log_chunk_buffer_ttl_sec = 300`
  - `log_chunk_reaper_interval_sec = 5.0`

## Tests

`tests/test_log_chunk_assembler.py` — 23 cases:

- wire-format roundtrip + garbage rejection + encode validations
- happy-path assembly
- out-of-order (non-final) arrival
- duplicate `seq` ignored
- missing `seq` on `is_final` → `ChunkStateError`
- `total` mismatch → `ChunkStateError`
- `max_count` / `max_bytes` caps → `ChunkStateError`
- different requests / different devices isolated
- reaper drops stalled buffers, preserves active ones
- 20-chunk assembled payload byte-for-byte match
- `drop()` helper idempotency

Also bumped `protocol_version == 1` assertions → `2` in
`tests/test_schemas.py` and `tests/test_device_logs.py`. Other tests
(e.g. `test_websocket.py`, `test_temperature.py`) still send
`protocol_version = 1` and continue to work because `1` is still in
`SUPPORTED_PROTOCOL_VERSIONS`.

## What's NOT in this PR

- No Pi-side changes — companion PR in `sslivins/agora` follows.
- No HTTP upload, no `upload_url`, no aiohttp changes.
- `_pending_log_requests` map + legacy `LOGS_RESPONSE` shim stay — 3e.
- No DB migration. All chunking state is in-process.

## Migration / safety

- Schema unchanged; no Alembic revision.
- Fully backward compatible: a Pi still running protocol v1 that only
  sends `LOGS_RESPONSE` text frames is unaffected.
- `LGCK` is only routed to the assembler when the 4-byte magic matches
  — other binary frames are logged and dropped, preserving room to add
  future binary message types.

Refs #345.
