### PR TITLE
fix(bootstrap): harden A.3 endpoints post-deploy review (#420)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -87,6 +87,22 @@ class Settings(SharedSettings):
     # returns 503 once the cap is reached to protect the DB from
     # registration spam.
     pending_registrations_max: int = 50_000
+    # TTLs for the ``pending_registrations`` reaper loop.  All in
+    # seconds; set 0 to disable a given sweep.
+    # * ``unpolled`` — row created but the device never polled.  Tight
+    #   window because this is where registration-spam junk accumulates
+    #   (1h default).
+    # * ``polled`` — device polled but admin hasn't adopted.  Generous
+    #   window so a technician has time to scan the QR and hit /adopt
+    #   from the UI (24h default).
+    # * ``adopted`` — row was adopted; device almost certainly fetched
+    #   the payload already.  Keep briefly for troubleshooting, then
+    #   drop (24h default).
+    bootstrap_reaper_unpolled_ttl_seconds: int = 3600
+    bootstrap_reaper_polled_ttl_seconds: int = 86_400
+    bootstrap_reaper_adopted_ttl_seconds: int = 86_400
+    # How often the reaper loop wakes up to run a sweep.
+    bootstrap_reaper_interval_seconds: int = 3600
     # TTL for the in-memory nonce cache used by ``/register`` (scope=fleet)
     # and ``/connect-token`` (scope=connect-token).  Must be >= the larger
     # of the two timestamp-skew windows (300s for /register, 60s for

--- a/cms/main.py
+++ b/cms/main.py
@@ -49,6 +49,9 @@ from cms.services.storage import (
 from cms.services.log_blob import init_log_storage
 from cms.services.version_checker import version_check_loop
 from cms.services.device_purge import device_purge_loop
+from cms.services.pending_registration_reaper import (
+    pending_registration_reaper_loop,
+)
 from cms.services.transcoder import (
     deleted_asset_reaper_loop,
     outbox_drain_loop,
@@ -457,6 +460,9 @@ async def lifespan(app: FastAPI):
     backfill_task = asyncio.create_task(_backfill_media_metadata(settings))
     version_check_task = asyncio.create_task(version_check_loop())
     device_purge_task = asyncio.create_task(device_purge_loop())
+    pending_reg_reaper_task = asyncio.create_task(
+        pending_registration_reaper_loop()
+    )
     key_rotation_task = asyncio.create_task(service_key_rotation_loop())
     alert_refresh_task = asyncio.create_task(_alert_settings_refresh_loop())
     capture_monitor_task = asyncio.create_task(stream_capture_monitor_loop())
@@ -573,6 +579,7 @@ async def lifespan(app: FastAPI):
     backfill_task.cancel()
     version_check_task.cancel()
     device_purge_task.cancel()
+    pending_reg_reaper_task.cancel()
     key_rotation_task.cancel()
     alert_refresh_task.cancel()
     capture_monitor_task.cancel()
@@ -596,6 +603,10 @@ async def lifespan(app: FastAPI):
         pass
     try:
         await device_purge_task
+    except asyncio.CancelledError:
+        pass
+    try:
+        await pending_reg_reaper_task
     except asyncio.CancelledError:
         pass
     try:

--- a/cms/routers/bootstrap.py
+++ b/cms/routers/bootstrap.py
@@ -223,6 +223,10 @@ async def register(
         await db.rollback()
         logger.warning("/register rejected: %s", e)
         raise HTTPException(status_code=503, detail="registration_capacity_exceeded") from e
+    except device_bootstrap.BootstrapPubkeyMismatch as e:
+        await db.rollback()
+        logger.warning("/register rejected: %s", e)
+        raise HTTPException(status_code=409, detail="pubkey_mismatch") from e
     except HTTPException:
         await db.rollback()
         raise
@@ -379,16 +383,17 @@ async def connect_token(
     _ip_ratelimited(request, key="connect-token", limit=120, window_sec=60)
 
     from sqlalchemy import select as _select
-    from cms.models.device import Device
+    from cms.models.device import Device, DeviceStatus
 
     device = (
         await db.execute(
             _select(Device).where(Device.id == body.device_id)
         )
     ).scalar_one_or_none()
-    if device is None or not device.pubkey:
+    if device is None or not device.pubkey or device.status != DeviceStatus.ADOPTED:
         # Uniform 401 for "no device", "device exists but no pubkey
-        # (revoked)", and "signature fails".  Don't leak which.
+        # (revoked)", "device not in adopted state (pending/removed)",
+        # and "signature fails".  Don't leak which.
         raise HTTPException(status_code=401, detail="unauthorized")
 
     if not device_identity.timestamp_within_skew(body.timestamp, 60):

--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -55,6 +55,16 @@ class BootstrapPendingNotFound(Exception):
     """
 
 
+class BootstrapPubkeyMismatch(Exception):
+    """Raised by :func:`register_device` if a re-registration for the
+    same ``pairing_secret_hash`` submits a different pubkey than the
+    existing unadopted row.  Prevents an attacker (with fleet HMAC +
+    pairing secret) from hijacking an in-flight registration by swapping
+    their own pubkey in before adoption — the adopted payload would then
+    be ECIES-encrypted to the attacker.  Router translates to HTTP 409.
+    """
+
+
 # ---------------------------------------------------------------------
 # /register
 # ---------------------------------------------------------------------
@@ -109,12 +119,21 @@ async def register_device(
         # Return the existing row as-is so the caller still gets a 202.
         if existing.adopted_at is not None:
             return existing
-        # Defence-in-depth: refresh identity fields.  If a device
-        # factory-resets but somehow retained its pairing secret (should
-        # not happen per spec), the new pubkey/device_id wins so adoption
-        # encrypts to the right recipient.
-        existing.device_id = device_id
-        existing.pubkey = pubkey_b64
+        # Security: require the pubkey to match the existing unadopted
+        # row.  Allowing pubkey replacement here would let anyone with the
+        # fleet HMAC secret AND the pairing secret swap in their own
+        # pubkey before adoption, causing the admin-encrypted config
+        # payload to be delivered to the attacker.  Legit "same device
+        # retries" always re-uses the same keypair.  A factory-reset
+        # device generates a new keypair AND a new pairing secret, so
+        # it lands on the fresh-registration path below, not here.
+        if existing.pubkey != pubkey_b64:
+            raise BootstrapPubkeyMismatch(
+                "pairing_secret_hash already in use by a different pubkey"
+            )
+        # Same-pubkey retry: refresh transport metadata only.  We do not
+        # rewrite ``device_id`` either — it is keypair-stable and the
+        # caller already proved possession of the keypair via fleet HMAC.
         existing.connection_metadata = metadata or None
         existing.ip_address = ip_address
         existing.updated_at = now
@@ -203,6 +222,82 @@ async def get_bootstrap_status(
         row.polled_at = datetime.now(timezone.utc)
         await db.flush()
     return row
+
+
+# ---------------------------------------------------------------------
+# pending_registrations GC (TTL reaper)
+# ---------------------------------------------------------------------
+
+
+async def reap_pending_registrations(
+    *,
+    db: AsyncSession,
+    unpolled_ttl_seconds: int,
+    polled_ttl_seconds: int,
+    adopted_ttl_seconds: int,
+) -> int:
+    """Delete expired ``pending_registrations`` rows.
+
+    Three TTLs, applied in descending order of aggressiveness:
+
+    * ``unpolled_ttl_seconds`` — rows never polled by any device.  Most
+      likely junk: HMAC-authed but the device either never came back
+      online or is a bad actor burning cap slots.  Aggressive default
+      (1h).
+    * ``polled_ttl_seconds`` — rows a device polled but admin never
+      adopted.  Legit pending registrations fall here; give admins
+      generous time to notice the device in the UI (24h).
+    * ``adopted_ttl_seconds`` — rows already adopted.  The device has
+      polled the ciphertext (or we presume it has) and doesn't need the
+      payload anymore; keep for a short window for troubleshooting then
+      drop.  Zero or negative disables.
+
+    Returns the total number of rows deleted.  Idempotent — safe to run
+    on every replica, though the caller should gate behind a leader
+    lock to avoid wasted DB work.
+    """
+    from sqlalchemy import delete, or_, and_
+
+    now = datetime.now(timezone.utc)
+    total = 0
+
+    if unpolled_ttl_seconds > 0:
+        cutoff = now - timedelta(seconds=unpolled_ttl_seconds)
+        result = await db.execute(
+            delete(PendingRegistration).where(
+                PendingRegistration.adopted_at.is_(None),
+                PendingRegistration.polled_at.is_(None),
+                PendingRegistration.created_at < cutoff,
+            )
+        )
+        total += result.rowcount or 0
+
+    if polled_ttl_seconds > 0:
+        cutoff = now - timedelta(seconds=polled_ttl_seconds)
+        result = await db.execute(
+            delete(PendingRegistration).where(
+                PendingRegistration.adopted_at.is_(None),
+                PendingRegistration.polled_at.is_not(None),
+                PendingRegistration.polled_at < cutoff,
+            )
+        )
+        total += result.rowcount or 0
+
+    if adopted_ttl_seconds > 0:
+        cutoff = now - timedelta(seconds=adopted_ttl_seconds)
+        result = await db.execute(
+            delete(PendingRegistration).where(
+                PendingRegistration.adopted_at.is_not(None),
+                PendingRegistration.adopted_at < cutoff,
+            )
+        )
+        total += result.rowcount or 0
+
+    if total > 0:
+        await db.commit()
+    else:
+        await db.rollback()
+    return total
 
 
 # ---------------------------------------------------------------------

--- a/cms/services/pending_registration_reaper.py
+++ b/cms/services/pending_registration_reaper.py
@@ -1,0 +1,70 @@
+"""Background loop that reaps expired ``pending_registrations`` rows.
+
+Paired with the hard cap in ``register_device`` (``pending_registrations_max``),
+this loop prevents the table from filling up indefinitely under
+registration spam or buggy firmware that re-registers on a tight loop
+without ever polling bootstrap-status.
+
+Gated behind a session-advisory lock so only one replica runs the DELETE
+pass at a time — duplicate deletes would be idempotent but waste DB
+round-trips.  Per-tick body is :func:`reap_pending_registrations` so
+tests can drive it deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+async def pending_registration_reaper_loop() -> None:
+    """Background loop — wakes on ``bootstrap_reaper_interval_seconds``."""
+    from cms.auth import get_settings
+    from cms.database import get_db
+    from cms.services.device_bootstrap import reap_pending_registrations
+    from cms.services.leader import session_advisory_lock
+
+    _LOCK_ID = 0x4147_4F52_41_03  # 'AGORA' + 03
+
+    # Wait for startup to settle.
+    try:
+        await asyncio.sleep(30)
+    except asyncio.CancelledError:
+        return
+
+    while True:
+        try:
+            settings = get_settings()
+            interval = max(60, int(settings.bootstrap_reaper_interval_seconds))
+            async with session_advisory_lock(_LOCK_ID) as got:
+                if got:
+                    async for db in get_db():
+                        deleted = await reap_pending_registrations(
+                            db=db,
+                            unpolled_ttl_seconds=int(
+                                settings.bootstrap_reaper_unpolled_ttl_seconds
+                            ),
+                            polled_ttl_seconds=int(
+                                settings.bootstrap_reaper_polled_ttl_seconds
+                            ),
+                            adopted_ttl_seconds=int(
+                                settings.bootstrap_reaper_adopted_ttl_seconds
+                            ),
+                        )
+                        if deleted:
+                            logger.info(
+                                "Reaped %d expired pending_registrations row(s)",
+                                deleted,
+                            )
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            logger.exception("Error in pending_registrations reaper loop")
+
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            return

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -725,3 +725,205 @@ class TestConnectToken:
         assert r1.status_code == 200
         r2 = await unauthed_client.post("/api/devices/connect-token", json=body)
         assert r2.status_code == 401
+
+    async def test_non_adopted_status_returns_401(
+        self, unauthed_client, stub_wps_transport, db_session,
+    ):
+        """A Device row that exists and still has its pubkey but is not
+        in ``ADOPTED`` state (e.g. PENDING, or left behind by a removal
+        flow that nulled status but not pubkey) must not be able to mint
+        fresh WPS JWTs.  Prevents bypass of admin revocation that only
+        changed ``status`` without clearing ``pubkey``.
+        """
+        from cms.models.device import Device, DeviceStatus
+
+        priv, pub_b64 = _gen_keypair()
+        device = Device(
+            id=str(uuid.uuid4()), name="ct-pending",
+            status=DeviceStatus.PENDING, pubkey=pub_b64,
+        )
+        db_session.add(device)
+        await db_session.commit()
+
+        ts = int(time.time())
+        nonce = uuid.uuid4().hex
+        sig = _sign_connect_token(priv, device.id, ts, nonce)
+        r = await unauthed_client.post(
+            "/api/devices/connect-token",
+            json={"device_id": device.id, "timestamp": ts,
+                  "nonce": nonce, "signature": sig},
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------
+# /register — pubkey-hijack defence
+# ---------------------------------------------------------------------
+
+
+class TestRegisterPubkeyHijack:
+    async def test_same_pairing_hash_different_pubkey_returns_409(
+        self, unauthed_client, fleet_secret_enabled, db_session,
+    ):
+        """Attacker (with the fleet HMAC secret + the leaked pairing
+        secret) must not be able to overwrite an existing unadopted
+        pending row's pubkey with their own.  Doing so would cause the
+        admin's adopt-time ECIES-encrypted payload to be decryptable by
+        the attacker instead of the real device.
+        """
+        _, pub_legit = _gen_keypair()
+        _, pub_attacker = _gen_keypair()
+        _, pairing_hash = _pairing_pair()
+
+        body1 = {
+            "device_id": "pi-legit", "pubkey": pub_legit,
+            "pairing_secret_hash": pairing_hash,
+        }
+        r1 = await unauthed_client.post(
+            "/api/devices/register", json=body1,
+            headers=_fleet_headers(
+                device_id=body1["device_id"], pubkey_b64=pub_legit,
+                pairing_secret_hash_hex=pairing_hash,
+            ),
+        )
+        assert r1.status_code == 202
+
+        body2 = {
+            "device_id": "pi-attacker", "pubkey": pub_attacker,
+            "pairing_secret_hash": pairing_hash,
+        }
+        r2 = await unauthed_client.post(
+            "/api/devices/register", json=body2,
+            headers=_fleet_headers(
+                device_id=body2["device_id"], pubkey_b64=pub_attacker,
+                pairing_secret_hash_hex=pairing_hash,
+            ),
+        )
+        assert r2.status_code == 409
+        assert r2.json()["detail"] == "pubkey_mismatch"
+
+        # DB still shows the legitimate pubkey untouched.
+        from cms.models.pending_registration import PendingRegistration
+        from sqlalchemy import select
+        row = (
+            await db_session.execute(
+                select(PendingRegistration).where(
+                    PendingRegistration.pairing_secret_hash == pairing_hash,
+                )
+            )
+        ).scalar_one()
+        assert row.pubkey == pub_legit
+        assert row.device_id == "pi-legit"
+
+
+# ---------------------------------------------------------------------
+# pending_registrations TTL reaper
+# ---------------------------------------------------------------------
+
+
+class TestPendingRegistrationsReaper:
+    async def test_unpolled_expired_row_deleted(self, db_session):
+        """Rows that were created, HMAC-authed, but never polled get
+        dropped once the unpolled TTL elapses.  Main defence against
+        registration spam burning cap slots.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timedelta, timezone
+        from cms.models.pending_registration import PendingRegistration
+        from cms.services.device_bootstrap import reap_pending_registrations
+        from sqlalchemy import select, func
+
+        stale_ts = datetime.now(timezone.utc) - timedelta(hours=2)
+        db_session.add(PendingRegistration(
+            id=_uuid.uuid4(), device_id="old", pubkey="stale-pubkey",
+            pairing_secret_hash="a" * 64,
+            created_at=stale_ts, updated_at=stale_ts,
+        ))
+        db_session.add(PendingRegistration(
+            id=_uuid.uuid4(), device_id="fresh", pubkey="fresh-pubkey",
+            pairing_secret_hash="b" * 64,
+        ))
+        await db_session.commit()
+
+        deleted = await reap_pending_registrations(
+            db=db_session,
+            unpolled_ttl_seconds=3600,
+            polled_ttl_seconds=86_400,
+            adopted_ttl_seconds=86_400,
+        )
+        assert deleted == 1
+
+        remaining = (
+            await db_session.execute(
+                select(func.count()).select_from(PendingRegistration)
+            )
+        ).scalar_one()
+        assert remaining == 1
+
+    async def test_polled_unadopted_uses_polled_ttl(self, db_session):
+        """A row the device has polled survives past the unpolled TTL
+        so admins have time to finish the adoption flow — but is still
+        eventually reaped if adoption never happens.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timedelta, timezone
+        from cms.models.pending_registration import PendingRegistration
+        from cms.services.device_bootstrap import reap_pending_registrations
+        from sqlalchemy import select, func
+
+        # Polled 2h ago — past unpolled TTL (1h) but within polled TTL (24h).
+        polled_ts = datetime.now(timezone.utc) - timedelta(hours=2)
+        db_session.add(PendingRegistration(
+            id=_uuid.uuid4(), device_id="polled-recent",
+            pubkey="pk-recent", pairing_secret_hash="c" * 64,
+            polled_at=polled_ts,
+        ))
+        # Polled 30h ago — past polled TTL.
+        polled_old_ts = datetime.now(timezone.utc) - timedelta(hours=30)
+        db_session.add(PendingRegistration(
+            id=_uuid.uuid4(), device_id="polled-old",
+            pubkey="pk-old", pairing_secret_hash="d" * 64,
+            polled_at=polled_old_ts,
+        ))
+        await db_session.commit()
+
+        deleted = await reap_pending_registrations(
+            db=db_session,
+            unpolled_ttl_seconds=3600,
+            polled_ttl_seconds=86_400,
+            adopted_ttl_seconds=86_400,
+        )
+        assert deleted == 1
+
+        rows = (
+            await db_session.execute(select(PendingRegistration))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].device_id == "polled-recent"
+
+    async def test_adopted_expired_row_deleted(self, db_session):
+        """Adopted rows are kept briefly for troubleshooting then
+        dropped.  Bounds long-term table growth for adopted devices too.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timedelta, timezone
+        from cms.models.pending_registration import PendingRegistration
+        from cms.services.device_bootstrap import reap_pending_registrations
+        from sqlalchemy import select, func
+
+        adopted_ts = datetime.now(timezone.utc) - timedelta(hours=48)
+        db_session.add(PendingRegistration(
+            id=_uuid.uuid4(), device_id="ancient-adopted",
+            pubkey="pk-adopted", pairing_secret_hash="e" * 64,
+            adopted_at=adopted_ts,
+        ))
+        await db_session.commit()
+
+        deleted = await reap_pending_registrations(
+            db=db_session,
+            unpolled_ttl_seconds=3600,
+            polled_ttl_seconds=86_400,
+            adopted_ttl_seconds=86_400,
+        )
+        assert deleted == 1
+


### PR DESCRIPTION
## Summary

Three post-deploy rubber-duck findings on Stage A.3 (PR #424, issue #420) addressed in one patch. None are incidents — `FLEET_REGISTER_SECRETS` is still empty in prod so no firmware is hitting these endpoints yet — but all three must land before A.5 switches the fleet over.

## What

### 1. Pubkey-hijack defence on `/register`

Previously, `register_device` rewrote `existing.pubkey` on any re-registration keyed by `pairing_secret_hash`. An attacker with the fleet HMAC secret **and** a leaked pairing secret could swap their own pubkey into an unadopted pending row and then receive the admin-encrypted config payload.

Now: if the incoming pubkey differs from the existing unadopted row's pubkey, reject with `409 pubkey_mismatch`. Same-pubkey retries still refresh `connection_metadata` / `ip_address`.

Legit factory-reset flow unaffected: a factory-reset device generates a **new** keypair **and** a new pairing secret, so it lands on the fresh-registration path (with the partial unique index protecting pubkey uniqueness), not here.

### 2. `pending_registrations` TTL reaper

The 50K hard cap was permanent without a GC loop — once filled, `/register` stays 503 until manual DB cleanup. New `pending_registration_reaper_loop` runs hourly (configurable), gated behind a session-advisory lock, applying three TTLs:

| TTL | Default | Who it catches |
|---|---|---|
| `bootstrap_reaper_unpolled_ttl_seconds` | 1h | Registration spam — HMAC-authed but device never polled |
| `bootstrap_reaper_polled_ttl_seconds` | 24h | Polled but admin never adopted — gives techs time to finish QR flow |
| `bootstrap_reaper_adopted_ttl_seconds` | 24h | Adopted rows kept briefly for troubleshooting then dropped |

Set any TTL to `0` to disable that sweep.

### 3. `/connect-token` enforces `DeviceStatus.ADOPTED`

Previously, any Device row with a pubkey could mint fresh WPS JWTs — so a device left in `PENDING` (or a future state that kept the pubkey for audit while revoking access) would bypass revocation. Now require `status == ADOPTED`; uniform 401 response so we don't leak status transitions.

## Tests

5 new tests added:

- `TestConnectToken::test_non_adopted_status_returns_401`
- `TestRegisterPubkeyHijack::test_same_pairing_hash_different_pubkey_returns_409`
- `TestPendingRegistrationsReaper::test_unpolled_expired_row_deleted`
- `TestPendingRegistrationsReaper::test_polled_unadopted_uses_polled_ttl`
- `TestPendingRegistrationsReaper::test_adopted_expired_row_deleted`

Full runs:
- `tests/test_bootstrap_endpoints.py` — **26/26** pass
- 4-file related suite (bootstrap + device_identity + adoption + lifespan) — **98/98** pass
