### PR TITLE
refactor(scheduler): DB-back skip state via SkipSnapshot

### DIFF
--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
@@ -13,6 +14,7 @@ from shared.database import get_session_factory as _get_session_factory
 from cms.models.asset import Asset, AssetVariant, VariantStatus
 from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.schedule import Schedule
+from cms.models.schedule_device_skip import ScheduleDeviceSkip
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import ScheduleEntry, SyncMessage
@@ -27,66 +29,120 @@ def _asset_display_name(asset) -> str:
         return "—"
     return asset.display_name or asset.original_filename or asset.filename
 
-# Track last sync hash per device to avoid re-sending identical syncs
+# Track last sync hash per device to avoid re-sending identical syncs.
+# NOTE: this is replica-local. Under N>1 replicas two replicas may both
+# push to the same device, but the device firmware deduplicates via the
+# sync_hash echoed in acks. See docs/multi-replica.md.
 _last_sync_hash: dict[str, str] = {}
 
 # Confirmed playback: minimal tracking of what each device has confirmed
 # it's playing.  Populated by WS PLAYBACK_STARTED, cleared by PLAYBACK_ENDED
 # or device disconnect.  Only stores {device_id: {schedule_id, since}}.
+# NOTE: replica-local. Tracked separately in the confirmed-playing-dbback
+# todo; every replica gets its own view until that lands.
 _confirmed_playing: dict[str, dict] = {}
 _now_playing = _confirmed_playing  # backwards-compat alias for tests
 
