### PR TITLE
feat(wps): add register handler on WPS upstream-webhook path (#345)

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -35,6 +35,7 @@ from cms.database import get_db
 from cms.models.device import Device
 from cms.services.device_inbound import InboundContext, dispatch_device_message
 from cms.services.device_manager import device_manager
+from cms.services.device_register import register_known_device
 from cms.services.transport import get_transport
 from shared.wps_signature import verify_signature
 
@@ -161,17 +162,50 @@ async def events_receiver(
             )
             return Response(status_code=400, content="body is not JSON")
 
-        # Look up the device row — dispatch_device_message wants a
-        # fully-hydrated ORM instance on the context.  Stage 2b.2 does
-        # NOT port the direct-WS register/adoption handshake over to the
-        # webhook path, so if the device row is missing we log and drop.
+        # Look up the device row.  The connect-token endpoint that
+        # mints WPS URLs requires the device to exist + have a valid
+        # X-Device-API-Key, so a device reaching us here should
+        # already be provisioned.  If the row is missing we have a
+        # race (row deleted between connect-token and the first
+        # message), not a new-device bootstrap — drop and move on.
         result = await db.execute(select(Device).where(Device.id == ce_user_id))
         device = result.scalar_one_or_none()
         if device is None:
             logger.warning(
-                "WPS message from unknown device %s — registration over WPS "
-                "not implemented yet (Stage 2b.2)", ce_user_id,
+                "WPS message from unknown device %s — connect-token race "
+                "or row was deleted mid-session", ce_user_id,
             )
+            return Response(status_code=204)
+
+        transport = get_transport()
+
+        # ---- register handshake over WPS -----------------------------
+        #
+        # Mirrors the ``else`` (known-device) branch of
+        # ``cms/routers/ws.py``: refresh metadata, verify/mint the
+        # device_auth_token, auto-assign a profile.  Brand-new devices
+        # still bootstrap over direct-WS — they can't hit connect-token
+        # without an API key and a device row.
+        if msg.get("type") == "register":
+            reg_result = await register_known_device(device, msg, db)
+            if reg_result.orphaned:
+                # Over direct-WS we'd close 4004.  Over WPS we can't
+                # close the WPS connection from here; the device is
+                # now ORPHANED in the DB so subsequent inbound messages
+                # will land the same way, and admins see the status.
+                logger.warning(
+                    "WPS device %s failed auth — marked ORPHANED", ce_user_id,
+                )
+                return Response(status_code=204)
+            if reg_result.auth_assigned is not None:
+                try:
+                    await transport.send_to_device(
+                        ce_user_id, reg_result.auth_assigned,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to push auth_assigned to WPS device %s", ce_user_id,
+                    )
             return Response(status_code=204)
 
         base_url = _get_asset_base_url(request, settings)
@@ -185,7 +219,6 @@ async def events_receiver(
             device_status=device.status.value if device.status else "pending",
             group_name="",
         )
-        transport = get_transport()
 
         async def _send(payload: dict) -> None:
             await transport.send_to_device(ce_user_id, payload)

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -1,7 +1,6 @@
 """WebSocket endpoint for device connections."""
 
 import asyncio
-import hashlib
 import logging
 import secrets
 from datetime import datetime, timezone
@@ -13,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cms.auth import get_settings
 from cms.database import get_db
 from cms.models.device import Device, DeviceStatus
-from cms.models.device_profile import DeviceProfile
 from cms.schemas.protocol import (
     PROTOCOL_VERSION,
     SUPPORTED_PROTOCOL_VERSIONS,
@@ -27,6 +25,12 @@ from cms.services.device_inbound import (
     rotate_api_key,
 )
 from cms.services.device_manager import device_manager
+from cms.services.device_register import (
+    _DEVICE_TYPE_PROFILE_MAP,
+    auto_assign_profile as _auto_assign_profile,
+    hash_token as _hash_token,
+    register_known_device,
+)
 from cms.services.alert_service import alert_service
 from cms.services.log_chunk_assembler import (
     handle_frame as handle_log_chunk_frame,
@@ -40,11 +44,6 @@ router = APIRouter()
 
 # Device sends status every 30s; timeout at 45s to detect dead connections quickly
 WS_RECEIVE_TIMEOUT = 45
-
-
-def _hash_token(token: str) -> str:
-    """SHA-256 hash of a token for storage."""
-    return hashlib.sha256(token.encode()).hexdigest()
 
 
 def get_asset_base_url(request=None) -> str:
@@ -67,39 +66,8 @@ def get_asset_base_url(request=None) -> str:
     return "http://localhost:8080"
 
 
-# Mapping of device_type substrings to built-in profile names.
-# Checked in order — more specific patterns first.
-_DEVICE_TYPE_PROFILE_MAP = {
-    "pi zero 2 w": "pi-zero-2w",
-    "raspberry pi zero 2 w": "pi-zero-2w",
-    "pi 5": "pi-5",
-    "pi 4": "pi-4",
-}
-
-
-async def _auto_assign_profile(device: Device, db: AsyncSession) -> None:
-    """Auto-assign a device profile based on device_type if not already set."""
-    if device.profile_id or not device.device_type:
-        return
-
-    dt_lower = device.device_type.lower()
-    profile_name = None
-    for pattern, name in _DEVICE_TYPE_PROFILE_MAP.items():
-        if pattern in dt_lower:
-            profile_name = name
-            break
-
-    if not profile_name:
-        return
-
-    result = await db.execute(
-        select(DeviceProfile).where(DeviceProfile.name == profile_name)
-    )
-    profile = result.scalar_one_or_none()
-    if profile:
-        device.profile_id = profile.id
-        await db.commit()
-        logger.info("Auto-assigned profile '%s' to device %s", profile_name, device.id)
+# Mapping of device_type substrings to built-in profile names moved to
+# cms/services/device_register.py so the WPS webhook path can share it.
 
 
 @router.websocket("/ws/device")
@@ -139,8 +107,6 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
             await websocket.close(code=4003)
             return
 
-        auth_token = raw.get("auth_token", "")
-
         # ── 2. Authenticate ──
         result = await db.execute(select(Device).where(Device.id == device_id))
         device = result.scalar_one_or_none()
@@ -177,62 +143,21 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
             # Auto-assign profile based on device_type
             await _auto_assign_profile(device, db)
         else:
-            # Known device — verify auth token if device has one stored
-            if device.device_auth_token_hash:
-                if not auth_token:
-                    # Empty token = device was re-flashed / factory reset.
-                    # Reset to PENDING and assign a new auth token so the
-                    # device can re-register without admin intervention.
-                    logger.info(
-                        "Device %s connected with empty token (likely re-flashed) "
-                        "— resetting to pending", device_id,
+            # Known device — delegate to the shared helper that the WPS
+            # webhook path also uses.  Orphaned → close 4004; otherwise
+            # push any newly-minted auth token back to the device.
+            reg_result = await register_known_device(device, raw, db)
+            if reg_result.orphaned:
+                await websocket.send_json({
+                    "error": (
+                        "Invalid credentials — device marked as orphaned. "
+                        "An admin must re-adopt this device."
                     )
-                    device.status = DeviceStatus.PENDING
-                    device.device_auth_token_hash = None
-                    device.last_seen = datetime.now(timezone.utc)
-                    await db.commit()
-
-                    device_auth_token = secrets.token_urlsafe(32)
-                    device.device_auth_token_hash = _hash_token(device_auth_token)
-                    await db.commit()
-
-                    auth_msg = AuthAssignedMessage(device_auth_token=device_auth_token)
-                    await websocket.send_json(auth_msg.model_dump(mode="json"))
-                    logger.info("New auth token assigned to re-flashed device %s", device_id)
-                elif _hash_token(auth_token) != device.device_auth_token_hash:
-                    logger.warning("Device %s failed auth — marking as orphaned", device_id)
-                    device.status = DeviceStatus.ORPHANED
-                    device.last_seen = datetime.now(timezone.utc)
-                    await db.commit()
-                    await websocket.send_json({"error": "Invalid credentials — device marked as orphaned. An admin must re-adopt this device."})
-                    await websocket.close(code=4004)
-                    return
-            else:
-                # Device exists but has no auth token yet — assign one
-                device_auth_token = secrets.token_urlsafe(32)
-                device.device_auth_token_hash = _hash_token(device_auth_token)
-                await db.commit()
-                auth_msg = AuthAssignedMessage(device_auth_token=device_auth_token)
-                await websocket.send_json(auth_msg.model_dump(mode="json"))
-                logger.info("Auth token assigned to existing device %s", device_id)
-
-            # Update device stats
-            device.firmware_version = raw.get("firmware_version", device.firmware_version)
-            device.device_type = raw.get("device_type", device.device_type)
-            reg_codecs = raw.get("supported_codecs")
-            if reg_codecs is not None:
-                device.supported_codecs = ",".join(reg_codecs)
-            device.storage_capacity_mb = raw.get("storage_capacity_mb", device.storage_capacity_mb)
-            device.storage_used_mb = raw.get("storage_used_mb", device.storage_used_mb)
-            device.last_seen = datetime.now(timezone.utc)
-            # Update name only if user explicitly set it via captive portal
-            reg_name = raw.get("device_name", "")
-            if reg_name and raw.get("device_name_custom", False):
-                device.name = reg_name
-            await db.commit()
-
-            # Auto-assign profile if not already set
-            await _auto_assign_profile(device, db)
+                })
+                await websocket.close(code=4004)
+                return
+            if reg_result.auth_assigned is not None:
+                await websocket.send_json(reg_result.auth_assigned)
 
         # ── 3. Register connection ──
         client_ip = raw.get("ip_address") or (websocket.client.host if websocket.client else None)

--- a/cms/services/device_register.py
+++ b/cms/services/device_register.py
@@ -1,0 +1,181 @@
+"""Shared device registration logic.
+
+The direct-WebSocket endpoint (``cms/routers/ws.py``) and the Azure Web
+PubSub upstream webhook (``cms/routers/wps_webhook.py``) both receive a
+``register`` message as the first thing a device says over the wire.
+Most of the bookkeeping — metadata refresh, auth-token handling, profile
+auto-assign — is identical in both transports, so it lives here.
+
+The only case that stays transport-specific is the brand-new-device
+bootstrap: that path touches the raw WebSocket in ``ws.py`` to push an
+``AuthAssignedMessage`` back over the wire before the normal message
+loop starts.  Over WPS, brand-new devices can't even reach
+``connect-token`` (which requires a device row + API key), so WPS
+traffic only sees the known-device branch — ``register_known_device``
+below.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.device import Device, DeviceStatus
+from cms.models.device_profile import DeviceProfile
+from cms.schemas.protocol import AuthAssignedMessage
+
+logger = logging.getLogger("agora.cms.device_register")
+
+
+# Mapping of device_type substrings to built-in profile names.
+# Checked in order — more specific patterns first.
+_DEVICE_TYPE_PROFILE_MAP = {
+    "pi zero 2 w": "pi-zero-2w",
+    "raspberry pi zero 2 w": "pi-zero-2w",
+    "pi 5": "pi-5",
+    "pi 4": "pi-4",
+}
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 hash of a token for DB storage."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def auto_assign_profile(device: Device, db: AsyncSession) -> None:
+    """Auto-assign a device profile based on device_type if not already set."""
+    if device.profile_id or not device.device_type:
+        return
+
+    dt_lower = device.device_type.lower()
+    profile_name: str | None = None
+    for pattern, name in _DEVICE_TYPE_PROFILE_MAP.items():
+        if pattern in dt_lower:
+            profile_name = name
+            break
+
+    if not profile_name:
+        return
+
+    result = await db.execute(
+        select(DeviceProfile).where(DeviceProfile.name == profile_name)
+    )
+    profile = result.scalar_one_or_none()
+    if profile:
+        device.profile_id = profile.id
+        await db.commit()
+        logger.info("Auto-assigned profile '%s' to device %s", profile_name, device.id)
+
+
+class RegisterResult:
+    """Outcome of a known-device register.
+
+    ``auth_assigned`` is a ready-to-send ``AuthAssignedMessage`` payload
+    dict if the transport needs to push a new device_auth_token to the
+    device; ``None`` otherwise.
+
+    ``orphaned`` is True if the device failed auth — the transport
+    should refuse the connection (direct-WS: close 4004; WPS: no-op
+    because the Azure-side auth already succeeded, so the next message
+    will just hit the same orphaned state).
+    """
+
+    __slots__ = ("auth_assigned", "orphaned")
+
+    def __init__(
+        self,
+        *,
+        auth_assigned: dict[str, Any] | None = None,
+        orphaned: bool = False,
+    ) -> None:
+        self.auth_assigned = auth_assigned
+        self.orphaned = orphaned
+
+
+async def register_known_device(
+    device: Device,
+    raw: dict[str, Any],
+    db: AsyncSession,
+) -> RegisterResult:
+    """Apply a ``register`` message from an already-provisioned device.
+
+    Mirrors the ``else`` branch of the original register handler in
+    ``cms/routers/ws.py``:
+
+      * If the device already has an ``device_auth_token_hash`` set:
+          - empty ``auth_token`` in the register payload → treat as a
+            re-flashed device: reset to PENDING and assign a fresh
+            auth token.
+          - wrong ``auth_token`` → mark ORPHANED, return ``orphaned``.
+          - correct token → accept; no new auth-assigned reply.
+      * If the device has no stored token yet → mint one.
+
+    Metadata (firmware/codecs/storage/last_seen/name) is refreshed
+    from the register payload in all accepted cases.  Profile
+    auto-assignment runs at the end.
+    """
+    auth_token = raw.get("auth_token", "")
+    auth_assigned: dict[str, Any] | None = None
+
+    if device.device_auth_token_hash:
+        if not auth_token:
+            # Empty token = device was re-flashed / factory reset.
+            logger.info(
+                "Device %s connected with empty token (likely re-flashed) "
+                "— resetting to pending", device.id,
+            )
+            device.status = DeviceStatus.PENDING
+            device.device_auth_token_hash = None
+            device.last_seen = datetime.now(timezone.utc)
+            await db.commit()
+
+            new_token = secrets.token_urlsafe(32)
+            device.device_auth_token_hash = hash_token(new_token)
+            await db.commit()
+
+            auth_assigned = AuthAssignedMessage(
+                device_auth_token=new_token,
+            ).model_dump(mode="json")
+            logger.info("New auth token assigned to re-flashed device %s", device.id)
+        elif hash_token(auth_token) != device.device_auth_token_hash:
+            logger.warning("Device %s failed auth — marking as orphaned", device.id)
+            device.status = DeviceStatus.ORPHANED
+            device.last_seen = datetime.now(timezone.utc)
+            await db.commit()
+            return RegisterResult(orphaned=True)
+    else:
+        # Device row exists but no auth token yet — assign one.
+        new_token = secrets.token_urlsafe(32)
+        device.device_auth_token_hash = hash_token(new_token)
+        await db.commit()
+        auth_assigned = AuthAssignedMessage(
+            device_auth_token=new_token,
+        ).model_dump(mode="json")
+        logger.info("Auth token assigned to existing device %s", device.id)
+
+    # Refresh metadata from the register payload.
+    device.firmware_version = raw.get("firmware_version", device.firmware_version)
+    device.device_type = raw.get("device_type", device.device_type)
+    reg_codecs = raw.get("supported_codecs")
+    if reg_codecs is not None:
+        device.supported_codecs = ",".join(reg_codecs)
+    device.storage_capacity_mb = raw.get(
+        "storage_capacity_mb", device.storage_capacity_mb,
+    )
+    device.storage_used_mb = raw.get("storage_used_mb", device.storage_used_mb)
+    device.last_seen = datetime.now(timezone.utc)
+    # Update name only if user explicitly set it via captive portal
+    reg_name = raw.get("device_name", "")
+    if reg_name and raw.get("device_name_custom", False):
+        device.name = reg_name
+    await db.commit()
+
+    await auto_assign_profile(device, db)
+
+    return RegisterResult(auth_assigned=auth_assigned)

--- a/tests/test_device_register.py
+++ b/tests/test_device_register.py
@@ -1,0 +1,258 @@
+"""Unit tests for cms.services.device_register.register_known_device.
+
+Exercises the shared helper that both the direct-WebSocket endpoint
+(cms/routers/ws.py) and the WPS upstream webhook (cms/routers/wps_webhook.py)
+use to process a ``register`` message from a device whose row already
+exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cms.models.device import DeviceStatus
+from cms.services.device_register import (
+    hash_token,
+    register_known_device,
+)
+
+
+class _FakeDB:
+    """Tiny async-session stand-in that records commits + can return
+    a DeviceProfile row for the auto-assign query."""
+
+    def __init__(self, profile_row=None):
+        self.commits = 0
+        self.profile_row = profile_row
+
+    async def execute(self, stmt, *args, **kwargs):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=self.profile_row)
+        return result
+
+    async def commit(self):
+        self.commits += 1
+
+
+def _make_device(
+    *,
+    id: str = "pi-1",
+    name: str = "Kiosk",
+    device_auth_token_hash: str | None = None,
+    status: DeviceStatus = DeviceStatus.ADOPTED,
+    device_type: str = "",
+    firmware_version: str = "1.0.0",
+    supported_codecs: str = "",
+    storage_capacity_mb: int = 0,
+    storage_used_mb: int = 0,
+    profile_id=None,
+) -> MagicMock:
+    """Build a MagicMock that quacks like a Device ORM row with the
+    writable attributes the helper touches."""
+    d = MagicMock()
+    d.id = id
+    d.name = name
+    d.device_auth_token_hash = device_auth_token_hash
+    d.status = status
+    d.device_type = device_type
+    d.firmware_version = firmware_version
+    d.supported_codecs = supported_codecs
+    d.storage_capacity_mb = storage_capacity_mb
+    d.storage_used_mb = storage_used_mb
+    d.profile_id = profile_id
+    d.last_seen = None
+    return d
+
+
+@pytest.mark.asyncio
+class TestRegisterKnownDevice:
+    async def test_valid_auth_token_accepts_without_new_token(self):
+        token = "known-token"
+        device = _make_device(device_auth_token_hash=hash_token(token))
+        db = _FakeDB()
+
+        result = await register_known_device(
+            device,
+            {
+                "type": "register",
+                "device_id": "pi-1",
+                "auth_token": token,
+                "firmware_version": "1.11.7",
+            },
+            db,
+        )
+
+        assert result.orphaned is False
+        assert result.auth_assigned is None
+        assert device.firmware_version == "1.11.7"
+        assert device.status == DeviceStatus.ADOPTED
+        # device_auth_token_hash must be unchanged
+        assert device.device_auth_token_hash == hash_token(token)
+
+    async def test_empty_auth_token_treats_as_reflashed(self):
+        """Empty token + existing hash → reset to PENDING, mint new token."""
+        device = _make_device(
+            device_auth_token_hash=hash_token("old-token"),
+            status=DeviceStatus.ADOPTED,
+        )
+        db = _FakeDB()
+
+        result = await register_known_device(
+            device,
+            {
+                "type": "register",
+                "device_id": "pi-1",
+                "auth_token": "",
+            },
+            db,
+        )
+
+        assert result.orphaned is False
+        assert result.auth_assigned is not None
+        assert result.auth_assigned["type"] == "auth_assigned"
+        assert "device_auth_token" in result.auth_assigned
+        assert device.status == DeviceStatus.PENDING
+        # Hash should have been replaced with a new one.
+        assert device.device_auth_token_hash is not None
+        assert device.device_auth_token_hash != hash_token("old-token")
+        assert device.device_auth_token_hash == hash_token(
+            result.auth_assigned["device_auth_token"],
+        )
+
+    async def test_wrong_auth_token_marks_orphaned(self):
+        device = _make_device(device_auth_token_hash=hash_token("real-token"))
+        db = _FakeDB()
+
+        result = await register_known_device(
+            device,
+            {
+                "type": "register",
+                "device_id": "pi-1",
+                "auth_token": "impostor-token",
+            },
+            db,
+        )
+
+        assert result.orphaned is True
+        assert result.auth_assigned is None
+        assert device.status == DeviceStatus.ORPHANED
+
+    async def test_no_stored_token_mints_one(self):
+        """Device exists but has never been assigned an auth token."""
+        device = _make_device(device_auth_token_hash=None)
+        db = _FakeDB()
+
+        result = await register_known_device(
+            device,
+            {"type": "register", "device_id": "pi-1", "auth_token": ""},
+            db,
+        )
+
+        assert result.orphaned is False
+        assert result.auth_assigned is not None
+        assert device.device_auth_token_hash is not None
+        assert device.device_auth_token_hash == hash_token(
+            result.auth_assigned["device_auth_token"],
+        )
+
+    async def test_metadata_refresh_from_payload(self):
+        device = _make_device(
+            device_auth_token_hash=hash_token("t"),
+            firmware_version="1.0.0",
+            device_type="",
+            supported_codecs="",
+            storage_capacity_mb=0,
+            storage_used_mb=0,
+        )
+        db = _FakeDB()
+
+        await register_known_device(
+            device,
+            {
+                "type": "register",
+                "device_id": "pi-1",
+                "auth_token": "t",
+                "firmware_version": "1.12.0",
+                "device_type": "Raspberry Pi 5",
+                "supported_codecs": ["h264", "vp8"],
+                "storage_capacity_mb": 32768,
+                "storage_used_mb": 100,
+            },
+            db,
+        )
+
+        assert device.firmware_version == "1.12.0"
+        assert device.device_type == "Raspberry Pi 5"
+        assert device.supported_codecs == "h264,vp8"
+        assert device.storage_capacity_mb == 32768
+        assert device.storage_used_mb == 100
+        assert device.last_seen is not None
+
+    async def test_device_name_not_overridden_unless_custom(self):
+        """Register payloads only update device.name when the captive-portal
+        flag device_name_custom=True is set — otherwise keep the CMS-side
+        name."""
+        device = _make_device(
+            device_auth_token_hash=hash_token("t"), name="Lobby-CMS-Named",
+        )
+        db = _FakeDB()
+
+        # Default: no custom flag → name unchanged
+        await register_known_device(
+            device,
+            {
+                "type": "register", "device_id": "pi-1", "auth_token": "t",
+                "device_name": "something-from-device",
+            },
+            db,
+        )
+        assert device.name == "Lobby-CMS-Named"
+
+        # With the custom flag → name is replaced
+        await register_known_device(
+            device,
+            {
+                "type": "register", "device_id": "pi-1", "auth_token": "t",
+                "device_name": "User-Picked-Name",
+                "device_name_custom": True,
+            },
+            db,
+        )
+        assert device.name == "User-Picked-Name"
+
+    async def test_auto_assign_profile_runs_when_unset(self):
+        """When device has no profile and device_type matches the map,
+        the helper looks up + assigns the matching profile."""
+        device = _make_device(
+            device_auth_token_hash=hash_token("t"),
+            device_type="Raspberry Pi 5",
+            profile_id=None,
+        )
+        profile_row = MagicMock(id="profile-pi5-uuid", name="pi-5")
+        db = _FakeDB(profile_row=profile_row)
+
+        await register_known_device(
+            device,
+            {"type": "register", "device_id": "pi-1", "auth_token": "t"},
+            db,
+        )
+
+        assert device.profile_id == "profile-pi5-uuid"
+
+    async def test_auto_assign_profile_skipped_when_already_set(self):
+        device = _make_device(
+            device_auth_token_hash=hash_token("t"),
+            device_type="Raspberry Pi 5",
+            profile_id="already-set",
+        )
+        db = _FakeDB(profile_row=MagicMock(id="other", name="pi-5"))
+
+        await register_known_device(
+            device,
+            {"type": "register", "device_id": "pi-1", "auth_token": "t"},
+            db,
+        )
+
+        assert device.profile_id == "already-set"

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -244,8 +244,13 @@ class TestSystemEvents:
 @pytest.mark.asyncio
 class TestUserEvents:
     async def test_unknown_device_is_logged_and_204(self, client, app_and_session):
-        """Until the register-over-WPS handshake is ported, messages
-        from devices with no DB row are dropped with a warning."""
+        """Devices with no DB row are dropped with a warning.
+
+        The connect-token endpoint that mints WPS URLs requires the
+        device row to exist + have a valid X-Device-API-Key, so unknown
+        devices reaching the webhook imply a race (row deleted mid-session)
+        rather than a new-device bootstrap.
+        """
         app, session = app_and_session
         session.device_row = None
 
@@ -322,6 +327,151 @@ class TestUserEvents:
             },
         )
         assert r.status_code == 400
+
+    async def test_register_over_wps_calls_helper_and_pushes_auth(
+        self, client, app_and_session,
+    ):
+        """A register message over WPS runs the shared known-device helper
+        and pushes any newly-minted auth_assigned payload back to the
+        device via the transport — it does NOT fall through to
+        dispatch_device_message (register isn't a dispatcher event)."""
+        app, session = app_and_session
+        device = MagicMock()
+        device.id = "pi-wps"
+        device.name = "Kiosk"
+        device.group_id = None
+        device.status = MagicMock(value="adopted")
+        session.device_row = device
+
+        auth_payload = {"type": "auth_assigned", "device_auth_token": "new-token"}
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg"
+        payload = {
+            "type": "register",
+            "device_id": "pi-wps",
+            "auth_token": "",
+            "firmware_version": "1.11.7",
+        }
+
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=auth_payload,
+            )),
+        ) as mock_reg, patch(
+            "cms.routers.wps_webhook.dispatch_device_message",
+            new=AsyncMock(return_value=None),
+        ) as mock_dispatch, patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+
+        assert r.status_code == 204
+        mock_reg.assert_awaited_once()
+        args, _ = mock_reg.call_args
+        assert args[0] is device
+        assert args[1] == payload
+        fake_transport.send_to_device.assert_awaited_once_with("pi-wps", auth_payload)
+        mock_dispatch.assert_not_called()
+
+    async def test_register_over_wps_no_auth_token_no_push(
+        self, client, app_and_session,
+    ):
+        """If the helper returns auth_assigned=None (token was valid),
+        the transport is not hit."""
+        app, session = app_and_session
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg-ok"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "valid-token",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        fake_transport.send_to_device.assert_not_called()
+
+    async def test_register_over_wps_orphaned_device(self, client, app_and_session):
+        """Orphaned result returns 204 without pushing — direct-WS path
+        would close 4004 but over WPS we can't close from here."""
+        app, session = app_and_session
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="orphaned"),
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-orph"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=True, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "wrong-token",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        fake_transport.send_to_device.assert_not_called()
 
 
 # ---------------------------------------------------------------- unknown type


