### PR TITLE
Persist scheduler MISSED state to DB (N>1 failover safety)

### DIFF
--- a/alembic/versions/0009_schedule_missed_events.py
+++ b/alembic/versions/0009_schedule_missed_events.py
@@ -1,0 +1,63 @@
+"""schedule_missed_events table (N>1 failover dedup for MISSED alerts)
+
+Issue #344 multi-replica audit — MEDIUM severity.
+
+Persists the scheduler's MISSED-event dedup + grace-clock state that
+was previously held in ``cms.services.scheduler._missed_logged`` and
+``_offline_since`` module-level dicts.  The scheduler loop is leader-
+gated, so under normal operation only one replica writes these rows,
+but on leader failover (deploy rollover / pod crash) the new leader
+would otherwise start with empty memory — (a) restarting the grace
+clock from zero, delaying MISSED emission, and (b) re-emitting MISSED
+for schedule+device combos the prior leader already alerted on.
+
+No foreign keys: stale rows are cleaned up by the scheduler's own
+pruning pass, and we deliberately avoid FKs so a concurrent delete of
+a schedule or device can't trigger the session-wide rollback hazard
+that ``_log_event`` has on FK violations.
+
+Revision ID: 0009
+Revises: 0008
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind is not None else "sqlite"
+    if dialect == "postgresql":
+        schedule_id_col = sa.Column(
+            "schedule_id", UUID(as_uuid=True), primary_key=True, nullable=False,
+        )
+    else:
+        # SQLite (unit tests): use CHAR(36) for UUIDs.
+        schedule_id_col = sa.Column(
+            "schedule_id", sa.String(36), primary_key=True, nullable=False,
+        )
+
+    op.create_table(
+        "schedule_missed_events",
+        schedule_id_col,
+        sa.Column("device_id", sa.String(length=64), primary_key=True, nullable=False),
+        sa.Column("occurrence_date", sa.Date(), primary_key=True, nullable=False),
+        sa.Column(
+            "first_seen_offline_at", sa.DateTime(timezone=True), nullable=False,
+        ),
+        sa.Column("emitted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade is not supported for this migration.")

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -15,6 +15,7 @@ from cms.models.notification_pref import UserNotificationPref  # noqa: F401
 from cms.models.schedule import Schedule  # noqa: F401
 from cms.models.schedule_device_skip import ScheduleDeviceSkip  # noqa: F401
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent  # noqa: F401
+from cms.models.schedule_missed_event import ScheduleMissedEvent  # noqa: F401
 from cms.models.setting import CMSSetting  # noqa: F401
 from cms.models.user import Role, User, UserGroup  # noqa: F401
 

--- a/cms/models/schedule_missed_event.py
+++ b/cms/models/schedule_missed_event.py
@@ -1,0 +1,60 @@
+"""Scheduler MISSED-event dedup ORM model.
+
+Persists the dedup + grace-clock state for scheduler MISSED alerts
+that was previously held in the module-level ``_missed_logged`` and
+``_offline_since`` dicts in ``cms.services.scheduler``.
+
+Under N>1 replicas the scheduler loop is leader-gated, so only one
+replica at a time writes these rows under normal operation.  The
+table's value is realised on **leader failover** (deploy rollover,
+pod crash): without it, the new leader starts with empty memory and
+would (a) restart the grace clock from zero, delaying MISSED
+emission, and (b) re-emit MISSED for a schedule+device combo the
+prior leader already alerted on.
+
+Schema choices:
+  * PK ``(schedule_id, device_id, occurrence_date)`` — dedup key is
+    per calendar day in the server's local timezone.  Overnight
+    schedules therefore get "max one MISSED per local day", which is
+    acceptable semantics for this alert type.
+  * ``first_seen_offline_at`` preserves the current grace-clock
+    semantics (clock starts when the scheduler first observes
+    ``active schedule × offline device``, *not* when the device
+    disconnected).
+  * ``emitted_at`` is NULL until the CAS UPDATE claims the emission;
+    non-NULL thereafter.  Serves as the dedup flag across replicas.
+  * No foreign keys — we clean up stale rows via the scheduler's own
+    pruning pass, and avoiding FKs removes the transaction-rollback
+    hazard that ``_log_event`` has on FK violations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cms.database import Base
+
+
+class ScheduleMissedEvent(Base):
+    __tablename__ = "schedule_missed_events"
+
+    schedule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True,
+    )
+    device_id: Mapped[str] = mapped_column(
+        String(64), primary_key=True,
+    )
+    occurrence_date: Mapped[date] = mapped_column(
+        Date(), primary_key=True,
+    )
+    first_seen_offline_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    emitted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import logging
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -16,6 +17,7 @@ from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.schedule import Schedule
 from cms.models.schedule_device_skip import ScheduleDeviceSkip
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
+from cms.models.schedule_missed_event import ScheduleMissedEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import ScheduleEntry, SyncMessage
 from cms.services.transport import get_transport
