### PR TITLE
feat(bootstrap): device_identity crypto service (#420)

### DIFF
--- a/cms/services/device_identity.py
+++ b/cms/services/device_identity.py
@@ -1,0 +1,346 @@
+"""Cryptographic primitives for the HTTPS device-bootstrap flow.
+
+Pure helpers for the three signature/encryption surfaces introduced by
+the bootstrap redesign (umbrella issue #420):
+
+1. **Ed25519 request signing** — devices sign canonicalised bytes when
+   hitting ``POST /api/devices/connect-token`` (no transport-level
+   authentication; the signature is the auth).
+2. **ECIES encryption to a device's identity key** — CMS encrypts the
+   bootstrap outbox payload (WPS URL + JWT) with the device's public key
+   so the reply to the anonymous ``GET /api/devices/bootstrap-status``
+   endpoint is useless to anyone but the device.
+3. **Fleet HMAC verification** — ``/api/devices/register`` is anonymous
+   but gated by a shared per-fleet secret so random internet scanners
+   can't create junk pending_registrations rows.
+
+Plus an in-memory TTL nonce cache used to block replay of both signed
+``/connect-token`` requests and fleet-HMAC ``/register`` requests.
+
+This module is intentionally self-contained and has **no FastAPI /
+SQLAlchemy / asyncio dependencies beyond an asyncio.Lock for the nonce
+cache** so it can be unit-tested in isolation.
+
+Nonce cache scope note
+----------------------
+The default :class:`InMemoryNonceCache` is a **per-process** cache.  It
+is only safe when the CMS runs as a single process with a single asyncio
+event loop.  In particular it is **not** safe under:
+
+- ``N > 1`` replicas (each replica has its own cache)
+- multiple uvicorn workers in one container
+- overlapping rolling deploys (two revisions active simultaneously)
+- blue/green deploys
+
+Stage 4 of the multi-replica rollout (tracked in ``#344``) will replace
+this with a DB-backed cache via the :class:`NonceCache` protocol before
+``minReplicas`` is bumped past 1.  Until then the CMS is pinned to
+``minReplicas=maxReplicas=1`` and this cache is the authoritative
+replay-protection primitive.
+
+Under ``N > 1`` without a shared cache, an attacker who captured a valid
+signed request in flight would get an ``N`` replay window (one replay
+per replica).  Damage is bounded by:
+
+- the 60s timestamp skew on ``/connect-token`` (replay must land in
+  one minute),
+- the 300s skew on fleet HMAC (five minutes),
+- the rate limits on both endpoints,
+- and, for ``/connect-token``, the fact that a replay only re-mints a
+  WPS JWT for the device that already owns the signature — no
+  privilege escalation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import hashlib
+import hmac
+import os
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+# ---------------------------------------------------------------------
+# Ed25519 request signing
+# ---------------------------------------------------------------------
+
+
+def connect_token_canonical_bytes(
+    device_id: str, timestamp: str, nonce: str,
+) -> bytes:
+    """Canonical byte representation of a ``/connect-token`` request.
+
+    Must be bit-identical between firmware signer and CMS verifier.
+    Fixed schema, pipe-delimited — no JSON canonicalisation needed.
+    """
+    return f"{device_id}|{timestamp}|{nonce}".encode("utf-8")
+
+
+def verify_ed25519_signature(
+    pubkey_b64: str, message: bytes, signature_b64: str,
+) -> bool:
+    """Return ``True`` iff ``signature_b64`` is a valid ed25519 signature
+    over ``message`` under ``pubkey_b64``.
+
+    Never raises on malformed input — returns ``False`` instead so the
+    caller can emit a uniform ``401`` without leaking which specific
+    field was bad.
+    """
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(base64.b64decode(pubkey_b64))
+        sig = base64.b64decode(signature_b64)
+        pub.verify(sig, message)
+    except (ValueError, InvalidSignature, TypeError):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------
+# Ed25519 → X25519 for ECIES
+# ---------------------------------------------------------------------
+
+
+def _ed25519_pub_to_x25519(pub_bytes: bytes) -> X25519PublicKey:
+    """Convert an ed25519 public key to the matching X25519 public key.
+
+    Standard curve isomorphism: ``cryptography`` doesn't expose a direct
+    converter, but we can round-trip via the raw Edwards point.  PyNaCl
+    has a one-liner (``crypto_sign_ed25519_pk_to_curve25519``); we
+    replicate it with the standard library.
+    """
+    # Reference: RFC 7748 / libsodium crypto_sign_ed25519_pk_to_curve25519.
+    # The Montgomery u-coordinate is (1 + y) / (1 - y) mod p with y
+    # recovered from the encoded point.  We defer to the standard
+    # implementation in ``cryptography``'s internals... but since that
+    # isn't public API, use the math directly.
+    if len(pub_bytes) != 32:
+        raise ValueError("ed25519 public key must be 32 bytes")
+    # Decode little-endian y with the sign bit masked off.
+    y = int.from_bytes(pub_bytes, "little") & ((1 << 255) - 1)
+    p = (1 << 255) - 19
+    # Reject non-canonical encodings (y must be reduced mod p).
+    if y >= p:
+        raise ValueError("ed25519 public key y-coordinate is not canonical")
+    # u = (1 + y) / (1 - y) mod p
+    denom = (1 - y) % p
+    if denom == 0:
+        # y == 1 → point at infinity on the Edwards curve.
+        raise ValueError("ed25519 public key maps to point at infinity")
+    inv = pow(denom, p - 2, p)
+    u = ((1 + y) * inv) % p
+    # Reject degenerate/low-order u values (u == 0 is the identity on the
+    # Montgomery curve; u == 1 is also a known low-order point).
+    if u in (0, 1):
+        raise ValueError("ed25519 public key maps to a low-order x25519 point")
+    u_bytes = u.to_bytes(32, "little")
+    return X25519PublicKey.from_public_bytes(u_bytes)
+
+
+# ---------------------------------------------------------------------
+# ECIES to an ed25519 recipient
+# ---------------------------------------------------------------------
+
+
+_ECIES_HKDF_INFO = b"agora-bootstrap-ecies-v1"
+
+
+def encrypt_for_device(pubkey_b64: str, plaintext: bytes) -> str:
+    """ECIES-encrypt ``plaintext`` for the holder of ``pubkey_b64``.
+
+    Wire format (base64 of the concatenation):
+
+        ``ephemeral_x25519_pub (32B) || nonce (12B) || ciphertext || tag (16B)``
+
+    The AES-GCM tag is appended to the ciphertext by ``AESGCM.encrypt``,
+    so the layout is effectively ``[32 || 12 || ciphertext_with_tag]``.
+    """
+    try:
+        recip_ed = base64.b64decode(pubkey_b64, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise ValueError("invalid base64 recipient public key") from e
+    recip_x = _ed25519_pub_to_x25519(recip_ed)
+
+    eph_priv = X25519PrivateKey.generate()
+    eph_pub_bytes = eph_priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+    shared = eph_priv.exchange(recip_x)
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32 + 12,
+        salt=None,
+        info=_ECIES_HKDF_INFO,
+    ).derive(shared)
+    key, nonce = key_material[:32], key_material[32:]
+
+    ct = AESGCM(key).encrypt(nonce, plaintext, associated_data=None)
+    return base64.b64encode(eph_pub_bytes + nonce + ct).decode("ascii")
+
+
+# ---------------------------------------------------------------------
+# Fleet HMAC
+# ---------------------------------------------------------------------
+
+
+def fleet_hmac_input(
+    *,
+    device_id: str,
+    pubkey: str,
+    pairing_secret_hash: str,
+    fleet_id: str,
+    timestamp: str,
+    nonce: str,
+) -> bytes:
+    """Canonical MAC input for ``POST /api/devices/register``.
+
+    Must match the device-side constructor byte-for-byte.  Schema is
+    frozen as of issue #420; any future change becomes a breaking
+    firmware bump.
+    """
+    parts = [
+        "register",
+        device_id,
+        pubkey,
+        pairing_secret_hash,
+        fleet_id,
+        timestamp,
+        nonce,
+    ]
+    return "|".join(parts).encode("utf-8")
+
+
+def compute_fleet_hmac(secret: bytes, message: bytes) -> str:
+    """HMAC-SHA256 of ``message`` under ``secret``, hex-encoded."""
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+
+
+def verify_fleet_hmac(
+    secret: bytes, message: bytes, mac_hex: str,
+) -> bool:
+    """Constant-time verification of a fleet HMAC.  Never raises."""
+    if not isinstance(mac_hex, str):
+        return False
+    try:
+        expected = compute_fleet_hmac(secret, message)
+        return hmac.compare_digest(expected, mac_hex.lower())
+    except (TypeError, ValueError, AttributeError):
+        return False
+
+
+# ---------------------------------------------------------------------
+# Timestamp skew helpers
+# ---------------------------------------------------------------------
+
+
+def timestamp_within_skew(ts_unix: int, skew_seconds: int) -> bool:
+    """Return True if ``ts_unix`` is within ``±skew_seconds`` of now."""
+    return abs(int(time.time()) - int(ts_unix)) <= int(skew_seconds)
+
+
+# ---------------------------------------------------------------------
+# Nonce cache (replay protection)
+# ---------------------------------------------------------------------
+
+
+class NonceCache(Protocol):
+    """Protocol for replay-protection caches.
+
+    Implementations must be safe to call from async FastAPI handlers.
+    A cache entry is keyed by ``scope`` (e.g. ``"fleet"``,
+    ``"connect-token"``) to prevent cross-endpoint collisions.
+
+    Callers should use :meth:`check_and_record` — a single atomic call
+    that both checks for replay and records the nonce.  The separate
+    ``seen`` / ``record`` methods exist for diagnostics / tests only;
+    using them in a hot path is a TOCTOU bug waiting to happen.
+    """
+
+    async def check_and_record(self, scope: str, nonce: str) -> bool:
+        """Atomic seen+record.  Returns True if fresh (accept),
+        False if replay (reject).
+        """
+        ...
+
+    async def seen(self, scope: str, nonce: str) -> bool: ...
+    async def record(self, scope: str, nonce: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    expires_at: float
+
+
+class InMemoryNonceCache:
+    """Simple per-process TTL nonce cache.
+
+    Safe under asyncio concurrency; not shared across replicas.  See the
+    module docstring for replay-window implications.
+    """
+
+    def __init__(self, ttl_seconds: int = 600) -> None:
+        self._ttl = ttl_seconds
+        self._entries: dict[tuple[str, str], _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def seen(self, scope: str, nonce: str) -> bool:
+        async with self._lock:
+            self._gc_locked()
+            return (scope, nonce) in self._entries
+
+    async def record(self, scope: str, nonce: str) -> None:
+        async with self._lock:
+            self._entries[(scope, nonce)] = _CacheEntry(
+                expires_at=time.time() + self._ttl,
+            )
+
+    async def check_and_record(self, scope: str, nonce: str) -> bool:
+        """Atomic ``seen`` + ``record``.  Returns True if accepted
+        (nonce was fresh), False if it was a replay.
+        """
+        async with self._lock:
+            self._gc_locked()
+            key = (scope, nonce)
+            if key in self._entries:
+                return False
+            self._entries[key] = _CacheEntry(
+                expires_at=time.time() + self._ttl,
+            )
+            return True
+
+    def _gc_locked(self) -> None:
+        now = time.time()
+        expired = [k for k, v in self._entries.items() if v.expires_at <= now]
+        for k in expired:
+            self._entries.pop(k, None)
+
+
+# ---------------------------------------------------------------------
+# Misc helpers
+# ---------------------------------------------------------------------
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def random_nonce(nbytes: int = 16) -> str:
+    """Hex-encoded cryptographically random nonce."""
+    return os.urandom(nbytes).hex()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ jinja2>=3.1,<4.0
 itsdangerous>=2.2,<3.0
 python-multipart>=0.0.18,<1.0
 bcrypt>=4.0,<5.0
+cryptography>=43,<47
 httpx>=0.27,<1.0
 tzdata>=2024.1
 

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -1,0 +1,383 @@
+"""Unit tests for cms.services.device_identity.
+
+Pure-function tests — no fixtures, no DB.  Exercises:
+
+- Ed25519 sign/verify round trip (via the ``cryptography`` library's own
+  signer on the device side).
+- ECIES round trip (encrypt_for_device + decrypt with matching x25519).
+- Fleet HMAC compute/verify + tamper detection.
+- Timestamp skew helper.
+- InMemoryNonceCache TTL + replay detection.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+)
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from cms.services.device_identity import (
+    InMemoryNonceCache,
+    _ECIES_HKDF_INFO,
+    _ed25519_pub_to_x25519,
+    compute_fleet_hmac,
+    connect_token_canonical_bytes,
+    encrypt_for_device,
+    fleet_hmac_input,
+    random_nonce,
+    sha256_hex,
+    timestamp_within_skew,
+    verify_ed25519_signature,
+    verify_fleet_hmac,
+)
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def _gen_ed25519():
+    priv = Ed25519PrivateKey.generate()
+    pub_bytes = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return priv, base64.b64encode(pub_bytes).decode("ascii")
+
+
+def _decrypt_bootstrap(
+    pubkey_b64: str, priv_ed: Ed25519PrivateKey, wire_b64: str,
+) -> bytes:
+    """Device-side ECIES decrypt, mirroring the firmware path."""
+    wire = base64.b64decode(wire_b64)
+    eph_pub_bytes, nonce, ct = wire[:32], wire[32:44], wire[44:]
+
+    # Convert our ed25519 *private* key to x25519.  libsodium exposes
+    # this as crypto_sign_ed25519_sk_to_curve25519 — we emulate by
+    # hashing the seed and clamping per RFC 7748, which is exactly
+    # what that function does internally.
+    seed = priv_ed.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    h = hashlib.sha512(seed).digest()
+    a = bytearray(h[:32])
+    a[0] &= 248
+    a[31] &= 127
+    a[31] |= 64
+    x_priv = X25519PrivateKey.from_private_bytes(bytes(a))
+
+    eph_pub = X25519PublicKey.from_public_bytes(eph_pub_bytes)
+    shared = x_priv.exchange(eph_pub)
+
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32 + 12,
+        salt=None,
+        info=_ECIES_HKDF_INFO,
+    ).derive(shared)
+    key, _expected_nonce = key_material[:32], key_material[32:]
+    return AESGCM(key).decrypt(nonce, ct, associated_data=None)
+
+
+# ---------------------------------------------------------------------
+# Ed25519 signing
+# ---------------------------------------------------------------------
+
+
+class TestEd25519Signing:
+    def test_round_trip_accepts_valid_signature(self):
+        priv, pub_b64 = _gen_ed25519()
+        msg = connect_token_canonical_bytes("dev-1", "2026-04-24T00:00:00Z", "abc")
+        sig = priv.sign(msg)
+        sig_b64 = base64.b64encode(sig).decode("ascii")
+
+        assert verify_ed25519_signature(pub_b64, msg, sig_b64) is True
+
+    def test_rejects_tampered_message(self):
+        priv, pub_b64 = _gen_ed25519()
+        msg = b"hello"
+        sig_b64 = base64.b64encode(priv.sign(msg)).decode("ascii")
+
+        assert verify_ed25519_signature(pub_b64, b"HELLO", sig_b64) is False
+
+    def test_rejects_signature_from_wrong_key(self):
+        priv_a, _ = _gen_ed25519()
+        _, pub_b = _gen_ed25519()
+        msg = b"hello"
+        sig_b64 = base64.b64encode(priv_a.sign(msg)).decode("ascii")
+
+        assert verify_ed25519_signature(pub_b, msg, sig_b64) is False
+
+    @pytest.mark.parametrize(
+        "bad_pub, bad_sig",
+        [
+            ("!!!not-b64!!!", "AAAA"),
+            ("AAAA", "!!!not-b64!!!"),
+            ("", ""),
+            ("AAAA", "AAAA"),  # valid b64 but wrong length/material
+        ],
+    )
+    def test_malformed_input_returns_false_not_raise(self, bad_pub, bad_sig):
+        assert (
+            verify_ed25519_signature(bad_pub, b"message", bad_sig) is False
+        )
+
+
+# ---------------------------------------------------------------------
+# Canonical bytes
+# ---------------------------------------------------------------------
+
+
+def test_connect_token_canonical_is_pipe_delimited_utf8():
+    out = connect_token_canonical_bytes("dev-1", "2026-04-24T00:00:00Z", "n1")
+    assert out == b"dev-1|2026-04-24T00:00:00Z|n1"
+
+
+def test_fleet_hmac_input_uses_fixed_schema():
+    out = fleet_hmac_input(
+        device_id="dev-1",
+        pubkey="KEY",
+        pairing_secret_hash="HASH",
+        fleet_id="fleet-main",
+        timestamp="1714000000",
+        nonce="NONCE",
+    )
+    assert out == b"register|dev-1|KEY|HASH|fleet-main|1714000000|NONCE"
+
+
+# ---------------------------------------------------------------------
+# ECIES
+# ---------------------------------------------------------------------
+
+
+class TestECIES:
+    def test_round_trip(self):
+        priv, pub_b64 = _gen_ed25519()
+        plaintext = b'{"wps_jwt":"abc","wps_url":"wss://x"}'
+
+        wire = encrypt_for_device(pub_b64, plaintext)
+        decrypted = _decrypt_bootstrap(pub_b64, priv, wire)
+
+        assert decrypted == plaintext
+
+    def test_different_keys_yield_different_ciphertext(self):
+        _, pub_a = _gen_ed25519()
+        _, pub_b = _gen_ed25519()
+        pt = b"same plaintext"
+
+        ct_a = encrypt_for_device(pub_a, pt)
+        ct_b = encrypt_for_device(pub_b, pt)
+        assert ct_a != ct_b
+
+    def test_same_key_two_calls_use_different_ephemeral(self):
+        """Ephemeral keypair must be fresh per call (IND-CPA)."""
+        _, pub = _gen_ed25519()
+        ct1 = encrypt_for_device(pub, b"x")
+        ct2 = encrypt_for_device(pub, b"x")
+        assert ct1 != ct2
+
+    def test_wrong_private_key_cannot_decrypt(self):
+        _priv_a, pub_a = _gen_ed25519()
+        priv_b, _pub_b = _gen_ed25519()
+        wire = encrypt_for_device(pub_a, b"secret")
+
+        with pytest.raises(Exception):  # AESGCM tag verification fails
+            _decrypt_bootstrap(pub_a, priv_b, wire)
+
+    def test_rejects_malformed_base64_pubkey(self):
+        with pytest.raises(ValueError):
+            encrypt_for_device("not!valid!base64!@#$", b"x")
+
+    def test_rejects_wrong_length_pubkey(self):
+        short = base64.b64encode(b"\x00" * 16).decode("ascii")
+        with pytest.raises(ValueError):
+            encrypt_for_device(short, b"x")
+
+    def test_rejects_non_canonical_y(self):
+        # y = p (non-canonical encoding; field element not reduced mod p).
+        p = (1 << 255) - 19
+        bad = p.to_bytes(32, "little")
+        bad_b64 = base64.b64encode(bad).decode("ascii")
+        with pytest.raises(ValueError):
+            encrypt_for_device(bad_b64, b"x")
+
+    def test_rejects_y_equals_one(self):
+        # y = 1 → denom (1-y) = 0; the Edwards identity point.
+        one = (1).to_bytes(32, "little")
+        b64 = base64.b64encode(one).decode("ascii")
+        with pytest.raises(ValueError):
+            encrypt_for_device(b64, b"x")
+
+    def test_rejects_zero_pubkey(self):
+        # y = 0 → u = (1+0)/(1-0) = 1, a low-order Montgomery point.
+        zero = (0).to_bytes(32, "little")
+        b64 = base64.b64encode(zero).decode("ascii")
+        with pytest.raises(ValueError):
+            encrypt_for_device(b64, b"x")
+
+    def test_ed25519_to_x25519_matches_libsodium_reference(self):
+        """Sanity check: converting an ed25519 pubkey to x25519 and doing
+        a round-trip DH with the matching private key (via the same
+        hashing trick firmware uses) yields a shared secret.
+        """
+        priv = Ed25519PrivateKey.generate()
+        pub_bytes = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        x_pub = _ed25519_pub_to_x25519(pub_bytes)
+
+        # Build the matching x25519 private key from the ed25519 seed.
+        seed = priv.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        h = hashlib.sha512(seed).digest()
+        a = bytearray(h[:32])
+        a[0] &= 248
+        a[31] &= 127
+        a[31] |= 64
+        x_priv = X25519PrivateKey.from_private_bytes(bytes(a))
+
+        eph = X25519PrivateKey.generate()
+        shared_sender = eph.exchange(x_pub)
+        shared_recipient = x_priv.exchange(eph.public_key())
+        assert shared_sender == shared_recipient
+
+
+# ---------------------------------------------------------------------
+# Fleet HMAC
+# ---------------------------------------------------------------------
+
+
+class TestFleetHmac:
+    def test_compute_is_deterministic(self):
+        assert compute_fleet_hmac(b"s", b"m") == compute_fleet_hmac(b"s", b"m")
+
+    def test_verify_accepts_valid_mac(self):
+        msg = fleet_hmac_input(
+            device_id="d", pubkey="p", pairing_secret_hash="h",
+            fleet_id="f", timestamp="1", nonce="n",
+        )
+        mac = compute_fleet_hmac(b"secret", msg)
+        assert verify_fleet_hmac(b"secret", msg, mac) is True
+
+    def test_verify_rejects_wrong_secret(self):
+        msg = b"msg"
+        mac = compute_fleet_hmac(b"right", msg)
+        assert verify_fleet_hmac(b"wrong", msg, mac) is False
+
+    def test_verify_rejects_tampered_message(self):
+        mac = compute_fleet_hmac(b"s", b"msg")
+        assert verify_fleet_hmac(b"s", b"MSG", mac) is False
+
+    def test_verify_is_case_insensitive_on_hex(self):
+        mac = compute_fleet_hmac(b"s", b"m")
+        assert verify_fleet_hmac(b"s", b"m", mac.upper()) is True
+
+    def test_verify_returns_false_on_non_string_mac(self):
+        # Anonymous endpoint; must never 500 on bad input.
+        mac = compute_fleet_hmac(b"s", b"m")
+        assert verify_fleet_hmac(b"s", b"m", None) is False  # type: ignore[arg-type]
+        assert verify_fleet_hmac(b"s", b"m", 12345) is False  # type: ignore[arg-type]
+        assert verify_fleet_hmac(b"s", b"m", b"bytes") is False  # type: ignore[arg-type]
+        # Sanity — still works for real mac.
+        assert verify_fleet_hmac(b"s", b"m", mac) is True
+
+
+# ---------------------------------------------------------------------
+# Timestamp skew
+# ---------------------------------------------------------------------
+
+
+class TestTimestampSkew:
+    def test_accepts_now(self):
+        assert timestamp_within_skew(int(time.time()), 60) is True
+
+    def test_rejects_far_past(self):
+        assert timestamp_within_skew(int(time.time()) - 600, 60) is False
+
+    def test_rejects_far_future(self):
+        assert timestamp_within_skew(int(time.time()) + 600, 60) is False
+
+    def test_accepts_edge_of_window(self):
+        assert timestamp_within_skew(int(time.time()) - 60, 60) is True
+
+
+# ---------------------------------------------------------------------
+# InMemoryNonceCache
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestInMemoryNonceCache:
+    async def test_first_use_accepted(self):
+        c = InMemoryNonceCache(ttl_seconds=60)
+        assert await c.check_and_record("connect-token", "n1") is True
+
+    async def test_replay_rejected(self):
+        c = InMemoryNonceCache(ttl_seconds=60)
+        await c.check_and_record("connect-token", "n1")
+        assert await c.check_and_record("connect-token", "n1") is False
+
+    async def test_different_scope_does_not_collide(self):
+        c = InMemoryNonceCache(ttl_seconds=60)
+        await c.check_and_record("fleet", "n1")
+        assert await c.check_and_record("connect-token", "n1") is True
+
+    async def test_expired_entry_replayable(self):
+        c = InMemoryNonceCache(ttl_seconds=0)
+        await c.check_and_record("s", "n1")
+        # TTL is 0 → expired on next gc sweep
+        await _sleep_ms(20)
+        assert await c.check_and_record("s", "n1") is True
+
+    async def test_seen_does_not_record(self):
+        c = InMemoryNonceCache(ttl_seconds=60)
+        assert await c.seen("s", "n1") is False
+        assert await c.seen("s", "n1") is False
+
+    async def test_record_then_seen(self):
+        c = InMemoryNonceCache(ttl_seconds=60)
+        await c.record("s", "n1")
+        assert await c.seen("s", "n1") is True
+
+
+async def _sleep_ms(ms: int):
+    import asyncio as _asyncio
+    await _asyncio.sleep(ms / 1000.0)
+
+
+# ---------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------
+
+
+def test_sha256_hex_matches_hashlib():
+    assert sha256_hex(b"abc") == hashlib.sha256(b"abc").hexdigest()
+
+
+def test_random_nonce_length_and_hex():
+    n = random_nonce(16)
+    assert len(n) == 32
+    int(n, 16)  # valid hex
+
+
+def test_random_nonce_is_actually_random():
+    assert random_nonce() != random_nonce()


