### PR TITLE
feat(infra): persist WPS transport config in bicep + CD pipeline

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -176,6 +176,7 @@ jobs:
               postgresAdminPassword='${{ secrets.POSTGRES_ADMIN_PASSWORD }}' \
               cmsSecretKey='${{ secrets.CMS_SECRET_KEY }}' \
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
+              wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -42,6 +42,14 @@ param cmsAdminUsername string = 'admin'
 @secure()
 param cmsAdminPassword string
 
+@description('Azure Web PubSub connection string for device transport (required in prod). When empty, CMS falls back to direct websocket mode.')
+@secure()
+param wpsConnectionString string = ''
+
+@description('Device transport mode: "wps" (multi-replica safe, routes via Azure Web PubSub) or "local" (direct CMS→device websockets, single-replica only).')
+@allowed(['wps', 'local'])
+param deviceTransport string = 'wps'
+
 @description('CMS container image (e.g., agoracr.azurecr.io/agora-cms:latest)')
 param cmsImage string = ''
 
@@ -197,6 +205,10 @@ module containerApps 'modules/containerApps.bicep' = {
 
     // Key Vault (service key exchange)
     keyVaultUri: keyVault.outputs.keyVaultUri
+
+    // Device transport (Azure Web PubSub)
+    wpsConnectionString: wpsConnectionString
+    deviceTransport: deviceTransport
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -53,6 +53,15 @@ param workerMemory string = '8Gi'
 // ── Azure Key Vault (service key exchange) ──
 param keyVaultUri string = ''
 
+// ── Azure Web PubSub (device transport) ──
+@description('Azure Web PubSub connection string used by CMS to relay device traffic through WPS. When empty, CMS falls back to direct /ws/device websocket mode.')
+@secure()
+param wpsConnectionString string = ''
+
+@description('Device transport mode: "wps" routes all device traffic through Azure Web PubSub (multi-replica safe); "local" uses direct CMS→device websockets (single-replica only).')
+@allowed(['wps', 'local'])
+param deviceTransport string = 'wps'
+
 // ── Container Apps Environment ──
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: '${environmentName}-logs'
@@ -148,6 +157,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'storage-connection-string'
           value: storageConnectionString
         }
+        {
+          name: 'wps-connection-string'
+          value: wpsConnectionString
+        }
       ]
     }
     template: {
@@ -207,6 +220,14 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               // source IP in audit logs.
               name: 'FORWARDED_ALLOW_IPS'
               value: containerAppsSubnetCidr
+            }
+            {
+              name: 'AGORA_CMS_DEVICE_TRANSPORT'
+              value: deviceTransport
+            }
+            {
+              name: 'AGORA_CMS_WPS_CONNECTION_STRING'
+              secretRef: 'wps-connection-string'
             }
           ]
           volumeMounts: [


### PR DESCRIPTION
# feat(infra): persist WPS transport config in bicep + CD pipeline

## Problem

Stage 4 of the multi-replica rollout flipped prod CMS to WPS device
transport by setting env vars directly on the live container app via
`az containerapp update`. The IaC (`infra/main.bicep` +
`publish-image.yml`) did NOT capture these, so the next `az deployment
group create` from CD would have wiped them and reverted the fleet to
broken direct-mode traffic on a single replica.

This PR makes the WPS config part of the bicep contract so it survives
redeploys, and threads the connection string through as a GitHub
Actions secret.

## Changes

### `infra/modules/containerApps.bicep`
- Added `wpsConnectionString` (secure) and `deviceTransport` params
  (default `'wps'`, `@allowed` list restricts to `wps`/`local`).
- Added `wps-connection-string` to the CMS container app secrets.
- Added two env vars to the CMS container:
  - `AGORA_CMS_DEVICE_TRANSPORT` (from `deviceTransport` param)
  - `AGORA_CMS_WPS_CONNECTION_STRING` (via `secretRef`)

### `infra/main.bicep`
- Added matching `wpsConnectionString` / `deviceTransport` params.
- Plumbed them through to the `containerApps` module call.

### `.github/workflows/publish-image.yml`
- Passes `wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}'`
  to `az deployment group create`.

### GitHub Secret
- `WPS_CONNECTION_STRING` was created in the repo secrets with the
  primary connection string from the prod WPS resource. (Set out-of-
  band; not part of this diff, but required for CD to succeed.)

## Validation

- `az bicep build --file infra/main.bicep` — clean (only pre-existing
  warnings on `outputs-should-not-contain-secrets` from acr/storage
  modules, unrelated to this PR).
- Live prod env already matches this shape:
  ```
  AGORA_CMS_DEVICE_TRANSPORT=wps
  AGORA_CMS_WPS_CONNECTION_STRING → secret 'wps-connection-string'
  ```
  So the next CD run is a no-op on prod — no rollout risk.

## Rollback

If WPS goes sideways, override at deploy time with
`deviceTransport=local` (also requires reverting firmware on any
WPS-only Pis, which we don't have yet — all Pis still support both).