@@ -144,17 +146,52 @@ async def load_skip_snapshot(db) -> SkipSnapshot:
     return SkipSnapshot(schedule_wide=sw, per_device=pd)
 
 
-# Track which schedule+device combos we've already logged as MISSED this eval cycle
-# Key: (schedule_id, device_id), cleared when the schedule/device combo resolves
-_missed_logged: set[tuple[str, str]] = set()
+# ── MISSED-event dedup (DB-backed, N>1 failover safe) ───────────────
+#
+# The scheduler's MISSED-alert dedup + grace-clock state used to live
+# in the ``_missed_logged`` and ``_offline_since`` module-level dicts.
+# Those are replica-local and on leader failover (deploy rollover,
+# pod crash) the new leader would start with empty memory, which both
+# (a) restarts the grace clock from zero, delaying MISSED emission, and
+# (b) re-emits MISSED for schedule+device combos the prior leader
+# already alerted on.  State now lives in ``schedule_missed_events``
+# keyed by (schedule_id, device_id, occurrence_date).
 
-# Track when a (schedule_id, device_id) combo was first seen offline
-# Only log MISSED after MISSED_GRACE_SECONDS of continuous offline
-_offline_since: dict[tuple[str, str], datetime] = {}
+def _insert_missed_event_stmt(schedule_id, device_id, occurrence_date, first_seen):
+    """Return a dialect-aware ``INSERT ... ON CONFLICT DO NOTHING`` stmt.
+
+    Ensures the first observation of ``(schedule, device, date)`` seeds
+    ``first_seen_offline_at`` without clobbering an existing grace-clock
+    entry written by a prior replica or tick.
+    """
+    from cms.database import get_engine
+    engine = get_engine()
+    dialect = engine.dialect.name if engine is not None else "sqlite"
+    if dialect == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+        return pg_insert(ScheduleMissedEvent).values(
+            schedule_id=schedule_id,
+            device_id=device_id,
+            occurrence_date=occurrence_date,
+            first_seen_offline_at=first_seen,
+        ).on_conflict_do_nothing(
+            index_elements=["schedule_id", "device_id", "occurrence_date"],
+        )
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+    return sqlite_insert(ScheduleMissedEvent).values(
+        schedule_id=schedule_id,
+        device_id=device_id,
+        occurrence_date=occurrence_date,
+        first_seen_offline_at=first_seen,
+    ).on_conflict_do_nothing(
+        index_elements=["schedule_id", "device_id", "occurrence_date"],
+    )
+
 
 EVAL_INTERVAL_SECONDS = 15
 MISSED_GRACE_SECONDS = 60
 SCHEDULE_WINDOW_DAYS = 30
+MISSED_RETENTION_DAYS = 7  # prune dedup rows older than this each tick
 
 
 async def _log_event(db, event: ScheduleLogEvent, schedule_name: str, device_name: str,
@@ -947,10 +984,13 @@ async def push_sync_to_affected_devices(schedule: Schedule, db) -> None:
 
 
 async def evaluate_schedules() -> None:
-    """Single evaluation pass: sync schedules to devices and detect MISSED playback."""
-    if not await get_transport().connected_count():
-        return
+    """Single evaluation pass: sync schedules to devices and detect MISSED playback.
 
+    Runs on every tick regardless of connected-device count — the MISSED
+    block specifically needs to fire when devices are offline, which is
+    when ``connected_count() == 0`` is most likely.  The sync-push loop
+    below no-ops when ``connected`` is empty.
+    """
     sf = _get_session_factory()
     if sf is None:
         return
@@ -1022,58 +1062,207 @@ async def evaluate_schedules() -> None:
             if _matches_now(s, local_now) and not skips.is_schedule_skipped(str(s.id))
         ]
 
