### PR TITLE
Shorten log-bundle retention to 1h and auto-expire on download

### DIFF
--- a/cms/routers/log_requests.py
+++ b/cms/routers/log_requests.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from datetime import datetime, timezone
 from typing import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -299,6 +300,12 @@ async def download_log_request(
         },
         request=request,
     )
+    # Once the user has the bundle, we have no reason to hold onto the
+    # blob.  Mark the row for immediate expiry so the next reaper tick
+    # deletes the blob and transitions the row to ``expired``.  We
+    # intentionally don't delete inline — the download response below
+    # still needs ``row.blob_path`` to stream through.
+    row.expires_at = datetime.now(timezone.utc)
     await db.commit()
 
     filename = f"{row.device_id}-{row.id[:8]}.tar.gz"

--- a/cms/services/log_outbox.py
+++ b/cms/services/log_outbox.py
@@ -41,9 +41,13 @@ from cms.models.log_request import (
 logger = logging.getLogger("agora.cms.log_outbox")
 
 
-# Default retention: Stage 3 arch doc targets a 30-day blob lifecycle.
+# Default retention for a newly-created log bundle.  Kept short because
+# the common case is "user clicks Download and is done" — the download
+# handler also sets ``expires_at`` to now on success so the next reaper
+# tick cleans the blob up within a few minutes.  The 1 h ceiling is the
+# safety net for bundles that are produced but never downloaded.
 # Individual callers can override by passing ``expires_in`` explicitly.
-DEFAULT_RETENTION = timedelta(days=30)
+DEFAULT_RETENTION = timedelta(hours=1)
 
 
 def _now() -> datetime:

--- a/cms/services/log_reaper.py
+++ b/cms/services/log_reaper.py
@@ -49,7 +49,7 @@ logger = logging.getLogger("agora.cms.log_reaper")
 
 # Defaults applied when the caller doesn't pass a Settings object.
 # Matches the AGORA_CMS_LOG_REAPER_* fields declared in cms.config.
-_DEFAULT_INTERVAL_SEC = 600.0  # 10 minutes — retention is measured in days
+_DEFAULT_INTERVAL_SEC = 600.0  # 10 minutes — matches the hourly retention
 _DEFAULT_BATCH_SIZE = 100
 
 

--- a/tests/test_log_requests_api.py
+++ b/tests/test_log_requests_api.py
@@ -310,6 +310,66 @@ class TestDownloadLogRequest:
         assert "attachment" in resp.headers.get("content-disposition", "")
 
     @pytest.mark.asyncio
+    async def test_successful_download_marks_row_for_expiry(
+        self, app, client, seeded, tmp_path,
+    ):
+        # Once the user has pulled the bundle we don't want to keep the
+        # blob around — the download handler should bump ``expires_at``
+        # to now so the next reaper tick cleans it up.
+        from datetime import datetime, timezone
+        from cms.services.log_blob import (
+            LocalLogBlobBackend,
+            init_log_storage,
+            set_log_backend,
+            write_log_blob,
+        )
+        from cms.auth import get_settings
+
+        settings = app.dependency_overrides[get_settings]()
+        set_log_backend(LocalLogBlobBackend(base_path=settings.asset_storage_path))
+        await init_log_storage(settings)
+
+        factory = get_session_factory()
+        async with factory() as db:
+            row = await log_outbox.create(db, device_id=DEVICE_ID)
+            await db.commit()
+            rid = row.id
+            original_expires_at = row.expires_at
+
+        blob_path = f"{DEVICE_ID}/{rid}.tar.gz"
+        payload = b"hello-tarball"
+        await write_log_blob(blob_path, payload)
+        async with factory() as db:
+            await log_outbox.mark_ready(
+                db, rid, blob_path=blob_path, size_bytes=len(payload),
+            )
+            await db.commit()
+
+        before = datetime.now(timezone.utc)
+        resp = await client.get(f"/api/logs/requests/{rid}/download")
+        assert resp.status_code == 200
+
+        async with factory() as db:
+            refreshed = await log_outbox.get(db, rid)
+            # Row stays ``ready`` with blob_path intact so the reaper
+            # can find the blob; only expires_at moves to "now".
+            assert refreshed.status == STATUS_READY
+            assert refreshed.blob_path == blob_path
+            assert refreshed.expires_at is not None
+            # SQLite strips tz info; normalise for comparison.
+            expires = refreshed.expires_at
+            if expires.tzinfo is None:
+                expires = expires.replace(tzinfo=timezone.utc)
+            original = original_expires_at
+            if original.tzinfo is None:
+                original = original.replace(tzinfo=timezone.utc)
+            assert expires <= datetime.now(timezone.utc)
+            # And it was genuinely moved forward — not just the
+            # original 1 h TTL.
+            assert expires < original
+            assert expires >= before
+
+    @pytest.mark.asyncio
     async def test_pending_row_returns_409(self, client, seeded):
         factory = get_session_factory()
         async with factory() as db:


### PR DESCRIPTION
# Shorten log-bundle retention and auto-expire on download

## Why

30 days was massively overkill. Once a user has downloaded a log bundle we have no reason to keep the blob around, and the previous `DEFAULT_RETENTION = timedelta(days=30)` meant Azure was holding log tarballs for a month whether anyone wanted them or not.

## What changed

- `cms/services/log_outbox.py` — `DEFAULT_RETENTION` is now **1 hour** instead of 30 days. That's the ceiling for bundles that are created but never downloaded.
- `cms/routers/log_requests.py` — when `/api/logs/requests/{id}/download` serves a bundle successfully, it now sets `row.expires_at = now(UTC)` before committing. The next reaper tick (≤10 min) deletes the blob and transitions the row to `expired`. The row still streams through with its `blob_path` intact — we only touch `expires_at`.
- `cms/services/log_reaper.py` — updated an outdated comment that said retention was "measured in days".

Net effect:

| Scenario | Old | New |
| --- | --- | --- |
| User downloads the bundle | Kept 30 d | Deleted within ~10 min |
| Bundle is never downloaded | Kept 30 d | Kept up to 1 h |

## Tests

New test `test_successful_download_marks_row_for_expiry` in `tests/test_log_requests_api.py`:

- Creates a `ready` row with the default 1 h `expires_at`.
- Hits `/download`.
- Asserts the response is 200, the row is still `ready` with `blob_path` intact (so the reaper can find the blob), and `expires_at` has been moved forward to now (strictly before the original 1 h TTL, strictly ≥ the pre-request timestamp).

All 58 log-pipeline tests pass locally (`tests/test_log_requests_api.py`, `test_log_outbox.py`, `test_log_reaper.py`, `test_log_blob_azure_download.py`).

## No Azure config changes

This ships as code-only. The existing `cms/services/log_reaper.py` is the only delete path — no Azure Blob lifecycle rules are added or required. (Lifecycle rules can't express sub-day retention anyway.)
