### PR TITLE
Retire legacy POST /api/devices/{id}/logs (N>1 safety)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -25,7 +25,6 @@ from cms.schemas.device import (
     DeviceGroupUpdate,
     DeviceOut,
     DeviceUpdate,
-    LogRequest,
     SetPasswordRequest,
     ToggleRequest,
 )
@@ -686,37 +685,6 @@ async def delete_device(device_id: str, request: Request, db: AsyncSession = Dep
     await db.delete(device)
     await db.commit()
     return {"deleted": device_id}
-
-
-@router.post("/{device_id}/logs", dependencies=[Depends(require_permission(DEVICES_READ))])
-async def request_device_logs(
-    device_id: str,
-    request: Request,
-    body: LogRequest = LogRequest(),
-    db: AsyncSession = Depends(get_db),
-):
-    """Request logs from a connected device via WebSocket.
-
-    Returns a dict of {service_name: log_text}.
-    """
-    device = await _get_device_with_access(device_id, request, db)
-
-    if not await get_transport().is_connected(device_id):
-        raise HTTPException(status_code=409, detail="Device is not connected")
-
-    try:
-        logs = await get_transport().request_logs(device_id, services=body.services, since=body.since)
-    except TimeoutError as e:
-        raise HTTPException(status_code=504, detail=str(e))
-    except ValueError as e:
-        raise HTTPException(status_code=502, detail=str(e))
-    except RuntimeError as e:
-        # The device reported an error while collecting logs (e.g. journalctl
-        # not installed). Surface it as an upstream/bad-gateway response with
-        # the device's own error string so the operator can diagnose.
-        raise HTTPException(status_code=502, detail=str(e))
-
-    return {"device_id": device_id, "logs": logs}
 
 
 # ── Groups ──

--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -92,6 +92,4 @@ class ToggleRequest(BaseModel):
     enabled: StrictBool
 
 
-class LogRequest(BaseModel):
-    services: Optional[list[str]] = None
-    since: str = "24h"
+

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -32,7 +32,6 @@ from cms.schemas.protocol import (
     MessageType,
 )
 from cms.services.alert_service import alert_service
-from cms.services.device_manager import device_manager
 from cms.services.scheduler import (
     clear_now_playing,
     log_schedule_event,
@@ -459,14 +458,14 @@ async def dispatch_device_message(
         logs = msg.get("logs", {})
         error = msg.get("error")
         logger.info("Device %s sent logs (request %s, %d services)", device_id, request_id, len(logs))
-        device_manager.resolve_log_request(request_id, logs, error)
 
-        # Stage 3b back-compat shim: if ``request_id`` matches an outbox
-        # row (new async path), route the legacy inline payload into
-        # blob storage + flip the row.  Wrapped in its own try/except
-        # because a failure here must never break the legacy synchronous
-        # path above — LOGS_RESPONSE from old firmware still has to
-        # resolve the in-flight future.
+        # Route the inline JSON payload into the async outbox flow: when
+        # the device receives REQUEST_LOGS (either from an explicit
+        # ``dispatch_request_logs`` call or the drainer), its reply lands
+        # here, we fold the payload into a tar.gz blob and flip the
+        # outbox row to ``ready`` so the user-facing polling endpoint
+        # can serve it.  This is the *only* path that handles
+        # LOGS_RESPONSE since the synchronous RPC was retired.
         if request_id:
             try:
                 from cms.models.log_request import STATUS_PENDING, STATUS_SENT
@@ -505,7 +504,7 @@ async def dispatch_device_message(
                         await db.commit()
             except Exception:
                 logger.warning(
-                    "LOGS_RESPONSE outbox shim failed for request %s (device %s)",
+                    "LOGS_RESPONSE outbox write failed for request %s (device %s)",
                     request_id, device_id, exc_info=True,
                 )
 

--- a/cms/services/device_manager.py
+++ b/cms/services/device_manager.py
@@ -1,18 +1,20 @@
 """Device WebSocket connection registry.
 
-After Stage 2c (#344), this module only tracks per-replica ephemeral
-state — the live WebSocket objects this process owns and the
-``_pending_log_requests`` future map for synchronous log RPCs.
+After Stage 2c (#344) and the logs-RPC retirement (#345 Stage 3), this
+module only tracks per-replica ephemeral state — the live WebSocket
+objects this process owns.
 
 Presence (``online``), identity (``connection_id``), and telemetry
 (mode/asset/pipeline_state/cpu_temp_c/…) live on the ``devices`` table
 and are read via :mod:`cms.services.device_presence`.  ``ConnectedDevice``
 used to cache those fields too; that cache is now the DB row.
+
+The synchronous ``request_logs`` RPC and its in-memory future map were
+removed — everything now goes through the multi-replica-safe outbox in
+:mod:`cms.routers.log_requests`.
 """
 
-import asyncio
 import logging
-import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -63,7 +65,6 @@ class DeviceManager:
 
     def __init__(self):
         self._connections: dict[str, ConnectedDevice] = {}
-        self._pending_log_requests: dict[str, asyncio.Future] = {}
 
     def register(
         self,
@@ -113,67 +114,6 @@ class DeviceManager:
     async def broadcast(self, message: dict):
         for device_id in list(self._connections.keys()):
             await self.send_to_device(device_id, message)
-
-    async def request_logs(
-        self,
-        device_id: str,
-        services: list[str] | None = None,
-        since: str = "24h",
-        timeout: float = 30.0,
-    ) -> dict:
-        """Send a request_logs command to a device and await its response.
-
-        Returns the logs dict ``{service_name: log_text}`` or raises
-        TimeoutError/ValueError.  The awaiting future lives on this
-        replica — Stage 3 replaces this with a blob-upload outbox.
-        """
-        conn = self._connections.get(device_id)
-        if not conn:
-            raise ValueError(f"Device {device_id} is not connected")
-
-        request_id = str(uuid.uuid4())
-        fut: asyncio.Future = asyncio.get_running_loop().create_future()
-        self._pending_log_requests[request_id] = fut
-
-        from cms.schemas.protocol import RequestLogsMessage
-        msg = RequestLogsMessage(
-            request_id=request_id,
-            services=services,
-            since=since,
-        )
-        try:
-            await conn.send_json(msg.model_dump(mode="json"))
-        except Exception:
-            self._pending_log_requests.pop(request_id, None)
-            raise ValueError(f"Failed to send request to device {device_id}")
-
-        try:
-            result = await asyncio.wait_for(fut, timeout=timeout)
-            return result
-        except asyncio.TimeoutError:
-            self._pending_log_requests.pop(request_id, None)
-            raise TimeoutError(
-                f"Device {device_id} did not respond within {timeout}s",
-            )
-
-    def resolve_log_request(
-        self,
-        request_id: str,
-        logs: dict[str, str],
-        error: str | None = None,
-    ):
-        """Resolve a pending ``request_logs`` future.
-
-        Called by :func:`cms.services.device_inbound.dispatch_device_message`
-        when a ``logs_response`` frame arrives — the WPS webhook and the
-        direct-WS paths both dispatch through that function.
-        """
-        fut = self._pending_log_requests.pop(request_id, None)
-        if fut and not fut.done():
-            if error:
-                fut.set_exception(RuntimeError(error))
-            else:
-                fut.set_result(logs)
 
 
 # Singleton — shared across the application

--- a/cms/services/transport.py
+++ b/cms/services/transport.py
@@ -9,11 +9,15 @@ sees the same view.  Presence queries (``is_connected``,
 the DB — they are ``async`` and open a short-lived session from the
 configured session factory when the caller doesn't supply one.
 
-WS-lifecycle operations (``register``/``disconnect``/``update_status``/
-``resolve_log_request``) remain implementation details of the direct-WS
-connection registry on ``device_manager`` — only ``cms/routers/ws.py``
-and the unit tests that fabricate device connections import it
-directly.  Other code touches presence through this interface.
+WS-lifecycle operations (``register``/``disconnect``/``update_status``)
+remain implementation details of the direct-WS connection registry on
+``device_manager`` — only ``cms/routers/ws.py`` and the unit tests that
+fabricate device connections import it directly.  Other code touches
+presence through this interface.
+
+The synchronous ``request_logs`` RPC was retired in favour of the
+multi-replica-safe outbox in :mod:`cms.routers.log_requests`; only
+the fire-and-forget ``dispatch_request_logs`` method remains.
 """
 
 from __future__ import annotations
@@ -80,19 +84,6 @@ class DeviceTransport(ABC):
     @abstractmethod
     async def get_all_states(self) -> list[dict[str, Any]]:
         """Latest playback/health state for every connected device."""
-
-    @abstractmethod
-    async def request_logs(
-        self,
-        device_id: str,
-        services: list[str] | None = None,
-        since: str = "24h",
-        timeout: float = 30.0,
-    ) -> dict[str, str]:
-        """Synchronous RPC to pull device logs.
-
-        Stage 3 replaces this with a blob-upload outbox; this method will
-        be removed from the interface at that point."""
 
     @abstractmethod
     async def dispatch_request_logs(
@@ -176,17 +167,6 @@ class LocalDeviceTransport(DeviceTransport):
         async with _session() as db:
             return await device_presence.list_states(db)
 
-    async def request_logs(
-        self,
-        device_id: str,
-        services: list[str] | None = None,
-        since: str = "24h",
-        timeout: float = 30.0,
-    ) -> dict[str, str]:
-        return await self._manager.request_logs(
-            device_id, services=services, since=since, timeout=timeout,
-        )
-
     async def dispatch_request_logs(
         self,
         device_id: str,
@@ -196,8 +176,8 @@ class LocalDeviceTransport(DeviceTransport):
         since: str = "24h",
     ) -> None:
         # Look up the live WS directly — this transport is single-replica
-        # so if we don't own a socket, nobody does.  Do NOT register a
-        # future in ``_pending_log_requests``: the outbox owns state.
+        # so if we don't own a socket, nobody does.  The outbox row owns
+        # the state machine; we just fire the message.
         conn = self._manager.get(device_id)
         if conn is None:
             raise ValueError(f"Device {device_id} is not connected")

--- a/cms/services/wps_transport.py
+++ b/cms/services/wps_transport.py
@@ -10,10 +10,11 @@ registers presence and dispatches each payload through
 
 Presence + telemetry live in Postgres since Stage 2c (#344) — read-side
 helpers are shared with ``LocalDeviceTransport`` via
-:mod:`cms.services.device_presence`.  The only per-replica state the
-WPS path still keeps in-memory is the ``_pending_log_requests`` future
-map used by the synchronous logs RPC (see Stage 3 for the outbox
-replacement).
+:mod:`cms.services.device_presence`.  With the synchronous
+``request_logs`` RPC retired (#345 Stage 3), the WPS transport now holds
+no per-replica in-memory state at all — every mutable field this
+process used to cache is either on the DB row or in a transactional
+outbox.
 """
 
 from __future__ import annotations
@@ -44,14 +45,7 @@ class WPSTransport(DeviceTransport):
         self,
         connection_string: str,
         hub: str,
-        device_manager: Any | None = None,
     ) -> None:
-        if device_manager is None:
-            from cms.services.device_manager import device_manager as _dm
-            device_manager = _dm
-        # Only still needed for ``_pending_log_requests`` — the log RPC
-        # is replica-local by nature (the awaiting future lives here).
-        self._manager = device_manager
         self._hub = hub
         self._client: WebPubSubServiceClient = (
             WebPubSubServiceClient.from_connection_string(
@@ -116,48 +110,7 @@ class WPSTransport(DeviceTransport):
         async with _session() as db:
             return await device_presence.list_states(db)
 
-    # ---- synchronous RPC (logs) ----------------------------------------
-
-    async def request_logs(
-        self,
-        device_id: str,
-        services: list[str] | None = None,
-        since: str = "24h",
-        timeout: float = 30.0,
-    ) -> dict[str, str]:
-        """Send a ``request_logs`` command and await the device's reply.
-
-        The awaiting future is held in-process (per-replica) — Stage 3
-        will replace this with a blob-upload outbox so logs are
-        deliverable from any replica.
-        """
-        import asyncio
-        import uuid
-
-        from cms.schemas.protocol import RequestLogsMessage
-
-        if not await self.is_connected(device_id):
-            raise ValueError(f"Device {device_id} is not connected")
-
-        request_id = str(uuid.uuid4())
-        fut: asyncio.Future = asyncio.get_running_loop().create_future()
-        self._manager._pending_log_requests[request_id] = fut
-
-        msg = RequestLogsMessage(
-            request_id=request_id, services=services, since=since,
-        )
-        ok = await self.send_to_device(device_id, msg.model_dump(mode="json"))
-        if not ok:
-            self._manager._pending_log_requests.pop(request_id, None)
-            raise ValueError(f"Failed to send request to device {device_id}")
-
-        try:
-            return await asyncio.wait_for(fut, timeout=timeout)
-        except asyncio.TimeoutError:
-            self._manager._pending_log_requests.pop(request_id, None)
-            raise TimeoutError(
-                f"Device {device_id} did not respond within {timeout}s"
-            )
+    # ---- async log dispatch (fire-and-forget) --------------------------
 
     async def dispatch_request_logs(
         self,

--- a/mcp/cms_client.py
+++ b/mcp/cms_client.py
@@ -4,11 +4,35 @@ Authenticates using the MCP service key (X-API-Key header) and passes
 the real user identity via X-On-Behalf-Of for audit logging.
 """
 
+import asyncio
+import io
 import logging
+import tarfile
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_tar_gz(blob: bytes) -> dict[str, str]:
+    """Extract a ``tar.gz`` bundle into ``{service_name: log_text}``.
+
+    Strips any ``.log`` suffix so the output shape matches what the
+    legacy synchronous RPC returned.
+    """
+    out: dict[str, str] = {}
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile():
+                continue
+            fh = tf.extractfile(member)
+            if fh is None:
+                continue
+            name = member.name
+            if name.endswith(".log"):
+                name = name[:-4]
+            out[name] = fh.read().decode("utf-8", errors="replace")
+    return out
 
 
 class CMSClient:
@@ -133,12 +157,66 @@ class CMSClient:
     # ── Logs ──
 
     async def request_device_logs(
-        self, device_id: str, services: list[str] | None = None, since: str = "24h",
+        self,
+        device_id: str,
+        services: list[str] | None = None,
+        since: str = "24h",
+        *,
+        poll_timeout: float = 60.0,
+        poll_interval: float = 2.0,
     ) -> dict:
-        params = {"since": since}
+        """Create a log request, poll for completion, and return the logs.
+
+        Under the hood this exercises the multi-replica-safe async flow:
+        ``POST /api/logs/requests`` → poll ``GET .../{id}`` → ``GET
+        .../{id}/download`` (which returns a ``tar.gz`` bundle).  The
+        returned shape matches the legacy tool for callers that expected
+        ``{service_name: log_text}``.
+
+        If the device doesn't reply within ``poll_timeout`` seconds this
+        returns ``{"request_id", "status", "last_error"}`` — the row is
+        still live on the CMS and can be retrieved later.
+        """
+        body: dict = {"device_id": device_id, "since": since}
         if services:
-            params["services"] = services
-        return await self._post(f"/api/devices/{device_id}/logs", params)
+            body["services"] = services
+
+        created = await self._post("/api/logs/requests", body)
+        if not isinstance(created, dict) or "request_id" not in created:
+            raise RuntimeError(f"Unexpected create response: {created!r}")
+        request_id = created["request_id"]
+
+        deadline = asyncio.get_event_loop().time() + poll_timeout
+        last: dict = {"request_id": request_id, "status": created.get("status")}
+        while asyncio.get_event_loop().time() < deadline:
+            row = await self._get(f"/api/logs/requests/{request_id}")
+            if not isinstance(row, dict):
+                raise RuntimeError(f"Unexpected status response: {row!r}")
+            last = row
+            status = row.get("status")
+            if status == "ready":
+                resp = await self._client.get(
+                    f"/api/logs/requests/{request_id}/download",
+                )
+                resp.raise_for_status()
+                return _extract_tar_gz(resp.content)
+            if status == "failed":
+                return {
+                    "request_id": request_id,
+                    "status": "failed",
+                    "last_error": row.get("last_error"),
+                }
+            await asyncio.sleep(poll_interval)
+
+        return {
+            "request_id": request_id,
+            "status": last.get("status", "pending"),
+            "last_error": last.get("last_error"),
+            "message": (
+                "Device did not reply within "
+                f"{poll_timeout:.0f}s — request is still live on the CMS."
+            ),
+        }
 
     # ── Dashboard ──
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -588,10 +588,13 @@ async def get_device_logs(
     services: list[str] | None = None,
     since: str = "24h",
 ) -> str:
-    """Request logs from a connected device via its WebSocket connection.
+    """Request logs from a connected device and return the captured output.
 
-    Returns journalctl output from the device's agora services.
-    The device must be online (connected via WebSocket).
+    Creates an async log request on the CMS, waits for the device to
+    reply (up to ~60s), and returns the captured journalctl output as
+    ``{service_name: log_text}``.  If the device doesn't reply in time,
+    returns the request_id and status so the caller can retrieve it
+    later via the CMS UI or API.
 
     Args:
         device_id: ID of the device to get logs from.

--- a/tests/nightly/test_12_logs_roundtrip.py
+++ b/tests/nightly/test_12_logs_roundtrip.py
@@ -1,26 +1,24 @@
-"""Phase 9d: Logs round-trip — ``POST /api/devices/{id}/logs`` (#250).
+"""Phase 9d: Logs round-trip — ``POST /api/logs/requests`` (#345).
 
-Covers the end-to-end path for the "Get Logs" UI action:
+Covers the end-to-end path for the "Get Logs" UI action, now via the
+multi-replica-safe async outbox introduced in PR #345:
 
-1. Happy-ish path — CMS forwards the ``request_logs`` command over WS and
-   the simulator records it with ``services`` and ``since`` as sent. The
-   simulator container has no ``journalctl`` binary, so the device
-   responds with ``error="journalctl not available on this device"``;
-   the CMS router turns that into a 502 with the device's error string.
-   Either way, proof of delivery is the recorded command on the sim.
+1. Happy-ish path — ``POST /api/logs/requests`` enqueues an outbox row,
+   CMS forwards the ``request_logs`` command over WS, and the simulator
+   records it with ``services`` and ``since`` as sent. The simulator
+   container has no ``journalctl`` binary, so the device eventually
+   responds with an error that flips the row to ``failed``; we poll
+   ``GET /api/logs/requests/{id}`` until the row reaches a terminal
+   state (ready or failed). Proof of delivery is the recorded command
+   on the sim, which is independent of the terminal row status.
 
-2. Unknown device — ``POST /api/devices/unknown/logs`` returns 404 from
-   the ``_get_device_with_access`` guard.
+2. Unknown device — ``POST /api/logs/requests`` returns 404 from the
+   access-check guard that loads the device row.
 
-3. Disconnected device — forcing the target offline first makes the
-   endpoint short-circuit with 409 (``device not connected``) rather
-   than timing out.
-
-These tests are intentionally forgiving about the *content* of the
-successful response: the production path relies on a real ``journalctl``
-that isn't present in the sim container, so reaching a clean 200 would
-require either modifying the sim or seeding fake logs. Shipping end-to-end
-WS delivery coverage here; fake-logs fixture can follow later if needed.
+3. Disconnected device — forcing the target offline first still returns
+   202 (row created + queued); the terminal status will be "pending"
+   until the device reconnects and replies, so we just assert the row
+   exists and stays in a non-ready state.
 """
 
 from __future__ import annotations
@@ -35,7 +33,8 @@ from tests.nightly.helpers.simulator import SimulatorClient
 
 
 LOGS_RESPONSE_TIMEOUT_S = 45.0
-OFFLINE_DURATION_S = 15.0
+LOGS_POLL_TIMEOUT_S = 45.0
+OFFLINE_DURATION_S = 20.0
 OFFLINE_DETECT_TIMEOUT_S = 30.0
 ONLINE_DETECT_TIMEOUT_S = 45.0
 
@@ -69,6 +68,25 @@ def _wait_for_online(page: Page, device_id: str, expected: bool, *, timeout: flo
     )
 
 
+def _poll_log_request(
+    page: Page, request_id: str, *, timeout: float,
+    terminal: tuple[str, ...] = ("ready", "failed"),
+) -> dict:
+    """Poll ``GET /api/logs/requests/{id}`` until status is terminal or timeout."""
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        resp = page.request.get(f"/api/logs/requests/{request_id}")
+        assert resp.status == 200, (
+            f"GET /api/logs/requests/{request_id} -> {resp.status}: {resp.text()[:400]}"
+        )
+        last = resp.json()
+        if last.get("status") in terminal:
+            return last
+        time.sleep(1.0)
+    return last
+
+
 # ── fixtures ─────────────────────────────────────────────────────────────
 
 
@@ -97,32 +115,35 @@ def test_request_logs_delivers_request_logs_command_to_device(
     simulator: SimulatorClient,
     logs_device: str,
 ) -> None:
-    """POST /api/devices/{id}/logs -> the simulator records a
-    ``request_logs`` command containing request_id, services, since."""
+    """POST /api/logs/requests -> the simulator records a ``request_logs``
+    command containing request_id, services, since; the outbox row flips
+    to a terminal status (ready or failed)."""
     page = authenticated_page
     device_id = logs_device
 
     services = ["agora-player", "agora-cms-client"]
     since = "1h"
     resp = page.request.post(
-        f"/api/devices/{device_id}/logs",
-        data={"services": services, "since": since},
-        timeout=LOGS_RESPONSE_TIMEOUT_S * 1000,
+        "/api/logs/requests",
+        data={"device_id": device_id, "services": services, "since": since},
+        timeout=15_000,
+    )
+    assert resp.status == 202, (
+        f"POST /api/logs/requests -> {resp.status}: {resp.text()[:400]}"
+    )
+    created = resp.json()
+    request_id = created.get("request_id")
+    assert isinstance(request_id, str) and request_id, (
+        f"expected request_id in response, got: {created!r}"
+    )
+    # When the device is online we expect the initial dispatch to succeed
+    # synchronously and the API to report "sent".
+    assert created.get("status") == "sent", (
+        f"expected status=sent for online device, got: {created!r}"
     )
 
-    # Simulator has no journalctl; expect either 200 (fake logs somehow
-    # returned) or 502 (device reported an error). Never a raw 500.
-    assert resp.status in (200, 502), (
-        f"POST /api/devices/{device_id}/logs -> {resp.status}: {resp.text()[:400]}"
-    )
-    if resp.status == 502:
-        detail = (resp.json() or {}).get("detail", "")
-        assert "journalctl" in detail.lower() or "not available" in detail.lower(), (
-            f"expected device-side error message, got: {detail!r}"
-        )
-
-    # The simulator must have recorded the command irrespective of the
-    # eventual response — this is the real proof-of-delivery.
+    # The simulator must have recorded the command — this is the real
+    # proof-of-delivery irrespective of the eventual row status.
     matches = simulator.wait_for_command(
         device_id, "request_logs", timeout=LOGS_RESPONSE_TIMEOUT_S,
     )
@@ -131,7 +152,16 @@ def test_request_logs_delivers_request_logs_command_to_device(
     assert payload.get("type") == "request_logs"
     assert payload.get("services") == services
     assert payload.get("since") == since
-    assert isinstance(payload.get("request_id"), str) and payload["request_id"]
+    assert payload.get("request_id") == request_id
+
+    # The row should eventually reach a terminal state. Simulator has no
+    # journalctl, so "failed" is the most likely terminal status; a
+    # sufficiently-rigged sim could return "ready". Either is fine.
+    final = _poll_log_request(page, request_id, timeout=LOGS_POLL_TIMEOUT_S)
+    assert final.get("status") in ("ready", "failed"), (
+        f"log request {request_id} did not reach terminal status in "
+        f"{LOGS_POLL_TIMEOUT_S}s: {final!r}"
+    )
 
 
 def test_request_logs_unknown_device_returns_404(
@@ -139,19 +169,20 @@ def test_request_logs_unknown_device_returns_404(
 ) -> None:
     """Asking for logs on a non-existent device yields a clean 404."""
     resp = authenticated_page.request.post(
-        "/api/devices/nonexistent-device-zzz/logs",
-        data={},
+        "/api/logs/requests",
+        data={"device_id": "nonexistent-device-zzz"},
     )
     assert resp.status == 404, f"unexpected status: {resp.status} body={resp.text()[:400]}"
 
 
-def test_request_logs_on_disconnected_device_returns_409(
+def test_request_logs_on_disconnected_device_queues_pending(
     authenticated_page: Page,
     simulator: SimulatorClient,
     logs_device: str,
 ) -> None:
-    """When the target device is offline, the endpoint short-circuits with
-    409 from the ``is_connected`` guard rather than waiting for a timeout."""
+    """When the target device is offline, the new endpoint still accepts
+    the request (202) but the dispatch fails, so the row stays in a
+    non-``sent`` state until the device reconnects."""
     page = authenticated_page
     device_id = logs_device
 
@@ -160,13 +191,28 @@ def test_request_logs_on_disconnected_device_returns_409(
 
     try:
         resp = page.request.post(
-            f"/api/devices/{device_id}/logs",
-            data={},
+            "/api/logs/requests",
+            data={"device_id": device_id},
             timeout=15_000,
         )
-        assert resp.status == 409, (
-            f"expected 409 from disconnected device, got {resp.status}: {resp.text()[:400]}"
+        assert resp.status == 202, (
+            f"expected 202 while offline, got {resp.status}: {resp.text()[:400]}"
         )
+        body = resp.json()
+        # Dispatch failed (device offline) → status must NOT be "sent" right
+        # away. It should be "pending" with a last_error recorded when we
+        # poll.  Some scheduling may flip it before we read, but never to
+        # "ready" without the device having replied.
+        assert body.get("status") == "pending", (
+            f"expected status=pending for offline device, got: {body!r}"
+        )
+        request_id = body["request_id"]
+
+        row = page.request.get(f"/api/logs/requests/{request_id}").json()
+        assert row.get("status") in ("pending", "sent"), (
+            f"offline device log-request reached unexpected status: {row!r}"
+        )
+        assert row.get("status") != "ready"
     finally:
         # Make sure the device reconnects before downstream tests run.
         _wait_for_online(page, device_id, True, timeout=ONLINE_DETECT_TIMEOUT_S)

--- a/tests/test_device_logs.py
+++ b/tests/test_device_logs.py
@@ -1,181 +1,35 @@
-"""Tests for device log collection feature."""
+"""Tests for device log collection feature (post-PR-#345).
 
-import asyncio
-import json
+The synchronous ``POST /api/devices/{id}/logs`` RPC was retired for
+multi-replica safety.  These tests now cover:
+
+* the legacy endpoint is gone (404),
+* the in-process log buffer that powers ``GET /api/cms/logs``,
+* the over-the-wire ``RequestLogsMessage`` / ``LogsResponseMessage``
+  schemas that firmware still speaks.
+
+The new async flow (``POST /api/logs/requests`` + outbox + blob) has
+its own coverage in ``tests/test_log_requests_api.py``,
+``tests/test_log_drainer.py``, and ``tests/nightly/test_12_logs_roundtrip.py``.
+"""
 
 import pytest
-import pytest_asyncio
-
-from cms.models.device import Device, DeviceStatus
-from cms.services.device_manager import DeviceManager
 
 
-# ── DeviceManager log request/response tests ──
+# ── Legacy endpoint removal ──
 
 
-class FakeWS:
-    """Fake WebSocket that records sent messages."""
-
-    def __init__(self):
-        self.sent = []
-
-    async def send_json(self, data: dict):
-        self.sent.append(data)
-
-
-class TestDeviceManagerLogRequests:
+class TestRetiredEndpoint:
     @pytest.mark.asyncio
-    async def test_request_logs_sends_message(self):
-        dm = DeviceManager()
-        ws = FakeWS()
-        dm.register("dev-1", ws)
-
-        # Start the request but don't await it — we need to resolve it
-        task = asyncio.create_task(dm.request_logs("dev-1", since="1h", timeout=2.0))
-
-        # Give the task a chance to send the message
-        await asyncio.sleep(0.05)
-
-        # A request_logs message should have been sent
-        assert len(ws.sent) == 1
-        msg = ws.sent[0]
-        assert msg["type"] == "request_logs"
-        assert msg["since"] == "1h"
-        assert "request_id" in msg
-
-        # Resolve with fake logs
-        dm.resolve_log_request(msg["request_id"], {"agora-player": "some logs"})
-        result = await task
-        assert result == {"agora-player": "some logs"}
-
-    @pytest.mark.asyncio
-    async def test_request_logs_with_service_filter(self):
-        dm = DeviceManager()
-        ws = FakeWS()
-        dm.register("dev-1", ws)
-
-        task = asyncio.create_task(
-            dm.request_logs("dev-1", services=["agora-api"], timeout=2.0)
+    async def test_legacy_endpoint_returns_404(self, client):
+        """``POST /api/devices/{id}/logs`` was retired in PR #345."""
+        resp = await client.post(
+            "/api/devices/any-id/logs", json={"since": "1h"},
         )
-        await asyncio.sleep(0.05)
-
-        msg = ws.sent[0]
-        assert msg["services"] == ["agora-api"]
-
-        dm.resolve_log_request(msg["request_id"], {"agora-api": "api logs"})
-        result = await task
-        assert result == {"agora-api": "api logs"}
-
-    @pytest.mark.asyncio
-    async def test_request_logs_timeout(self):
-        dm = DeviceManager()
-        ws = FakeWS()
-        dm.register("dev-1", ws)
-
-        with pytest.raises(TimeoutError):
-            await dm.request_logs("dev-1", timeout=0.1)
-
-    @pytest.mark.asyncio
-    async def test_request_logs_device_not_connected(self):
-        dm = DeviceManager()
-
-        with pytest.raises(ValueError, match="not connected"):
-            await dm.request_logs("nonexistent", timeout=1.0)
-
-    @pytest.mark.asyncio
-    async def test_resolve_log_request_with_error(self):
-        dm = DeviceManager()
-        ws = FakeWS()
-        dm.register("dev-1", ws)
-
-        task = asyncio.create_task(dm.request_logs("dev-1", timeout=2.0))
-        await asyncio.sleep(0.05)
-
-        msg = ws.sent[0]
-        dm.resolve_log_request(msg["request_id"], {}, error="journalctl not available")
-
-        with pytest.raises(RuntimeError, match="journalctl not available"):
-            await task
-
-    def test_resolve_unknown_request_id(self):
-        dm = DeviceManager()
-        # Should not raise
-        dm.resolve_log_request("nonexistent-id", {"svc": "data"})
-
-
-# ── REST API tests ──
-
-
-@pytest_asyncio.fixture
-async def device_in_db(db_session):
-    """Create a test device in the database."""
-    device = Device(
-        id="log-test-device",
-        name="Log Test Device",
-        status=DeviceStatus.ADOPTED,
-        firmware_version="1.0.0",
-        storage_capacity_mb=1000,
-        storage_used_mb=100,
-    )
-    db_session.add(device)
-    await db_session.commit()
-    return device
-
-
-class TestDeviceLogsAPI:
-    @pytest.mark.asyncio
-    async def test_request_logs_device_not_found(self, client):
-        resp = await client.post("/api/devices/nonexistent/logs")
         assert resp.status_code == 404
 
-    @pytest.mark.asyncio
-    async def test_request_logs_device_offline(self, client, device_in_db):
-        resp = await client.post(
-            "/api/devices/log-test-device/logs",
-            json={"since": "1h"},
-        )
-        assert resp.status_code == 409
-        assert "not connected" in resp.json()["detail"]
 
-    @pytest.mark.asyncio
-    @pytest.mark.timeout(60)
-    async def test_request_logs_success(self, client, device_in_db):
-        from cms.services.device_manager import device_manager
-
-        ws = FakeWS()
-        device_manager.register("log-test-device", ws)
-
-        async def fake_resolve():
-            """Simulate the device responding with logs."""
-            # Wait for the WS message to arrive (PostgreSQL DB queries
-            # may take longer than SQLite, so a fixed sleep is racy).
-            for _ in range(200):
-                if ws.sent:
-                    break
-                await asyncio.sleep(0.05)
-            msg = ws.sent[-1]
-            device_manager.resolve_log_request(
-                msg["request_id"],
-                {"agora-player": "player log output", "agora-api": "api log output"},
-            )
-
-        try:
-            task = asyncio.create_task(fake_resolve())
-            resp = await client.post(
-                "/api/devices/log-test-device/logs",
-                json={"since": "1h"},
-            )
-            await task
-            assert resp.status_code == 200
-            data = resp.json()
-            assert data["device_id"] == "log-test-device"
-            assert "agora-player" in data["logs"]
-            assert "agora-api" in data["logs"]
-        finally:
-            device_manager.disconnect("log-test-device")
-
-
-# ── CMS-only log endpoint (new async UI flow) ──
+# ── CMS-only log endpoint (unchanged, retains coverage here) ──
 
 
 class TestCmsLogsEndpoint:

--- a/tests/test_device_transport_contract.py
+++ b/tests/test_device_transport_contract.py
@@ -38,8 +38,11 @@ class TestLocalDeviceTransportContract:
     # async and DB-backed.  ``update_status`` was removed from
     # ``DeviceManager`` (moved to ``device_presence.update_status``).
     #
+    # PR #345 retired the synchronous ``request_logs`` RPC on the
+    # transport interface; the async ``dispatch_request_logs`` flow is
+    # covered by ``tests/test_log_requests_api.py`` + ``tests/test_log_drainer.py``.
     # The unit-testable transport surface that doesn't need a session
-    # factory is send_to_device and request_logs — those remain below.
+    # factory is just ``send_to_device``.
 
     @pytest.mark.asyncio
     async def test_send_to_device_success(self):
@@ -49,35 +52,6 @@ class TestLocalDeviceTransportContract:
         ok = await t.send_to_device("d1", {"type": "ping"})
         assert ok is True
         assert ws.sent == [{"type": "ping"}]
-
-    @pytest.mark.asyncio
-    async def test_request_logs_resolves_via_manager_hook(self):
-        t, dm = _fresh_local()
-
-        captured: list[dict] = []
-
-        class CaptureWS:
-            async def send_json(self, data):
-                captured.append(data)
-
-        dm.register("d1", CaptureWS())
-
-        # Fire request_logs; capture the request_id from the WS message and
-        # resolve it synchronously from the "device".
-        import asyncio
-        task = asyncio.create_task(t.request_logs("d1", services=["agora"]))
-        await asyncio.sleep(0)
-        # Spin briefly until the message hits CaptureWS.
-        for _ in range(100):
-            if captured:
-                break
-            await asyncio.sleep(0.01)
-        assert captured, "request_logs never dispatched"
-        rid = captured[0]["request_id"]
-
-        dm.resolve_log_request(rid, logs={"agora": "hello"})
-        result = await asyncio.wait_for(task, timeout=1.0)
-        assert result == {"agora": "hello"}
 
     def test_transport_is_an_abc(self):
         # Cannot instantiate the abstract base

--- a/tests/test_log_drainer.py
+++ b/tests/test_log_drainer.py
@@ -101,9 +101,6 @@ class FakeTransport:
     async def get_all_states(self):  # pragma: no cover
         raise NotImplementedError
 
-    async def request_logs(self, *a, **kw):  # pragma: no cover
-        raise NotImplementedError
-
     async def set_state_flags(self, *a, **kw):  # pragma: no cover
         raise NotImplementedError
 

--- a/tests/test_log_requests_api.py
+++ b/tests/test_log_requests_api.py
@@ -73,9 +73,6 @@ class FakeTransport:
     async def get_all_states(self):
         return []
 
-    async def request_logs(self, device_id, services=None, since="24h", timeout=30.0):
-        raise NotImplementedError
-
     async def set_state_flags(self, device_id, **flags):
         pass
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1866,11 +1866,13 @@ class TestDeviceActionIDOR:
             await ac.aclose()
 
     async def test_logs_blocked_cross_group(self, app, db_session):
-        """POST /api/devices/{id}/logs should return 403 for device in another group."""
+        """POST /api/logs/requests should return 403 for device in another group."""
         dev_id, email = await self._setup_cross_group_device(db_session)
         ac = await _login_as(app, email)
         try:
-            resp = await ac.post(f"/api/devices/{dev_id}/logs")
+            resp = await ac.post(
+                "/api/logs/requests", json={"device_id": dev_id},
+            )
             assert resp.status_code == 403
         finally:
             await ac.aclose()

--- a/tests/test_rbac_matrix.py
+++ b/tests/test_rbac_matrix.py
@@ -57,7 +57,8 @@ ENDPOINTS: list[EP] = [
     # ── Devices ──
     EP("GET", "/api/devices", (ADMIN, OPERATOR, VIEWER)),
     EP("GET", f"/api/devices/{_FAKE_ID}", (ADMIN, OPERATOR, VIEWER)),
-    EP("POST", f"/api/devices/{_FAKE_ID}/logs", (ADMIN, OPERATOR, VIEWER)),
+    EP("POST", "/api/logs/requests", (ADMIN, OPERATOR, VIEWER),
+       json_body={"device_id": _FAKE_ID}),
     EP("PATCH", f"/api/devices/{_FAKE_ID}", (ADMIN, OPERATOR), json_body={}),
     EP("POST", "/api/devices/check-updates", (ADMIN,)),
     EP("POST", f"/api/devices/{_FAKE_ID}/password", (ADMIN,), json_body={}),

--- a/tests/test_wps_transport.py
+++ b/tests/test_wps_transport.py
@@ -46,7 +46,6 @@ def _make_transport(manager: DeviceManager | None = None):
         t = WPSTransport(
             "Endpoint=http://broker:7080;AccessKey=k;Version=1.0;",
             hub="agora",
-            device_manager=manager,
         )
     return t, fake_client, manager
 
@@ -115,17 +114,6 @@ class TestClientAccessToken:
         _, kwargs = c.get_client_access_token.call_args
         assert kwargs["user_id"] == "pi-1"
         assert kwargs["minutes_to_expire"] == 30
-
-
-@pytest.mark.asyncio
-class TestRequestLogs:
-    # Stage 2c: ``request_logs`` now checks connectivity via async
-    # ``is_connected`` which hits the DB.  These unit tests bypassed the
-    # app fixture and relied on the now-removed in-memory
-    # ``register_remote`` path.  The contract is exercised through the
-    # Local transport's ``test_request_logs_resolves_via_manager_hook``
-    # in ``test_device_transport_contract.py`` (which uses a fresh DB).
-    pass
 
 
 @pytest.mark.asyncio

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -74,7 +74,6 @@ async def app_and_session(monkeypatch):
     # Fresh DeviceManager for every test — isolation across webhook events.
     from cms.services import device_manager as dm_module
     dm_module.device_manager._connections.clear()
-    dm_module.device_manager._pending_log_requests.clear()
 
     # Stub Settings that satisfies the receiver's needs.
     class _S:


### PR DESCRIPTION
## Problem

The legacy `POST /api/devices/{id}/logs` endpoint holds an in-memory
`asyncio.Future` in a module-level `_pending_log_requests` dict
(`DeviceManager`). Under N>1 replicas, a log request accepted on
replica A waits for a WS response that arrives on replica B — the
future on A never resolves and the caller times out. This is a hard
blocker for the multi-replica rollout.

We already shipped the replacement flow (`/api/logs/requests` +
transactional outbox + blob storage) and the new UI on the device
settings page has been using it exclusively for weeks. The legacy
endpoint is now dead code that only exists to trap us at N=2.

## Change

* Delete `POST /api/devices/{id}/logs` and its Pydantic schema.
* Drop `_pending_log_requests`, `request_logs`, `resolve_log_request`
  from `DeviceManager`.
* Drop `request_logs` from the abstract `DeviceTransport`,
  `LocalDeviceTransport`, and `WPSTransport`. `WPSTransport.__init__`
  no longer takes `device_manager` (it was only used for that dict).
* `device_inbound.py` still handles `logs_response` messages (Pi
  uploads inline payload → tar.gz → flips outbox row to `ready`). This
  is now the **primary** path, not a back-compat shim — relabelled the
  comment accordingly.
* **MCP tool**: rewired `mcp/cms_client.request_device_logs` to the
  new async flow — POST create, poll `GET /api/logs/requests/{id}`
  up to ~60s, download + extract tar.gz, return `{service: log_text}`
  (same shape as before). Timeout / failure returns structured dict
  with `request_id` so callers can retry.
* **Nightly e2e** (`test_12_logs_roundtrip.py`) fully rewritten for
  the new async flow: 3 scenarios (delivery+poll, unknown → 404,
  offline → 202 pending, not 409).
* All unit-test fallout fixed. New `TestRetiredEndpoint` asserts the
  old endpoint returns 404.

## Validation plan

* Focused unit test suite: `test_device_logs`,
  `test_device_transport_contract`, `test_wps_transport`,
  `test_wps_webhook`, `test_log_drainer`, `test_log_requests_api`,
  `test_rbac_matrix` — all green locally.
* CI runs the full suite.
* Post-deploy prod validation: curl the deleted endpoint → expect 404;
  curl new endpoint → 202 with request_id; grep new revision logs for
  zero `_pending_log_requests` / `request_logs(` references.

Part of the N>1 replica hardening campaign (#344).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
