### PR TITLE
fix(alerts): DB-back temperature alert state for N>1 replica safety

### DIFF
--- a/alembic/versions/0008_device_alert_state_temp.py
+++ b/alembic/versions/0008_device_alert_state_temp.py
@@ -1,0 +1,63 @@
+"""device_alert_state temperature columns (N=2 fix for temp alerts)
+
+Issue #344 multi-replica audit — HIGH severity.
+
+Adds the persisted temperature-alert state columns that back the
+rewritten ``AlertService.check_temperature`` DB-CAS logic.  Without
+these, two CMS replicas processing STATUS heartbeats for the same
+device via Azure Web PubSub webhook routing will each maintain
+independent ``_temp_states`` dicts and can double-fire temperature
+alerts (or miss cooldowns that the other replica already applied).
+
+The row is serialized via ``SELECT ... FOR UPDATE`` inside
+``check_temperature``, so only one replica at a time can inspect-and-
+mutate a given device's temp state.  The ``temp_last_sample_ts``
+column also guards against out-of-order webhook delivery (an older
+sample arriving after a newer one should be ignored).
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "device_alert_state",
+        sa.Column(
+            "temp_level",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'normal'"),
+        ),
+    )
+    op.add_column(
+        "device_alert_state",
+        sa.Column(
+            "temp_last_alert_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "device_alert_state",
+        sa.Column(
+            "temp_last_sample_ts",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade is not supported for this migration.")

--- a/cms/models/device_alert_state.py
+++ b/cms/models/device_alert_state.py
@@ -1,9 +1,11 @@
 """DeviceAlertState — per-device alert state for multi-replica safety.
 
 Backs the ``cms.services.alert_service`` loop under N>1 replicas so the
-"device has been offline for ≥ grace period, fire notification" logic
-stops depending on replica-local asyncio timer tasks.  See
-``alembic/versions/0007_alert_state_upgrade_claim.py``.
+"device has been offline for ≥ grace period, fire notification" and
+"device CPU temp crossed threshold, fire notification" logic stop
+depending on replica-local dicts.  See
+``alembic/versions/0007_alert_state_upgrade_claim.py`` and
+``alembic/versions/0008_device_alert_state_temp.py``.
 """
 
 from __future__ import annotations
@@ -19,6 +21,8 @@ from cms.database import Base
 class DeviceAlertState(Base):
     """Persisted per-device alert flags.
 
+    Offline detection
+    -----------------
     ``offline_since`` is set by the disconnect path *only* when it is
     currently NULL (online→offline transition) — duplicate disconnects
     don't reset the grace window.  The leader-gated offline-sweep loop
@@ -27,6 +31,24 @@ class DeviceAlertState(Base):
     both fields in a single CAS and, if ``offline_notified`` was
     previously TRUE, emits the "back online" notification in the same
     transaction.
