### PR TITLE
feat(bootstrap): partial unique index on devices.pubkey (Stage A.2, #420)

### DIFF
--- a/alembic/versions/0011_devices_pubkey_unique.py
+++ b/alembic/versions/0011_devices_pubkey_unique.py
@@ -1,0 +1,43 @@
+"""partial unique index on devices.pubkey
+
+Bootstrap redesign (umbrella issue #420): enforces that no two devices
+can be adopted with the same ed25519 public key.  Must land before any
+code path writes a real ``devices.pubkey`` value (i.e. before Stage A.3
+endpoints).
+
+Uses a *partial* index ``WHERE pubkey IS NOT NULL`` so that:
+
+- the many existing rows with ``pubkey IS NULL`` (legacy API-key devices)
+  don't all collide on a shared NULL value, and
+- pubkey uniqueness is only enforced once a device actually has one.
+
+SQLite supports partial indexes as of 3.8.0 which covers our test matrix.
+
+Revision ID: 0011
+Revises: 0010
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_devices_pubkey_unique",
+        "devices",
+        ["pubkey"],
+        unique=True,
+        postgresql_where="pubkey IS NOT NULL",
+        sqlite_where="pubkey IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0011 is not supported")

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum as PyEnum
 
-from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Integer, String, Text, text
+from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -37,7 +37,16 @@ class DeviceGroup(Base):
 
 class Device(Base):
     __tablename__ = "devices"
-    __table_args__ = {"extend_existing": True}
+    __table_args__ = (
+        Index(
+            "ix_devices_pubkey_unique",
+            "pubkey",
+            unique=True,
+            postgresql_where=text("pubkey IS NOT NULL"),
+            sqlite_where=text("pubkey IS NOT NULL"),
+        ),
+        {"extend_existing": True},
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)  # Pi serial or UUID
     name: Mapped[str] = mapped_column(String(100), default="")


### PR DESCRIPTION
Follow-up to #421. Prevents two devices from being adopted with the same ed25519 pubkey.

Partial index (`WHERE pubkey IS NOT NULL`) so existing API-key devices with `pubkey=NULL` don't all collide on a shared NULL.

Must land before Stage A.3 endpoints — they will be the first writers of a non-NULL pubkey.

Rubber-duck flagged this gap during A.1 prod validation.

Refs #420.