### PR TITLE
fix(bootstrap): resolve pending-reg reaper lock collision (#420)

### DIFF
--- a/cms/services/pending_registration_reaper.py
+++ b/cms/services/pending_registration_reaper.py
@@ -27,7 +27,7 @@ async def pending_registration_reaper_loop() -> None:
     from cms.services.device_bootstrap import reap_pending_registrations
     from cms.services.leader import session_advisory_lock
 
-    _LOCK_ID = 0x4147_4F52_41_03  # 'AGORA' + 03
+    _LOCK_ID = 0x4147_4F52_41_05  # 'AGORA' + 05 (01 backfill, 02 device_purge, 03 capture_monitor, 04 asset_reaper)
 
     # Wait for startup to settle.
     try:


### PR DESCRIPTION
Post-deploy rubber-duck on #425 caught that the new pending_registration reaper uses advisory lock ID 0x4147_4F52_41_03, which `stream_capture_monitor_loop` (`cms/services/transcoder.py:455`) already owns. On Postgres the two loops would serialize against each other, causing the reaper to silently skip ticks whenever capture-monitor held the lock.

Bumped to `0x4147_4F52_41_05` (01 backfill, 02 device_purge, 03 capture_monitor, 04 asset_reaper, 05 pending_reg reaper).