### PR DESCRIPTION
## Stage A.2 — device_identity crypto service

Part of the bootstrap redesign umbrella #420. Pure-functions layer that the Stage A.3 endpoints PR will consume. Intentionally no FastAPI/SQLAlchemy deps so it can be unit-tested in full isolation.

### What lands

- `cms/services/device_identity.py`
  - `connect_token_canonical_bytes` / `verify_ed25519_signature` — request signing for `POST /api/devices/connect-token` (the signature is the auth; no transport-level creds).
  - `encrypt_for_device` — ECIES to a device's ed25519 identity key for the bootstrap outbox payload. Wire format:
    ```
    base64( eph_x25519_pub(32) || nonce(12) || AESGCM_ct_with_tag )
    ```
    HKDF info string `"agora-bootstrap-ecies-v1"` must match firmware.
  - `fleet_hmac_input` / `compute_fleet_hmac` / `verify_fleet_hmac` — per-fleet shared-secret HMAC for anonymous `/api/devices/register`.
  - `timestamp_within_skew` — ±N-second clock skew helper.
  - `NonceCache` Protocol + `InMemoryNonceCache` — TTL + async-lock in-memory replay cache. Callers should use `check_and_record` (atomic) — that's now a first-class Protocol method.
- `tests/test_device_identity.py` — 38 unit tests, no fixtures.
- `requirements.txt` — explicit `cryptography>=43,<47` pin (was transitive via azure-storage).