+
+    Temperature monitoring
+    ----------------------
+    Temp alerts are event-driven (fired from STATUS heartbeats), not
+    periodic, so they don't need leader election — the row-level
+    ``SELECT ... FOR UPDATE`` inside ``check_temperature`` serializes
+    concurrent replicas handling the same device.
+
+    - ``temp_level`` tracks the last-observed level ("normal" /
+      "warning" / "critical").  Default "normal" matches the
+      pre-persistence behavior.
+    - ``temp_last_alert_at`` is the timestamp of the last TEMP_HIGH /
+      TEMP_CLEARED emission for this device; used for cooldown and
+      reminder-path scheduling.
+    - ``temp_last_sample_ts`` is the timestamp of the last STATUS
+      sample that mutated this row; older samples arriving out of
+      order are ignored.  Sourced from the WPS ``ce-time`` header
+      (Azure server time) when available, else ``datetime.now(UTC)``.
     """
 
     __tablename__ = "device_alert_state"
@@ -52,4 +74,16 @@ class DeviceAlertState(Base):
         nullable=False,
         default=False,
         server_default=text("false"),
+    )
+    temp_level: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="normal",
+        server_default=text("'normal'"),
+    )
+    temp_last_alert_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    temp_last_sample_ts: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )

--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, Request, Response
 from sqlalchemy import select
@@ -274,6 +275,36 @@ async def events_receiver(
             return Response(status_code=204)
 
         base_url = _get_asset_base_url(request, settings)
+
+        # Parse CloudEvents 1.0 ``ce-time`` header (RFC 3339).  This is
+        # the Azure server time the event was produced — we use it as
+        # the monotonic timestamp for persisted temperature-alert state
+        # so out-of-order webhook deliveries don't overwrite newer
+        # state with older data.
+        received_at: datetime | None = None
+        ce_time_raw = request.headers.get("ce-time")
+        if ce_time_raw:
+            try:
+                # fromisoformat accepts ``+00:00`` but not ``Z`` until
+                # 3.11; normalize just in case.
+                received_at = datetime.fromisoformat(
+                    ce_time_raw.replace("Z", "+00:00"),
+                )
+                if received_at.tzinfo is None:
+                    received_at = received_at.replace(tzinfo=timezone.utc)
+            except ValueError:
+                logger.warning(
+                    "Malformed ce-time header '%s' on WPS webhook for %s "
+                    "(conn=%s); falling back to server now()",
+                    ce_time_raw, ce_user_id, ce_connection_id,
+                )
+        else:
+            logger.warning(
+                "Missing ce-time header on WPS webhook for %s (conn=%s); "
+                "falling back to server now()",
+                ce_user_id, ce_connection_id,
+            )
+
         ctx = InboundContext(
             device_id=ce_user_id,
             device=device,
@@ -283,6 +314,7 @@ async def events_receiver(
             device_name=device.name or ce_user_id,
             device_status=device.status.value if device.status else "pending",
             group_name="",
+            received_at=received_at,
         )
 
         async def _send(payload: dict) -> None:

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -1,25 +1,29 @@
 """Alert service — DB-backed device health monitoring (Stage 4 of #344).
 
-Two independent alert streams:
+Two independent alert streams, both persisted in ``device_alert_state``
+so they survive replica failover and don't double-fire across replicas:
 
-1. **Offline detection** — persisted in ``device_alert_state`` so alerts
-   survive failover and don't double-fire across replicas.  The
-   disconnect path only transitions ``offline_since`` NULL→timestamp
-   (duplicate disconnects don't reset the grace window).  A
-   leader-gated sweep loop (:func:`offline_sweep_once` driven from
-   ``cms/main.py``) flips ``offline_notified`` and emits the
-   "offline" notification + event in a single transaction.  The
-   reconnect path CAS-consumes ``offline_notified`` in the same
-   transaction that emits the "back online" notification, so a race
-   between two replicas handling the reconnect only lets one of them
-   fire the alert.
+1. **Offline detection** — the disconnect path only transitions
+   ``offline_since`` NULL→timestamp (duplicate disconnects don't reset
+   the grace window).  A leader-gated sweep loop
+   (:func:`offline_sweep_once` driven from ``cms/main.py``) flips
+   ``offline_notified`` and emits the "offline" notification + event
+   in a single transaction.  The reconnect path CAS-consumes
+   ``offline_notified`` in the same transaction that emits the "back
+   online" notification, so a race between two replicas handling the
+   reconnect only lets one of them fire the alert.
 
-2. **Temperature monitoring** — still replica-local.  Temp alerts
-   come from STATUS heartbeats; under WPS those land on whichever
-   replica the webhook is routed to.  Each replica maintains its own
-   cooldown state; duplicate temperature warnings are acceptable (and
-   arguably informative), so persisting this state is not a
-   correctness requirement for multi-replica.
+2. **Temperature monitoring** — STATUS heartbeats land on whichever
+   replica the WPS webhook is routed to.  ``check_temperature`` locks
+   the device's ``device_alert_state`` row via ``SELECT ... FOR
+   UPDATE`` and inspects-and-mutates the persisted ``temp_level`` /
+   ``temp_last_alert_at`` / ``temp_last_sample_ts`` columns in one
+   transaction.  Out-of-order samples (older ``sample_ts`` than the
+   one stored) are ignored.  High-temperature alerts are never
+   deduped away silently: if a device sits at warning or critical for
+   longer than the cooldown, we re-emit a reminder alert so the
+   operator is notified every cooldown window.  No leader election is
+   needed — the row lock is the serializer.
 
 Notifications use scope="group" so only users with access to the
 device's group (plus admins via groups:view_all) see them in the bell.
@@ -50,6 +54,28 @@ def _to_uuid(val: str | _uuid.UUID | None) -> _uuid.UUID | None:
     return val if isinstance(val, _uuid.UUID) else _uuid.UUID(str(val))
 
 
+def _upsert_alert_state_stmt(device_id: str):
+    """Return a dialect-aware ``INSERT ... ON CONFLICT DO NOTHING`` stmt.
+
+    Used to lazily create a ``device_alert_state`` row for a device the
+    first time we need to mutate its temp state.  Postgres path uses
+    ``ON CONFLICT DO NOTHING``; sqlite tests use ``OR IGNORE``.
+    """
+    from cms.database import get_engine
+    engine = get_engine()
+    dialect = engine.dialect.name if engine is not None else "sqlite"
+    if dialect == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+        return pg_insert(DeviceAlertState).values(
+            device_id=device_id, temp_level="normal",
+        ).on_conflict_do_nothing(index_elements=["device_id"])
+    # sqlite / other
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+    return sqlite_insert(DeviceAlertState).values(
+        device_id=device_id, temp_level="normal",
+    ).on_conflict_do_nothing(index_elements=["device_id"])
+
+
 logger = logging.getLogger("agora.cms.alerts")
 
 # Default settings (overridable via CMSSetting)
@@ -59,27 +85,14 @@ DEFAULT_TEMP_CRITICAL_C = 80.0
 DEFAULT_TEMP_COOLDOWN_SECONDS = 300
 
 
-class _TempState:
-    """Per-device temperature alert state machine (in-memory, replica-local)."""
-
-    __slots__ = ("level", "last_alert_at")
-
-    def __init__(self):
-        self.level: str = "normal"   # "normal", "warning", "critical"
-        self.last_alert_at: Optional[datetime] = None
-
-
 class AlertService:
-    """Singleton service wired into the WebSocket handler.
+    """Singleton service wired into the WebSocket + WPS webhook handlers.
 
-    Offline alerting state lives in the ``device_alert_state`` table so
-    it survives replica failover and doesn't double-fire.  Temperature
-    alert state is in-memory per replica (see module docstring for
-    rationale).
+    All alert state lives in the ``device_alert_state`` table so it
+    survives replica failover and doesn't double-fire under N>1.
     """
 
     def __init__(self):
-        self._temp_states: dict[str, _TempState] = {}
         # Cached settings (refreshed periodically by
         # ``_alert_settings_refresh_loop`` in ``cms/main.py``).
         self._offline_grace_seconds: int = DEFAULT_OFFLINE_GRACE_SECONDS
@@ -438,147 +451,301 @@ class AlertService:
         await db.commit()
         return emitted
 
-    # ── Temperature monitoring (replica-local, unchanged) ──
+    # ── Temperature monitoring (DB-backed, multi-replica safe) ──
 
-    def check_temperature(
+    def _classify_temp(self, cpu_temp_c: float) -> str:
+        """Map a temperature reading to a level string."""
+        if cpu_temp_c >= self._temp_critical_c:
+            return "critical"
+        if cpu_temp_c >= self._temp_warning_c:
+            return "warning"
+        return "normal"
+
+    async def check_temperature(
         self,
+        db: AsyncSession,
         device_id: str,
         cpu_temp_c: Optional[float],
         device_name: str,
         group_id: Optional[str],
         group_name: str,
         status: str,
+        sample_ts: Optional[datetime] = None,
     ):
-        """Called on every STATUS heartbeat.  Only alerts for adopted+grouped devices."""
-        if cpu_temp_c is None or status != "adopted" or not group_id:
+        """Persistently track temperature alert state for a device.
+
+        Called on every STATUS heartbeat.  Serializes concurrent
+        replicas via ``SELECT ... FOR UPDATE`` on the
+        ``device_alert_state`` row for this device.
+
+        Firing rules (in order of precedence):
+
+        - Out-of-order samples (older ``sample_ts`` than the last
+          one stored) are ignored.
+        - Ungrouped / non-adopted / missing-reading paths RESET the
+          persisted temp state so re-adoption or re-grouping starts
+          fresh.  This prevents a device that was at ``warning``,
+          got ungrouped, then later regrouped from suppressing the
+          first warning in its new scope.
+        - Transitions between adjacent levels (normal↔warning,
+          warning↔critical, normal↔critical) fire an event +
+          notification.
+        - A cooldown applies to re-firing *after a cleared event*
+          (normal→non-normal): we wait at least ``cooldown`` since
+          the last alert before firing again.  Escalations (warning
+          →critical) fire immediately regardless of cooldown so we
+          never miss the more serious level.
+        - If the device stays at ``warning`` or ``critical`` for
+          longer than the cooldown, we emit a reminder TEMP_HIGH
+          every cooldown.  User requirement: "never miss a high-temp
+          alert."
+
+        The bell notification insert + DeviceEvent insert + state
+        mutation all happen inside the same ``db.commit()`` so a
+        crash between them rolls back cleanly.
+
+        ``sample_ts`` should come from the Azure WPS ``ce-time``
+        header (CloudEvents 1.0) when available.  Falls back to
+        ``datetime.now(UTC)`` — logged loudly when that happens so
+        missing headers can be spotted in prod.
+        """
+        if cpu_temp_c is None:
             return
 
-        state = self._temp_states.get(device_id)
+        # Ungrouped / non-adopted: reset persisted state so the first
+        # alert after re-adoption/regrouping fires cleanly.
+        if status != "adopted" or not group_id:
+            await self._reset_temp_state(db, device_id)
+            return
+
+        if sample_ts is None:
+            sample_ts = datetime.now(timezone.utc)
+            logger.warning(
+                "check_temperature for %s had no sample_ts; using server "
+                "now() as fallback (ce-time header likely missing from "
+                "WPS webhook)",
+                device_id,
+            )
+
+        new_level = self._classify_temp(cpu_temp_c)
+
+        # Lazily create the alert-state row; no-op if already present.
+        try:
+            await db.execute(_upsert_alert_state_stmt(device_id))
+        except Exception:
+            # The row may already exist; fine.  Other errors (FK
+            # violation from a not-yet-created device) bubble below.
+            logger.debug("Upsert of device_alert_state row for %s failed "
+                         "(likely already exists)", device_id)
+
+        # Lock the row for the duration of this transaction.  Under
+        # Postgres this serializes concurrent replicas processing
+        # heartbeats for the same device.  Under sqlite it degrades
+        # to a no-op but the test suite doesn't race on the same row.
+        stmt = (
+            select(DeviceAlertState)
+            .where(DeviceAlertState.device_id == device_id)
+            .with_for_update()
+        )
+        try:
+            result = await db.execute(stmt)
+            state = result.scalar_one_or_none()
+        except Exception:
+            logger.exception(
+                "Failed to lock device_alert_state for %s; skipping temp "
+                "alert this cycle", device_id,
+            )
+            return
+
         if state is None:
-            state = _TempState()
-            self._temp_states[device_id] = state
+            # Upsert failed AND the row doesn't exist — probably the
+            # device FK isn't there yet.  Log and bail.
+            logger.warning(
+                "device_alert_state row for %s unexpectedly missing after "
+                "upsert; skipping temp alert",
+                device_id,
+            )
+            return
 
-        # Determine new level
-        if cpu_temp_c >= self._temp_critical_c:
-            new_level = "critical"
-        elif cpu_temp_c >= self._temp_warning_c:
-            new_level = "warning"
-        else:
-            new_level = "normal"
+        # Reject stale samples (out-of-order webhook delivery).  We
+        # compare >= so that a duplicate retry with the same ts is a
+        # no-op (idempotent).  SQLite strips tzinfo on read, so
+        # normalize both sides to naive-UTC for the comparison.  In
+        # Postgres both are TIMESTAMPTZ and compare naturally.
+        def _to_naive_utc(dt: datetime) -> datetime:
+            if dt.tzinfo is not None:
+                return dt.astimezone(timezone.utc).replace(tzinfo=None)
+            return dt
 
-        if new_level == state.level:
-            return  # No transition
-
-        old_level = state.level
-        now = datetime.now(timezone.utc)
-
-        # Cooldown: don't re-alert within cooldown after a cleared event
-        if (
-            old_level == "normal"
-            and new_level != "normal"
-            and state.last_alert_at
-        ):
-            elapsed = (now - state.last_alert_at).total_seconds()
-            if elapsed < self._temp_cooldown_seconds:
+        if state.temp_last_sample_ts is not None:
+            stored = _to_naive_utc(state.temp_last_sample_ts)
+            incoming = _to_naive_utc(sample_ts)
+            if stored >= incoming:
                 return
 
-        state.level = new_level
+        old_level = state.temp_level
+        cooldown = timedelta(seconds=self._temp_cooldown_seconds)
+        if state.temp_last_alert_at is None:
+            past_cooldown = True
+        else:
+            last_alert = _to_naive_utc(state.temp_last_alert_at)
+            incoming_naive = _to_naive_utc(sample_ts)
+            past_cooldown = last_alert + cooldown <= incoming_naive
 
-        if new_level == "normal" and old_level != "normal":
-            # Temperature cleared
-            state.last_alert_at = now
-            asyncio.create_task(
-                self._create_temp_event(
-                    device_id, device_name, group_id, group_name,
-                    DeviceEventType.TEMP_CLEARED, cpu_temp_c, old_level,
-                )
-            )
+        should_fire = False
+        event_type: DeviceEventType | None = None
+        notif_level = "info"
+
+        if old_level != new_level:
+            # Transition.
+            if new_level == "normal":
+                # Cleared.  Always fire (no cooldown on good news).
+                should_fire = True
+                event_type = DeviceEventType.TEMP_CLEARED
+                notif_level = "success"
+            elif old_level == "warning" and new_level == "critical":
+                # Escalation — never miss a critical.
+                should_fire = True
+                event_type = DeviceEventType.TEMP_HIGH
+                notif_level = "error"
+            else:
+                # normal→warning, normal→critical, critical→warning.
+                # Apply cooldown.
+                if past_cooldown:
+                    should_fire = True
+                    event_type = DeviceEventType.TEMP_HIGH
+                    notif_level = "error" if new_level == "critical" else "warning"
         elif new_level != "normal":
-            # Temperature high (warning or critical)
-            state.last_alert_at = now
-            asyncio.create_task(
-                self._create_temp_event(
-                    device_id, device_name, group_id, group_name,
-                    DeviceEventType.TEMP_HIGH, cpu_temp_c, new_level,
-                )
+            # Same non-normal level.  Reminder path: re-alert every
+            # cooldown window so sustained high temperatures aren't
+            # silently swallowed.
+            if past_cooldown:
+                should_fire = True
+                event_type = DeviceEventType.TEMP_HIGH
+                notif_level = "error" if new_level == "critical" else "warning"
+
+        # Always advance the monotonic sample timestamp + stored level
+        # so future samples see accurate state — even on a no-fire
+        # branch (we learned something new even if we don't alert).
+        state.temp_level = new_level
+        state.temp_last_sample_ts = sample_ts
+
+        if should_fire and event_type is not None:
+            state.temp_last_alert_at = sample_ts
+            await self._emit_temp_alert(
+                db, device_id, device_name, group_id, group_name,
+                event_type=event_type,
+                notif_level=notif_level,
+                cpu_temp_c=cpu_temp_c,
+                new_level=new_level,
+                previous_level=old_level,
             )
 
-    async def _create_temp_event(
+        await db.commit()
+
+    async def _reset_temp_state(self, db: AsyncSession, device_id: str):
+        """Clear persisted temp state for a device.
+
+        Called when a STATUS heartbeat arrives for a device that is
+        ungrouped, non-adopted, or has no temperature reading.  The
+        next valid high-temp reading will then fire normally.
+
+        Uses a plain UPDATE; no-op if the row doesn't exist.  Does
+        not commit — caller owns the transaction.
+        """
+        try:
+            stmt = (
+                update(DeviceAlertState)
+                .where(DeviceAlertState.device_id == device_id)
+                .values(
+                    temp_level="normal",
+                    temp_last_alert_at=None,
+                    temp_last_sample_ts=None,
+                )
+            )
+            await db.execute(stmt)
+            await db.commit()
+        except Exception:
+            logger.exception("Failed to reset temp state for %s", device_id)
+
+    async def _emit_temp_alert(
         self,
+        db: AsyncSession,
         device_id: str,
         device_name: str,
         group_id: str,
         group_name: str,
+        *,
         event_type: DeviceEventType,
+        notif_level: str,
         cpu_temp_c: float,
-        level: str,
+        new_level: str,
+        previous_level: str,
     ):
-        """Create a temperature event + notification."""
-        try:
-            from cms.database import get_db
-            gid = _to_uuid(group_id)
-            async for db in get_db():
-                event = DeviceEvent(
-                    device_id=device_id,
-                    device_name=device_name,
-                    group_id=gid,
-                    group_name=group_name,
-                    event_type=event_type,
-                    details={
-                        "cpu_temp_c": cpu_temp_c,
-                        "threshold_warning": self._temp_warning_c,
-                        "threshold_critical": self._temp_critical_c,
-                        "level": level,
-                    },
-                )
-                db.add(event)
+        """Insert a DeviceEvent + Notification for a temperature transition.
 
-                if event_type == DeviceEventType.TEMP_HIGH:
-                    notif_level = "error" if level == "critical" else "warning"
-                    title = f"High temperature: {device_name}"
-                    message = (
-                        f"Device '{device_name}' in group '{group_name}' "
-                        f"is at {cpu_temp_c:.1f}°C ({level})."
-                    )
-                else:
-                    notif_level = "success"
-                    title = f"Temperature normal: {device_name}"
-                    message = (
-                        f"Device '{device_name}' in group '{group_name}' "
-                        f"temperature returned to normal ({cpu_temp_c:.1f}°C)."
-                    )
+        Caller owns the transaction (we only ``db.add``; no commit).
+        """
+        gid = _to_uuid(group_id)
+        details = {
+            "cpu_temp_c": cpu_temp_c,
+            "threshold_warning": self._temp_warning_c,
+            "threshold_critical": self._temp_critical_c,
+            "level": new_level,
+            "previous_level": previous_level,
+        }
+        db.add(DeviceEvent(
+            device_id=device_id,
+            device_name=device_name,
+            group_id=gid,
+            group_name=group_name,
+            event_type=event_type,
+            details=details,
+        ))
 
-                notification = Notification(
-                    scope="group",
-                    level=notif_level,
-                    title=title,
-                    message=message,
-                    group_id=gid,
-                    details={
-                        "device_id": device_id,
-                        "event_type": event_type,
-                        "cpu_temp_c": cpu_temp_c,
-                    },
-                )
-                db.add(notification)
-                await db.commit()
-                logger.info(
-                    "Temperature %s notification for device %s (%.1f°C)",
-                    event_type, device_id, cpu_temp_c,
-                )
-                break
-        except Exception:
-            logger.exception("Failed to create temp event for device %s", device_id)
+        if event_type == DeviceEventType.TEMP_HIGH:
+            title = f"High temperature: {device_name}"
+            message = (
+                f"Device '{device_name}' in group '{group_name}' "
+                f"is at {cpu_temp_c:.1f}°C ({new_level})."
+            )
+        else:
+            title = f"Temperature normal: {device_name}"
+            message = (
+                f"Device '{device_name}' in group '{group_name}' "
+                f"temperature returned to normal ({cpu_temp_c:.1f}°C)."
+            )
+
+        db.add(Notification(
+            scope="group",
+            level=notif_level,
+            title=title,
+            message=message,
+            group_id=gid,
+            details={
+                "device_id": device_id,
+                "event_type": event_type.value if hasattr(event_type, "value") else str(event_type),
+                "cpu_temp_c": cpu_temp_c,
+                "level": new_level,
+                "previous_level": previous_level,
+            },
+        ))
+        logger.info(
+            "Temperature %s for device %s (%.1f°C, %s→%s)",
+            event_type, device_id, cpu_temp_c, previous_level, new_level,
+        )
 
     # ── Cleanup ──
 
     def cleanup_device(self, device_id: str):
-        """Remove in-memory temp state for a device (e.g. when deleted).
+        """Backward-compat no-op.
 
-        DB-backed offline state is cleaned up by the ``ON DELETE CASCADE``
-        on ``device_alert_state.device_id``.
+        Previously cleaned up the in-memory ``_temp_states`` dict.
+        Now that all temp state lives in ``device_alert_state``, the
+        ``ON DELETE CASCADE`` on ``device_alert_state.device_id``
+        handles cleanup when a device is deleted.
         """
-        self._temp_states.pop(device_id, None)
+        return
 
 
 # Singleton

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -60,6 +60,13 @@ class InboundContext:
     device_name: str = ""
     device_status: str = "pending"
     group_name: str = ""
+    # Azure server time the current inbound message was received at
+    # (parsed from WPS ``ce-time`` header).  Used as the monotonic
+    # timestamp for persisted temperature alert state so out-of-order
+    # webhook deliveries don't overwrite newer state with older data.
+    # None on the direct-WebSocket path (local transport); callers then
+    # fall back to ``datetime.now(UTC)``.
+    received_at: datetime | None = None
 
 
 async def _resolve_asset_for_device(
@@ -298,14 +305,19 @@ async def dispatch_device_message(
         except Exception:
             logger.exception("Failed to log error transition for %s", device_id)
 
-        # Check temperature thresholds
-        alert_service.check_temperature(
+        # Check temperature thresholds (DB-backed, multi-replica safe).
+        # sample_ts comes from Azure WPS ce-time header when available.
+        # In local-transport mode ctx.received_at is None; alert_service
+        # falls back to server now() with a loud log.
+        await alert_service.check_temperature(
+            db,
             device_id,
             cpu_temp_c=msg.get("cpu_temp_c"),
             device_name=ctx.device_name,
             group_id=ctx.group_id,
             group_name=ctx.group_name,
             status=ctx.device_status,
+            sample_ts=getattr(ctx, "received_at", None),
         )
 
         # Rotate API key if due

--- a/tests/test_device_alerts.py
+++ b/tests/test_device_alerts.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -285,27 +286,41 @@ class TestOfflineDetection:
 
 
 class TestTemperatureAlerts:
-    """Test temperature threshold monitoring and hysteresis."""
+    """Test temperature threshold monitoring and hysteresis (DB-backed)."""
+
+    _UNSET = object()
+
+    async def _call(
+        self, app, svc, info, temp, *, sample_ts=None, status="adopted",
+        group_id=_UNSET,
+    ):
+        """Helper: run ``check_temperature`` against the test DB."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await svc.check_temperature(
+                db,
+                info["device_id"],
+                cpu_temp_c=temp,
+                device_name=info["device_name"],
+                group_id=info["group_id"] if group_id is self._UNSET else group_id,
+                group_name=info["group_name"],
+                status=status,
+                sample_ts=sample_ts,
+            )
+            break
 
     @pytest.mark.asyncio
     async def test_warning_threshold(self, app, seed_group_and_device, fresh_alert_service):
         """Crossing the warning threshold creates a TEMP_HIGH event."""
         info = seed_group_and_device
         svc = fresh_alert_service
+        t0 = datetime.now(timezone.utc)
 
         # Send temp below threshold — no alert
-        svc.check_temperature(
-            info["device_id"], 65.0, info["device_name"],
-            info["group_id"], info["group_name"], status="adopted",
-        )
-        await asyncio.sleep(0.3)
-
+        await self._call(app, svc, info, 65.0, sample_ts=t0)
         # Send temp above warning
-        svc.check_temperature(
-            info["device_id"], 72.0, info["device_name"],
-            info["group_id"], info["group_name"], status="adopted",
-        )
-        await asyncio.sleep(0.5)
+        await self._call(app, svc, info, 72.0, sample_ts=t0 + timedelta(seconds=1))
 
         from cms.database import get_db
         factory = app.dependency_overrides[get_db]
@@ -334,11 +349,7 @@ class TestTemperatureAlerts:
         info = seed_group_and_device
         svc = fresh_alert_service
 
-        svc.check_temperature(
-            info["device_id"], 85.0, info["device_name"],
-            info["group_id"], info["group_name"], status="adopted",
-        )
-        await asyncio.sleep(0.5)
+        await self._call(app, svc, info, 85.0, sample_ts=datetime.now(timezone.utc))
 
         from cms.database import get_db
         factory = app.dependency_overrides[get_db]
@@ -366,20 +377,10 @@ class TestTemperatureAlerts:
         """Temperature returning to normal creates a TEMP_CLEARED event."""
         info = seed_group_and_device
         svc = fresh_alert_service
+        t0 = datetime.now(timezone.utc)
 
-        # Go high
-        svc.check_temperature(
-            info["device_id"], 75.0, info["device_name"],
-            info["group_id"], info["group_name"], status="adopted",
-        )
-        await asyncio.sleep(0.5)
-
-        # Go back to normal
-        svc.check_temperature(
-            info["device_id"], 55.0, info["device_name"],
-            info["group_id"], info["group_name"], status="adopted",
-        )
-        await asyncio.sleep(0.5)
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        await self._call(app, svc, info, 55.0, sample_ts=t0 + timedelta(seconds=1))
 
         from cms.database import get_db
         factory = app.dependency_overrides[get_db]
@@ -393,6 +394,11 @@ class TestTemperatureAlerts:
             assert DeviceEventType.TEMP_HIGH in types
             assert DeviceEventType.TEMP_CLEARED in types
 
+            cleared = [e for e in events if e.event_type == DeviceEventType.TEMP_CLEARED]
+            # previous_level should be preserved in details so operators
+            # can see what was cleared from.
+            assert cleared[0].details.get("previous_level") == "warning"
+
             notifs = (await db.execute(
                 select(Notification).where(
                     Notification.group_id == uuid.UUID(info["group_id"]),
@@ -403,51 +409,232 @@ class TestTemperatureAlerts:
             break
 
     @pytest.mark.asyncio
-    async def test_no_duplicate_alerts(self, fresh_alert_service):
-        """Repeated heartbeats at same temp level don't create duplicate alerts."""
+    async def test_no_duplicate_alerts_same_level(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Repeated heartbeats at same temp level, within cooldown, don't fire duplicates."""
+        info = seed_group_and_device
         svc = fresh_alert_service
-        gid = str(uuid.uuid4())
+        svc._temp_cooldown_seconds = 60
+        t0 = datetime.now(timezone.utc)
 
-        # First: go warning
-        svc.check_temperature("dev1", 75.0, "Dev1", gid, "G", status="adopted")
-        # Same level again — should be ignored
-        svc.check_temperature("dev1", 76.0, "Dev1", gid, "G", status="adopted")
-        svc.check_temperature("dev1", 74.0, "Dev1", gid, "G", status="adopted")
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Subsequent same-level samples within cooldown: no new event.
+        await self._call(app, svc, info, 76.0, sample_ts=t0 + timedelta(seconds=1))
+        await self._call(app, svc, info, 74.0, sample_ts=t0 + timedelta(seconds=2))
 
-        # Only one transition happened
-        state = svc._temp_states["dev1"]
-        assert state.level == "warning"
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.TEMP_HIGH,
+                )
+            )).scalars().all()
+            assert len(events) == 1
+            break
 
     @pytest.mark.asyncio
-    async def test_cooldown_prevents_flapping(self, fresh_alert_service):
-        """After temp clears, cooldown prevents immediate re-alert."""
+    async def test_reminder_fires_after_cooldown(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Sustained high-temp past cooldown fires a reminder TEMP_HIGH.
+
+        User requirement: "never miss a high-temp alert."
+        """
+        info = seed_group_and_device
         svc = fresh_alert_service
-        svc._temp_cooldown_seconds = 60  # Long cooldown
-        gid = str(uuid.uuid4())
+        svc._temp_cooldown_seconds = 10
+        t0 = datetime.now(timezone.utc)
 
-        # Go high
-        svc.check_temperature("dev2", 75.0, "Dev2", gid, "G", status="adopted")
-        # Go normal (cleared)
-        svc.check_temperature("dev2", 55.0, "Dev2", gid, "G", status="adopted")
-        # Go high again within cooldown — should be suppressed
-        svc.check_temperature("dev2", 75.0, "Dev2", gid, "G", status="adopted")
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Past cooldown, still warning — should fire a reminder.
+        await self._call(app, svc, info, 75.0, sample_ts=t0 + timedelta(seconds=15))
 
-        state = svc._temp_states["dev2"]
-        assert state.level == "normal"  # Didn't transition because of cooldown
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.TEMP_HIGH,
+                )
+            )).scalars().all()
+            assert len(events) == 2
+            break
 
     @pytest.mark.asyncio
-    async def test_none_temp_ignored(self, fresh_alert_service):
-        """None temperature values are silently ignored."""
+    async def test_escalation_bypasses_cooldown(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """warning→critical always fires, even inside cooldown window."""
+        info = seed_group_and_device
         svc = fresh_alert_service
-        svc.check_temperature("dev3", None, "Dev3", str(uuid.uuid4()), "G", status="adopted")
-        assert "dev3" not in svc._temp_states
+        svc._temp_cooldown_seconds = 600  # Long cooldown
+        t0 = datetime.now(timezone.utc)
+
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Within cooldown, escalating to critical: MUST fire.
+        await self._call(app, svc, info, 85.0, sample_ts=t0 + timedelta(seconds=1))
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.TEMP_HIGH,
+                )
+            )).scalars().all()
+            assert len(events) == 2
+            levels = [e.details["level"] for e in events]
+            assert "warning" in levels
+            assert "critical" in levels
+            break
 
     @pytest.mark.asyncio
-    async def test_pending_device_temp_ignored(self, fresh_alert_service):
-        """Pending devices don't trigger temperature alerts."""
+    async def test_stale_sample_ignored(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Out-of-order delivery: older sample_ts doesn't overwrite newer state."""
+        info = seed_group_and_device
         svc = fresh_alert_service
-        svc.check_temperature("dev4", 85.0, "Dev4", str(uuid.uuid4()), "G", status="pending")
-        assert "dev4" not in svc._temp_states
+        t0 = datetime.now(timezone.utc)
+
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Stale sample — older ts, lower temp. Must be ignored.
+        await self._call(app, svc, info, 55.0, sample_ts=t0 - timedelta(seconds=30))
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one()
+            assert state.temp_level == "warning"
+            # SQLite strips tzinfo on round-trip; compare naive-UTC.
+            stored_ts = state.temp_last_sample_ts
+            if stored_ts.tzinfo is not None:
+                stored_ts = stored_ts.astimezone(timezone.utc).replace(tzinfo=None)
+            assert stored_ts == t0.replace(tzinfo=None)
+
+            cleared = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.TEMP_CLEARED,
+                )
+            )).scalars().all()
+            assert len(cleared) == 0
+            break
+
+    @pytest.mark.asyncio
+    async def test_none_temp_ignored(self, app, seed_group_and_device, fresh_alert_service):
+        """None temperature values are silently ignored (no state written)."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+        await self._call(app, svc, info, None, sample_ts=datetime.now(timezone.utc))
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one_or_none()
+            # Either no row or default 'normal' state — just assert no
+            # non-normal state leaked.
+            assert state is None or state.temp_level == "normal"
+            break
+
+    @pytest.mark.asyncio
+    async def test_pending_device_temp_resets_state(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Non-adopted heartbeat resets any persisted temp state.
+
+        Prevents the following bug: device A warns at 75°C, gets
+        unadopted, later re-adopted in a different group — first
+        warning should fire cleanly, not be suppressed by stale state.
+        """
+        info = seed_group_and_device
+        svc = fresh_alert_service
+        t0 = datetime.now(timezone.utc)
+
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Now pretend the device got unadopted and sends a pending
+        # heartbeat — state should reset.
+        await self._call(
+            app, svc, info, 90.0, sample_ts=t0 + timedelta(seconds=1),
+            status="pending",
+        )
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one_or_none()
+            assert state is not None
+            assert state.temp_level == "normal"
+            assert state.temp_last_alert_at is None
+            assert state.temp_last_sample_ts is None
+            break
+
+    @pytest.mark.asyncio
+    async def test_ungrouped_device_temp_resets_state(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Ungrouped device resets temp state even if still adopted."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+        t0 = datetime.now(timezone.utc)
+
+        await self._call(app, svc, info, 75.0, sample_ts=t0)
+        # Device got un-grouped — state should reset.
+        await self._call(
+            app, svc, info, 90.0, sample_ts=t0 + timedelta(seconds=1),
+            group_id=None,
+        )
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one_or_none()
+            assert state is not None
+            assert state.temp_level == "normal"
+            break
+
+    @pytest.mark.asyncio
+    async def test_sample_ts_fallback_to_now_when_missing(
+        self, app, seed_group_and_device, fresh_alert_service,
+    ):
+        """Missing sample_ts falls back to server now() with a log warning."""
+        info = seed_group_and_device
+        svc = fresh_alert_service
+        # No sample_ts — exercises the fallback path.
+        await self._call(app, svc, info, 75.0, sample_ts=None)
+
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.TEMP_HIGH,
+                )
+            )).scalars().all()
+            assert len(events) == 1
+            break
 
 
 # ── Device Events API Tests ──
