### PR TITLE
feat(cms): gate /ws/device router behind local transport mode

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -404,12 +404,13 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("Failed to log CMS_STARTED event")
 
-    # ── Device transport selection (issue #344 Stage 2b.2) ──
-    # Default is "local" (direct WebSocket via cms/routers/ws.py, today's
-    # behaviour).  Setting AGORA_CMS_DEVICE_TRANSPORT=wps swaps in the
-    # WPSTransport + mounts the upstream webhook receiver — the /ws/device
-    # endpoint stays registered so a running deployment can flip back by
-    # restarting, but devices talk to it through Azure Web PubSub instead.
+    # Device transport selection (issue #344 Stage 2b.2).
+    # Default is "local" (direct WebSocket via cms/routers/ws.py).  Setting
+    # AGORA_CMS_DEVICE_TRANSPORT=wps swaps in the WPSTransport + mounts the
+    # upstream webhook receiver.  The /ws/device endpoint is ONLY mounted in
+    # local mode (see include_router call near the end of this module) —
+    # flipping back requires a container restart, which Container Apps does
+    # automatically on any env-var change.
     from cms.services import transport as transport_module
     from cms.services.transport import LocalDeviceTransport
     if settings.device_transport == "wps":
@@ -654,7 +655,12 @@ app.include_router(device_events_router)
 app.include_router(users_router)
 app.include_router(roles_router)
 app.include_router(stream_probe_router)
-app.include_router(ws_router)
+# /ws/device is only mounted in local transport mode. In WPS mode, devices
+# reach the CMS via Azure Web PubSub, and exposing a direct websocket is a
+# security/confusion risk (devices that connect there appear "online" but
+# commands routed through WPS are silently dropped).
+if get_settings().device_transport == "local":
+    app.include_router(ws_router)
 app.include_router(ui_router)
 
 


### PR DESCRIPTION
# feat(cms): gate /ws/device router behind local transport mode

## Problem

Previously the `/ws/device` router was unconditionally mounted, even when
`AGORA_CMS_DEVICE_TRANSPORT=wps`. That left a live direct-websocket
endpoint in prod that devices could still connect to — but any commands
CMS sent them would route through WPS and silently drop, making the
device appear "online" while being functionally unreachable.

This was a known design smell flagged in the prior Stage 2b.2 review
(see comment in `cms/main.py` before this PR). Now that WPS transport
is validated in prod, it's safe to close.

## Change

Gate the `app.include_router(ws_router)` call on
`get_settings().device_transport == "local"` so WPS-mode deployments
have no direct device websocket surface.

The default transport is still `"local"`, so:
- Test suites are unaffected.
- Local dev loops (docker-compose) continue to work.
- Rollback = flip env var back to `local` + restart, same as today.

Also updated the docstring block in the lifespan handler that
previously described keeping `/ws/device` registered for flipback —
Container Apps already rotates revisions on any env change, so
"registered for flipback" was never meaningful.

## Out of scope

Full removal of direct-transport code (`cms/routers/ws.py`, local
`WebSocketManager`, test fixtures) is deferred to an epic — that
requires a firmware OTA gate + test rewrite against a mock WPS.
