### PR TITLE
fix(ui): per-device End Now hides schedule from Coming Up

### DIFF
--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -440,6 +440,8 @@ def get_upcoming_schedules(
     now_playing: list[dict] | None = None,
     offline_device_ids: set[str] | None = None,
     skipped_schedule_ids: set[str] | None = None,
+    per_device_skipped: set[tuple[str, str]] | None = None,
+    target_devices_by_schedule: dict[str, set[str]] | None = None,
 ) -> list[dict]:
     """Return schedules starting within the next 24 hours.
 
@@ -451,14 +453,27 @@ def get_upcoming_schedules(
     today or tomorrow.
 
     ``skipped_schedule_ids`` is the set of schedule IDs (as strings) that the
-    operator has "Ended Now" and should therefore be hidden from the upcoming
-    list.  Callers should pass ``skips.schedule_wide.keys()`` from a
-    :func:`load_skip_snapshot` (filtered to active entries) — the default of
-    ``None`` treats no schedules as skipped, which is safe for unit tests
-    that never exercise the skip path.
+    operator has "Ended Now" (schedule-wide) and should therefore be hidden
+    from the upcoming list.  Callers should pass
+    ``skips.schedule_wide.keys()`` from a :func:`load_skip_snapshot`
+    (filtered to active entries) — the default of ``None`` treats no
+    schedules as skipped, which is safe for unit tests that never exercise
+    the skip path.
+
+    ``per_device_skipped`` is the set of ``(schedule_id, device_id)`` tuples
+    with active per-device skips (from ``skips.per_device.keys()``).  When
+    combined with ``target_devices_by_schedule`` (mapping schedule_id →
+    set of ADOPTED target device ids), a schedule whose time window matches
+    but whose *every adopted target* has an active per-device skip is
+    filtered out.  This prevents "End Now" on a per-device row from leaving
+    the schedule stuck in "Coming Up" with a "Starting…" badge.  Both args
+    must be provided together to activate per-device filtering; either
+    ``None`` disables it (safe default for tests).
     """
     _offline = offline_device_ids or set()
     _skipped_ids: set[str] = set(skipped_schedule_ids or ())
+    _per_device_skipped: set[tuple[str, str]] = set(per_device_skipped or ())
+    _targets_by_sched: dict[str, set[str]] = target_devices_by_schedule or {}
     local_now = now.astimezone(tz).replace(tzinfo=None)
     today = local_now.date()
     tomorrow = today + timedelta(days=1)
@@ -486,7 +501,17 @@ def get_upcoming_schedules(
             if str(s.id) in _winning_sids:
                 continue  # currently winning — shown in Now Playing
             if str(s.id) in _skipped_ids:
-                continue  # deliberately ended via End Now
+                continue  # deliberately ended via End Now (schedule-wide)
+            # Per-device End Now: if every ADOPTED target has an active
+            # per-device skip for this schedule, hide it from Coming Up
+            # too.  (Dashboard "End Now" button always posts device_id,
+            # so a single-target schedule ends up here rather than in
+            # schedule_wide.)
+            sid_str = str(s.id)
+            targets = _targets_by_sched.get(sid_str)
+            if targets:
+                if all((sid_str, did) in _per_device_skipped for did in targets):
+                    continue
             # Check if genuinely preempted (higher-priority schedule active on same target)
             resume_at = _find_resume_time(s, schedules, local_now)
             if resume_at is not None:
@@ -783,6 +808,36 @@ async def _get_target_device_ids(schedule: Schedule, db) -> list[str]:
         )
         return [row[0] for row in result.all()]
     return []