-# Skipped schedule occurrences: {schedule_id: skip_until_local_datetime}.
-# Schedule-wide skips (applies to every device targeted by the schedule).
-_skipped: dict[str, datetime] = {}
-# Per-device skips: {(schedule_id, device_id): skip_until_local_datetime}.
-# Used when an operator ends a schedule for a single device via the dashboard.
-_device_skipped: dict[tuple[str, str], datetime] = {}
-_skipped_loaded: bool = False
+
+# ── Skip-state snapshot (DB-backed) ───────────────────────────────────
+#
+# Skip state (which schedules the operator has "ended now" for the rest
+# of the day, schedule-wide or per-device) lives in two DB tables:
+#   - Schedule.skipped_until          (schedule-wide)
+#   - ScheduleDeviceSkip              (per-device)
+#
+# Historically this module kept an in-memory cache mirroring those rows,
+# but the cache was written only by the replica that handled the skip
+# API call. Under multi-replica deployments every other replica would
+# happily push syncs containing the "skipped" schedule (and the scheduler
+# loop on a different replica would evaluate as if no skip existed).
+#
+# The cache is now gone. Every top-level consumer (scheduler tick,
+# build_device_sync, push_sync_to_device, compute_now_playing, UI
+# routes calling get_upcoming_schedules) loads a fresh SkipSnapshot
+# from the DB at the start of its pass and threads it through. The
+# snapshot is cheap — two small indexed queries — and is consistent for
+# the duration of a single request/tick.
+
+@dataclass(frozen=True)
+class SkipSnapshot:
+    """Immutable view of currently-persisted schedule skips.
+
+    ``schedule_wide`` maps ``schedule_id`` -> ``skip_until`` (naive local
+    datetime, CMS timezone).  ``per_device`` maps
+    ``(schedule_id, device_id)`` -> ``skip_until``.
+    """
+
+    schedule_wide: dict[str, datetime] = field(default_factory=dict)
+    per_device: dict[tuple[str, str], datetime] = field(default_factory=dict)
+
+    @classmethod
+    def empty(cls) -> "SkipSnapshot":
+        return cls()
+
+    def active_as_of(self, local_now: datetime) -> "SkipSnapshot":
+        """Return a new snapshot with expired entries dropped."""
+        sw = {
+            sid: until for sid, until in self.schedule_wide.items()
+            if local_now < until
+        }
+        pd = {
+            key: until for key, until in self.per_device.items()
+            if local_now < until
+        }
+        return SkipSnapshot(schedule_wide=sw, per_device=pd)
+
+    def expired_schedule_ids(self, local_now: datetime) -> list[str]:
+        return [
+            sid for sid, until in self.schedule_wide.items()
+            if local_now >= until
+        ]
+
+    def expired_device_pairs(self, local_now: datetime) -> list[tuple[str, str]]:
+        return [
+            key for key, until in self.per_device.items()
+            if local_now >= until
+        ]
+
+    def is_schedule_skipped(self, schedule_id: str) -> bool:
+        """True iff a schedule-wide skip is active for this schedule."""
+        return schedule_id in self.schedule_wide
+
+    def is_skipped_for_device(self, schedule_id: str, device_id: str) -> bool:
+        """True iff schedule is skipped for this device (wide OR per-device)."""
+        if schedule_id in self.schedule_wide:
+            return True
+        return (schedule_id, device_id) in self.per_device
 
 
-async def _ensure_skips_loaded(db) -> None:
-    """Load persisted skips (schedule-wide + per-device) from DB on first call."""
-    global _skipped_loaded
-    if _skipped_loaded:
-        return
-    skip_result = await db.execute(
+async def load_skip_snapshot(db) -> SkipSnapshot:
+    """Load all persisted skips from DB into an immutable snapshot.
+
+    Two small indexed queries.  Returns both expired and active entries;
+    callers that only want active ones should call ``.active_as_of(now)``.
+    """
+    sw: dict[str, datetime] = {}
+    sw_result = await db.execute(
         select(Schedule.id, Schedule.skipped_until)
         .where(Schedule.skipped_until.isnot(None))
     )
-    for sid, until in skip_result.all():
-        _skipped[str(sid)] = until.replace(tzinfo=None) if until.tzinfo else until
+    for sid, until in sw_result.all():
+        sw[str(sid)] = until.replace(tzinfo=None) if until.tzinfo else until
 
-    from cms.models.schedule_device_skip import ScheduleDeviceSkip
-    dev_skip_result = await db.execute(
+    pd: dict[tuple[str, str], datetime] = {}
+    pd_result = await db.execute(
         select(
             ScheduleDeviceSkip.schedule_id,
             ScheduleDeviceSkip.device_id,
             ScheduleDeviceSkip.skip_until,
         )
     )
-    for sid, did, until in dev_skip_result.all():
+    for sid, did, until in pd_result.all():
         key = (str(sid), did)
-        _device_skipped[key] = until.replace(tzinfo=None) if until.tzinfo else until
+        pd[key] = until.replace(tzinfo=None) if until.tzinfo else until
 
-    _skipped_loaded = True
-    if _skipped or _device_skipped:
-        logger.info(
-            "Loaded %d schedule skips and %d per-device skips from DB",
-            len(_skipped), len(_device_skipped),
-        )
+    return SkipSnapshot(schedule_wide=sw, per_device=pd)
 
-
-def is_schedule_skipped_for_device(schedule_id: str, device_id: str) -> bool:
-    """Return True if this schedule is currently skipped for the given device.
-
-    Covers both schedule-wide (``_skipped``) and per-device (``_device_skipped``)
-    skips.  The scheduler should treat a skipped schedule/device combo as if the
-    schedule were not active.
-    """
-    if schedule_id in _skipped:
-        return True
-    return (schedule_id, device_id) in _device_skipped
 
 # Track which schedule+device combos we've already logged as MISSED this eval cycle
 # Key: (schedule_id, device_id), cleared when the schedule/device combo resolves
@@ -168,45 +224,47 @@ def clear_now_playing(device_id: str) -> dict | None:
 
 def skip_schedule_until(
     schedule_id: str,
-    until: datetime,
+    until: datetime | None = None,
     device_id: str | None = None,
 ) -> None:
-    """Skip a schedule until ``until``.
+    """Invalidate confirmed-playing cache after a skip has been written to DB.
 
-    If ``device_id`` is omitted, the skip applies to every device targeted by
-    the schedule (legacy behavior).  If provided, only that device is skipped —
-    other devices on the same schedule continue to play.
+    **NOTE:** as of the scheduler-state-dbback refactor, this function no
+    longer stores skip state.  Skip state is persisted in
+    ``Schedule.skipped_until`` / ``ScheduleDeviceSkip`` by the API router.
+    All read paths load a fresh :class:`SkipSnapshot` from DB and don't
+    consult any module-level cache.
 
-    The function also removes matching entries from ``_confirmed_playing`` so
-    the dashboard reflects the change immediately.
+    The function is kept (with its original signature) because the router
+    still needs a hook to invalidate the process-local
+    ``_confirmed_playing`` dict so the dashboard reflects the change on
+    this replica immediately.  The ``until`` parameter is ignored.
     """
+    _ = until  # signature-compat only; skip state is persisted in DB
     if device_id is None:
-        _skipped[schedule_id] = until
-        to_remove = [did for did, info in _confirmed_playing.items() if info.get("schedule_id") == schedule_id]
+        to_remove = [
+            did for did, info in _confirmed_playing.items()
+            if info.get("schedule_id") == schedule_id
+        ]
         for did in to_remove:
             _confirmed_playing.pop(did, None)
         return
 
-    _device_skipped[(schedule_id, device_id)] = until
     info = _confirmed_playing.get(device_id)
     if info and info.get("schedule_id") == schedule_id:
         _confirmed_playing.pop(device_id, None)
 
 
 def clear_schedule_skip(schedule_id: str, device_id: str | None = None) -> None:
-    """Remove an active skip so the schedule can be re-evaluated.
+    """No-op kept for router backward-compat.
 
-    With ``device_id=None`` the schedule-wide skip AND all per-device skips
-    for this schedule are cleared.  With a specific ``device_id`` only that
-    one per-device skip is cleared.
+    Prior to scheduler-state-dbback this cleared the module-level skip
+    dicts so a freshly-enabled schedule would re-evaluate.  Now that skip
+    state lives only in the DB (and expired rows are purged by the
+    scheduler tick), the API router's DB writes are authoritative and
+    no in-memory cleanup is needed.
     """
-    if device_id is None:
-        _skipped.pop(schedule_id, None)
-        keys = [k for k in _device_skipped if k[0] == schedule_id]
-        for k in keys:
-            _device_skipped.pop(k, None)
-        return
-    _device_skipped.pop((schedule_id, device_id), None)
+    _ = schedule_id, device_id  # signature-compat only
 
 
 def clear_sync_hash(device_id: str) -> None:
@@ -223,7 +281,9 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
 
     Returns a list of dicts ready for the dashboard template / JSON API.
     """
-    await _ensure_skips_loaded(db)
+    skips = (await load_skip_snapshot(db)).active_as_of(
+        now.astimezone(tz).replace(tzinfo=None)
+    )
     from shared.models.asset import AssetType
 
     local_now = now.astimezone(tz).replace(tzinfo=None)
@@ -242,7 +302,7 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
     # Filter to currently active schedules (in their time window, not skipped)
     active = [
         s for s in schedules
-        if _matches_now(s, local_now) and str(s.id) not in _skipped
+        if _matches_now(s, local_now) and not skips.is_schedule_skipped(str(s.id))
     ]
 
     if not active:
@@ -262,7 +322,7 @@ async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
         # Drop any device with an active per-device skip on this schedule
         target_ids = [
             did for did in target_ids
-            if (str(s.id), did) not in _device_skipped
+            if not skips.is_skipped_for_device(str(s.id), did)
         ]
         if not target_ids:
             continue
@@ -323,6 +383,7 @@ def get_upcoming_schedules(
     schedules: list, now: datetime, tz: ZoneInfo,
     now_playing: list[dict] | None = None,
     offline_device_ids: set[str] | None = None,
+    skipped_schedule_ids: set[str] | None = None,
 ) -> list[dict]:
     """Return schedules starting within the next 24 hours.
 
@@ -332,8 +393,16 @@ def get_upcoming_schedules(
 
     Each entry includes start/end time, duration, countdown, and whether it's
     today or tomorrow.
+
+    ``skipped_schedule_ids`` is the set of schedule IDs (as strings) that the
+    operator has "Ended Now" and should therefore be hidden from the upcoming
+    list.  Callers should pass ``skips.schedule_wide.keys()`` from a
+    :func:`load_skip_snapshot` (filtered to active entries) — the default of
+    ``None`` treats no schedules as skipped, which is safe for unit tests
+    that never exercise the skip path.
     """
     _offline = offline_device_ids or set()
+    _skipped_ids: set[str] = set(skipped_schedule_ids or ())
     local_now = now.astimezone(tz).replace(tzinfo=None)
     today = local_now.date()
     tomorrow = today + timedelta(days=1)
@@ -360,7 +429,7 @@ def get_upcoming_schedules(
                 continue  # legacy: no preemption info available
             if str(s.id) in _winning_sids:
                 continue  # currently winning — shown in Now Playing
-            if str(s.id) in _skipped:
+            if str(s.id) in _skipped_ids:
                 continue  # deliberately ended via End Now
             # Check if genuinely preempted (higher-priority schedule active on same target)
             resume_at = _find_resume_time(s, schedules, local_now)
@@ -701,11 +770,20 @@ def _sync_hash(sync: SyncMessage) -> str:
     return hashlib.md5(sync.model_dump_json().encode()).hexdigest()
 
 
-async def build_device_sync(device_id: str, db) -> SyncMessage | None:
+async def build_device_sync(
+    device_id: str,
+    db,
+    skips: "SkipSnapshot | None" = None,
+) -> SyncMessage | None:
     """Build a full SyncMessage for a specific device.
 
     Used by both the scheduler loop and the on-change push.
     Returns None if the database isn't ready.
+
+    ``skips`` is an optional pre-loaded snapshot of active schedule skips.
+    If omitted, this function loads and filters one itself.  The scheduler
+    tick passes its own snapshot in to amortize the cost across every
+    device it syncs.
     """
     # Read configured timezone (per-device overrides CMS global)
     tz_result = await db.execute(
@@ -720,6 +798,11 @@ async def build_device_sync(device_id: str, db) -> SyncMessage | None:
     # PDT is still valid at 9 PM PDT even though it's April 2nd UTC).
     local_now = now.astimezone(ZoneInfo(cms_tz))
     local_cutoff = cutoff.astimezone(ZoneInfo(cms_tz))
+
+    if skips is None:
+        skips = (await load_skip_snapshot(db)).active_as_of(
+            local_now.replace(tzinfo=None)
+        )
 
     # Load device with default asset
     dev_result = await db.execute(
@@ -805,7 +888,7 @@ async def build_device_sync(device_id: str, db) -> SyncMessage | None:
         if device_id in target_ids:
             # Skip if this schedule's current occurrence is being skipped
             # (either schedule-wide, or just for this device).
-            if is_schedule_skipped_for_device(str(s.id), device_id):
+            if skips.is_skipped_for_device(str(s.id), device_id):
                 continue
             entries.append(_schedule_to_entry(s, variant_checksums))
 
@@ -822,10 +905,18 @@ async def build_device_sync(device_id: str, db) -> SyncMessage | None:
     )
 
 
-async def push_sync_to_device(device_id: str, db) -> None:
-    """Build and push a fresh sync to a single connected device."""
-    await _ensure_skips_loaded(db)
+async def push_sync_to_device(
+    device_id: str,
+    db,
+    skips: "SkipSnapshot | None" = None,
+) -> None:
+    """Build and push a fresh sync to a single connected device.
 
+    ``skips`` may be an already-loaded :class:`SkipSnapshot` (active
+    entries only) so the scheduler tick can share one snapshot across
+    every device it syncs.  If omitted, :func:`build_device_sync` loads
+    its own.
+    """
     if not await get_transport().is_connected(device_id):
         return
 
@@ -835,7 +926,7 @@ async def push_sync_to_device(device_id: str, db) -> None:
     if status != DeviceStatus.ADOPTED:
         return
 
-    sync = await build_device_sync(device_id, db)
+    sync = await build_device_sync(device_id, db, skips=skips)
     if sync is None:
         return
 
@@ -867,8 +958,6 @@ async def evaluate_schedules() -> None:
     now = datetime.now(timezone.utc)
 
     async with sf() as db:
-        await _ensure_skips_loaded(db)
-
         # Read timezone for schedule evaluation
         tz_result = await db.execute(
             select(CMSSetting.value).where(CMSSetting.key == "timezone")
@@ -876,11 +965,18 @@ async def evaluate_schedules() -> None:
         tz_name = tz_result.scalar_one_or_none() or "UTC"
         local_now = now.astimezone(ZoneInfo(tz_name)).replace(tzinfo=None)
 
+        # Load the full skip snapshot once for this tick.  We use the
+        # raw snapshot to compute expirations, then derive an
+        # "active-as-of-now" view for downstream filtering.
+        raw_skips = await load_skip_snapshot(db)
+        skips = raw_skips.active_as_of(local_now)
+
         connected = set(await get_transport().connected_ids())
 
-        # Push full sync to each connected device (dedup via hash)
+        # Push full sync to each connected device (dedup via hash).
+        # Share the snapshot across all devices to amortize the DB load.
         for did in connected:
-            await push_sync_to_device(did, db)
+            await push_sync_to_device(did, db, skips=skips)
 
         # ── Detect MISSED schedules ──
         result = await db.execute(
@@ -893,11 +989,9 @@ async def evaluate_schedules() -> None:
         )
         schedules = result.scalars().all()
 
-        # Purge expired skips (memory + DB) — schedule-wide
-        expired = [sid for sid, until in _skipped.items() if local_now >= until]
+        # Purge expired schedule-wide skips from DB.
+        expired = raw_skips.expired_schedule_ids(local_now)
         for sid in expired:
-            _skipped.pop(sid, None)
-            # Clear DB column
             await db.execute(
                 Schedule.__table__.update()
                 .where(Schedule.id == sid)
@@ -909,11 +1003,9 @@ async def evaluate_schedules() -> None:
         if expired:
             await db.commit()
 
-        # Purge expired per-device skips
-        from cms.models.schedule_device_skip import ScheduleDeviceSkip
-        dev_expired = [k for k, until in _device_skipped.items() if local_now >= until]
+        # Purge expired per-device skips from DB.
+        dev_expired = raw_skips.expired_device_pairs(local_now)
         for key in dev_expired:
-            _device_skipped.pop(key, None)
             sid, did = key
             await db.execute(
                 ScheduleDeviceSkip.__table__.delete().where(
@@ -927,7 +1019,7 @@ async def evaluate_schedules() -> None:
 
         active = [
             s for s in schedules
-            if _matches_now(s, local_now) and str(s.id) not in _skipped
+            if _matches_now(s, local_now) and not skips.is_schedule_skipped(str(s.id))
         ]
 
         # Detect MISSED schedules: active schedules targeting offline adopted devices
@@ -946,7 +1038,7 @@ async def evaluate_schedules() -> None:
             for did in target_ids:
                 key = (str(s.id), did)
                 # Don't flag MISSED for a device whose skip is active.
-                if key in _device_skipped:
+                if skips.is_skipped_for_device(str(s.id), did):
                     _offline_since.pop(key, None)
                     continue
                 if did in connected or did not in all_adopted:

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -947,7 +947,6 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
         else:
             upcoming_q = upcoming_q.where(sqlalchemy.false())
     sched_q = await db.execute(upcoming_q)
-    sched_q = await db.execute(upcoming_query)
     all_schedules = sched_q.scalars().all()
     offline_set = set(offline_ids)
     _skips_for_ui = (await load_skip_snapshot(db)).active_as_of(

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -576,7 +576,7 @@ async def setup_complete(
 @router.get("/", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     from datetime import datetime as _dt, timezone as _tz
-    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules
+    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot
     from cms.auth import get_user_group_ids
 
     # CMS timezone
@@ -741,7 +741,15 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     sched_q = await db.execute(upcoming_query)
     all_schedules = sched_q.scalars().all()
     offline_set = set(d.id for d in offline_devices)
-    upcoming = get_upcoming_schedules(all_schedules, now, tz, now_playing=now_playing, offline_device_ids=offline_set)
+    _skips_for_ui = (await load_skip_snapshot(db)).active_as_of(
+        now.astimezone(tz).replace(tzinfo=None)
+    )
+    upcoming = get_upcoming_schedules(
+        all_schedules, now, tz,
+        now_playing=now_playing,
+        offline_device_ids=offline_set,
+        skipped_schedule_ids=set(_skips_for_ui.schedule_wide.keys()),
+    )
     upcoming_today = [u for u in upcoming if u["day_label"] == "today"]
     upcoming_tomorrow = [u for u in upcoming if u["day_label"] == "tomorrow"]
 
@@ -822,7 +830,7 @@ async def server_time_json(db: AsyncSession = Depends(get_db)):
 async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
     """Lightweight JSON endpoint for dashboard polling."""
     from datetime import datetime as _dt, timezone as _tz
-    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules
+    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot
     from cms.auth import get_user_group_ids
 
     tz_name = await get_setting(db, SETTING_TIMEZONE) or "UTC"
@@ -939,9 +947,18 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
         else:
             upcoming_q = upcoming_q.where(sqlalchemy.false())
     sched_q = await db.execute(upcoming_q)
+    sched_q = await db.execute(upcoming_query)
     all_schedules = sched_q.scalars().all()
     offline_set = set(offline_ids)
-    upcoming = get_upcoming_schedules(all_schedules, now, tz, now_playing=now_playing, offline_device_ids=offline_set)
+    _skips_for_ui = (await load_skip_snapshot(db)).active_as_of(
+        now.astimezone(tz).replace(tzinfo=None)
+    )
+    upcoming = get_upcoming_schedules(
+        all_schedules, now, tz,
+        now_playing=now_playing,
+        offline_device_ids=offline_set,
+        skipped_schedule_ids=set(_skips_for_ui.schedule_wide.keys()),
+    )
 
     # Recent activity count for change detection
     from datetime import timedelta

--- a/tests/test_display_name.py
+++ b/tests/test_display_name.py
@@ -14,9 +14,8 @@ from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.schedule import Schedule
 from cms.services.scheduler import (
     _asset_display_name,
-    _skipped,
     _now_playing,
-    _ensure_skips_loaded,
+    load_skip_snapshot,
 )
 
 
@@ -223,19 +222,13 @@ class TestScheduleApiDisplayName:
 
 @pytest.mark.asyncio
 class TestSkippedUntilPersistence:
-    """Test that End Now writes skipped_until to DB and _ensure_skips_loaded reads it back."""
+    """Test that End Now writes skipped_until to DB and load_skip_snapshot reads it back."""
 
     def setup_method(self):
-        import cms.services.scheduler as _sched
-        _skipped.clear()
         _now_playing.clear()
-        _sched._skipped_loaded = False
 
     def teardown_method(self):
-        import cms.services.scheduler as _sched
-        _skipped.clear()
         _now_playing.clear()
-        _sched._skipped_loaded = False
 
     async def test_end_now_persists_skipped_until(self, client, db_session):
         """POST end-now should write skipped_until to the schedule row."""
@@ -258,8 +251,8 @@ class TestSkippedUntilPersistence:
             skipped_val = result.scalar_one()
             assert skipped_val is not None
 
-    async def test_ensure_skips_loaded_reads_from_db(self, db_session):
-        """_ensure_skips_loaded should populate _skipped from DB rows."""
+    async def test_load_skip_snapshot_reads_from_db(self, db_session):
+        """load_skip_snapshot should surface schedule rows with skipped_until."""
         group = await _seed_group(db_session)
         asset = await _create_asset(db_session)
         sched = await _seed_schedule(db_session, asset, group)
@@ -269,26 +262,21 @@ class TestSkippedUntilPersistence:
         sched.skipped_until = future
         await db_session.commit()
 
-        # Simulate fresh start: _skipped is empty, _skipped_loaded is False
-        _skipped.clear()
+        snap = await load_skip_snapshot(db_session)
+        assert str(sched.id) in snap.schedule_wide
 
-        await _ensure_skips_loaded(db_session)
-
-        assert str(sched.id) in _skipped
-
-    async def test_ensure_skips_loaded_idempotent(self, db_session):
-        """Second call should not re-query or duplicate entries."""
+    async def test_load_skip_snapshot_repeatable(self, db_session):
+        """Two calls return equivalent content — no hidden caching."""
         group = await _seed_group(db_session)
         asset = await _create_asset(db_session)
         sched = await _seed_schedule(db_session, asset, group)
         sched.skipped_until = datetime.now(timezone.utc) + timedelta(hours=6)
         await db_session.commit()
 
-        await _ensure_skips_loaded(db_session)
-        count_after_first = len(_skipped)
-
-        await _ensure_skips_loaded(db_session)
-        assert len(_skipped) == count_after_first
+        snap_a = await load_skip_snapshot(db_session)
+        snap_b = await load_skip_snapshot(db_session)
+        assert snap_a.schedule_wide == snap_b.schedule_wide
+        assert snap_a.per_device == snap_b.per_device
 
     async def test_schedule_edit_clears_skipped_until(self, client, db_session):
         """Editing a schedule should clear its skipped_until in DB."""
@@ -315,6 +303,7 @@ class TestSkippedUntilPersistence:
         assert skipped_val is None
 
     async def test_no_skips_loaded_when_db_empty(self, db_session):
-        """When no schedules have skipped_until, _skipped stays empty."""
-        await _ensure_skips_loaded(db_session)
-        assert len(_skipped) == 0
+        """When no schedules have skipped_until, snapshot is empty."""
+        snap = await load_skip_snapshot(db_session)
+        assert len(snap.schedule_wide) == 0
+        assert len(snap.per_device) == 0

--- a/tests/test_end_now_per_device.py
+++ b/tests/test_end_now_per_device.py
@@ -2,12 +2,16 @@
 
 The End Now button on the dashboard should only affect the clicked device.
 Prior behavior skipped the schedule for every device in the target group.
+
+After the scheduler-state-dbback refactor, skip state lives exclusively in
+the DB (``Schedule.skipped_until`` and ``ScheduleDeviceSkip``) — these
+tests write skips directly to the database and assert that
+:func:`build_device_sync` and :func:`load_skip_snapshot` honor them.
 """
 
 from __future__ import annotations
 
-import uuid
-from datetime import datetime, time, timedelta
+from datetime import datetime, time
 
 import pytest
 import pytest_asyncio
@@ -19,84 +23,17 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_device_skip import ScheduleDeviceSkip
 from cms.models.setting import CMSSetting
 from cms.services import scheduler as sched_mod
-from cms.services.scheduler import (
-    build_device_sync,
-    clear_schedule_skip,
-    is_schedule_skipped_for_device,
-    skip_schedule_until,
-)
+from cms.services.scheduler import build_device_sync, load_skip_snapshot
 
 
 @pytest.fixture(autouse=True)
 def _reset_scheduler_state():
-    """Per-test isolation for module-level skip dicts."""
-    sched_mod._skipped.clear()
-    sched_mod._device_skipped.clear()
-    sched_mod._skipped_loaded = False
+    """Clear the remaining replica-local scheduler caches between tests."""
+    sched_mod._confirmed_playing.clear()
+    sched_mod._last_sync_hash.clear()
     yield
-    sched_mod._skipped.clear()
-    sched_mod._device_skipped.clear()
-    sched_mod._skipped_loaded = False
-
-
-class TestInMemorySkipHelpers:
-    def test_schedule_wide_skip(self):
-        sid = str(uuid.uuid4())
-        until = datetime(2030, 1, 1, 12, 0)
-        skip_schedule_until(sid, until)
-        assert is_schedule_skipped_for_device(sid, "dev-a")
-        assert is_schedule_skipped_for_device(sid, "dev-b")
-
-    def test_per_device_skip_isolation(self):
-        sid = str(uuid.uuid4())
-        until = datetime(2030, 1, 1, 12, 0)
-        skip_schedule_until(sid, until, device_id="dev-a")
-        assert is_schedule_skipped_for_device(sid, "dev-a")
-        assert not is_schedule_skipped_for_device(sid, "dev-b")
-
-    def test_schedule_wide_overrides_per_device(self):
-        sid = str(uuid.uuid4())
-        until = datetime(2030, 1, 1, 12, 0)
-        skip_schedule_until(sid, until, device_id="dev-a")
-        skip_schedule_until(sid, until)  # schedule-wide
-        assert is_schedule_skipped_for_device(sid, "dev-a")
-        assert is_schedule_skipped_for_device(sid, "dev-b")
-
-    def test_clear_device_skip_only(self):
-        sid = str(uuid.uuid4())
-        until = datetime(2030, 1, 1, 12, 0)
-        skip_schedule_until(sid, until, device_id="dev-a")
-        skip_schedule_until(sid, until, device_id="dev-b")
-        clear_schedule_skip(sid, device_id="dev-a")
-        assert not is_schedule_skipped_for_device(sid, "dev-a")
-        assert is_schedule_skipped_for_device(sid, "dev-b")
-
-    def test_clear_all_drops_per_device_skips(self):
-        sid = str(uuid.uuid4())
-        until = datetime(2030, 1, 1, 12, 0)
-        skip_schedule_until(sid, until, device_id="dev-a")
-        skip_schedule_until(sid, until, device_id="dev-b")
-        clear_schedule_skip(sid)
-        assert not is_schedule_skipped_for_device(sid, "dev-a")
-        assert not is_schedule_skipped_for_device(sid, "dev-b")
-
-    def test_per_device_skip_clears_only_that_confirmed_playing(self):
-        sid = str(uuid.uuid4())
-        sched_mod._confirmed_playing["dev-a"] = {"schedule_id": sid, "since": "t"}
-        sched_mod._confirmed_playing["dev-b"] = {"schedule_id": sid, "since": "t"}
-        skip_schedule_until(sid, datetime(2030, 1, 1, 12, 0), device_id="dev-a")
-        assert "dev-a" not in sched_mod._confirmed_playing
-        assert "dev-b" in sched_mod._confirmed_playing
-        sched_mod._confirmed_playing.clear()
-
-    def test_schedule_wide_skip_clears_all_confirmed_playing(self):
-        sid = str(uuid.uuid4())
-        sched_mod._confirmed_playing["dev-a"] = {"schedule_id": sid, "since": "t"}
-        sched_mod._confirmed_playing["dev-b"] = {"schedule_id": sid, "since": "t"}
-        skip_schedule_until(sid, datetime(2030, 1, 1, 12, 0))
-        assert "dev-a" not in sched_mod._confirmed_playing
-        assert "dev-b" not in sched_mod._confirmed_playing
-        sched_mod._confirmed_playing.clear()
+    sched_mod._confirmed_playing.clear()
+    sched_mod._last_sync_hash.clear()
 
 
 @pytest.mark.asyncio
@@ -134,7 +71,12 @@ class TestPerDeviceSkipAgainstDB:
     async def test_build_sync_drops_schedule_only_for_skipped_device(self, db):
         """Skipping for device A must not affect device B's sync."""
         sched, d1, d2 = await self._setup(db)
-        skip_schedule_until(str(sched.id), datetime(2099, 1, 1), device_id=d1.id)
+        db.add(ScheduleDeviceSkip(
+            schedule_id=sched.id,
+            device_id=d1.id,
+            skip_until=datetime(2099, 1, 1),
+        ))
+        await db.commit()
 
         sync_a = await build_device_sync(d1.id, db)
         sync_b = await build_device_sync(d2.id, db)
@@ -146,7 +88,8 @@ class TestPerDeviceSkipAgainstDB:
     async def test_build_sync_honors_schedule_wide_skip(self, db):
         """Schedule-wide skip still removes schedule from every device."""
         sched, d1, d2 = await self._setup(db)
-        skip_schedule_until(str(sched.id), datetime(2099, 1, 1))
+        sched.skipped_until = datetime(2099, 1, 1)
+        await db.commit()
 
         sync_a = await build_device_sync(d1.id, db)
         sync_b = await build_device_sync(d2.id, db)
@@ -154,28 +97,40 @@ class TestPerDeviceSkipAgainstDB:
         assert len(sync_a.schedules) == 0
         assert len(sync_b.schedules) == 0
 
-    async def test_persisted_per_device_skip_is_loaded_on_first_use(self, db):
-        """_ensure_skips_loaded picks up schedule_device_skips rows."""
+    async def test_load_skip_snapshot_reads_both_scopes(self, db):
+        """load_skip_snapshot must surface both schedule-wide and per-device skips."""
         sched, d1, d2 = await self._setup(db)
+        sched.skipped_until = datetime(2099, 1, 1)
         db.add(ScheduleDeviceSkip(
             schedule_id=sched.id,
-            device_id=d1.id,
+            device_id=d2.id,
             skip_until=datetime(2099, 1, 1),
         ))
         await db.commit()
 
-        # Simulate cold boot: wipe in-memory, then trigger a build that loads
-        sched_mod._device_skipped.clear()
-        sched_mod._skipped_loaded = False
+        snap = await load_skip_snapshot(db)
+        assert str(sched.id) in snap.schedule_wide
+        assert (str(sched.id), d2.id) in snap.per_device
+        assert snap.is_schedule_skipped(str(sched.id))
+        assert snap.is_skipped_for_device(str(sched.id), d2.id)
+        # Schedule-wide skip also blocks d1 via is_skipped_for_device
+        assert snap.is_skipped_for_device(str(sched.id), d1.id)
 
-        # Force the load and verify it populated the dict
-        await sched_mod._ensure_skips_loaded(db)
-        assert (str(sched.id), d1.id) in sched_mod._device_skipped, (
-            f"expected ({str(sched.id)!r}, {d1.id!r}) in {sched_mod._device_skipped}"
-        )
+    async def test_active_as_of_drops_expired_entries(self, db):
+        """Expired skips should not appear in the active-as-of view."""
+        sched, d1, _ = await self._setup(db)
+        sched.skipped_until = datetime(2000, 1, 1)  # long past
+        db.add(ScheduleDeviceSkip(
+            schedule_id=sched.id,
+            device_id=d1.id,
+            skip_until=datetime(2000, 1, 1),
+        ))
+        await db.commit()
 
-        sync_a = await build_device_sync(d1.id, db)
-        sync_b = await build_device_sync(d2.id, db)
-
-        assert len(sync_a.schedules) == 0
-        assert len(sync_b.schedules) == 1
+        snap = await load_skip_snapshot(db)
+        active = snap.active_as_of(datetime(2030, 1, 1))
+        assert not active.is_schedule_skipped(str(sched.id))
+        assert not active.is_skipped_for_device(str(sched.id), d1.id)
+        # But expired_* still reports them for the purge loop
+        assert str(sched.id) in snap.expired_schedule_ids(datetime(2030, 1, 1))
+        assert (str(sched.id), d1.id) in snap.expired_device_pairs(datetime(2030, 1, 1))

--- a/tests/test_scheduler_advanced.py
+++ b/tests/test_scheduler_advanced.py
@@ -15,21 +15,18 @@ from cms.models.schedule import Schedule
 from cms.models.setting import CMSSetting
 from cms.services.scheduler import (
     _matches_now,
-    _skipped,
     _now_playing,
     _last_sync_hash,
     _offline_since,
     _missed_logged,
     MISSED_GRACE_SECONDS,
     build_device_sync,
-    clear_schedule_skip,
     clear_sync_hash,
     clear_now_playing,
     evaluate_schedules,
     get_now_playing,
     get_upcoming_schedules,
     set_now_playing,
-    skip_schedule_until,
 )
 
 
@@ -89,95 +86,54 @@ def _make_schedule_with_asset(
     return s
 
 
-# ── skip_schedule_until / End Now ──
+# ── Skipped schedules (End Now) — now DB-backed via skipped_schedule_ids kwarg ──
 
 
-class TestSkipSchedule:
-    """Tests for the in-memory skip mechanism (End Now feature)."""
+class TestSkipScheduleBehavior:
+    """After the dbback refactor, skip state is passed as a set to
+    ``get_upcoming_schedules`` (and loaded from DB inside scheduler tick).
+    These tests cover the hide-in-upcoming behavior."""
 
     def setup_method(self):
-        _skipped.clear()
         _now_playing.clear()
         _last_sync_hash.clear()
 
     def teardown_method(self):
-        _skipped.clear()
         _now_playing.clear()
         _last_sync_hash.clear()
 
-    def test_skip_adds_to_skipped_dict(self):
-        until = datetime(2026, 3, 29, 17, 0)
-        skip_schedule_until("sched-1", until)
-        assert "sched-1" in _skipped
-        assert _skipped["sched-1"] == until
-
-    def test_skip_removes_from_now_playing(self):
-        _now_playing["device-a"] = {"schedule_id": "sched-1", "device_id": "device-a"}
-        _now_playing["device-b"] = {"schedule_id": "sched-2", "device_id": "device-b"}
-
-        skip_schedule_until("sched-1", datetime(2026, 3, 29, 17, 0))
-
-        assert "device-a" not in _now_playing
-        assert "device-b" in _now_playing
-
-    def test_skip_removes_multiple_devices_same_schedule(self):
-        _now_playing["d1"] = {"schedule_id": "sched-1", "device_id": "d1"}
-        _now_playing["d2"] = {"schedule_id": "sched-1", "device_id": "d2"}
-        _now_playing["d3"] = {"schedule_id": "sched-2", "device_id": "d3"}
-
-        skip_schedule_until("sched-1", datetime(2026, 3, 29, 17, 0))
-
-        assert "d1" not in _now_playing
-        assert "d2" not in _now_playing
-        assert "d3" in _now_playing
-
-    def test_skip_nonexistent_schedule_is_harmless(self):
-        skip_schedule_until("no-such-id", datetime(2026, 3, 29, 17, 0))
-        assert "no-such-id" in _skipped
-        assert len(_now_playing) == 0
-
-    def test_get_now_playing_returns_list(self):
-        _now_playing["d1"] = {"schedule_id": "s1", "device_id": "d1"}
-        _now_playing["d2"] = {"schedule_id": "s2", "device_id": "d2"}
-
-        result = get_now_playing()
-        assert isinstance(result, list)
-        assert len(result) == 2
-
-    def test_clear_skip_removes_entry(self):
-        skip_schedule_until("sched-1", datetime(2026, 3, 29, 17, 0))
-        assert "sched-1" in _skipped
-        clear_schedule_skip("sched-1")
-        assert "sched-1" not in _skipped
-
-    def test_clear_skip_nonexistent_is_harmless(self):
-        clear_schedule_skip("no-such-id")
-        assert "no-such-id" not in _skipped
-
-    def test_clear_skip_allows_schedule_to_reappear(self):
-        """After clearing a skip, the schedule should appear in upcoming again."""
+    def test_skipped_schedule_hidden_from_upcoming(self):
         low = _make_schedule(
-            time(8, 0), time(17, 0), priority=1, name="Resumed",
+            time(8, 0), time(17, 0), priority=1, name="Ended",
             group_id=uuid.uuid4(),
         )
-        skip_schedule_until(str(low.id), datetime(2026, 3, 28, 17, 0))
-
         now = datetime(2026, 3, 28, 12, 0, tzinfo=timezone.utc)
-        np = []
-
-        # Should not appear while skipped
-        result = get_upcoming_schedules([low], now, ZoneInfo("UTC"), now_playing=np)
+        result = get_upcoming_schedules(
+            [low], now, ZoneInfo("UTC"), now_playing=[],
+            skipped_schedule_ids={str(low.id)},
+        )
         assert len(result) == 0
 
-        # Clear the skip
-        clear_schedule_skip(str(low.id))
-
-        # Should now be visible again
-        result = get_upcoming_schedules([low], now, ZoneInfo("UTC"), now_playing=np)
-        # It won't show in "upcoming" as preempted because there's no winner,
-        # but it won't be hidden by the skip filter either.
-        # The key assertion is that the _skipped dict no longer blocks it.
-        assert str(low.id) not in _skipped
+    def test_default_no_skip_does_not_hide(self):
+        """Omitting skipped_schedule_ids must not spuriously hide schedules."""
+        low = _make_schedule(
+            time(8, 0), time(17, 0), priority=1, name="Running",
+            group_id=uuid.uuid4(),
+        )
+        now = datetime(2026, 3, 28, 12, 0, tzinfo=timezone.utc)
+        # No explicit skip set. Without a higher-priority winner the
+        # schedule would itself be the winner, so just assert absence of
+        # any "skipped" filter by passing a now_playing entry that makes
+        # the schedule preempted — it should surface as preempted=True.
+        high = _make_schedule(
+            time(8, 0), time(17, 0), priority=10, name="High",
+            group_id=low.group_id,
+        )
+        np = [{"schedule_id": str(high.id), "device_id": "d1",
+               "schedule_name": "High", "asset": "a", "since": now.isoformat()}]
+        result = get_upcoming_schedules([low, high], now, ZoneInfo("UTC"), now_playing=np)
+        # Low must show up as preempted because skipped_schedule_ids defaults to empty
+        assert any(r.get("preempted") for r in result)
 
 
 class TestClearSyncHash:
@@ -324,17 +280,18 @@ class TestPrioritySelection:
         s2 = _make_schedule_with_asset(time(9, 0), time(17, 0), priority=1, name="Low", group_id=gid)
         now = datetime(2026, 3, 28, 12, 0)
 
-        _skipped.clear()
-        _skipped[str(s1.id)] = datetime(2026, 3, 28, 17, 0)
+        # Simulate the post-refactor pattern: caller loads a SkipSnapshot
+        # and filters on membership.  Here we use a plain set literal
+        # equivalent to ``snap.schedule_wide.keys()`` for the active-
+        # as-of view.
+        skipped_ids = {str(s1.id)}
 
         active = [
             s for s in [s1, s2]
-            if _matches_now(s, now) and str(s.id) not in _skipped
+            if _matches_now(s, now) and str(s.id) not in skipped_ids
         ]
         assert len(active) == 1
         assert active[0].name == "Low"
-
-        _skipped.clear()
 
 
 # ── get_upcoming_schedules tests ──
@@ -613,11 +570,9 @@ class TestEndNowEndpoint:
         return resp.json()["id"]
 
     def setup_method(self):
-        _skipped.clear()
         _now_playing.clear()
 
     def teardown_method(self):
-        _skipped.clear()
         _now_playing.clear()
 
     async def test_end_now_success(self, client, db_session):
@@ -627,7 +582,12 @@ class TestEndNowEndpoint:
         data = resp.json()
         assert data["ended"] == sched_id
         assert "resumes_after" in data
-        assert sched_id in _skipped
+        # Post-refactor: skip state lives in DB only.
+        from sqlalchemy import select
+        row = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert row is not None
 
     async def test_end_now_not_found(self, client):
         resp = await client.post("/api/schedules/00000000-0000-0000-0000-000000000000/end-now")
@@ -660,10 +620,10 @@ class TestBuildDeviceSyncSkipped:
             yield session
 
     def setup_method(self):
-        _skipped.clear()
+        pass
 
     def teardown_method(self):
-        _skipped.clear()
+        pass
 
     async def _setup(self, db):
         setting = CMSSetting(key="timezone", value="UTC")
@@ -683,11 +643,12 @@ class TestBuildDeviceSyncSkipped:
         )
         db.add(sched)
         await db.commit()
-        return str(sched.id)
+        return sched
 
     async def test_skipped_schedule_excluded_from_sync(self, db):
-        sched_id = await self._setup(db)
-        _skipped[sched_id] = datetime(2026, 3, 29, 17, 0)
+        sched = await self._setup(db)
+        sched.skipped_until = datetime(2099, 1, 1)
+        await db.commit()
 
         sync = await build_device_sync("skip-pi-01", db)
         assert sync is not None
@@ -695,7 +656,6 @@ class TestBuildDeviceSyncSkipped:
 
     async def test_unskipped_schedule_included(self, db):
         await self._setup(db)
-        # Don't skip anything
         sync = await build_device_sync("skip-pi-01", db)
         assert len(sync.schedules) == 1
         assert sync.schedules[0].name == "Skippable"
@@ -708,12 +668,10 @@ class TestNowPlayingCleanup:
     def setup_method(self):
         _now_playing.clear()
         _last_sync_hash.clear()
-        _skipped.clear()
 
     def teardown_method(self):
         _now_playing.clear()
         _last_sync_hash.clear()
-        _skipped.clear()
 
     async def test_now_playing_cleared_when_schedule_deleted(self, app, db_session):
         """Deleting a schedule should clear its _now_playing entries."""

--- a/tests/test_scheduler_preemption.py
+++ b/tests/test_scheduler_preemption.py
@@ -11,7 +11,6 @@ from cms.models.schedule import Schedule
 from cms.services.scheduler import (
     _find_resume_time,
     _matches_now,
-    _skipped,
     get_upcoming_schedules,
 )
 
@@ -195,24 +194,20 @@ class TestLegacyBehavior:
 class TestSkippedNotPreempted:
     """Schedules ended via End Now should not appear as preempted."""
 
-    def setup_method(self):
-        _skipped.clear()
-
-    def teardown_method(self):
-        _skipped.clear()
-
     def test_skipped_schedule_hidden(self):
         """A schedule that was 'Ended Now' should not appear in upcoming."""
         low = _make_schedule(
             time(8, 0), time(17, 0), priority=1, name="Ended",
             group_id=uuid.uuid4(),
         )
-        _skipped[str(low.id)] = datetime(2026, 3, 28, 17, 0)
 
         now = datetime(2026, 3, 28, 12, 0, tzinfo=timezone.utc)
         np = []  # no winner
 
-        result = get_upcoming_schedules([low], now, UTC, now_playing=np)
+        result = get_upcoming_schedules(
+            [low], now, UTC, now_playing=np,
+            skipped_schedule_ids={str(low.id)},
+        )
         assert len(result) == 0
 
     def test_skipped_while_preempted_hidden(self):
@@ -227,12 +222,14 @@ class TestSkippedNotPreempted:
             time(8, 0), time(17, 0), priority=10, name="High",
             group_id=gid,
         )
-        _skipped[str(low.id)] = datetime(2026, 3, 28, 17, 0)
 
         now = datetime(2026, 3, 28, 12, 0, tzinfo=timezone.utc)
         np = [_now_playing_entry(high, "d1")]
 
-        result = get_upcoming_schedules([low, high], now, UTC, now_playing=np)
+        result = get_upcoming_schedules(
+            [low, high], now, UTC, now_playing=np,
+            skipped_schedule_ids={str(low.id)},
+        )
         assert len(result) == 0
 
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -539,7 +539,9 @@ class TestEndNowClearedOnEdit:
 
     async def test_patch_clears_end_now_skip(self, client, db_session):
         """PATCH /api/schedules/<id> should clear any active End Now skip."""
-        from cms.services.scheduler import _skipped
+        from sqlalchemy import select
+        from cms.models.schedule import Schedule
+        import uuid
 
         group_id, asset_id = await self._seed(db_session)
 
@@ -557,18 +559,27 @@ class TestEndNowClearedOnEdit:
         # End it now
         resp = await client.post(f"/api/schedules/{sched_id}/end-now")
         assert resp.status_code == 200
-        assert sched_id in _skipped
+        row = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert row is not None
 
         # Edit the schedule (even without real changes)
         resp = await client.patch(f"/api/schedules/{sched_id}", json={"name": "End Now Test"})
         assert resp.status_code == 200
 
-        # The skip should be cleared
-        assert sched_id not in _skipped
+        # The skip should be cleared in the DB
+        db_session.expire_all()
+        row = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert row is None
 
     async def test_toggle_enabled_clears_skip(self, client, db_session):
         """Toggling enabled on a skipped schedule should clear the skip."""
-        from cms.services.scheduler import _skipped
+        from sqlalchemy import select
+        from cms.models.schedule import Schedule
+        import uuid
 
         group_id, asset_id = await self._seed(db_session)
 
@@ -583,11 +594,19 @@ class TestEndNowClearedOnEdit:
 
         # End it now
         await client.post(f"/api/schedules/{sched_id}/end-now")
-        assert sched_id in _skipped
+        db_session.expire_all()
+        row = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert row is not None
 
         # Toggle enabled off then on
         await client.patch(f"/api/schedules/{sched_id}", json={"enabled": False})
-        assert sched_id not in _skipped
+        db_session.expire_all()
+        row = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert row is None
 
 
 @pytest.mark.asyncio
@@ -610,8 +629,8 @@ class TestEndNowPerDevice:
         return str(group.id), str(asset.id), d1.id, d2.id
 
     async def test_end_now_with_device_id_scopes_skip(self, client, db_session):
-        from cms.services import scheduler as sched_mod
         from cms.models.schedule_device_skip import ScheduleDeviceSkip
+        from cms.models.schedule import Schedule
         from sqlalchemy import select
 
         group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)
@@ -626,9 +645,6 @@ class TestEndNowPerDevice:
         assert created.status_code == 201
         sched_id = created.json()["id"]
 
-        sched_mod._skipped.clear()
-        sched_mod._device_skipped.clear()
-
         resp = await client.post(
             f"/api/schedules/{sched_id}/end-now",
             json={"device_id": dev_a},
@@ -638,22 +654,26 @@ class TestEndNowPerDevice:
         assert body["device_id"] == dev_a
 
         # Schedule-wide skip must NOT be set; per-device skip must be set.
-        assert sched_id not in sched_mod._skipped
-        assert (sched_id, dev_a) in sched_mod._device_skipped
-        assert (sched_id, dev_b) not in sched_mod._device_skipped
-
-        # And persisted to DB
         import uuid
+        db_session.expire_all()
+        sched_wide = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert sched_wide is None
+
         rows = (await db_session.execute(
             select(ScheduleDeviceSkip.device_id).where(
                 ScheduleDeviceSkip.schedule_id == uuid.UUID(sched_id)
             )
         )).scalars().all()
-        assert rows == [dev_a]
+        assert sorted(rows) == [dev_a]
 
     async def test_end_now_without_body_still_schedule_wide(self, client, db_session):
         """Back-compat: POST with no body skips all devices on the schedule."""
-        from cms.services import scheduler as sched_mod
+        from cms.models.schedule_device_skip import ScheduleDeviceSkip
+        from cms.models.schedule import Schedule
+        from sqlalchemy import select
+        import uuid
 
         group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)
 
@@ -666,13 +686,20 @@ class TestEndNowPerDevice:
         })
         sched_id = created.json()["id"]
 