### PR DESCRIPTION
# Add register handler on WPS upstream-webhook path (stage 2b.2 closeout)

## Problem

`cms/routers/wps_webhook.py` explicitly dropped any `register` message from a
device connecting over Azure Web PubSub:

```python
# Stage 2b.2 does NOT port the direct-WS register/adoption handshake over to
# the webhook path, so if the device row is missing we log and drop.
logger.warning(
    "WPS message from unknown device %s — registration over WPS "
    "not implemented yet (Stage 2b.2)", ce_user_id,
)
return Response(status_code=204)
```

On top of that, even if the device row existed, a `register` message would
fall through to `dispatch_device_message`, which has no `register` branch —
it would be silently swallowed.  That means a simulator (or any device)
connecting over WPS and sending a register as its first message would never
get its metadata refreshed, never get a new auth token, and never get a
profile auto-assigned.  Blocks the `agora-device-simulator` WPS mode and
Stage 4 validation.

## Fix

1. **New shared helper** — `cms/services/device_register.py` extracts the
   known-device branch of `cms/routers/ws.py` (auth-token verify / mint,
   metadata refresh, profile auto-assign) into `register_known_device()`.
   Returns a `RegisterResult(auth_assigned, orphaned)` so the transport
   layer owns framing.

2. **`cms/routers/ws.py`** — replaces the inline known-device block with a
   call to the helper.  New-device bootstrap stays put (that path still
   has to touch the raw WebSocket to push the first auth_assigned before
   the message loop runs, and it's direct-WS-only for now).  Re-exports
   `_DEVICE_TYPE_PROFILE_MAP` and `_auto_assign_profile` for existing
   test imports.

3. **`cms/routers/wps_webhook.py`** — special-cases
   `msg["type"] == "register"` in the `azure.webpubsub.user.*` branch and
   calls the same helper.  Any newly-minted `auth_assigned` payload is
   pushed back to the device via `transport.send_to_device()`.  Orphaned
   devices return 204 (we can't close the WPS socket from here; the row
   is now ORPHANED in the DB so subsequent inbound messages hit the same
   outcome and admins see it).

## Scope — what this does NOT do

Brand-new-device bootstrap over WPS is intentionally out of scope.  The
`POST /api/devices/{id}/connect-token` endpoint that mints WPS URLs
already requires the device row to exist + a valid `X-Device-API-Key`
header, so a device reaching the WPS webhook implies it's already
provisioned.  Un-adopted devices keep bootstrapping via direct-WS (which
is still available); the flip to WPS happens after first adoption.

## Tests

* `tests/test_device_register.py` (NEW) — 8 unit tests covering:
  * valid token → no new auth_assigned, metadata refreshed
  * empty token → reset to PENDING + mint new token
  * wrong token → ORPHANED, no refresh
  * no stored token → mint one
  * metadata refresh (firmware, codecs, storage)
  * `device_name_custom` flag respected
  * profile auto-assign fires only when `profile_id` is unset

* `tests/test_wps_webhook.py` — 3 new tests under `TestUserEvents`:
  * `test_register_over_wps_calls_helper_and_pushes_auth`
  * `test_register_over_wps_no_auth_token_no_push`
  * `test_register_over_wps_orphaned_device`

Existing coverage (`test_multi_board_profiles.py`, `test_wps_webhook.py`
dispatch/sys-event cases, device manager, device transport, wps transport,
device presence) all remain green.

## Follow-ups

Tracked as `sim-wps-transport-mode` — add `AGORA_CMS_TRANSPORT=wps` mode to
`agora-device-simulator`, using a separate `X-Device-API-Key` config path
(matches real Pi behavior).  Depends on this PR.

---

Part of #345.
