### PR TITLE
feat: Stage 3e log-blob reaper (#345)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -69,3 +69,9 @@ class Settings(SharedSettings):
     log_chunk_max_bytes: int = 22_020_096  # 21 MiB
     log_chunk_buffer_ttl_sec: int = 300
     log_chunk_reaper_interval_sec: float = 5.0
+
+    # Log-blob reaper (issue #345 Stage 3e).  Periodically scans the
+    # ``log_requests`` table for rows whose ``expires_at`` has passed,
+    # deletes the associated blob, and flips the row to ``expired``.
+    log_reaper_interval_sec: float = 600.0  # 10 minutes
+    log_reaper_batch_size: int = 100

--- a/cms/main.py
+++ b/cms/main.py
@@ -371,6 +371,22 @@ async def lifespan(app: FastAPI):
         )
     )
 
+    # ── Log-blob reaper (issue #345 Stage 3e) ──
+    # Walks ``log_requests`` for rows past ``expires_at`` on a slow
+    # cadence (10 min default), deletes the blob, and flips the row to
+    # ``expired``.  Bounds device-logs container growth to the default
+    # 30-day retention window.  Uses ``FOR UPDATE SKIP LOCKED`` on PG
+    # so concurrent replicas don't race on the same row.
+    from cms.services.log_reaper import run_loop as log_reaper_run_loop
+    log_reaper_stop = asyncio.Event()
+    log_reaper_task = asyncio.create_task(
+        log_reaper_run_loop(
+            _get_session_factory,
+            settings=settings,
+            stop_event=log_reaper_stop,
+        )
+    )
+
     # Log CMS startup to the event log (so upgrades/restarts show up in the timeline)
     try:
         from cms.models.device_event import DeviceEvent, DeviceEventType
@@ -454,6 +470,7 @@ async def lifespan(app: FastAPI):
     outbox_drain_task.cancel()
     log_drainer_stop.set()
     log_chunk_reaper_stop.set()
+    log_reaper_stop.set()
     try:
         await scheduler_task
     except asyncio.CancelledError:
@@ -510,6 +527,16 @@ async def lifespan(app: FastAPI):
             pass
     except Exception:
         logger.exception("log_chunk_reaper: error during shutdown")