-        sched_mod._skipped.clear()
-        sched_mod._device_skipped.clear()
-
         resp = await client.post(f"/api/schedules/{sched_id}/end-now")
         assert resp.status_code == 200
-        assert sched_id in sched_mod._skipped
-        assert not any(k[0] == sched_id for k in sched_mod._device_skipped)
+
+        db_session.expire_all()
+        sched_wide = (await db_session.execute(
+            select(Schedule.skipped_until).where(Schedule.id == uuid.UUID(sched_id))
+        )).scalar_one()
+        assert sched_wide is not None
+        rows = (await db_session.execute(
+            select(ScheduleDeviceSkip.device_id).where(
+                ScheduleDeviceSkip.schedule_id == uuid.UUID(sched_id)
+            )
+        )).scalars().all()
+        assert rows == []
 
     async def test_end_now_rejects_unknown_device(self, client, db_session):
         group_id, asset_id, dev_a, dev_b = await self._seed_two_devices(db_session)

--- a/tests/test_transition_gap.py
+++ b/tests/test_transition_gap.py
@@ -13,10 +13,7 @@ import pytest
 
 from cms.models.asset import Asset, AssetType
 from cms.models.schedule import Schedule
-from cms.services.scheduler import (
-    _skipped,
-    get_upcoming_schedules,
-)
+from cms.services.scheduler import get_upcoming_schedules
 
 UTC = ZoneInfo("UTC")
 