+
+
+async def load_target_devices_by_schedule(
+    schedules: list[Schedule], db
+) -> dict[str, set[str]]:
+    """Bulk-resolve {schedule_id_str: {adopted_device_ids}} for many schedules.
+
+    Single indexed SQL query over the distinct ``group_id`` set referenced
+    by ``schedules``; used by dashboard / schedules UI to feed
+    ``get_upcoming_schedules(..., target_devices_by_schedule=...)`` without
+    per-schedule DB round-trips.  Only ADOPTED devices count as targets —
+    matches :func:`_get_target_device_ids`.
+    """
+    group_ids = {s.group_id for s in schedules if s.group_id}
+    if not group_ids:
+        return {}
+    result = await db.execute(
+        select(Device.group_id, Device.id).where(
+            Device.group_id.in_(group_ids),
+            Device.status == DeviceStatus.ADOPTED,
+        )
+    )
+    devices_by_group: dict = {}
+    for gid, did in result.all():
+        devices_by_group.setdefault(gid, set()).add(did)
+    return {
+        str(s.id): devices_by_group.get(s.group_id, set())
+        for s in schedules
+        if s.group_id
+    }
 
 
 def _schedule_to_entry(s: Schedule, variant_checksums: dict[str, str] | None = None) -> ScheduleEntry:

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -576,7 +576,7 @@ async def setup_complete(
 @router.get("/", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     from datetime import datetime as _dt, timezone as _tz
-    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot
+    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot, load_target_devices_by_schedule
     from cms.auth import get_user_group_ids
 
     # CMS timezone
@@ -744,11 +744,14 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     _skips_for_ui = (await load_skip_snapshot(db)).active_as_of(
         now.astimezone(tz).replace(tzinfo=None)
     )
+    _targets_for_ui = await load_target_devices_by_schedule(all_schedules, db)
     upcoming = get_upcoming_schedules(
         all_schedules, now, tz,
         now_playing=now_playing,
         offline_device_ids=offline_set,
         skipped_schedule_ids=set(_skips_for_ui.schedule_wide.keys()),
+        per_device_skipped=set(_skips_for_ui.per_device.keys()),
+        target_devices_by_schedule=_targets_for_ui,
     )
     upcoming_today = [u for u in upcoming if u["day_label"] == "today"]
     upcoming_tomorrow = [u for u in upcoming if u["day_label"] == "tomorrow"]
@@ -830,7 +833,7 @@ async def server_time_json(db: AsyncSession = Depends(get_db)):
 async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
     """Lightweight JSON endpoint for dashboard polling."""
     from datetime import datetime as _dt, timezone as _tz
-    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot
+    from cms.services.scheduler import compute_now_playing, get_upcoming_schedules, load_skip_snapshot, load_target_devices_by_schedule
     from cms.auth import get_user_group_ids
 
     tz_name = await get_setting(db, SETTING_TIMEZONE) or "UTC"
@@ -952,11 +955,14 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
     _skips_for_ui = (await load_skip_snapshot(db)).active_as_of(
         now.astimezone(tz).replace(tzinfo=None)
     )
+    _targets_for_ui = await load_target_devices_by_schedule(all_schedules, db)
     upcoming = get_upcoming_schedules(
         all_schedules, now, tz,
         now_playing=now_playing,
         offline_device_ids=offline_set,
         skipped_schedule_ids=set(_skips_for_ui.schedule_wide.keys()),
+        per_device_skipped=set(_skips_for_ui.per_device.keys()),
+        target_devices_by_schedule=_targets_for_ui,
     )
 
     # Recent activity count for change detection

--- a/tests/test_per_device_skip_upcoming.py
+++ b/tests/test_per_device_skip_upcoming.py
@@ -1,0 +1,134 @@
+"""Regression: per-device "End Now" should hide a schedule from
+"Coming Up" when every adopted target device has an active
+per-device skip.
+
+Bug: dashboard's End Now button always posts ``device_id``, so the
+server writes a per-device ``ScheduleDeviceSkip`` row (not
+``Schedule.skipped_until``).  Before the fix, ``get_upcoming_schedules``
+only received schedule-wide skips, so a single-target schedule
+re-appeared in Coming Up with a stuck "Starting…" badge.
+"""
+
+import uuid
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+from cms.models.asset import Asset, AssetType
+from cms.models.schedule import Schedule
+from cms.services.scheduler import get_upcoming_schedules
+
+
+UTC = ZoneInfo("UTC")
+
+
+def _make_schedule(
+    start_time: time, end_time: time, *, group_id=None, name: str = "s",
+) -> Schedule:
+    asset = Asset(
+        filename="video.mp4", asset_type=AssetType.VIDEO,
+        size_bytes=1000, checksum="abc",
+    )
+    s = Schedule(
+        name=name,
+        asset_id=uuid.uuid4(),
+        group_id=group_id,
+        enabled=True,
+        start_time=start_time,
+        end_time=end_time,
+        priority=0,
+    )
+    s.id = uuid.uuid4()
+    s.asset = asset
+    s.device = None
+    s.group = None
+    return s
+
+
+def _noon_utc() -> datetime:
+    # Noon today in UTC so the 08:00-17:00 window matches "now"
+    return datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+
+
+class TestPerDeviceSkipHidesSchedule:
+    """When ``per_device_skipped`` covers every ADOPTED target device
+    of a schedule, it should be hidden from Coming Up even though the
+    time window matches and there is no now_playing entry for it."""
+
+    def test_single_target_hidden_when_per_device_skipped(self):
+        gid = uuid.uuid4()
+        did = "dev-A"
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="solo")
+        now = _noon_utc()
+        # Empty now_playing (device stopped after End Now)
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            per_device_skipped={(str(s.id), did)},
+            target_devices_by_schedule={str(s.id): {did}},
+        )
+        assert result == []
+
+    def test_multi_target_all_skipped_hidden(self):
+        gid = uuid.uuid4()
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="multi")
+        now = _noon_utc()
+        targets = {"dev-A", "dev-B", "dev-C"}
+        per_device = {(str(s.id), d) for d in targets}
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            per_device_skipped=per_device,
+            target_devices_by_schedule={str(s.id): targets},
+        )
+        assert result == []
+
+    def test_multi_target_partial_skip_not_hidden_by_per_device(self):
+        """Only some target devices skipped: per-device filter does NOT
+        hide the schedule.  (Other device would normally be playing and
+        show as ``winning`` via now_playing, but this unit-level test
+        just asserts the per-device branch doesn't over-filter.)
+        """
+        gid = uuid.uuid4()
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="multi")
+        now = _noon_utc()
+        targets = {"dev-A", "dev-B"}
+        # Only A skipped; B still available
+        per_device = {(str(s.id), "dev-A")}
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            per_device_skipped=per_device,
+            target_devices_by_schedule={str(s.id): targets},
+        )
+        # Not filtered by per-device; falls through to "starting" entry
+        # (no now_playing winner yet) — this matches pre-fix behaviour
+        # for the "some targets skipped, others transitioning" case.
+        assert len(result) == 1
+        assert result[0]["starting"] is True
+
+    def test_no_per_device_info_preserves_legacy_behaviour(self):
+        """When callers don't provide per-device info (the default),
+        behaviour is unchanged — schedule shows as starting."""
+        gid = uuid.uuid4()
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="legacy")
+        now = _noon_utc()
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+        )
+        assert len(result) == 1
+        assert result[0]["starting"] is True
+
+    def test_targets_only_pending_devices_does_not_hide(self):
+        """If ADOPTED target set is empty (e.g. all devices pending),
+        ``target_devices_by_schedule`` maps to an empty set — the
+        per-device branch's ``all(...)`` on empty is True, but the
+        helper returns an empty set only when group has no ADOPTED
+        devices.  Guard: we only filter when ``targets`` is truthy."""
+        gid = uuid.uuid4()
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="empty-targets")
+        now = _noon_utc()
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            per_device_skipped=set(),
+            target_devices_by_schedule={str(s.id): set()},
+        )
+        # Empty targets → per-device branch skipped → legacy "starting"
+        assert len(result) == 1
+        assert result[0]["starting"] is True


