### PR TITLE
chore: remove legacy /api/logs/download endpoint

### DIFF
--- a/cms/routers/log_requests.py
+++ b/cms/routers/log_requests.py
@@ -8,9 +8,9 @@ one device-facing upload endpoint:
 * ``GET    /api/logs/requests/{id}/download``    — fetch the tar.gz
 * ``POST   /api/devices/{device_id}/logs/{id}/upload`` — Pi uploads
 
-The user-facing endpoints use the standard RBAC + group scoping that
-``/api/logs/download`` already applies.  The upload endpoint uses
-device-token auth (reused from the asset download path).
+The user-facing endpoints use the standard RBAC + group scoping.
+The upload endpoint uses device-token auth (reused from the asset
+download path).
 
 See ``docs/multi-replica-architecture.md`` §Stage 3 and
 ``cms/models/log_request.py`` for the schema.

--- a/cms/routers/logs.py
+++ b/cms/routers/logs.py
@@ -1,39 +1,32 @@
 """Log collection API.
 
-The legacy ``POST /api/logs/download`` endpoint below is **deprecated** and
-retained only as a safety net while the UI migration to the async outbox
-API (``/api/logs/requests``) bakes in prod.  It does a synchronous
-``request_logs`` call per device which does not work under N>1 CMS
-replicas (the WS target may live on a different replica than the one
-handling the HTTP request).  It will be removed once the UI has been
-verified and the back-compat shim in
-:mod:`cms.services.device_inbound` covers old firmware cases.
-
-New user flow uses:
+New async flow (see sslivins/agora-cms#345 Stage 3):
 
 * ``POST   /api/logs/requests``                  — enqueue per-device
 * ``GET    /api/logs/requests/{id}``             — poll status
 * ``GET    /api/logs/requests/{id}/download``    — download bundle
 * ``GET    /api/cms/logs``                       — CMS in-memory log buffer
+
+The legacy synchronous ``POST /api/logs/download`` endpoint was removed
+on 2026-04-22.  It did a blocking ``request_logs`` call per device
+which cannot work under N>1 CMS replicas (the WS target may live on
+a different replica than the one handling the HTTP request).  The UI
+has migrated to the async outbox flow and client-side zip bundling,
+so the endpoint was deleted with no bake period.
 """
 
-import asyncio
 import io
 import logging
 import zipfile
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cms.auth import require_auth, require_permission, get_user_group_ids
+from cms.auth import require_auth, require_permission
 from cms.database import get_db
 from cms.permissions import LOGS_READ
-from cms.models.device import Device
-from cms.services.transport import get_transport
 from cms.services.audit_service import audit_log
 
 logger = logging.getLogger("agora.cms.logs")
@@ -42,113 +35,6 @@ router = APIRouter(prefix="/api/logs", dependencies=[Depends(require_auth)])
 
 # Separate router for ``/api/cms/logs`` so it's not nested under ``/api/logs``.
 cms_logs_router = APIRouter(prefix="/api/cms", dependencies=[Depends(require_auth)])