@@ -603,26 +790,13 @@ class TestNotificationPrefsAPI:
 # ── Cleanup test ──
 
 class TestAlertServiceCleanup:
-    """Test cleanup of in-memory state."""
+    """Test cleanup_device is a safe no-op post-DB-migration."""
 
     @pytest.mark.asyncio
-    async def test_cleanup_cancels_timer(self, fresh_alert_service):
-        """cleanup_device clears in-memory temp state (offline state is DB-backed)."""
+    async def test_cleanup_is_noop(self, fresh_alert_service):
+        """cleanup_device is a no-op (temp state lives in DB, cascade-deleted)."""
         svc = fresh_alert_service
-        gid = str(uuid.uuid4())
-        # Put a temp-state entry in the in-memory dict so cleanup has
-        # something to clear.
-        svc.check_temperature("dev-clean", 75.0, "Cleanup Dev", gid, "G", status="adopted")
-        assert "dev-clean" in svc._temp_states
-
+        # Should not raise — previously cleared in-memory state, now
+        # delegated to the ON DELETE CASCADE on device_alert_state.
         svc.cleanup_device("dev-clean")
-        assert "dev-clean" not in svc._temp_states
-
-    @pytest.mark.asyncio
-    async def test_cleanup_removes_temp_state(self, fresh_alert_service):
-        svc = fresh_alert_service
-        svc.check_temperature("dev-tc", 75.0, "D", str(uuid.uuid4()), "G", status="adopted")
-        assert "dev-tc" in svc._temp_states
-
-        svc.cleanup_device("dev-tc")
-        assert "dev-tc" not in svc._temp_states
+        svc.cleanup_device("nonexistent-device")