### PR DESCRIPTION
# fix(ui): per-device End Now now hides schedule from Coming Up

## Bug

User reported: clicking "End Now" on a live schedule in the Now
Playing row ends playback on the device, but the schedule immediately
re-appears in the "Coming Up" list with a pulsing **"Starting…"** badge
stuck in the "Starts in" column instead of being hidden until its next
occurrence.

## Root cause

`cms/templates/dashboard.html`'s `endNow()` handler **always** posts
`{device_id: deviceId}`, so the server takes the per-device branch in
`cms/routers/schedules.py::end_schedule_now` and writes a
`ScheduleDeviceSkip` row (not `Schedule.skipped_until`).

The dashboard/schedules UI only passed `SkipSnapshot.schedule_wide`
keys to `get_upcoming_schedules`. Per-device skips were invisible to
that function. Result:

* `_matches_now(s)` → True (time window unchanged)
* Schedule is no longer winning (device stopped playing it)
* Schedule ID not in the `_skipped_ids` set (per-device skip was
  written instead of schedule-wide)
* Not preempted → falls through to `_starting_entry(s, ...)` → shows
  "Starting…" badge forever.

## Fix

Thread per-device skip info and adopted-target mapping into
`get_upcoming_schedules` and filter out a schedule when **every
ADOPTED target device** has an active per-device skip.

Changes:

* `cms/services/scheduler.py`:
  * `get_upcoming_schedules` gains two optional params:
    `per_device_skipped: set[tuple[str, str]]` (from
    `SkipSnapshot.per_device.keys()`) and
    `target_devices_by_schedule: dict[str, set[str]]`.
  * Filters inside the existing `_matches_now` branch, alongside the
    schedule-wide skip check.
  * New helper `load_target_devices_by_schedule(schedules, db)` bulk-
    resolves `{schedule_id: {adopted_device_ids}}` in a single
    indexed SQL query.  Uses `DeviceStatus.ADOPTED` only (matches
    existing `_get_target_device_ids`) so pending / orphaned devices
    in the group don't block the hide.
* `cms/ui.py`: both dashboard and `/schedules` pages now compute
  `per_device_skipped` + `target_devices_by_schedule` and pass them
  through.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Single-target schedule, user ends it on the one device | Shows "Starting…" in Coming Up | Hidden from Coming Up |
| Multi-target schedule, user ends on all targets | Shows "Starting…" | Hidden |
| Multi-target schedule, user ends on 1 of 3 | Shows "Starting…" (incorrect) | Stays in Now Playing on the 2 devices still playing (winning path already handles) |
| Group contains pending/orphaned devices | — | Those don't block the hide |
| Schedule-wide "End Now" (no device_id) | Hidden (unchanged) | Hidden (unchanged) |
| Caller omits per-device info (tests) | — | Legacy behaviour preserved |

## Tests

5 new regression tests in `tests/test_per_device_skip_upcoming.py`
covering the matrix above. Existing 268 scheduler + UI tests pass.

## Why this is replica-safe

`ScheduleDeviceSkip` rows are the single source of truth (no in-process
cache for the read path). Any replica renders the same filtered list
from the shared DB — `scheduler-state-dbback` already eliminated the
stale in-memory cache. This change just wires the existing per-device
state through to the UI layer.
