### PR TITLE
fix(ui): enforce v===1 on bootstrap QR payload (#420)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -685,7 +685,7 @@ function _parsePairingQr(text) {
         try { obj = JSON.parse(t); }
         catch (_) { obj = undefined; }
         if (obj !== undefined) {
-            if (obj && typeof obj.secret === "string") {
+            if (obj && obj.v === 1 && typeof obj.secret === "string") {
                 const s = obj.secret.trim();
                 return s.length >= 8 && s.length <= 128 ? s : null;
             }


### PR DESCRIPTION
Duck-verified follow-up to #428. One-line change: `_parsePairingQr` now requires `obj.v === 1` before accepting the secret. Future firmware may legitimately use v=2 with a different schema; failing closed on unknown versions is the safer contract.