-        # Detect MISSED schedules: active schedules targeting offline adopted devices
-        # Only log MISSED after MISSED_GRACE_SECONDS of continuous offline
+        # ── Detect MISSED schedules (DB-backed dedup + grace clock) ──
+        #
+        # For each (active schedule × offline adopted device) pair:
+        #   1. Upsert a ``schedule_missed_events`` row keyed by
+        #      (schedule_id, device_id, occurrence_date).  ON CONFLICT
+        #      DO NOTHING preserves the original ``first_seen_offline_at``
+        #      so the grace clock survives leader failover and sampling
+        #      skew between replicas.
+        #   2. Once elapsed >= grace, atomically claim emission via
+        #      ``UPDATE ... WHERE emitted_at IS NULL RETURNING`` — only
+        #      one replica can win for a given (schedule, device, date).
+        #   3. Commit the claim *before* writing the ScheduleLog entry,
+        #      so a downstream ``_log_event`` rollback (FK fallback on
+        #      deleted schedule/device) cannot resurrect the claim and
+        #      cause a duplicate MISSED emission on the next tick.
         all_adopted_q = await db.execute(
             select(Device.id, Device.name).where(Device.status == DeviceStatus.ADOPTED)
         )
         all_adopted = {r[0]: (r[1] or r[0]) for r in all_adopted_q.all()}
 
         utc_now = datetime.now(timezone.utc)
+        occurrence_date = local_now.date()
+
+        # (active_offline_keys) drives both emission and cleanup below.
+        # ``active_offline_context`` preserves the schedule/device names
+        # and asset filename we need for the MISSED log entry.
+        active_offline_keys: set[tuple[str, str]] = set()
+        active_offline_context: dict[tuple[str, str], dict] = {}
 
         for s in active:
             if not s.asset:
                 continue
             target_ids = await _get_target_device_ids(s, db)
             for did in target_ids:
-                key = (str(s.id), did)
                 # Don't flag MISSED for a device whose skip is active.
                 if skips.is_skipped_for_device(str(s.id), did):
-                    _offline_since.pop(key, None)
                     continue
                 if did in connected or did not in all_adopted:
-                    # Device is online or not adopted — clear offline tracking
-                    _offline_since.pop(key, None)
+                    # Device is online or not adopted.
                     continue
-                # Device is offline and adopted
-                if key not in _offline_since:
-                    _offline_since[key] = utc_now
-                elapsed = (utc_now - _offline_since[key]).total_seconds()
-                if elapsed >= MISSED_GRACE_SECONDS and key not in _missed_logged:
-                    _missed_logged.add(key)
-                    await _log_event(
-                        db, ScheduleLogEvent.MISSED,
-                        schedule_name=s.name,
-                        device_name=all_adopted.get(did, did),
-                        asset_filename=_asset_display_name(s.asset),
-                        schedule_id=s.id, device_id=did,
-                        details=f"Device offline for {int(elapsed)}s",
-                    )
+                key = (str(s.id), did)
+                active_offline_keys.add(key)
+                active_offline_context[key] = {
+                    "schedule_id": s.id,
+                    "_device_id": did,
+                    "schedule_name": s.name,
+                    "device_name": all_adopted.get(did, did),
+                    "asset_filename": _asset_display_name(s.asset),
+                }
 
-        # Clear missed/offline tracking for combos that are no longer active
-        active_keys = set()
-        for s in active:
-            if not s.asset:
+        # Step 1: seed the dedup row (no-op if already present).
+        for (_sid_str, did), ctx in active_offline_context.items():
+            await db.execute(
+                _insert_missed_event_stmt(
+                    ctx["schedule_id"], did, occurrence_date, utc_now,
+                )
+            )
+        if active_offline_context:
+            await db.commit()
+
+        # Step 2: for each active×offline pair whose grace window has
+        # elapsed, claim emission + write the MISSED log atomically in a
+        # single outer transaction.  The ScheduleLog INSERT runs inside a
+        # SAVEPOINT so a FK violation (schedule/device deleted mid-tick)
+        # can be retried with null FKs without discarding the CAS claim.
+        # If the savepoint AND its fallback both fail, we revert the CAS
+        # claim (set ``emitted_at`` back to NULL) so the next tick retries
+        # rather than silently dropping the MISSED.
+        from sqlalchemy.exc import IntegrityError
+
+        grace_cutoff = utc_now - timedelta(seconds=MISSED_GRACE_SECONDS)
+        for (_sid_str, did), ctx in active_offline_context.items():
+            # CAS claim.
+            claim_result = await db.execute(
+                ScheduleMissedEvent.__table__.update()
+                .where(
+                    (ScheduleMissedEvent.schedule_id == ctx["schedule_id"])
+                    & (ScheduleMissedEvent.device_id == did)
+                    & (ScheduleMissedEvent.occurrence_date == occurrence_date)
+                    & (ScheduleMissedEvent.emitted_at.is_(None))
+                    & (ScheduleMissedEvent.first_seen_offline_at <= grace_cutoff)
+                )
+                .values(emitted_at=utc_now)
+                .returning(ScheduleMissedEvent.first_seen_offline_at)
+            )
+            row = claim_result.first()
+            if row is None:
                 continue