--- a/tests/test_thermal_thresholds_settings.py
+++ b/tests/test_thermal_thresholds_settings.py
@@ -11,7 +11,9 @@ the service. What was missing: proof that those DB-driven thresholds
 threshold of 60°C really does classify 61°C as "warning" (when the
 default threshold of 70°C wouldn't).
 
-This file fills that gap.
+This file fills that gap by exercising the pure-function
+``_classify_temp`` classifier directly; the full DB-backed
+``check_temperature`` path is covered by ``test_device_alerts.py``.
 """
 
 from __future__ import annotations
@@ -19,12 +21,6 @@ from __future__ import annotations
 import pytest
 
 from cms.services.alert_service import AlertService
-
-# ``check_temperature`` schedules follow-up work via ``asyncio.create_task``,
-# which needs a running event loop. Mark every test async so pytest-asyncio
-# provides one. We don't ``await`` the spawned tasks — they hit the DB and
-# we only care about the classification side effect on ``_temp_states``.
-pytestmark = pytest.mark.asyncio
 
 
 def _svc(*, warning: float, critical: float, cooldown: int = 300) -> AlertService:
@@ -35,89 +31,55 @@ def _svc(*, warning: float, critical: float, cooldown: int = 300) -> AlertServic
     return svc
 
 
-def _check(svc: AlertService, device_id: str, temp: float) -> str | None:
-    """Fire a check and return the resulting state.level (None if no state)."""
-    svc.check_temperature(
-        device_id=device_id,
-        cpu_temp_c=temp,
-        device_name="dev-1",
-        group_id="11111111-1111-1111-1111-111111111111",
-        group_name="Group 1",
-        status="adopted",
-    )
-    state = svc._temp_states.get(device_id)
-    return state.level if state else None
-
-
 class TestCustomWarningThreshold:
-    async def test_warning_at_low_threshold(self):
+    def test_warning_at_low_threshold(self):
         """At warning=60°C, 61°C classifies as warning."""
         svc = _svc(warning=60.0, critical=90.0)
-        assert _check(svc, "dev-low", 61.0) == "warning"
+        assert svc._classify_temp(61.0) == "warning"
 
-    async def test_warning_at_high_threshold(self):
+    def test_warning_at_high_threshold(self):
         """At warning=85°C, 80°C is still normal (default would be warning)."""
         svc = _svc(warning=85.0, critical=95.0)
-        level = _check(svc, "dev-high", 80.0)
-        # Normal on first call leaves state.level == "normal" (the dataclass default)
-        # and does not queue an event. We just assert it was NOT classified as warning.
-        assert level != "warning", (
-            f"80°C with warning threshold 85°C should not be warning; got {level}"
-        )
+        assert svc._classify_temp(80.0) == "normal"
 
-    async def test_critical_at_low_threshold(self):
+    def test_critical_at_low_threshold(self):
         """At critical=70°C, 75°C classifies as critical."""
         svc = _svc(warning=60.0, critical=70.0)
-        assert _check(svc, "dev-crit", 75.0) == "critical"
+        assert svc._classify_temp(75.0) == "critical"
 
-    async def test_boundary_exactly_at_warning(self):
+    def test_boundary_exactly_at_warning(self):
         """Temperature exactly at warning threshold classifies as warning (>=)."""
         svc = _svc(warning=65.0, critical=85.0)
-        assert _check(svc, "dev-boundary-w", 65.0) == "warning"
+        assert svc._classify_temp(65.0) == "warning"
 
-    async def test_boundary_exactly_at_critical(self):
+    def test_boundary_exactly_at_critical(self):
         """Temperature exactly at critical threshold classifies as critical (>=)."""
         svc = _svc(warning=65.0, critical=85.0)
-        assert _check(svc, "dev-boundary-c", 85.0) == "critical"
+        assert svc._classify_temp(85.0) == "critical"
 
-    async def test_just_below_custom_warning_stays_normal(self):
+    def test_just_below_custom_warning_stays_normal(self):
         """Just under the custom warning threshold stays normal."""
         svc = _svc(warning=50.0, critical=70.0)
-        level = _check(svc, "dev-just-below", 49.9)
-        assert level in (None, "normal")
+        assert svc._classify_temp(49.9) == "normal"
 
 
 class TestThresholdChangeDuringLifetime:
     """Re-reading settings mid-run should change classification on next check."""
 
-    async def test_lowering_warning_triggers_new_warning(self):
+    def test_lowering_warning_triggers_new_warning(self):
         svc = _svc(warning=80.0, critical=95.0)
-        assert _check(svc, "dev-change", 75.0) in (None, "normal")
+        assert svc._classify_temp(75.0) == "normal"
         svc._temp_warning_c = 70.0
-        assert _check(svc, "dev-change", 75.0) == "warning"
+        assert svc._classify_temp(75.0) == "warning"
 
-    async def test_raising_warning_clears_previous_warning(self):
+    def test_raising_warning_clears_previous_warning(self):
         svc = _svc(warning=60.0, critical=90.0)
-        assert _check(svc, "dev-raise", 70.0) == "warning"
+        assert svc._classify_temp(70.0) == "warning"
         svc._temp_warning_c = 80.0
-        assert _check(svc, "dev-raise", 70.0) == "normal"
+        assert svc._classify_temp(70.0) == "normal"
 
 
-class TestCustomCooldown:
-    """After clearing, a new alert should respect the DB-driven cooldown seconds."""
-
-    async def test_cooldown_value_is_respected(self):
-        """Short cooldown = next alert after clear should fire on next heartbeat."""
-        import datetime as _dt
-
-        svc = _svc(warning=60.0, critical=90.0, cooldown=1)
-        assert _check(svc, "dev-cooldown", 70.0) == "warning"
-        assert _check(svc, "dev-cooldown", 50.0) == "normal"
-        state = svc._temp_states["dev-cooldown"]
-        state.last_alert_at = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=2)
-        assert _check(svc, "dev-cooldown", 75.0) == "warning"
-
-
+@pytest.mark.asyncio
 async def test_refresh_settings_changes_classification(app, db_session):
     """End-to-end: save settings via ``set_setting``, refresh_settings(), classify.
 
@@ -140,5 +102,4 @@ async def test_refresh_settings_changes_classification(app, db_session):
     assert svc._temp_cooldown_seconds == 10
 
     # Behavior: 60°C with new 55° threshold should warn (would be normal under defaults).
-    level = _check(svc, "dev-e2e", 60.0)
-    assert level == "warning"
+    assert svc._classify_temp(60.0) == "warning"

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -311,6 +311,124 @@ class TestUserEvents:
             # send closure should be wired to the current transport.
             assert callable(kwargs["send"])
 
+    async def test_ce_time_header_parsed_into_received_at(
+        self, client, app_and_session,
+    ):
+        """ce-time header (CloudEvents 1.0) is parsed into ctx.received_at.
+
+        Temperature-alert dedupe relies on this monotonic timestamp;
+        this test guards against regressions that drop the header.
+        """
+        from datetime import datetime, timezone
+
+        app, session = app_and_session
+        device = MagicMock()
+        device.id = "pi-ce"
+        device.name = "L"
+        device.group_id = None
+        device.status = MagicMock(value="adopted")
+        session.device_row = device
+
+        cid = "conn-ce"
+        payload = {"type": "STATUS", "cpu_temp_c": 50.0}
+        with patch(
+            "cms.routers.wps_webhook.dispatch_device_message",
+            new=AsyncMock(return_value=None),
+        ) as mock_dispatch:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-ce",
+                    "ce-eventName": "message",
+                    "ce-signature": _sig(cid),
+                    "ce-time": "2026-04-23T06:30:00.123Z",
+                },
+            )
+            assert r.status_code == 204
+            _, kwargs = mock_dispatch.call_args
+            received_at = kwargs["ctx"].received_at
+            assert received_at is not None
+            assert received_at == datetime(
+                2026, 4, 23, 6, 30, 0, 123000, tzinfo=timezone.utc,
+            )
+
+    async def test_ce_time_missing_falls_back_to_none(
+        self, client, app_and_session,
+    ):
+        """Missing ce-time header results in ctx.received_at=None.
+
+        alert_service then falls back to server now() with a warning
+        log.  Prevents a hard failure if Azure ever drops the header.
+        """
+        app, session = app_and_session
+        device = MagicMock()
+        device.id = "pi-no-time"
+        device.name = "L"
+        device.group_id = None
+        device.status = MagicMock(value="adopted")
+        session.device_row = device
+
+        cid = "conn-no-time"
+        payload = {"type": "STATUS"}
+        with patch(
+            "cms.routers.wps_webhook.dispatch_device_message",
+            new=AsyncMock(return_value=None),
+        ) as mock_dispatch:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-no-time",
+                    "ce-eventName": "message",
+                    "ce-signature": _sig(cid),
+                },
+            )
+            assert r.status_code == 204
+            _, kwargs = mock_dispatch.call_args
+            assert kwargs["ctx"].received_at is None
+
+    async def test_ce_time_malformed_falls_back_to_none(
+        self, client, app_and_session,
+    ):
+        """Malformed ce-time header is logged and ctx.received_at=None."""
+        app, session = app_and_session
+        device = MagicMock()
+        device.id = "pi-bad-time"
+        device.name = "L"
+        device.group_id = None
+        device.status = MagicMock(value="adopted")
+        session.device_row = device
+
+        cid = "conn-bad-time"
+        payload = {"type": "STATUS"}
+        with patch(
+            "cms.routers.wps_webhook.dispatch_device_message",
+            new=AsyncMock(return_value=None),
+        ) as mock_dispatch:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-bad-time",
+                    "ce-eventName": "message",
+                    "ce-signature": _sig(cid),
+                    "ce-time": "totally not a timestamp",
+                },
+            )
+            assert r.status_code == 204
+            _, kwargs = mock_dispatch.call_args
+            assert kwargs["ctx"].received_at is None
+
     async def test_non_json_body_is_400(self, client, app_and_session):
         _, session = app_and_session
         session.device_row = MagicMock(


### PR DESCRIPTION
## Summary

HIGH-priority fix from multi-replica audit: make temperature-alert
handling correct under N>1 CMS replicas.

Before this change, `AlertService.check_temperature` maintained a
per-instance `_temp_states` dict keyed by device id.  Under Azure Web
PubSub the webhook for a single device can land on *any* CMS replica,
so two replicas would each maintain independent state for the same
device and could double-fire alerts or miss a cooldown the other
replica already applied.

## Behaviour changes (user-visible)

- **Reminder-every-cooldown for sustained high temps.**  Previously a
  sustained warning or critical only fired once at the threshold
  crossing.  Now, if temperature stays in a warning/critical band
  across a full cooldown window, we fire another reminder alert.
  The user explicitly requested "never miss a high-temp alert".
- **Escalation bypasses cooldown.**  warning → critical always fires
  immediately, regardless of when the last alert was sent.
- **TEMP_CLEARED always fires**, regardless of cooldown (good news
  never suppressed).
- No change to thresholds, notification recipients, or the user-
  configurable cooldown/hysteresis settings.

## Technical changes

- New migration `0008_device_alert_state_temp.py` adds three columns
  to `device_alert_state`:
  `temp_level` (normal/warning/critical), `temp_last_alert_at`,
  `temp_last_sample_ts`.
- `AlertService.check_temperature` is now `async`, takes a
  `AsyncSession` + optional `sample_ts`, and serialises the state
  transition with `SELECT … FOR UPDATE` (Postgres) / ordinary read
  (SQLite falls back cleanly for tests).
- Dialect-aware upsert via `on_conflict_do_nothing` (PG + SQLite).
- `sample_ts` comes from the Azure WPS `ce-time` CloudEvents 1.0
  header.  Out-of-order webhooks (older sample arriving after newer)
  are now ignored instead of corrupting state.
- Missing/malformed `ce-time` header logs a WARNING and falls back to
  `datetime.now(UTC)` — we never fail a webhook on a bad header.
- Local `/ws/device` path still works; it passes `received_at=None`
  and hits the same fallback.
- Deleted the old in-memory `_TempState` class and `_temp_states`
  dict.  `cleanup_device()` is now a no-op (kept for back-compat —
  the `ON DELETE CASCADE` on `device_alert_state` handles real
  cleanup).

## Test coverage

- `tests/test_device_alerts.py` — rewrote `TestTemperatureAlerts`
  with 12 async DB-backed tests covering the full transition matrix,
  the new reminder-after-cooldown behaviour, escalation-bypasses-
  cooldown, out-of-order-sample rejection, and state reset when the
  device goes ungrouped / orphaned.
- `tests/test_thermal_thresholds_settings.py` — converted to pure-
  sync tests against the extracted `_classify_temp` helper so we
  don't need a live DB for threshold math.
- `tests/test_wps_webhook.py` — added three tests for the `ce-time`
  header parsing path (valid RFC 3339, missing, malformed).
- Local full suite for the three files above: **60 passed**.

## Rubber-duck findings adopted

- CAS predicate was originally `WHERE temp_level = :old` which races
  under concurrent reads; switched to `SELECT … FOR UPDATE` row lock
  so the read-modify-write is atomic under Postgres.
- Preserve `old_level` from the same SELECT we lock with (saves a
  round-trip and guarantees consistency).
- Reset persisted temp state when the device transitions to
  ungrouped/orphaned so the first alert on re-adoption fires cleanly.
- Don't trust device-reported timestamps; use `ce-time` (authoritative
  Azure ingestion time) and fall back to server `now()` with a loud
  log if the header is absent.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
