### PR TITLE
WPS webhook: wire alert_service + stale-conn guard

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -32,7 +32,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cms.auth import get_settings
 from cms.config import Settings
 from cms.database import get_db
-from cms.models.device import Device
+from cms.models.device import Device, DeviceGroup
+from cms.services.alert_service import alert_service
 from cms.services.device_inbound import InboundContext, dispatch_device_message
 from cms.services.device_manager import device_manager
 from cms.services.device_register import register_known_device
@@ -145,7 +146,47 @@ async def events_receiver(
     if ce_type == "azure.webpubsub.sys.disconnected":
         if ce_user_id:
             from cms.services import device_presence
-            await device_presence.mark_offline(db, ce_user_id)
+            # Guard the presence flip with the closing connection's id.
+            # Under N>=2 an old socket on replica A can receive
+            # ``sys.disconnected`` *after* the device has already
+            # reconnected on replica B; without this guard we'd flip
+            # ``online=false`` for the fresh session and fire a bogus
+            # OFFLINE alert.  ``mark_offline`` returns False when the
+            # stored ``connection_id`` no longer matches — in that case
+            # we also skip the alert-service notification.
+            was_current = await device_presence.mark_offline(
+                db, ce_user_id, expected_connection_id=ce_connection_id,
+            )
+            if not was_current:
+                logger.info(
+                    "WPS device %s: stale disconnect suppressed "
+                    "(connection_id replaced)", ce_user_id,
+                )
+                return Response(status_code=204)
+            # Load the device + group so alert_service has the name /
+            # group context it needs to route the OFFLINE event and
+            # (eventually, via the sweep loop) the offline notification.
+            result = await db.execute(select(Device).where(Device.id == ce_user_id))
+            device = result.scalar_one_or_none()
+            if device is not None:
+                _group_id = str(device.group_id) if device.group_id else None
+                _device_name = device.name or ce_user_id
+                _device_status = device.status.value if device.status else "pending"
+                _group_name = ""
+                if device.group_id:
+                    g = await db.execute(
+                        select(DeviceGroup.name).where(
+                            DeviceGroup.id == device.group_id,
+                        )
+                    )
+                    _group_name = g.scalar_one_or_none() or ""
+                alert_service.device_disconnected(
+                    ce_user_id,
+                    device_name=_device_name,
+                    group_id=_group_id,
+                    group_name=_group_name,
+                    status=_device_status,
+                )
         return Response(status_code=204)
 
     # ---- user events ---------------------------------------------------
@@ -206,6 +247,30 @@ async def events_receiver(
                     logger.exception(
                         "Failed to push auth_assigned to WPS device %s", ce_user_id,
                     )
+            # Notify alert service of reconnection — mirrors ws.py's
+            # direct-WS register path.  This is what emits the ONLINE
+            # device_event, clears ``offline_notified`` on
+            # ``device_alert_state``, and (if applicable) fires the
+            # "back online" notification.  Without this call, WPS
+            # devices silently skip all alert-service bookkeeping.
+            _group_id = str(device.group_id) if device.group_id else None
+            _device_name = device.name or ce_user_id
+            _device_status = device.status.value if device.status else "pending"
+            _group_name = ""
+            if device.group_id:
+                g = await db.execute(
+                    select(DeviceGroup.name).where(
+                        DeviceGroup.id == device.group_id,
+                    )
+                )
+                _group_name = g.scalar_one_or_none() or ""
+            alert_service.device_reconnected(
+                ce_user_id,
+                device_name=_device_name,
+                group_id=_group_id,
+                group_name=_group_name,
+                status=_device_status,
+            )
             return Response(status_code=204)
 
         base_url = _get_asset_base_url(request, settings)

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -498,6 +498,206 @@ class TestUnknownEventType:
         assert r.status_code == 400
 
 
+# ---------------------------------------------------------------- alert_service hooks
+#
+# Regression guard for the gap discovered during PR #404 prod validation:
+# the WPS webhook path never fired alert_service.device_{re,dis}connected,
+# so every online/offline lifecycle event on WPS-only devices (which is
+# now 100% of prod) silently skipped alert bookkeeping — zero
+# ``device_events`` rows, zero notifications, zero
+# ``device_alert_state`` updates.  These tests pin the contract.
+
+
+@pytest.mark.asyncio
+class TestAlertServiceHooks:
+    async def test_register_success_fires_device_reconnected(
+        self, client, app_and_session,
+    ):
+        """Happy path: a valid WPS register message triggers
+        alert_service.device_reconnected so the ONLINE event is logged
+        and any prior offline alert state is cleared."""
+        _, session = app_and_session
+        device = MagicMock(id="pi-recon", group_id="g-1", status=MagicMock(value="adopted"))
+        device.name = "Lobby"
+        session.device_row = device
+
+        cid = "conn-recon"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.alert_service"
+        ) as mock_alert:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-recon",
+                    "auth_token": "valid",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-recon",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_alert.device_reconnected.assert_called_once()
+        kwargs = mock_alert.device_reconnected.call_args.kwargs
+        assert mock_alert.device_reconnected.call_args.args[0] == "pi-recon"
+        assert kwargs["device_name"] == "Lobby"
+        assert kwargs["group_id"] == "g-1"
+        assert kwargs["status"] == "adopted"
+
+    async def test_orphaned_register_does_not_fire_reconnect(
+        self, client, app_and_session,
+    ):
+        """Orphaned devices must not emit an ONLINE alert — the
+        register was rejected, not accepted."""
+        _, session = app_and_session
+        device = MagicMock(id="pi-orph", group_id=None, status=MagicMock(value="orphaned"))
+        device.name = "Old"
+        session.device_row = device
+
+        cid = "conn-orph-alert"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=True, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.alert_service"
+        ) as mock_alert:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-orph",
+                    "auth_token": "wrong",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-orph",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_alert.device_reconnected.assert_not_called()
+
+    async def test_disconnected_with_matching_conn_id_fires_alert(
+        self, client, app_and_session,
+    ):
+        """sys.disconnected for the *current* connection loads the
+        device + group and fires alert_service.device_disconnected."""
+        _, session = app_and_session
+        device = MagicMock(id="pi-dc", group_id="g-2", status=MagicMock(value="adopted"))
+        device.name = "Kitchen"
+        session.device_row = device
+
+        cid = "cid-current"
+        with patch(
+            "cms.routers.wps_webhook.alert_service"
+        ) as mock_alert:
+            r = await client.post(
+                "/internal/wps/events",
+                content=b"{}",
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.sys.disconnected",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-dc",
+                    "ce-eventName": "disconnected",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_alert.device_disconnected.assert_called_once()
+        assert mock_alert.device_disconnected.call_args.args[0] == "pi-dc"
+        kwargs = mock_alert.device_disconnected.call_args.kwargs
+        assert kwargs["device_name"] == "Kitchen"
+        assert kwargs["group_id"] == "g-2"
+        assert kwargs["status"] == "adopted"
+
+    async def test_disconnected_stale_conn_id_suppressed(
+        self, client, app_and_session,
+    ):
+        """If the stored connection_id has been replaced (the device
+        already reconnected on another replica), mark_offline returns
+        False and we must NOT fire a disconnect alert — the device
+        isn't actually offline."""
+        _, session = app_and_session
+        device = MagicMock(id="pi-stale", group_id="g-3", status=MagicMock(value="adopted"))
+        device.name = "Lobby"
+        session.device_row = device
+
+        # Force the guard to reject: mark_offline returns False when
+        # rowcount == 0 (stored connection_id no longer matches).
+        original_execute = session.execute
+
+        async def _rowcount_zero(stmt, *a, **kw):
+            result = await original_execute(stmt, *a, **kw)
+            # Only the UPDATE from mark_offline is affected — SELECTs
+            # coming after would also see rowcount=0, but our code
+            # returns before issuing any SELECT when was_current is False.
+            result.rowcount = 0
+            return result
+
+        session.execute = _rowcount_zero
+
+        cid = "cid-stale"
+        with patch(
+            "cms.routers.wps_webhook.alert_service"
+        ) as mock_alert:
+            r = await client.post(
+                "/internal/wps/events",
+                content=b"{}",
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.sys.disconnected",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-stale",
+                    "ce-eventName": "disconnected",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_alert.device_disconnected.assert_not_called()
+
+    async def test_disconnected_unknown_device_no_alert(
+        self, client, app_and_session,
+    ):
+        """If the guard matches but the device row was deleted between
+        register and disconnect, the SELECT returns None and we skip
+        the alert path quietly — no crash, no alert, just 204."""
+        _, session = app_and_session
+        session.device_row = None  # no row to load
+
+        cid = "cid-ghost"
+        with patch(
+            "cms.routers.wps_webhook.alert_service"
+        ) as mock_alert:
+            r = await client.post(
+                "/internal/wps/events",
+                content=b"{}",
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.sys.disconnected",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-ghost",
+                    "ce-eventName": "disconnected",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_alert.device_disconnected.assert_not_called()
+
+
 # ---------------------------------------------------------------- multi-key
 
 


### PR DESCRIPTION
## Summary

The WPS webhook path (`cms/routers/wps_webhook.py`) never called
`alert_service.device_reconnected` / `device_disconnected`.  PR #401
moved all prod traffic onto WPS, so for the last ~24h prod has logged
**zero** online/offline `device_events`, **zero** notifications, and
**zero** `device_alert_state` rows — even though devices are clearly
flapping (reconnects are happening, presence is working).

This PR wires the two hooks into the WPS path so the alert side-channel
comes back online.  It also fixes a latent N>=2 race the rubber duck
caught: `sys.disconnected` was calling `device_presence.mark_offline`
**without** `expected_connection_id`, so an old socket closing on
replica A after the device had already reconnected on replica B would
falsely flip `online=false` and fire a bogus OFFLINE alert.

## Discovery context

Found during PR #404 prod validation:
- PR #404 ("N=2 hardening") deploys cleanly, but the CAS paths it
  hardens are never exercised because the upstream `alert_service`
  calls were silently missing on WPS.
- Timeline: last `online`/`offline` event in prod DB is 2026-04-22
  20:36:36Z.  PR #401 merged at 21:01:29Z.  No lifecycle events
  since, across 4 CMS restarts with devices reconnecting each time.

## Changes

**`cms/routers/wps_webhook.py`**

1. `sys.disconnected` — guard `mark_offline` with `expected_connection_id
   =ce_connection_id`.  Suppress the alert (just return 204) when the
   guard rejects the write.  On a successful flip, load `Device` +
   `DeviceGroup.name` and call `alert_service.device_disconnected(...)`.
2. `user.register` (success, non-orphaned) — after the optional
   `auth_assigned` push and before the final 204, load the group name
   and call `alert_service.device_reconnected(...)`.

Mirrors the semantics and context-loading pattern already in
`cms/routers/ws.py` for the legacy direct-WS path.

**`tests/test_wps_webhook.py`** — 5 new tests in `TestAlertServiceHooks`:

- `test_register_success_fires_device_reconnected` — happy path pins
  the hook is called with the expected device/group/status kwargs.
- `test_orphaned_register_does_not_fire_reconnect` — orphaned path
  (rejected register) must not emit an ONLINE alert.
- `test_disconnected_with_matching_conn_id_fires_alert` — a current
  disconnect loads the device row and fires the OFFLINE alert.
- `test_disconnected_stale_conn_id_suppressed` — when `mark_offline`
  returns False (stale connection_id), we return 204 without firing
  the alert.  This is the N>=2 race guard.
- `test_disconnected_unknown_device_no_alert` — if the device row was
  deleted between register and disconnect, we skip cleanly.

## Not in scope (follow-up)

`wps_transport.py` and `transport.py` still call
`device_presence.mark_offline()` directly on send failure / 404
without an alert hook.  That's a second hole in the same channel but
will be addressed separately — not gated on this hotfix.

## Validation plan

After merge + deploy:
- Query `device_events` for `event_type IN ('online','offline')` rows
  with `occurred_at > <deploy-time>` on real prod devices.
- Confirm `device_alert_state` rows lazily appear for adopted+grouped
  devices as they flap.
- Force a reconnect on the test Pi and verify an ONLINE event is
  written within seconds.

## Risks

- Small.  Adds two code paths that should have been there since PR #401;
  touches only the WPS webhook routes.
- `device_presence.mark_offline` already supported
  `expected_connection_id` — no migration, no schema change.
- No backfill needed: `alert_service._record_{re,dis}connect` lazily
  creates `device_alert_state` rows on next lifecycle event.