-            target_ids = await _get_target_device_ids(s, db)
-            for did in target_ids:
-                if did not in connected and did in all_adopted:
-                    active_keys.add((str(s.id), did))
-        _missed_logged.difference_update(_missed_logged - active_keys)
-        # Clear offline_since for combos no longer relevant
-        stale_offline = [k for k in _offline_since if k not in active_keys]
-        for k in stale_offline:
-            del _offline_since[k]
+
+            first_seen = row[0]
+            # SQLite strips timezone — coerce naive timestamps to UTC.
+            if first_seen.tzinfo is None:
+                first_seen = first_seen.replace(tzinfo=timezone.utc)
+            elapsed = int((utc_now - first_seen).total_seconds())
+
+            # Write ScheduleLog inside a nested SAVEPOINT so a FK failure
+            # (schedule or device deleted mid-tick) can be caught and
+            # retried without rolling back the CAS claim above.  Catch
+            # ANY exception — high-temperature / missed-schedule alerts
+            # must never be silently dropped.
+            log_written = False
+            _sched_id = ctx["schedule_id"] if isinstance(ctx["schedule_id"], uuid.UUID) else None
+            if not isinstance(ctx["schedule_id"], uuid.UUID):
+                try:
+                    _sched_id = uuid.UUID(str(ctx["schedule_id"]))
+                except (ValueError, TypeError):
+                    _sched_id = None
+            try:
+                async with db.begin_nested():
+                    db.add(ScheduleLog(
+                        schedule_id=_sched_id,
+                        schedule_name=ctx["schedule_name"],
+                        device_id=did,
+                        device_name=ctx["device_name"],
+                        asset_filename=ctx["asset_filename"],
+                        event=ScheduleLogEvent.MISSED,
+                        details=f"Device offline for {elapsed}s",
+                    ))
+                log_written = True
+            except IntegrityError:
+                logger.warning(
+                    "ScheduleLog FK violation for MISSED "
+                    "(schedule=%s device=%s) — retrying without FKs",
+                    _sched_id, did,
+                )
+                try:
+                    async with db.begin_nested():
+                        db.add(ScheduleLog(
+                            schedule_id=None,
+                            schedule_name=ctx["schedule_name"],
+                            device_id=None,
+                            device_name=ctx["device_name"],
+                            asset_filename=ctx["asset_filename"],
+                            event=ScheduleLogEvent.MISSED,
+                            details=f"Device offline for {elapsed}s",
+                        ))
+                    log_written = True
+                except Exception:
+                    logger.exception(
+                        "ScheduleLog null-FK retry failed for MISSED "
+                        "(schedule=%s device=%s)",
+                        _sched_id, did,
+                    )
+            except Exception:
+                logger.exception(
+                    "ScheduleLog insert failed for MISSED "
+                    "(schedule=%s device=%s) — claim will be reverted "
+                    "so next tick retries",
+                    _sched_id, did,
+                )
+
+            if not log_written:
+                # Revert the CAS claim so the next tick retries rather
+                # than silently dropping the MISSED alert.
+                await db.execute(
+                    ScheduleMissedEvent.__table__.update()
+                    .where(
+                        (ScheduleMissedEvent.schedule_id == ctx["schedule_id"])
+                        & (ScheduleMissedEvent.device_id == did)
+                        & (ScheduleMissedEvent.occurrence_date == occurrence_date)
+                        & (ScheduleMissedEvent.emitted_at == utc_now)
+                    )
+                    .values(emitted_at=None)
+                )
+
+        # Commit the claim + log (or revert) as a single atomic unit per
+        # tick.  If this commit itself fails the whole batch rolls back
+        # and the next tick will retry every claim it attempted here.
+        await db.commit()
+
+        # Cleanup: drop dedup rows whose (schedule, device) combo is no
+        # longer in the active-offline set for today (device reconnected
+        # or schedule deactivated) so a subsequent offline stretch gets
+        # a fresh grace clock.  Also prune rows older than the retention
+        # window so the table doesn't grow unbounded.
+        stale_today_q = await db.execute(
+            select(
+                ScheduleMissedEvent.schedule_id, ScheduleMissedEvent.device_id,
+            ).where(ScheduleMissedEvent.occurrence_date == occurrence_date)
+        )
+        stale_today = [
+            (sid, did) for sid, did in stale_today_q.all()
+            if (str(sid), did) not in active_offline_keys
+        ]
+        for sid, did in stale_today:
+            await db.execute(
+                ScheduleMissedEvent.__table__.delete().where(
+                    (ScheduleMissedEvent.schedule_id == sid)
+                    & (ScheduleMissedEvent.device_id == did)
+                    & (ScheduleMissedEvent.occurrence_date == occurrence_date)
+                )
+            )
+        retention_cutoff = occurrence_date - timedelta(days=MISSED_RETENTION_DAYS)
+        await db.execute(
+            ScheduleMissedEvent.__table__.delete().where(
+                ScheduleMissedEvent.occurrence_date < retention_cutoff
+            )
+        )
+        # Always commit here so cleanup is visible to the next tick even
+        # when there were no emission claims above.
+        await db.commit()
 
         # Clean up _confirmed_playing for devices that disconnected
         stale = [did for did in list(_confirmed_playing) if did not in connected]