-
-
-class LogDownloadRequest(BaseModel):
-    device_ids: list[str] = []
-    include_cms: bool = True
-    services: list[str] | None = None
-    since: str = "24h"
-
-
-@router.post("/download", dependencies=[Depends(require_permission(LOGS_READ))], deprecated=True)
-async def download_logs(req: LogDownloadRequest, request: Request, db: AsyncSession = Depends(get_db)):
-    """**Deprecated.** Synchronous multi-device log collection; see module docstring.
-
-    Collect logs from selected devices (+ optionally CMS) and return a zip file.
-    """
-    logger.warning(
-        "legacy /api/logs/download called (device_ids=%d, include_cms=%s); "
-        "UI should migrate to /api/logs/requests",
-        len(req.device_ids), req.include_cms,
-    )
-    # Validate the requesting user has group access to every requested device
-    user = getattr(request.state, "user", None)
-    if user and req.device_ids:
-        group_ids = await get_user_group_ids(user, db)
-        if group_ids is not None:  # None = admin
-            result = await db.execute(
-                select(Device.id).where(
-                    Device.id.in_(req.device_ids),
-                    Device.group_id.notin_(group_ids) if group_ids else True,
-                )
-            )
-            forbidden = [r[0] for r in result.all()]
-            if forbidden:
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"Not authorised for device(s): {', '.join(forbidden)}",
-                )
-
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    buf = io.BytesIO()
-
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        # ── Device logs ──
-        tasks = {}
-        connected_ids = set(await get_transport().connected_ids())
-        for device_id in req.device_ids:
-            if device_id in connected_ids:
-                tasks[device_id] = get_transport().request_logs(
-                    device_id,
-                    services=req.services,
-                    since=req.since,
-                    timeout=30.0,
-                )
-
-        results = {}
-        if tasks:
-            gathered = await asyncio.gather(
-                *tasks.values(), return_exceptions=True,
-            )
-            results = dict(zip(tasks.keys(), gathered))
-
-        for device_id in req.device_ids:
-            if device_id not in tasks:
-                # Device not connected — add a note
-                zf.writestr(
-                    f"{device_id}/not_connected.txt",
-                    f"Device {device_id} was not connected at the time of log collection.",
-                )
-                continue
-
-            result = results[device_id]
-            if isinstance(result, Exception):
-                zf.writestr(
-                    f"{device_id}/error.txt",
-                    f"Failed to collect logs: {result}",
-                )
-            else:
-                for service_name, log_text in result.items():
-                    safe_name = service_name.replace("/", "_").replace("\\", "_")
-                    zf.writestr(f"{device_id}/{safe_name}.log", log_text)
-
-        # ── CMS logs ──
-        if req.include_cms:
-            from cms.main import _log_buffer
-            cms_log_text = "\n".join(_log_buffer)
-            zf.writestr("cms/cms.log", cms_log_text)
-
-    buf.seek(0)
-    filename = f"agora-logs-{timestamp}.zip"
-    await audit_log(
-        db, user=getattr(request.state, "user", None),
-        action="logs.download", resource_type="logs",
-        description=f"Downloaded logs ({len(req.device_ids)} device(s), cms={req.include_cms})",
-        details={
-            "device_ids": list(req.device_ids),
-            "include_cms": req.include_cms,
-            "services": req.services,
-            "since": req.since,
-        },
-        request=request,
-    )
-    await db.commit()
-    return StreamingResponse(
-        buf,
-        media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
 
 
 # ── CMS-only log download (new async UI flow) ───────────────────────
@@ -161,10 +47,9 @@ async def download_cms_logs(request: Request, db: AsyncSession = Depends(get_db)
     """Download the CMS in-memory log buffer as a zip.
 
     Small, synchronous endpoint used by the new UI flow to fetch CMS
-    logs separately from per-device log bundles.  Unlike the legacy
-    ``/api/logs/download`` path this does not reach across the network
-    to devices, so it is safe under N>1 replicas (each replica returns
-    its own buffer; we document this caveat in the UI).
+    logs separately from per-device log bundles.  Does not reach
+    across the network to devices, so it is safe under N>1 replicas
+    (each replica returns its own buffer; the UI documents this).
     """
     from cms.main import _log_buffer
 

--- a/tests/test_device_logs.py
+++ b/tests/test_device_logs.py
@@ -175,47 +175,6 @@ class TestDeviceLogsAPI:
             device_manager.disconnect("log-test-device")
 
 
-# ── Log download (zip) endpoint tests ──
-
-
-class TestLogDownloadAPI:
-    @pytest.mark.asyncio
-    async def test_download_cms_only(self, client):
-        """Download zip with only CMS logs (no devices selected)."""
-        resp = await client.post(
-            "/api/logs/download",
-            json={"device_ids": [], "include_cms": True, "since": "1h"},
-        )
-        assert resp.status_code == 200
-        assert resp.headers["content-type"] == "application/zip"
-        assert "agora-logs-" in resp.headers.get("content-disposition", "")
-
-    @pytest.mark.asyncio
-    async def test_download_offline_device(self, client, device_in_db):
-        """Offline devices should get a not_connected.txt in the zip."""
-        import io
-        import zipfile
-
-        resp = await client.post(
-            "/api/logs/download",
-            json={"device_ids": ["log-test-device"], "include_cms": False, "since": "1h"},
-        )
-        assert resp.status_code == 200
-
-        zf = zipfile.ZipFile(io.BytesIO(resp.content))
-        names = zf.namelist()
-        assert any("not_connected" in n for n in names)
-
-    @pytest.mark.asyncio
-    async def test_download_nothing_selected(self, client):
-        """No devices and no CMS logs should still return a valid (empty) zip."""
-        resp = await client.post(
-            "/api/logs/download",
-            json={"device_ids": [], "include_cms": False, "since": "1h"},
-        )
-        assert resp.status_code == 200
-
-
 # ── CMS-only log endpoint (new async UI flow) ──
 
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -2090,46 +2090,26 @@ class TestAssetWriteIDOR:
 
 @pytest.mark.asyncio
 class TestLogsDownloadIDOR:
-    """Verify log download endpoint enforces group scoping on device IDs."""
+    """Placeholder — the legacy /api/logs/download endpoint that these
+    tests covered was removed on 2026-04-22.  Per-device group scoping
+    is now exercised via the async /api/logs/requests flow in
+    ``test_log_requests.py``.  Class is retained as a breadcrumb in
+    case grep brings someone here.
+    """
 
-    async def test_logs_download_blocked_cross_group_device(self, app, db_session):
-        """POST /api/logs/download with a device in another group should return 403."""
-        group_a = await _create_group(db_session, f"LogDl A {uuid.uuid4().hex[:6]}")
-        group_b = await _create_group(db_session, f"LogDl B {uuid.uuid4().hex[:6]}")
-        dev_id = f"logdev-{uuid.uuid4().hex[:8]}"
-        dev = Device(id=dev_id, name="Log Device",
-                     status=DeviceStatus.ADOPTED, group_id=group_b.id)
-        db_session.add(dev)
-        await db_session.commit()
-        email = f"logdl_{uuid.uuid4().hex[:6]}@test.com"
-        await _create_user(db_session, email=email, role_name="Operator", group_ids=[group_a.id])
-        ac = await _login_as(app, email)
-        try:
-            resp = await ac.post("/api/logs/download",
-                                 json={"device_ids": [dev_id], "include_cms": False})
-            assert resp.status_code == 403
-        finally:
-            await ac.aclose()
-
-    async def test_logs_download_allowed_own_group_device(self, app, db_session):
-        """POST /api/logs/download with a device in the user's group should not return 403."""
-        group = await _create_group(db_session, f"LogOk {uuid.uuid4().hex[:6]}")
-        dev_id = f"logok-{uuid.uuid4().hex[:8]}"
-        dev = Device(id=dev_id, name="Own Log Device",
-                     status=DeviceStatus.ADOPTED, group_id=group.id)
-        db_session.add(dev)
-        await db_session.commit()
-        email = f"logok_{uuid.uuid4().hex[:6]}@test.com"
-        await _create_user(db_session, email=email, role_name="Operator", group_ids=[group.id])
-        ac = await _login_as(app, email)
-        try:
-            # Device isn't connected so we'll get a different error, but NOT 403
-            resp = await ac.post("/api/logs/download",
-                                 json={"device_ids": [dev_id], "include_cms": False})
-            assert resp.status_code != 403, \
-                f"User should have access to own group device, got {resp.status_code}"
-        finally:
-            await ac.aclose()
+    async def test_legacy_endpoint_removed(self, app):
+        """Verify the deprecated endpoint is gone (returns 404/405)."""
+        from httpx import AsyncClient, ASGITransport
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as ac:
+            resp = await ac.post(
+                "/api/logs/download",
+                json={"device_ids": [], "include_cms": False},
+            )
+            assert resp.status_code in (404, 405, 401), (
+                f"Legacy /api/logs/download should be gone; got {resp.status_code}"
+            )
 
 
 # ── Group Management IDOR Tests ──

--- a/tests/test_rbac_matrix.py
+++ b/tests/test_rbac_matrix.py
@@ -127,7 +127,6 @@ ENDPOINTS: list[EP] = [
     EP("GET", "/api/audit-log/count", (ADMIN,)),
 
     # ── Logs ──
-    EP("POST", "/api/logs/download", (ADMIN, OPERATOR, VIEWER), json_body={}),
     EP("GET", "/api/cms/logs", (ADMIN, OPERATOR, VIEWER)),
 
     # ── Admin-managed API keys ──


### PR DESCRIPTION
## Summary

Removes the deprecated synchronous `POST /api/logs/download` endpoint.

Since PR #392, the UI drives log downloads through the async outbox flow:

- `POST /api/logs/requests` → returns `request_id`
- client polls `GET /api/logs/requests/{id}` → 200 when ready
- client `GET /api/logs/requests/{id}/download` streams the blob
- CMS-only logs come from `GET /api/cms/logs` (in-memory buffer zip)

Nothing else calls the legacy endpoint. No bake period requested.

## Changes

- `cms/routers/logs.py` — delete endpoint + `LogDownloadRequest` model + unused imports.
- `cms/routers/log_requests.py` — drop stale reference in module docstring.
- `tests/test_device_logs.py` — delete `TestLogDownloadAPI` (3 tests).
- `tests/test_rbac.py` — delete `TestLogsDownloadIDOR`; leave a thin placeholder that asserts the endpoint is gone.
- `tests/test_rbac_matrix.py` — remove the `/api/logs/download` row.

## Kept intact

- `GET /api/cms/logs` — still used by the UI for the CMS-side zip.
- `tests/test_logs_response_shim.py` — docstring mentions the legacy endpoint historically; shim itself handles device-side `LOGS_RESPONSE` payloads and is still in use.

## Validation

- `pytest tests/test_device_logs.py tests/test_rbac_matrix.py tests/test_logs_response_shim.py` — 271 passed locally.
- `grep /api/logs/download` — only meta references remain (docstring breadcrumb + the RBAC placeholder that checks the 404).

No DB migration, no config change, no client breakage.