@@ -66,12 +63,6 @@ class TestTransitionGap:
     """Schedule must stay visible when it enters its time window but the
     scheduler hasn't updated ``_now_playing`` yet."""
 
-    def setup_method(self):
-        _skipped.clear()
-
-    def teardown_method(self):
-        _skipped.clear()
-
     def test_active_schedule_not_yet_in_now_playing_stays_visible(self):
         """A schedule that just entered its window (not yet in now_playing)
         should appear in upcoming with ``starting=True``."""
@@ -119,10 +110,12 @@ class TestTransitionGap:
         s = _make_schedule(
             time(10, 0), time(11, 0), name="Ended", group_id=gid,
         )
-        _skipped[str(s.id)] = datetime(2026, 3, 28, 11, 0)
         now = datetime(2026, 3, 28, 10, 5, tzinfo=timezone.utc)
 
-        result = get_upcoming_schedules([s], now, UTC, now_playing=[])
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            skipped_schedule_ids={str(s.id)},
+        )
         assert len(result) == 0
 
 
@@ -130,12 +123,6 @@ class TestPreemptionTransitionGap:
     """When a higher-priority schedule enters its window during an active
     lower-priority schedule, it should not vanish while waiting for the
     scheduler to process the switch."""
-
-    def setup_method(self):
-        _skipped.clear()
-
-    def teardown_method(self):
-        _skipped.clear()
 
     def test_new_higher_priority_schedule_shows_starting(self):
         """Higher-priority schedule just entered its window — should show as
@@ -202,12 +189,6 @@ class TestPreemptionTransitionGap:
 class TestGroupScheduleTransitionGap:
     """Group-targeted schedules must also show 'starting' during the
     transition gap — they have device_id=None."""
-
-    def setup_method(self):
-        _skipped.clear()
-
-    def teardown_method(self):
-        _skipped.clear()
 
     def test_group_schedule_not_yet_in_now_playing_stays_visible(self):
         """A group schedule entering its window should show as 'starting'."""


### PR DESCRIPTION
## Stage 4 step 1 — DB-back scheduler skip state

First step of the multi-replica rollout (issue #344). **Pure refactor, no new infra, no behaviour change on 1 replica.**

### Problem

`cms/services/scheduler.py` kept two module-level dicts:

- `_skipped: dict[str, datetime]` — schedule-wide skips
- `_device_skipped: dict[tuple[str, str], datetime]` — per-device skips

Populated once at startup via `_ensure_skips_loaded`, then mutated by `skip_schedule_until` / `clear_schedule_skip` on the same replica. Under N>1 replicas, a skip written via API on replica B is invisible to the scheduler tick on replica A — false playback for the duration of the skip.

The underlying rows already exist (`Schedule.skipped_until`, `ScheduleDeviceSkip`), so this is purely a caching bug.

### Fix

Frozen `SkipSnapshot` dataclass + `load_skip_snapshot(db)` helper. Every scheduler path loads a fresh snapshot:

- `compute_now_playing` — prologue loads snapshot, filters active
- `get_upcoming_schedules` — new `skipped_schedule_ids` kwarg
- `build_device_sync` / `push_sync_to_device` — optional `skips` kwarg
- `evaluate_schedules` — one snapshot per tick, shared across devices; uses `expired_schedule_ids` / `expired_device_pairs` for DB purge

`skip_schedule_until` / `clear_schedule_skip` kept as thin hooks (only invalidate `_confirmed_playing`). The router at `cms/routers/schedules.py` continues to write DB directly and calls these as cache-invalidation hooks.

`cms/ui.py` (dashboard + api/dashboard) loads a snapshot and passes `skipped_schedule_ids` through.

### Tests

All skip-related tests rewritten to assert on DB state:

- `test_end_now_per_device.py` — new coverage for `load_skip_snapshot` + `active_as_of` + per-device isolation
- `test_scheduler_preemption.py`, `test_scheduler_advanced.py`, `test_display_name.py`, `test_schedules.py`, `test_transition_gap.py` — updated to DB assertions

151 targeted tests pass locally. Full suite runs in CI.

### Not touched (deferred to later Stage 4 steps)

- `_confirmed_playing`, `_missed_logged`, `_offline_since`, `_last_sync_hash` — still module-level; will address in later steps
- `_upgrading` set — tracked in `upgrading-dbback` todo
- Leader-election — tracked in `leader-lock-primitive` todo

### Risk

- Low. No schema change, no router change, no fleet-visible behaviour change on 1 replica.
- Extra DB query per tick / dashboard render. ~3000 tests pass locally on the affected files; full suite will run in CI.