--- a/tests/test_scheduler_advanced.py
+++ b/tests/test_scheduler_advanced.py
@@ -12,13 +12,12 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 from cms.models.asset import Asset, AssetType
 from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.schedule import Schedule
+from cms.models.schedule_missed_event import ScheduleMissedEvent
 from cms.models.setting import CMSSetting
 from cms.services.scheduler import (
     _matches_now,
     _now_playing,
     _last_sync_hash,
-    _offline_since,
-    _missed_logged,
     MISSED_GRACE_SECONDS,
     build_device_sync,
     clear_sync_hash,
@@ -1066,13 +1065,9 @@ class TestMissedGracePeriod:
 
     def setup_method(self):
         _now_playing.clear()
-        _missed_logged.clear()
-        _offline_since.clear()
 
     def teardown_method(self):
         _now_playing.clear()
-        _missed_logged.clear()
-        _offline_since.clear()
 
     async def test_missed_not_logged_before_grace_period(self, app, db_session):
         """MISSED should NOT be logged immediately when device goes offline."""
@@ -1121,10 +1116,18 @@ class TestMissedGracePeriod:
             assert len(missed_logs) == 0, \
                 "MISSED should NOT be logged before grace period expires"
 
-            # Verify offline tracking started
-            key = (str(sched.id), "grace-dev-01")
-            assert key in _offline_since, \
-                "_offline_since should track when device first seen offline"
+            # Verify offline tracking started in the DB (dedup row seeded)
+            tracker = await db_session.execute(
+                sa_select(ScheduleMissedEvent).where(
+                    ScheduleMissedEvent.schedule_id == sched.id,
+                    ScheduleMissedEvent.device_id == "grace-dev-01",
+                )
+            )
+            rows = tracker.scalars().all()
+            assert len(rows) == 1, \
+                "schedule_missed_events row should seed grace clock"
+            assert rows[0].emitted_at is None, \
+                "emitted_at must stay NULL before grace expires"
         finally:
             device_manager.disconnect("grace-dummy")
 
@@ -1163,11 +1166,17 @@ class TestMissedGracePeriod:
         device_manager.register("grace-dummy-2", FakeWS())
 
         try:
-            # Pre-seed _offline_since to simulate device offline > grace period
-            key = (str(sched.id), "grace-dev-02")
-            _offline_since[key] = datetime.now(timezone.utc) - timedelta(
-                seconds=MISSED_GRACE_SECONDS + 10
-            )
+            # Pre-seed dedup row with first_seen > grace period ago so the
+            # next tick's CAS claim fires immediately.
+            now = datetime.now(timezone.utc)
+            db_session.add(ScheduleMissedEvent(
+                schedule_id=sched.id,
+                device_id="grace-dev-02",
+                occurrence_date=now.date(),
+                first_seen_offline_at=now - timedelta(seconds=MISSED_GRACE_SECONDS + 10),
+                emitted_at=None,
+            ))
+            await db_session.commit()
 
             await evaluate_schedules()
 
@@ -1178,11 +1187,23 @@ class TestMissedGracePeriod:
             assert len(missed_logs) == 1, \
                 "MISSED should be logged after grace period expires"
             assert missed_logs[0].device_name == "Grace Device 2"
+
+            # Verify the dedup row was claimed (emitted_at set).
+            tracker = await db_session.execute(
+                sa_select(ScheduleMissedEvent).where(
+                    ScheduleMissedEvent.schedule_id == sched.id,
+                    ScheduleMissedEvent.device_id == "grace-dev-02",
+                )
+            )
+            row = tracker.scalars().one()
+            assert row.emitted_at is not None, \
+                "CAS claim should set emitted_at"
         finally:
             device_manager.disconnect("grace-dummy-2")
 
     async def test_missed_cleared_when_device_reconnects(self, app, db_session):
-        """When device reconnects, offline tracking should be cleared."""
+        """When device reconnects, dedup row should be removed so a later
+        offline stretch gets a fresh grace clock."""
         from cms.services.device_manager import device_manager
 
         setting = CMSSetting(key="timezone", value="UTC")
@@ -1207,9 +1228,16 @@ class TestMissedGracePeriod:
         db_session.add(sched)
         await db_session.commit()
 
-        key = (str(sched.id), "grace-dev-03")
-        # Pre-seed offline tracking
-        _offline_since[key] = datetime.now(timezone.utc) - timedelta(seconds=30)
+        # Pre-seed offline tracking in the DB (not module dict)
+        now = datetime.now(timezone.utc)
+        db_session.add(ScheduleMissedEvent(
+            schedule_id=sched.id,
+            device_id="grace-dev-03",
+            occurrence_date=now.date(),
+            first_seen_offline_at=now - timedelta(seconds=30),
+            emitted_at=None,
+        ))
+        await db_session.commit()
 
         # Connect the device
         class FakeWS:
@@ -1219,8 +1247,249 @@ class TestMissedGracePeriod:
 
         try:
             await evaluate_schedules()
-            # Offline tracking should be cleared since device is now connected
-            assert key not in _offline_since, \
-                "_offline_since should be cleared when device reconnects"
+            # Dedup row should be cleaned up because the device is back online.
+            from sqlalchemy import select as sa_select
+            tracker = await db_session.execute(
+                sa_select(ScheduleMissedEvent).where(
+                    ScheduleMissedEvent.schedule_id == sched.id,
+                    ScheduleMissedEvent.device_id == "grace-dev-03",
+                )
+            )
+            assert tracker.scalars().first() is None, \
+                "Dedup row should be cleared when device reconnects"
         finally:
             device_manager.disconnect("grace-dev-03")
+
+    async def test_missed_dedup_survives_failover(self, app, db_session):
+        """A second tick after the grace clock has been persisted (simulating
+        leader failover where the new leader has no in-memory state) MUST NOT
+        duplicate the MISSED alert."""
+        from cms.services.device_manager import device_manager
+        from cms.models.schedule_log import ScheduleLog
+        from sqlalchemy import select as sa_select
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(filename="fo.mp4", asset_type=AssetType.VIDEO,
+                      size_bytes=1000, checksum="fo1")
+        group = DeviceGroup(name="Failover Group")
+        device = Device(id="fo-dev-01", name="Failover Device",
+                        status=DeviceStatus.ADOPTED)
+        dummy = Device(id="fo-dummy", name="FO Dummy",
+                       status=DeviceStatus.ADOPTED)
+        db_session.add_all([setting, asset, group, device, dummy])
+        await db_session.flush()
+        device.group_id = group.id
+        sched = Schedule(
+            name="Failover Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        class FakeWS:
+            async def send_json(self, data): pass
+        device_manager.register("fo-dummy", FakeWS())
+
+        try:
+            now = datetime.now(timezone.utc)
+            # Persisted dedup row with grace already elapsed.
+            db_session.add(ScheduleMissedEvent(
+                schedule_id=sched.id,
+                device_id="fo-dev-01",
+                occurrence_date=now.date(),
+                first_seen_offline_at=now - timedelta(seconds=MISSED_GRACE_SECONDS + 5),
+                emitted_at=None,
+            ))
+            await db_session.commit()
+
+            # First tick claims + emits MISSED.
+            await evaluate_schedules()
+            # Second tick (simulating a new leader) must NOT re-emit.
+            await evaluate_schedules()
+
+            result = await db_session.execute(sa_select(ScheduleLog))
+            missed = [l for l in result.scalars().all() if l.event.value == "MISSED"]
+            assert len(missed) == 1, \
+                f"MISSED should fire exactly once across ticks; got {len(missed)}"
+        finally:
+            device_manager.disconnect("fo-dummy")
+
+    async def test_missed_not_duplicated_when_already_emitted(self, app, db_session):
+        """If the dedup row already has ``emitted_at`` set (prior leader
+        already alerted), a new tick MUST NOT re-emit even with grace
+        fully elapsed."""
+        from cms.services.device_manager import device_manager
+        from cms.models.schedule_log import ScheduleLog
+        from sqlalchemy import select as sa_select
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(filename="dup.mp4", asset_type=AssetType.VIDEO,
+                      size_bytes=1000, checksum="dup1")
+        group = DeviceGroup(name="Dup Group")
+        device = Device(id="dup-dev-01", name="Dup Device",
+                        status=DeviceStatus.ADOPTED)
+        dummy = Device(id="dup-dummy", name="Dup Dummy",
+                       status=DeviceStatus.ADOPTED)
+        db_session.add_all([setting, asset, group, device, dummy])
+        await db_session.flush()
+        device.group_id = group.id
+        sched = Schedule(
+            name="Dup Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        class FakeWS:
+            async def send_json(self, data): pass
+        device_manager.register("dup-dummy", FakeWS())
+
+        try:
+            now = datetime.now(timezone.utc)
+            # Pre-emitted dedup row — prior leader already fired MISSED.
+            db_session.add(ScheduleMissedEvent(
+                schedule_id=sched.id,
+                device_id="dup-dev-01",
+                occurrence_date=now.date(),
+                first_seen_offline_at=now - timedelta(seconds=MISSED_GRACE_SECONDS + 60),
+                emitted_at=now - timedelta(seconds=30),
+            ))
+            await db_session.commit()
+
+            await evaluate_schedules()
+
+            result = await db_session.execute(sa_select(ScheduleLog))
+            missed = [l for l in result.scalars().all() if l.event.value == "MISSED"]
+            assert len(missed) == 0, \
+                "MISSED should not re-fire when emitted_at is already set"
+        finally:
+            device_manager.disconnect("dup-dummy")
+
+    async def test_missed_detected_when_no_devices_connected(self, app, db_session):
+        """MISSED detection MUST run even when zero devices are connected —
+        that's precisely the scenario where MISSED alerts matter most."""
+        from cms.models.schedule_log import ScheduleLog
+        from sqlalchemy import select as sa_select
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(filename="none.mp4", asset_type=AssetType.VIDEO,
+                      size_bytes=1000, checksum="none1")
+        group = DeviceGroup(name="None Group")
+        device = Device(id="none-dev-01", name="None Device",
+                        status=DeviceStatus.ADOPTED)
+        db_session.add_all([setting, asset, group, device])
+        await db_session.flush()
+        device.group_id = group.id
+        sched = Schedule(
+            name="None Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        now = datetime.now(timezone.utc)
+        # Pre-seed grace clock so the first tick claims + emits.
+        db_session.add(ScheduleMissedEvent(
+            schedule_id=sched.id,
+            device_id="none-dev-01",
+            occurrence_date=now.date(),
+            first_seen_offline_at=now - timedelta(seconds=MISSED_GRACE_SECONDS + 5),
+            emitted_at=None,
+        ))
+        await db_session.commit()
+
+        # No devices registered via device_manager — connected_count == 0.
+        await evaluate_schedules()
+
+        result = await db_session.execute(sa_select(ScheduleLog))
+        missed = [l for l in result.scalars().all() if l.event.value == "MISSED"]
+        assert len(missed) == 1, \
+            "MISSED must fire when the only adopted device is offline"
+
+    async def test_missed_claim_reverted_if_log_write_fails(self, app, db_session, monkeypatch):
+        """If the ScheduleLog insert fails (both attempts), the CAS claim
+        MUST be reverted so the next tick retries rather than silently
+        dropping the MISSED."""
+        from cms.services.device_manager import device_manager
+        from cms.models.schedule_log import ScheduleLog
+        from sqlalchemy import select as sa_select
+        import cms.services.scheduler as scheduler_mod
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(filename="revert.mp4", asset_type=AssetType.VIDEO,
+                      size_bytes=1000, checksum="revert1")
+        group = DeviceGroup(name="Revert Group")
+        device = Device(id="revert-dev-01", name="Revert Device",
+                        status=DeviceStatus.ADOPTED)
+        dummy = Device(id="revert-dummy", name="Revert Dummy",
+                       status=DeviceStatus.ADOPTED)
+        db_session.add_all([setting, asset, group, device, dummy])
+        await db_session.flush()
+        device.group_id = group.id
+        sched = Schedule(
+            name="Revert Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        class FakeWS:
+            async def send_json(self, data): pass
+        device_manager.register("revert-dummy", FakeWS())
+
+        now = datetime.now(timezone.utc)
+        db_session.add(ScheduleMissedEvent(
+            schedule_id=sched.id,
+            device_id="revert-dev-01",
+            occurrence_date=now.date(),
+            first_seen_offline_at=now - timedelta(seconds=MISSED_GRACE_SECONDS + 5),
+            emitted_at=None,
+        ))
+        await db_session.commit()
+
+        # Monkeypatch ScheduleLog.__init__ so every log insert raises.
+        class _BoomError(Exception):
+            pass
+        orig_init = ScheduleLog.__init__
+        def _bad_init(self, *a, **kw):
+            raise _BoomError("simulated log insert failure")
+        monkeypatch.setattr(ScheduleLog, "__init__", _bad_init)
+
+        try:
+            await evaluate_schedules()
+        finally:
+            monkeypatch.setattr(ScheduleLog, "__init__", orig_init)
+            device_manager.disconnect("revert-dummy")
+
+        # Claim should have been reverted → emitted_at back to NULL, so
+        # next tick retries.
+        tracker = await db_session.execute(
+            sa_select(ScheduleMissedEvent).where(
+                ScheduleMissedEvent.schedule_id == sched.id,
+                ScheduleMissedEvent.device_id == "revert-dev-01",
+            )
+        )
+        row = tracker.scalars().one()
+        assert row.emitted_at is None, \
+            "CAS claim must be reverted when log write fails — " \
+            "otherwise MISSED is silently dropped forever"


### PR DESCRIPTION
## Summary

Move scheduler MISSED-alert dedup + grace-clock state from process-local
dicts (`_missed_logged`, `_offline_since`) to a DB-backed
`schedule_missed_events` table so **leader failover cannot cause
duplicate MISSED alerts or restarted grace clocks**.

This is one of the final multi-replica safety fixes (#344). Under N>1
the scheduler loop is already leader-gated (PR #403), so failover is
the concrete failure mode: the new leader would start blank → every
device in grace would reset its timer, and every already-emitted MISSED
could fire again.

MISSED alerts are operator-critical (same principle as the temp-alert
work): they must never be silently dropped or duplicated.

## Changes

- **New table** `schedule_missed_events` — PK `(schedule_id,
  device_id, occurrence_date)`, columns `first_seen_offline_at`,
  `emitted_at`. **No FKs** — avoids cascading rollbacks from
  `_log_event`'s FK-fallback path that would otherwise wipe our
  CAS claim. Dialect-aware `UUID` (PG) / `CHAR(36)` (SQLite).
- **Scheduler refactor**: dedup row seeded every tick via dialect-aware
  `INSERT ... ON CONFLICT DO NOTHING`. Emission is a CAS claim:
  `UPDATE ... WHERE emitted_at IS NULL AND first_seen_offline_at <=
  grace_cutoff RETURNING`. Claim + `ScheduleLog` write happen in a
  single outer transaction with the log insert wrapped in a
  `db.begin_nested()` SAVEPOINT — FK violations retry with null FKs
  inside the same transaction, and if even that fails we **revert the
  CAS claim so the next tick retries** rather than silently dropping
  the alert.
- **Removed the `connected_count() == 0` early return** at the top of
  `evaluate_schedules`. That guard was skipping MISSED detection
  entirely when all devices were offline — precisely when MISSED
  matters most. The sync-push loop below naturally no-ops with an
  empty connected set.
- **Cleanup**: per-tick DELETE of today's rows not in the active set,
  plus purge of rows older than 7 days.

## Tests

`tests/test_scheduler_advanced.py::TestMissedGracePeriod` — 7/7 pass:

- existing grace-window + emit-once behavior (rewritten to use DB state)
- `test_missed_dedup_survives_failover` — pre-seeded grace clock is
  honored; new leader does not restart the timer
- `test_missed_not_duplicated_when_already_emitted` — row with
  `emitted_at != NULL` is not re-fired
- `test_missed_detected_when_no_devices_connected` — MISSED fires when
  `connected_count() == 0`
- `test_missed_claim_reverted_if_log_write_fails` — when the log
  insert raises, `emitted_at` is reset to `NULL` so the next tick
  retries

Full scheduler suite green locally: 125/125.

## Rubber-duck findings addressed

- **B1 (silent MISSED loss if log write fails after claim commit)** —
  fixed by making claim + log atomic in one transaction via SAVEPOINT,
  with explicit revert if the log write fails for any reason.
  Regression test added.
- **B2 (early return skipped MISSED when all devices offline)** —
  fixed by removing the `connected_count()` gate. Regression test
  added.

## Multi-replica safety checklist

- [x] Leader-gated loop (pre-existing via `LeaderLease`)
- [x] State persisted in DB, not process memory
- [x] Writes are atomic (single commit per tick)
- [x] Log-write failures do not silently drop alerts
- [x] Dedup key uses occurrence date (tradeoff: max 1 MISSED per local
      day per schedule×device — accepted)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
