### PR TITLE
feat(bootstrap): pending_registrations model + devices.pubkey (Stage A.1, #420)

### DIFF
--- a/alembic/versions/0010_bootstrap_redesign_pending_registrations.py
+++ b/alembic/versions/0010_bootstrap_redesign_pending_registrations.py
@@ -1,0 +1,101 @@
+"""pending_registrations table + devices.pubkey column
+
+Bootstrap redesign (umbrella issue #420): adds storage for the
+HTTPS-based device onboarding flow (ed25519 identity + QR pairing).
+
+- ``pending_registrations``: staging table for devices between
+  ``POST /api/devices/register`` and ``POST /api/devices/adopt``.
+  Carries the device's public key, the pairing secret hash (adoption
+  lookup key), and — once adopted — the ECIES-encrypted bootstrap
+  payload waiting to be polled by the device.
+- ``devices.pubkey``: ed25519 public key (base64).  NULL during the
+  coexistence window for legacy devices that still authenticate with
+  an API key; populated at adoption time for new devices and by the
+  Stage C migration path for existing devices.
+
+This migration intentionally does NOT drop ``device_api_key_hash`` /
+``previous_api_key_hash`` / ``api_key_rotated_at`` / ``device_auth_token_hash``.
+Those columns remain in use by the legacy direct-WS bootstrap path
+through Stages B and C and are dropped in Stage D once the fleet has
+fully migrated.
+
+Revision ID: 0010
+Revises: 0009
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind is not None else "sqlite"
+
+    # ---- pending_registrations ----
+    if dialect == "postgresql":
+        id_col = sa.Column(
+            "id", UUID(as_uuid=True), primary_key=True, nullable=False,
+        )
+        metadata_col = sa.Column("connection_metadata", JSONB, nullable=True)
+    else:
+        # SQLite (unit tests): UUIDs as CHAR(36), JSON as TEXT.
+        id_col = sa.Column(
+            "id", sa.String(36), primary_key=True, nullable=False,
+        )
+        metadata_col = sa.Column("connection_metadata", sa.JSON(), nullable=True)
+
+    op.create_table(
+        "pending_registrations",
+        id_col,
+        sa.Column("device_id", sa.String(length=64), nullable=False),
+        sa.Column("pubkey", sa.Text(), nullable=False),
+        sa.Column(
+            "pairing_secret_hash",
+            sa.String(length=64),
+            nullable=False,
+            unique=True,
+        ),
+        metadata_col,
+        sa.Column("ip_address", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("polled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("adopted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("outbox_ciphertext", sa.Text(), nullable=True),
+        sa.Column("adopted_device_id", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_pending_registrations_pubkey",
+        "pending_registrations",
+        ["pubkey"],
+    )
+    op.create_index(
+        "ix_pending_registrations_created_at",
+        "pending_registrations",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_pending_registrations_polled_at",
+        "pending_registrations",
+        ["polled_at"],
+    )
+
+    # ---- devices.pubkey ----
+    op.add_column(
+        "devices",
+        sa.Column("pubkey", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade is not supported for this migration.")

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -12,6 +12,7 @@ from cms.models.leader_lease import LeaderLease  # noqa: F401
 from cms.models.log_request import LogRequest  # noqa: F401
 from cms.models.notification import Notification  # noqa: F401
 from cms.models.notification_pref import UserNotificationPref  # noqa: F401
+from cms.models.pending_registration import PendingRegistration  # noqa: F401
 from cms.models.schedule import Schedule  # noqa: F401
 from cms.models.schedule_device_skip import ScheduleDeviceSkip  # noqa: F401
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent  # noqa: F401

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -64,6 +64,15 @@ class Device(Base):
     device_api_key_hash: Mapped[str | None] = mapped_column(String(128), nullable=True)
     previous_api_key_hash: Mapped[str | None] = mapped_column(String(128), nullable=True)
     api_key_rotated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Bootstrap redesign (issue #420): ed25519 public key, base64-encoded.
+    # Populated by /api/devices/adopt when the device is first adopted via
+    # the QR flow, or by the Stage C migration endpoint for devices that
+    # still have an API key.  NULL during the coexistence window for
+    # devices adopted via the legacy WS path that have not migrated yet.
+    # When cleared (set to NULL), the device is effectively revoked —
+    # signed /connect-token requests will 401 and the device will fall
+    # back to bootstrap mode.
+    pubkey: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_seen: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     registered_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/cms/models/pending_registration.py
+++ b/cms/models/pending_registration.py
@@ -1,0 +1,102 @@
+"""PendingRegistration ORM model.
+
+Staging area for devices that have generated a keypair and pairing secret
+and are waiting for an admin to adopt them via the QR code flow.
+
+See umbrella issue #420 for the bootstrap redesign context.
+
+A row is created by ``POST /api/devices/register`` and is keyed by
+``pairing_secret_hash`` (SHA-256 of the device-generated pairing secret).
+Adoption (``POST /api/devices/adopt``) looks up the row by hash, creates
+a ``devices`` row, and writes the ECIES-encrypted bootstrap payload to
+``outbox_ciphertext`` so the next ``GET /api/devices/bootstrap-status``
+poll delivers it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Index, JSON, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cms.database import Base
+
+
+# Portable JSON column type: JSONB on PostgreSQL (for GIN-indexable querying
+# if we ever want it), JSON on SQLite (for unit tests).
+_JsonType = JSON().with_variant(JSONB(), "postgresql")
+
+
+class PendingRegistration(Base):
+    __tablename__ = "pending_registrations"
+    __table_args__ = (
+        Index("ix_pending_registrations_pubkey", "pubkey"),
+        Index("ix_pending_registrations_created_at", "created_at"),
+        Index("ix_pending_registrations_polled_at", "polled_at"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+
+    # Device-chosen identifier (Pi serial / hostname).  Not authoritative —
+    # adoption is keyed by pairing_secret_hash, not device_id, to prevent
+    # squatting.
+    device_id: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # Device ed25519 public key, base64-encoded.
+    pubkey: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # SHA-256 hex digest of the raw pairing secret displayed in the QR.
+    # This is what /adopt looks up against, so it is the effective primary
+    # key from an application standpoint.  Unique to prevent collisions.
+    pairing_secret_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True
+    )
+
+    # Arbitrary metadata the device reported at registration
+    # (firmware_version, device_type, hostname, etc.).
+    connection_metadata: Mapped[dict | None] = mapped_column(_JsonType, nullable=True)
+
+    # IP address seen on the /register request.  Used for rate-limit
+    # bookkeeping and audit trails only.
+    ip_address: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # Timestamps.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    # First successful /bootstrap-status poll — flips the row to the
+    # longer TTL.  NULL means the row has never been polled, which
+    # qualifies it for aggressive GC (1h) rather than the 24h TTL.
+    polled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Set by /adopt.  NULL means still pending.
+    adopted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # ECIES-encrypted bootstrap payload ({device_id, wps_jwt, wps_url,
+    # jwt_expires_at}), base64-encoded.  Populated by /adopt, consumed by
+    # /bootstrap-status.  NULL while the row is still pending.
+    outbox_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # After adoption, the UUID of the created ``devices`` row.  Kept for
+    # observability and to let the GC job verify the device exists before
+    # deleting the pending row.
+    adopted_device_id: Mapped[str | None] = mapped_column(String(64), nullable=True)


### PR DESCRIPTION
Stage A.1 of the bootstrap redesign (umbrella #420).

## What

- New `pending_registrations` ORM model + alembic migration `0010` (staging area for devices between `/register` and `/adopt`).
- New `devices.pubkey` column (nullable TEXT) for the ed25519 identity.
- Registered in `cms/models/__init__.py`.

## What this does NOT do

No endpoints, no crypto service, no UI, no GC job yet — those land in subsequent PRs under #420. Legacy API-key columns (`device_auth_token_hash`, `device_api_key_hash`, etc.) remain in use; Stage D drops them.

## Schema

`pending_registrations`:
- `id` UUID PK
- `device_id` TEXT (claimed identifier)
- `pubkey` TEXT (ed25519 pubkey; not unique at registration, unique per accepted adoption)
- `pairing_secret_hash` TEXT UNIQUE (sha256 of the secret shown in QR)
- `connection_metadata` JSONB/JSON (dialect-branched)
- `ip_address`, `created_at`, `updated_at`, `polled_at`, `adopted_at`, `outbox_ciphertext`, `adopted_device_id`

Indexes: `pubkey`, `created_at`, `polled_at`.

`devices.pubkey` TEXT NULL — coexistence w/ legacy API-key devices; see inline comment.

## Testing

- 321 tests pass in `tests/` (one pre-existing failure, `test_display_transition_emits_events`, also fails on `main` — unrelated datetime tz issue in WS handler).
- `test_migration_policy.py` green.
- Model uses `JSON().with_variant(JSONB(), "postgresql")` so SQLite tests work.

Refs #420.