+    try:
+        await asyncio.wait_for(log_reaper_task, timeout=5.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        log_reaper_task.cancel()
+        try:
+            await log_reaper_task
+        except asyncio.CancelledError:
+            pass
+    except Exception:
+        logger.exception("log_reaper: error during shutdown")
     # Close storage backend (Azure: close async blob client)
     if hasattr(backend, "close"):
         await backend.close()

--- a/cms/services/log_reaper.py
+++ b/cms/services/log_reaper.py
@@ -1,0 +1,244 @@
+"""Background blob-reaper for the ``log_requests`` outbox (Stage 3e of #345).
+
+One asyncio loop per CMS replica.  Each tick:
+
+1. Claim up to ``batch_size`` rows whose ``expires_at`` has passed
+   (``SELECT ... FOR UPDATE SKIP LOCKED`` on Postgres so overlapping
+   scans don't double-delete).
+2. For each row with a ``blob_path``, call
+   :func:`cms.services.log_blob.delete_log_blob`.  A blob that's
+   already gone (backend returns ``False``) is counted as a benign
+   miss — the row still transitions.
+3. Update the row to ``status=expired``, ``blob_path=NULL`` so the
+   UI sees the log bundle as cleaned up while the row lives on as
+   a history tombstone.  A later, longer-tenured retention pass
+   (not in this PR) can hard-delete rows whose ``expires_at`` is far
+   enough in the past.
+
+Idempotence:
+
+* Already-expired rows are filtered out by the claim query so we
+  never touch them twice.
+* A blob-delete failure (network blip, transient Azure error) keeps
+  the row as-is — the next tick retries.  The row stays "expired"
+  eligible because its ``expires_at`` is unchanged.
+
+See ``docs/multi-replica-architecture.md`` §Stage 3 for the overall
+retention design, and :mod:`cms.services.log_outbox` for the state
+machine helpers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.log_request import (
+    STATUS_EXPIRED,
+    LogRequest,
+)
+from cms.services.log_blob import delete_log_blob
+
+logger = logging.getLogger("agora.cms.log_reaper")
+
+
+# Defaults applied when the caller doesn't pass a Settings object.
+# Matches the AGORA_CMS_LOG_REAPER_* fields declared in cms.config.
+_DEFAULT_INTERVAL_SEC = 600.0  # 10 minutes — retention is measured in days
+_DEFAULT_BATCH_SIZE = 100
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_postgres(db: AsyncSession) -> bool:
+    bind = getattr(db, "bind", None)
+    if bind is None:
+        try:
+            bind = db.get_bind()
+        except Exception:
+            return False
+    return bind.dialect.name == "postgresql"
+
+
+def _resolve_config(settings: Any) -> int:
+    """Return ``batch_size`` from settings."""
+    if settings is None:
+        return _DEFAULT_BATCH_SIZE
+    return int(getattr(settings, "log_reaper_batch_size", _DEFAULT_BATCH_SIZE))
+
+
+# ── Claim helper ─────────────────────────────────────────────────────
+
+
+async def claim_expired_rows(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    batch_size: int,
+) -> list[LogRequest]:
+    """Return up to ``batch_size`` rows whose ``expires_at`` has passed
+    and that have not yet been marked ``expired``.
+
+    Rows with ``expires_at IS NULL`` (opt-out, e.g. forensic retention)
+    are excluded.
+
+    On Postgres the scan uses ``FOR UPDATE SKIP LOCKED`` so multiple
+    replicas can reap concurrently without double-deleting blobs.  On
+    SQLite (tests) the lock hint is dropped.
+    """
+    stmt = (
+        select(LogRequest)
+        .where(
+            LogRequest.expires_at.is_not(None),
+            LogRequest.expires_at <= now,
+            LogRequest.status != STATUS_EXPIRED,
+        )
+        .order_by(LogRequest.expires_at)
+        .limit(batch_size)
+        .execution_options(populate_existing=True)
+    )
+    if _is_postgres(db):
+        stmt = stmt.with_for_update(skip_locked=True)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+# ── Single tick ──────────────────────────────────────────────────────
+
+
+BlobDeleter = Callable[[str], Awaitable[bool]]
+
+
+async def reap_once(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    settings: Any = None,
+    blob_deleter: BlobDeleter | None = None,
+) -> dict:
+    """Run one reaper tick inside a single transaction.
+
+    Returns a stats dict::
+
+        {"claimed": N, "blobs_deleted": D, "blobs_missing": M,
+         "rows_expired": E, "errors": K}
+
+    ``blob_deleter`` is injectable for tests; production callers leave
+    it ``None`` to use :func:`cms.services.log_blob.delete_log_blob`.
+
+    Commits once at the end.  On any unexpected error the transaction
+    is rolled back and the exception propagates so the loop can log
+    and continue.
+    """
+    if now is None:
+        now = _now()
+    batch_size = _resolve_config(settings)
+    deleter: BlobDeleter = blob_deleter or delete_log_blob
+
+    stats = {
+        "claimed": 0,
+        "blobs_deleted": 0,
+        "blobs_missing": 0,
+        "rows_expired": 0,
+        "errors": 0,
+    }
+
+    try:
+        rows = await claim_expired_rows(db, now=now, batch_size=batch_size)
+        stats["claimed"] = len(rows)
+
+        for row in rows:
+            # Attempt blob delete first.  If the delete call errors we
+            # leave the row untouched and let the next tick retry —
+            # this is safer than marking the row expired and leaking
+            # the blob forever.
+            if row.blob_path:
+                try:
+                    existed = await deleter(row.blob_path)
+                except Exception:
+                    logger.exception(
+                        "log_reaper: blob delete failed for %s (row %s)",
+                        row.blob_path, row.id,
+                    )
+                    stats["errors"] += 1
+                    continue
+                if existed:
+                    stats["blobs_deleted"] += 1
+                else:
+                    stats["blobs_missing"] += 1
+
+            # Flip to expired + null the blob_path.  A row may already
+            # be terminal (``ready``, ``failed``); the reaper overrides
+            # that because ``expires_at`` is the authoritative retention
+            # signal — we want any surviving UI references to see the
+            # bundle as cleaned up.
+            await db.execute(
+                update(LogRequest)
+                .where(LogRequest.id == row.id)
+                .values(status=STATUS_EXPIRED, blob_path=None, updated_at=_now())
+            )
+            stats["rows_expired"] += 1
+
+        await db.commit()
+    except BaseException:
+        await db.rollback()
+        raise
+
+    if any(v for v in stats.values()):
+        logger.info("reap_once: %s", stats)
+    return stats
+
+
+# ── Loop ─────────────────────────────────────────────────────────────
+
+
+async def run_loop(
+    session_factory_getter: Callable[[], Any],
+    *,
+    settings: Any,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run :func:`reap_once` forever on a ``log_reaper_interval_sec``
+    cadence until ``stop_event`` is set.
+
+    A single tick failure (DB blip, transient blob backend error) is
+    logged and the loop keeps going.  ``asyncio.CancelledError`` is
+    propagated so the standard shutdown path works.
+    """
+    interval = float(
+        getattr(settings, "log_reaper_interval_sec", _DEFAULT_INTERVAL_SEC)
+    )
+    if stop_event is None:
+        stop_event = asyncio.Event()
+    logger.info("Log reaper loop started (interval=%.1fs)", interval)
+    try:
+        while not stop_event.is_set():
+            try:
+                factory = session_factory_getter()
+                if factory is None:
+                    logger.warning(
+                        "log_reaper: session factory not initialised; skipping tick",
+                    )
+                else:
+                    async with factory() as db:
+                        try:
+                            await reap_once(db, settings=settings)
+                        except Exception:
+                            logger.exception("log_reaper: reap_once failed")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("log_reaper: unexpected error in tick")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        logger.info("Log reaper loop stopped")

--- a/tests/test_log_reaper.py
+++ b/tests/test_log_reaper.py
@@ -1,0 +1,382 @@
+"""Tests for :mod:`cms.services.log_reaper` (Stage 3e of #345).
+
+Covers :func:`reap_once` — the single-tick workhorse — and a light
+smoke test of :func:`run_loop`'s shutdown path.  Structured to mirror
+``test_log_drainer.py``: drives the outbox helpers against
+``db_session`` fixtures and injects a fake blob deleter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+
+from cms.models.device import Device, DeviceStatus
+from cms.models.log_request import (
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_READY,
+    STATUS_SENT,
+    LogRequest,
+)
+from cms.services import log_outbox, log_reaper
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def _device(db_session):
+    """Seed a single adopted device for outbox rows to reference."""
+    d = Device(id="d-reaper-1", name="Reaper Test", status=DeviceStatus.ADOPTED)
+    db_session.add(d)
+    await db_session.commit()
+    return d
+
+
+def _make_settings(**overrides) -> SimpleNamespace:
+    base = {
+        "log_reaper_interval_sec": 600.0,
+        "log_reaper_batch_size": 100,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class FakeBlobDeleter:
+    """Records each ``delete`` call.  Return value is configurable
+    per-path via ``missing`` (backend says the blob wasn't there),
+    or globally via ``should_fail`` to raise.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.missing: set[str] = set()
+        self.should_fail = False
+        self.fail_exc: BaseException = RuntimeError("blob backend down")
+
+    async def __call__(self, relative_path: str) -> bool:
+        self.calls.append(relative_path)
+        if self.should_fail:
+            raise self.fail_exc
+        return relative_path not in self.missing
+
+
+async def _reload(db, request_id: str) -> LogRequest | None:
+    result = await db.execute(
+        select(LogRequest)
+        .where(LogRequest.id == request_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _set_row(db, request_id: str, **values) -> None:
+    await db.execute(
+        update(LogRequest).where(LogRequest.id == request_id).values(**values)
+    )
+    await db.commit()
+
+
+def _past(seconds: int = 60) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=seconds)
+
+
+def _future(seconds: int = 60) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+# ── Individual tick scenarios ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reaps_expired_row_with_blob(db_session, _device):
+    """Happy path: an expired ``ready`` row with a blob gets its blob
+    deleted, flips to ``expired``, and ``blob_path`` is cleared."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    blob_path = f"device-logs/{_device.id}/{row.id}.tar.gz"
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_READY,
+        blob_path=blob_path,
+        expires_at=_past(),
+    )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 1
+    assert stats["blobs_deleted"] == 1
+    assert stats["blobs_missing"] == 0
+    assert stats["rows_expired"] == 1
+    assert stats["errors"] == 0
+    assert deleter.calls == [blob_path]
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_EXPIRED
+    assert refreshed.blob_path is None
+
+
+@pytest.mark.asyncio
+async def test_reaps_expired_row_without_blob(db_session, _device):
+    """A failed row with NULL ``blob_path`` still transitions to
+    ``expired`` — no blob call is issued."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_FAILED,
+        blob_path=None,
+        expires_at=_past(),
+    )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 1
+    assert stats["blobs_deleted"] == 0
+    assert stats["rows_expired"] == 1
+    assert deleter.calls == []
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_EXPIRED
+
+
+@pytest.mark.asyncio
+async def test_skips_rows_not_yet_expired(db_session, _device):
+    """``expires_at`` in the future → row untouched, no stats."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_READY,
+        blob_path="device-logs/x/y.tar.gz",
+        expires_at=_future(3600),
+    )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 0
+    assert stats["rows_expired"] == 0
+    assert deleter.calls == []
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_READY
+    assert refreshed.blob_path == "device-logs/x/y.tar.gz"
+
+
+@pytest.mark.asyncio
+async def test_skips_rows_already_expired(db_session, _device):
+    """Idempotence — a row already in ``expired`` is filtered out by
+    the claim query so the deleter isn't called twice."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_EXPIRED,
+        blob_path=None,
+        expires_at=_past(),
+    )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 0
+    assert deleter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_skips_rows_with_null_expires_at(db_session, _device):
+    """``expires_at IS NULL`` (opt-out / forensic retention) is always
+    excluded from the reaper scan."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_READY,
+        blob_path="device-logs/forever/keep.tar.gz",
+        expires_at=None,
+    )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 0
+    assert deleter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_blob_is_benign(db_session, _device):
+    """Backend returns ``False`` (blob already gone) → still counts as
+    a successful expiry; ``blobs_missing`` is bumped for visibility."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    blob_path = f"device-logs/{_device.id}/{row.id}.tar.gz"
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_READY,
+        blob_path=blob_path,
+        expires_at=_past(),
+    )
+
+    deleter = FakeBlobDeleter()
+    deleter.missing.add(blob_path)
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 1
+    assert stats["blobs_deleted"] == 0
+    assert stats["blobs_missing"] == 1
+    assert stats["rows_expired"] == 1
+
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.status == STATUS_EXPIRED
+    assert refreshed.blob_path is None
+
+
+@pytest.mark.asyncio
+async def test_blob_delete_error_keeps_row(db_session, _device):
+    """Transient backend error → row is NOT marked expired.  The
+    next tick retries from the same state."""
+    row = await log_outbox.create(db_session, device_id=_device.id)
+    await db_session.commit()
+    blob_path = f"device-logs/{_device.id}/{row.id}.tar.gz"
+    await _set_row(
+        db_session,
+        row.id,
+        status=STATUS_READY,
+        blob_path=blob_path,
+        expires_at=_past(),
+    )
+
+    deleter = FakeBlobDeleter()
+    deleter.should_fail = True
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == 1
+    assert stats["blobs_deleted"] == 0
+    assert stats["rows_expired"] == 0
+    assert stats["errors"] == 1
+
+    refreshed = await _reload(db_session, row.id)
+    # Row untouched — blob_path + status preserved.
+    assert refreshed.status == STATUS_READY
+    assert refreshed.blob_path == blob_path
+
+
+@pytest.mark.asyncio
+async def test_batch_size_caps_work_per_tick(db_session, _device):
+    """``log_reaper_batch_size`` limits how many rows one tick
+    touches.  Remaining rows ride the next tick."""
+    ids: list[str] = []
+    for _ in range(5):
+        r = await log_outbox.create(db_session, device_id=_device.id)
+        ids.append(r.id)
+    await db_session.commit()
+    for rid in ids:
+        await _set_row(
+            db_session,
+            rid,
+            status=STATUS_READY,
+            blob_path=f"device-logs/{_device.id}/{rid}.tar.gz",
+            expires_at=_past(),
+        )
+
+    deleter = FakeBlobDeleter()
+    settings = _make_settings(log_reaper_batch_size=2)
+    stats = await log_reaper.reap_once(
+        db_session, blob_deleter=deleter, settings=settings,
+    )
+
+    assert stats["claimed"] == 2
+    assert stats["rows_expired"] == 2
+    assert len(deleter.calls) == 2
+
+    # Second tick mops up two more.
+    stats2 = await log_reaper.reap_once(
+        db_session, blob_deleter=deleter, settings=settings,
+    )
+    assert stats2["claimed"] == 2
+
+    # Third tick: one row left.
+    stats3 = await log_reaper.reap_once(
+        db_session, blob_deleter=deleter, settings=settings,
+    )
+    assert stats3["claimed"] == 1
+
+    # Fourth tick: nothing.
+    stats4 = await log_reaper.reap_once(
+        db_session, blob_deleter=deleter, settings=settings,
+    )
+    assert stats4["claimed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mixed_states_all_transition_to_expired(db_session, _device):
+    """Rows in ``pending``, ``sent``, ``ready``, and ``failed`` all
+    flip to ``expired`` once past ``expires_at``.  Matches the spec:
+    ``expires_at`` is the authoritative retention signal regardless
+    of the row's prior terminal-ness."""
+    states = [STATUS_PENDING, STATUS_SENT, STATUS_READY, STATUS_FAILED]
+    ids: list[str] = []
+    for state in states:
+        r = await log_outbox.create(db_session, device_id=_device.id)
+        ids.append(r.id)
+        await db_session.commit()
+        await _set_row(
+            db_session,
+            r.id,
+            status=state,
+            blob_path=f"device-logs/{_device.id}/{r.id}.tar.gz" if state == STATUS_READY else None,
+            expires_at=_past(),
+        )
+
+    deleter = FakeBlobDeleter()
+    stats = await log_reaper.reap_once(db_session, blob_deleter=deleter)
+
+    assert stats["claimed"] == len(states)
+    assert stats["rows_expired"] == len(states)
+    assert stats["blobs_deleted"] == 1  # only the READY row had a blob
+
+    for rid in ids:
+        refreshed = await _reload(db_session, rid)
+        assert refreshed.status == STATUS_EXPIRED
+        assert refreshed.blob_path is None
+
+
+# ── Loop smoke test ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_loop_stops_on_event(db_session):
+    """``run_loop`` exits cleanly when ``stop_event`` is set before the
+    first interval elapses."""
+    stop = asyncio.Event()
+    settings = _make_settings(log_reaper_interval_sec=0.05)
+
+    # Factory returns None → loop skips the tick and hits the sleep.
+    task = asyncio.create_task(
+        log_reaper.run_loop(
+            lambda: None,
+            settings=settings,
+            stop_event=stop,
+        )
+    )
+    # Let one or two ticks run, then ask it to stop.
+    await asyncio.sleep(0.15)
+    stop.set()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert task.done()


### PR DESCRIPTION
## Stage 3e — Log-blob reaper (issue #345)

Adds a background task on every CMS replica that walks the
`log_requests` outbox on a slow cadence (default 10 min), deletes
blobs for rows whose `expires_at` has passed, and flips the rows
to `status=expired` with `blob_path=NULL`.

Without this, the `device-logs` container grows unbounded — every
log bundle a user (or the drainer) pulls stays in Azure storage
forever.  The schema already has `expires_at` populated by
`log_outbox.create()` (30-day default retention) and a partial
index on it; this PR is the consumer.

### What ships

- `cms/services/log_reaper.py` — `reap_once(db)` single-tick helper
  plus a `run_loop()` driver.  Uses `SELECT ... FOR UPDATE SKIP LOCKED`
  on Postgres so concurrent replicas never double-delete.
- `cms/config.py` — two new settings:
  - `AGORA_CMS_LOG_REAPER_INTERVAL_SEC` (default **600** — 10 min)
  - `AGORA_CMS_LOG_REAPER_BATCH_SIZE` (default **100**)
- `cms/main.py` — lifespan wires `log_reaper_task` next to the
  drainer + chunk reaper, with a 5s graceful-shutdown window
  matching the existing pattern.
- `tests/test_log_reaper.py` — 10 tests covering:
  - Happy path (blob deleted, row → expired, `blob_path` cleared).
  - Row with NULL `blob_path` (failed rows past expiry).
  - Idempotence — future `expires_at` untouched; already-expired
    rows skipped; `expires_at IS NULL` opt-out respected.
  - Missing blob (backend returns `False`) counts as benign expiry.
  - Blob-delete error keeps the row (retried next tick).
  - Batch-size cap limits per-tick work.
  - All non-terminal/terminal statuses transition to `expired`
    once past `expires_at`.
  - `run_loop()` shutdown smoke test.

### Behaviour notes

- **Audit trail preserved.** Rows are marked `expired` rather than
  deleted so the UI's per-device request history still shows
  "expired" entries.  A future longer-retention hard-delete tier
  (say 180 days) is out of scope for this PR.
- **Blob-delete failures are transient.** A backend error
  (network blip, Azure 503) increments `stats["errors"]` and
  leaves the row as-is — the next 10-min tick retries from the
  same state.  This is safer than marking the row expired while
  leaking the blob.
- **Opt-out via NULL `expires_at`.** `log_outbox.create()` accepts
  `expires_in=None` for forensic retention.  The reaper skips
  those rows.
- **Multi-replica safe.** The `SKIP LOCKED` claim query guarantees
  at-most-one replica processes a given row per tick.  SQLite
  tests fall back to plain SELECTs (single-process, no contention).

### Test results

```
tests/test_log_reaper.py          10 passed
tests/test_log_drainer.py         passed
tests/test_log_outbox.py          passed
tests/test_log_requests_api.py    passed
tests/test_log_chunk_assembler.py passed
tests/test_logs_response_shim.py  passed
tests/test_device_logs.py         passed

Total: 104 passed in 48s
```

### Not in this PR

- Hard-delete tier for rows past expiry+180d — defer until needed.
- Archive format swap (tar.gz → zip) — coordinated Pi+CMS PR,
  separate from retention.
- `log_requests.archive_format` column — same future PR.

Progresses #345 (multi-replica rollout). Stage 3 of 3 on the log
outbox pillar (3a schema, 3b API, 3c chunking, 3d drainer, **3e
reaper**).