### Rubber-duck feedback addressed

- Ed25519→X25519 conversion now rejects:
  - non-canonical `y ≥ p`
  - the Edwards identity (y = 1 → denom = 0)
  - low-order Montgomery points (`u ∈ {0, 1}`)
- `verify_fleet_hmac` type-checks `mac_hex` and catches `AttributeError` so anonymous callers can never 500 on malformed input.
- `encrypt_for_device` uses strict base64 (`validate=True`) and raises `ValueError` on malformed pubkeys instead of passing garbage through.
- `check_and_record` is now on the `NonceCache` Protocol as the typed default (with a docstring calling it out as the correct API). `seen`/`record` kept only for diagnostics.
- Module docstring treats single-process as an **enforced deployment invariant**, with explicit follow-up to replace with a DB-backed cache before the multi-replica flip (#344 Stage 4).

### Tests

```
38 passed in 0.3s
```

New guard tests: `test_rejects_malformed_base64_pubkey`, `test_rejects_wrong_length_pubkey`, `test_rejects_non_canonical_y`, `test_rejects_y_equals_one`, `test_rejects_zero_pubkey`, `test_verify_returns_false_on_non_string_mac`.

### Not in this PR

- Endpoint wiring (routers/bootstrap.py) — Stage A.3.
- DB-backed nonce cache — deferred to #344 Stage 4 before N>1 flip.
- `slowapi` dep for rate limits — Stage A.3 adds it.

No migrations. No behaviour change in running services until the endpoints PR lands.
