### PR TITLE
feat(bootstrap): adopt pending devices by id from UI without pairing secret

### DIFF
--- a/cms/routers/bootstrap.py
+++ b/cms/routers/bootstrap.py
@@ -35,6 +35,7 @@ import hashlib
 import hmac
 import logging
 import time
+import uuid
 from collections import defaultdict, deque
 from datetime import datetime, timezone
 from typing import Any, Deque, Tuple
@@ -47,11 +48,14 @@ from cms.config import Settings
 from cms.database import get_db
 from cms.permissions import DEVICES_MANAGE
 from cms.schemas.bootstrap import (
+    AdoptPendingRequest,
     BootstrapAdoptRequest,
     BootstrapAdoptResponse,
     BootstrapStatusResponse,
     ConnectTokenRequest,
     ConnectTokenResponse,
+    PendingDeviceSummary,
+    PendingDevicesResponse,
     RegisterRequest,
     RegisterResponse,
 )
@@ -364,6 +368,199 @@ async def adopt(
     await db.commit()
 
     return BootstrapAdoptResponse(device_id=device.id, status="adopted")
+
+
+# ---------------------------------------------------------------------
+# /pending + /adopt-pending (UI-driven adopt-by-row-id flow)
+# ---------------------------------------------------------------------
+
+
+def _pending_to_summary(row) -> PendingDeviceSummary:
+    metadata = dict(row.connection_metadata or {})
+    return PendingDeviceSummary(
+        id=str(row.id),
+        device_id=row.device_id,
+        pubkey=row.pubkey,
+        metadata=metadata,
+        ip_address=row.ip_address,
+        created_at=(
+            row.created_at.isoformat().replace("+00:00", "Z")
+            if row.created_at is not None else ""
+        ),
+        polled_at=(
+            row.polled_at.isoformat().replace("+00:00", "Z")
+            if row.polled_at is not None else None
+        ),
+        has_polled=row.polled_at is not None,
+    )
+
+
+@router.get(
+    "/pending",
+    response_model=PendingDevicesResponse,
+    dependencies=[Depends(require_permission(DEVICES_MANAGE))],
+)
+async def list_pending(
+    db: AsyncSession = Depends(get_db),
+) -> PendingDevicesResponse:
+    """List every pending (un-adopted) device registration.
+
+    Drives the "Pending Devices" section of the devices page.  Items
+    are sorted newest-first so the most recently connected device is
+    always on top.
+    """
+    rows = await device_bootstrap.list_pending_registrations(db)
+    return PendingDevicesResponse(
+        items=[_pending_to_summary(r) for r in rows],
+    )
+
+
+@router.post(
+    "/adopt-pending",
+    response_model=BootstrapAdoptResponse,
+    dependencies=[Depends(require_permission(DEVICES_MANAGE))],
+)
+async def adopt_pending(
+    body: AdoptPendingRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> BootstrapAdoptResponse:
+    """Adopt a pending row by its id.
+
+    Same effect as ``POST /adopt`` with the pairing secret, but the
+    admin never sees the secret — it stays on the wire between the
+    device and CMS as an idempotency key.
+    """
+    _ip_ratelimited(request, key="adopt", limit=60, window_sec=60)
+    _user = getattr(request.state, "user", None)
+    _user_id = getattr(_user, "id", None) if _user is not None else None
+    if _user_id is not None:
+        now = time.monotonic()
+        bucket = _buckets[("adopt-user", str(_user_id))]
+        cutoff = now - 60
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= 60:
+            raise HTTPException(status_code=429, detail="rate_limited")
+        bucket.append(now)
+
+    try:
+        pending_uuid = uuid.UUID(body.pending_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=404, detail="pending_not_found")
+
+    async def _mint(device_row_id: str) -> dict[str, Any]:
+        transport = get_transport()
+        if not hasattr(transport, "get_client_access_token"):
+            raise HTTPException(
+                status_code=500,
+                detail="Transport does not support client tokens",
+            )
+        return await transport.get_client_access_token(
+            device_row_id,
+            minutes_to_expire=settings.bootstrap_wps_jwt_minutes,
+        )
+
+    try:
+        device, pending = await device_bootstrap.adopt_pending_by_id(
+            db=db,
+            pending_id=pending_uuid,
+            profile_id=body.profile_id,
+            name=body.name,
+            location=body.location,
+            group_id=body.group_id,
+            mint_wps_jwt=_mint,
+            settings=settings,
+        )
+    except device_bootstrap.BootstrapPendingNotFound:
+        await db.rollback()
+        raise HTTPException(status_code=404, detail="pending_not_found")
+    except device_bootstrap.BootstrapAlreadyAdopted:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="already_adopted")
+    except ValueError as e:
+        await db.rollback()
+        msg = str(e)
+        if msg in ("group_not_found", "profile_not_found"):
+            raise HTTPException(status_code=404, detail=msg) from e
+        raise HTTPException(status_code=400, detail=msg) from e
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception:
+        await db.rollback()
+        logger.exception("/adopt-pending internal error")
+        raise HTTPException(status_code=500, detail="internal_error")
+
+    await audit_log(
+        db,
+        user=getattr(request.state, "user", None),
+        action="device.adopt",
+        resource_type="device",
+        resource_id=str(device.id),
+        description=(
+            f"Adopted device '{device.name or device.id}' via pending list"
+        ),
+        details={
+            "name": device.name,
+            "location": device.location,
+            "group_id": str(device.group_id) if device.group_id else None,
+            "profile_id": str(device.profile_id) if device.profile_id else None,
+            "pending_id": str(pending.id),
+            "flow": "adopt-pending",
+        },
+        request=request,
+    )
+    await db.commit()
+
+    return BootstrapAdoptResponse(device_id=device.id, status="adopted")
+
+
+@router.delete(
+    "/pending/{pending_id}",
+    status_code=204,
+    dependencies=[Depends(require_permission(DEVICES_MANAGE))],
+)
+async def reject_pending(
+    pending_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Reject / drop an un-adopted pending row.
+
+    Useful for cleaning up bogus or duplicate registrations from the
+    UI without waiting for the reaper's TTL.  Refuses to delete rows
+    that have already been adopted.
+    """
+    try:
+        pending_uuid = uuid.UUID(pending_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=404, detail="pending_not_found")
+
+    try:
+        deleted = await device_bootstrap.delete_pending(db, pending_uuid)
+    except Exception:
+        await db.rollback()
+        logger.exception("/pending delete internal error")
+        raise HTTPException(status_code=500, detail="internal_error")
+
+    if not deleted:
+        await db.rollback()
+        raise HTTPException(status_code=404, detail="pending_not_found")
+
+    await audit_log(
+        db,
+        user=getattr(request.state, "user", None),
+        action="device.pending.reject",
+        resource_type="pending_registration",
+        resource_id=str(pending_uuid),
+        description="Rejected pending device registration from UI",
+        details={"pending_id": str(pending_uuid)},
+        request=request,
+    )
+    await db.commit()
+    return None
 
 
 @router.post("/connect-token", response_model=ConnectTokenResponse)

--- a/cms/schemas/bootstrap.py
+++ b/cms/schemas/bootstrap.py
@@ -52,9 +52,46 @@ class BootstrapAdoptRequest(BaseModel):
     profile_id: str = Field(min_length=1)  # uuid; required
 
 
+class AdoptPendingRequest(BaseModel):
+    """Request body for ``POST /api/devices/adopt-pending``.
+
+    Identifies the pending row by its primary key rather than the
+    pairing secret, so the admin never has to see or type the secret.
+    """
+
+    pending_id: str = Field(min_length=1)  # uuid
+    name: str | None = Field(default=None, max_length=100)
+    location: str | None = Field(default=None, max_length=255)
+    group_id: str | None = None  # uuid
+    profile_id: str = Field(min_length=1)  # uuid; required
+
+
 class BootstrapAdoptResponse(BaseModel):
     device_id: str
     status: str = "adopted"
+
+
+class PendingDeviceSummary(BaseModel):
+    """One row of the pending-devices list surfaced to admins.
+
+    Excludes ``pairing_secret_hash`` and ``outbox_ciphertext`` — those
+    are on-wire secrets the admin has no reason to see.  ``pubkey`` is
+    returned in full-string form but the UI only renders a short
+    fingerprint; full value is handy for support/debugging.
+    """
+
+    id: str  # uuid primary key, used to adopt via /adopt-pending
+    device_id: str  # device-chosen (Pi serial/hostname), advisory
+    pubkey: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    ip_address: str | None = None
+    created_at: str  # ISO 8601
+    polled_at: str | None = None  # ISO 8601
+    has_polled: bool = False
+
+
+class PendingDevicesResponse(BaseModel):
+    items: list[PendingDeviceSummary]
 
 
 # ---------------------------------------------------------------------

--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -321,7 +321,7 @@ def _build_bootstrap_payload(
     return json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
 
-async def _lock_pending_for_adoption(
+async def _lock_pending_by_hash(
     db: AsyncSession, pairing_secret_hash: str,
 ) -> PendingRegistration | None:
     """``SELECT ... FOR UPDATE`` on PostgreSQL; plain SELECT on SQLite.
@@ -338,10 +338,67 @@ async def _lock_pending_for_adoption(
     return (await db.execute(stmt)).scalar_one_or_none()
 
 
-async def adopt_device(
+# Back-compat alias for callers that imported the old name.
+_lock_pending_for_adoption = _lock_pending_by_hash
+
+
+async def _lock_pending_by_id(
+    db: AsyncSession, pending_id: uuid.UUID,
+) -> PendingRegistration | None:
+    """Same contract as :func:`_lock_pending_by_hash` but keyed by the
+    row's primary key.  Used by the adopt-by-pending-id UI flow so the
+    admin can adopt straight from the pending-devices list without
+    typing the pairing secret.  The secret is still generated and
+    transmitted; it is simply never surfaced to the admin.
+    """
+    stmt = select(PendingRegistration).where(
+        PendingRegistration.id == pending_id,
+    )
+    dialect = db.bind.dialect.name if db.bind is not None else ""
+    if dialect == "postgresql":
+        stmt = stmt.with_for_update()
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_pending_registrations(
+    db: AsyncSession,
+) -> list[PendingRegistration]:
+    """Return every un-adopted pending_registrations row, newest first.
+
+    Read-only; does not take a row-level lock.  Used by the admin-only
+    ``GET /api/devices/pending`` endpoint that powers the pending-devices
+    list in the UI.
+    """
+    stmt = (
+        select(PendingRegistration)
+        .where(PendingRegistration.adopted_at.is_(None))
+        .order_by(PendingRegistration.created_at.desc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def delete_pending(
+    db: AsyncSession, pending_id: uuid.UUID,
+) -> bool:
+    """Delete an un-adopted pending row.  Returns True if a row was
+    removed, False otherwise (missing or already adopted).
+
+    Refuses to delete adopted rows — those still carry the outbox
+    ciphertext that the device picks up on its next /bootstrap-status
+    poll, and the reaper cleans them up after adoption.
+    """
+    pending = await _lock_pending_by_id(db, pending_id)
+    if pending is None or pending.adopted_at is not None:
+        return False
+    await db.delete(pending)
+    await db.flush()
+    return True
+
+
+async def _perform_adoption(
     *,
     db: AsyncSession,
-    pairing_secret: str,
+    pending: PendingRegistration,
     profile_id: str,
     name: str | None,
     location: str | None,
@@ -349,22 +406,10 @@ async def adopt_device(
     mint_wps_jwt,  # async callable (device_id) -> dict(url=..., token=...)
     settings: Settings,
 ) -> tuple[Device, PendingRegistration]:
-    """Adopt a pending_registrations row.
-
-    Atomic: looks up (FOR UPDATE) the pending row by pairing-secret hash,
-    creates the ``devices`` row, mints a WPS JWT, ECIES-encrypts the
-    bootstrap payload to the device's pubkey, and writes everything in
-    a single transaction.  Caller is responsible for committing.
+    """Shared body for both adopt-by-pairing-secret and
+    adopt-by-pending-id.  Caller has already acquired the row lock and
+    confirmed ``pending.adopted_at is None``.
     """
-    pairing_secret_hash = device_identity.sha256_hex(
-        pairing_secret.encode("utf-8"),
-    )
-    pending = await _lock_pending_for_adoption(db, pairing_secret_hash)
-    if pending is None:
-        raise BootstrapPendingNotFound(pairing_secret_hash)
-    if pending.adopted_at is not None:
-        raise BootstrapAlreadyAdopted(pairing_secret_hash)
-
     # Validate optional group_id.
     if group_id is not None:
         try:
@@ -414,7 +459,7 @@ async def adopt_device(
         # another devices row (shouldn't happen because pending's
         # partial unique index on pubkey blocks concurrent pending
         # rows, but double-check).
-        raise BootstrapAlreadyAdopted(pairing_secret_hash) from e
+        raise BootstrapAlreadyAdopted(str(pending.id)) from e
 
     # Mint a fresh WPS JWT for the new device.
     access = await mint_wps_jwt(device_row_id)
@@ -444,3 +489,75 @@ async def adopt_device(
     await db.flush()
 
     return device, pending
+
+
+async def adopt_device(
+    *,
+    db: AsyncSession,
+    pairing_secret: str,
+    profile_id: str,
+    name: str | None,
+    location: str | None,
+    group_id: str | None,
+    mint_wps_jwt,  # async callable (device_id) -> dict(url=..., token=...)
+    settings: Settings,
+) -> tuple[Device, PendingRegistration]:
+    """Adopt a pending_registrations row by pairing secret.
+
+    Atomic: looks up (FOR UPDATE) the pending row by pairing-secret hash,
+    creates the ``devices`` row, mints a WPS JWT, ECIES-encrypts the
+    bootstrap payload to the device's pubkey, and writes everything in
+    a single transaction.  Caller is responsible for committing.
+    """
+    pairing_secret_hash = device_identity.sha256_hex(
+        pairing_secret.encode("utf-8"),
+    )
+    pending = await _lock_pending_by_hash(db, pairing_secret_hash)
+    if pending is None:
+        raise BootstrapPendingNotFound(pairing_secret_hash)
+    if pending.adopted_at is not None:
+        raise BootstrapAlreadyAdopted(pairing_secret_hash)
+    return await _perform_adoption(
+        db=db,
+        pending=pending,
+        profile_id=profile_id,
+        name=name,
+        location=location,
+        group_id=group_id,
+        mint_wps_jwt=mint_wps_jwt,
+        settings=settings,
+    )
+
+
+async def adopt_pending_by_id(
+    *,
+    db: AsyncSession,
+    pending_id: uuid.UUID,
+    profile_id: str,
+    name: str | None,
+    location: str | None,
+    group_id: str | None,
+    mint_wps_jwt,  # async callable (device_id) -> dict(url=..., token=...)
+    settings: Settings,
+) -> tuple[Device, PendingRegistration]:
+    """Adopt a pending_registrations row by its primary key.
+
+    Same transactional contract as :func:`adopt_device` — takes a
+    row-level lock, writes the devices row + outbox ciphertext
+    atomically, caller commits.  Used by the UI's pending-devices list.
+    """
+    pending = await _lock_pending_by_id(db, pending_id)
+    if pending is None:
+        raise BootstrapPendingNotFound(str(pending_id))
+    if pending.adopted_at is not None:
+        raise BootstrapAlreadyAdopted(str(pending_id))
+    return await _perform_adoption(
+        db=db,
+        pending=pending,
+        profile_id=profile_id,
+        name=name,
+        location=location,
+        group_id=group_id,
+        mint_wps_jwt=mint_wps_jwt,
+        settings=settings,
+    )

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -598,6 +598,278 @@ class TestAdopt:
 
 
 # ---------------------------------------------------------------------
+# /pending + /adopt-pending + DELETE /pending/{id}
+# ---------------------------------------------------------------------
+
+
+async def _register_one(
+    unauthed_client, device_id: str = "pi-x",
+) -> tuple[str, str, str, Ed25519PrivateKey]:
+    """Helper: call /register once and return (device_id, pairing_secret,
+    pairing_hash, priv)."""
+    priv, pub_b64 = _gen_keypair()
+    pairing_secret, pairing_hash = _pairing_pair()
+    headers = _fleet_headers(
+        device_id=device_id, pubkey_b64=pub_b64,
+        pairing_secret_hash_hex=pairing_hash,
+    )
+    r = await unauthed_client.post(
+        "/api/devices/register",
+        json={"device_id": device_id, "pubkey": pub_b64,
+              "pairing_secret_hash": pairing_hash},
+        headers=headers,
+    )
+    assert r.status_code == 202, r.text
+    return device_id, pairing_secret, pairing_hash, priv
+
+
+class TestListPending:
+    async def test_requires_auth(
+        self, unauthed_client, fleet_secret_enabled,
+    ):
+        r = await unauthed_client.get("/api/devices/pending")
+        assert r.status_code in (401, 403)
+
+    async def test_empty_list(self, client, fleet_secret_enabled):
+        r = await client.get("/api/devices/pending")
+        assert r.status_code == 200
+        assert r.json() == {"items": []}
+
+    async def test_lists_registered_device(
+        self, client, unauthed_client, fleet_secret_enabled,
+    ):
+        await _register_one(unauthed_client, device_id="pi-alpha")
+        r = await client.get("/api/devices/pending")
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert len(items) == 1
+        row = items[0]
+        assert row["device_id"] == "pi-alpha"
+        assert isinstance(row["id"], str)
+        uuid.UUID(row["id"])  # must parse as uuid
+        assert row["pubkey"]
+        # pairing_secret_hash and outbox_ciphertext MUST NOT leak
+        assert "pairing_secret_hash" not in row
+        assert "outbox_ciphertext" not in row
+        assert "pairing_secret" not in row
+
+    async def test_newest_first(
+        self, client, unauthed_client, fleet_secret_enabled,
+    ):
+        await _register_one(unauthed_client, device_id="pi-first")
+        await _register_one(unauthed_client, device_id="pi-second")
+        r = await client.get("/api/devices/pending")
+        items = r.json()["items"]
+        assert [i["device_id"] for i in items] == ["pi-second", "pi-first"]
+
+    async def test_adopted_rows_excluded(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        _, secret_a, _, _ = await _register_one(
+            unauthed_client, device_id="pi-adopted",
+        )
+        await _register_one(unauthed_client, device_id="pi-still-pending")
+        profile = await _seed_profile(db_session, name="excl")
+        adopt = await client.post(
+            "/api/devices/adopt",
+            json={"pairing_secret": secret_a,
+                  "profile_id": str(profile.id)},
+        )
+        assert adopt.status_code == 200
+        r = await client.get("/api/devices/pending")
+        items = r.json()["items"]
+        assert [i["device_id"] for i in items] == ["pi-still-pending"]
+
+
+class TestAdoptPending:
+    async def test_admin_adoption_by_pending_id(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        _, _, pairing_hash, priv = await _register_one(
+            unauthed_client, device_id="pi-by-id",
+        )
+        # Discover the pending_id via the list endpoint (admin-only).
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+
+        profile = await _seed_profile(db_session, name="byid-prof")
+        r = await client.post(
+            "/api/devices/adopt-pending",
+            json={
+                "pending_id": pending_id,
+                "name": "Lobby",
+                "profile_id": str(profile.id),
+            },
+        )
+        assert r.status_code == 200, r.text
+        device_id = r.json()["device_id"]
+
+        from cms.models.device import Device, DeviceStatus
+        from cms.models.pending_registration import PendingRegistration
+        from sqlalchemy import select
+
+        device = (
+            await db_session.execute(
+                select(Device).where(Device.id == device_id)
+            )
+        ).scalar_one()
+        assert device.status == DeviceStatus.ADOPTED
+        assert device.name == "Lobby"
+
+        pending = (
+            await db_session.execute(
+                select(PendingRegistration).where(
+                    PendingRegistration.pairing_secret_hash == pairing_hash,
+                )
+            )
+        ).scalar_one()
+        assert pending.adopted_at is not None
+        assert pending.outbox_ciphertext
+        # Device can still decrypt the outbox with its private key.
+        priv_raw = priv.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        plaintext = device_identity.decrypt_with_device_key(
+            priv_raw, pending.outbox_ciphertext,
+        )
+        payload = json.loads(plaintext)
+        assert payload["device_id"] == device_id
+
+    async def test_missing_auth_rejected(
+        self, unauthed_client, fleet_secret_enabled, db_session,
+    ):
+        profile = await _seed_profile(db_session, name="noauth-byid")
+        r = await unauthed_client.post(
+            "/api/devices/adopt-pending",
+            json={
+                "pending_id": str(uuid.uuid4()),
+                "profile_id": str(profile.id),
+            },
+        )
+        assert r.status_code in (401, 403)
+
+    async def test_unknown_pending_id_returns_404(
+        self, client, fleet_secret_enabled, stub_wps_transport, db_session,
+    ):
+        profile = await _seed_profile(db_session, name="unknown-byid")
+        r = await client.post(
+            "/api/devices/adopt-pending",
+            json={
+                "pending_id": str(uuid.uuid4()),
+                "profile_id": str(profile.id),
+            },
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"] == "pending_not_found"
+
+    async def test_malformed_uuid_returns_404(
+        self, client, fleet_secret_enabled, stub_wps_transport, db_session,
+    ):
+        profile = await _seed_profile(db_session, name="badid")
+        r = await client.post(
+            "/api/devices/adopt-pending",
+            json={
+                "pending_id": "not-a-uuid",
+                "profile_id": str(profile.id),
+            },
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"] == "pending_not_found"
+
+    async def test_already_adopted_returns_409(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        await _register_one(unauthed_client, device_id="pi-twice")
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+        profile = await _seed_profile(db_session, name="twice")
+        r1 = await client.post(
+            "/api/devices/adopt-pending",
+            json={"pending_id": pending_id,
+                  "profile_id": str(profile.id)},
+        )
+        assert r1.status_code == 200
+        r2 = await client.post(
+            "/api/devices/adopt-pending",
+            json={"pending_id": pending_id,
+                  "profile_id": str(profile.id)},
+        )
+        assert r2.status_code == 409
+
+    async def test_unknown_profile_returns_404(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport,
+    ):
+        await _register_one(unauthed_client, device_id="pi-noprof")
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+        r = await client.post(
+            "/api/devices/adopt-pending",
+            json={"pending_id": pending_id,
+                  "profile_id": str(uuid.uuid4())},
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"] == "profile_not_found"
+
+
+class TestRejectPending:
+    async def test_requires_auth(
+        self, unauthed_client, fleet_secret_enabled,
+    ):
+        r = await unauthed_client.delete(
+            f"/api/devices/pending/{uuid.uuid4()}"
+        )
+        assert r.status_code in (401, 403)
+
+    async def test_delete_removes_row(
+        self, client, unauthed_client, fleet_secret_enabled, db_session,
+    ):
+        await _register_one(unauthed_client, device_id="pi-rm")
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+        r = await client.delete(f"/api/devices/pending/{pending_id}")
+        assert r.status_code == 204
+        listing2 = await client.get("/api/devices/pending")
+        assert listing2.json()["items"] == []
+
+    async def test_unknown_id_returns_404(
+        self, client, fleet_secret_enabled,
+    ):
+        r = await client.delete(f"/api/devices/pending/{uuid.uuid4()}")
+        assert r.status_code == 404
+
+    async def test_malformed_uuid_returns_404(
+        self, client, fleet_secret_enabled,
+    ):
+        r = await client.delete("/api/devices/pending/not-a-uuid")
+        assert r.status_code == 404
+
+    async def test_already_adopted_cannot_be_rejected(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        _, pairing_secret, _, _ = await _register_one(
+            unauthed_client, device_id="pi-adopted-rm",
+        )
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+        profile = await _seed_profile(db_session, name="adopted-rm")
+        a = await client.post(
+            "/api/devices/adopt",
+            json={"pairing_secret": pairing_secret,
+                  "profile_id": str(profile.id)},
+        )
+        assert a.status_code == 200
+        r = await client.delete(f"/api/devices/pending/{pending_id}")
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------
 # /connect-token
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
# Stage A.5a — backend endpoints for adopt-by-pending-id

Part of umbrella issue #420 (bootstrap redesign). Firmware B.3 will use
this backend, but the main motivation is operator UX: admin clicks
"Adopt" on a pending row in the CMS UI and never has to see or type
the pairing secret. The secret still travels device→CMS as an
idempotency key; it just isn't surfaced.

## What this PR adds

Three new endpoints on the existing bootstrap router, all gated by
`DEVICES_MANAGE`:

- **`GET /api/devices/pending`** — lists un-adopted
  `pending_registrations` rows, newest first. Returns `id`, advisory
  `device_id`, `pubkey`, `metadata`, `ip_address`, `created_at`,
  `polled_at`, `has_polled`. Never leaks `pairing_secret_hash` or
  `outbox_ciphertext`.

- **`POST /api/devices/adopt-pending`** — adopts the row identified by
  `pending_id` rather than pairing secret. Body:
  `{pending_id, name?, location?, group_id?, profile_id}`. Same
  validation, same outbox-writing, same rate-limits, same audit-log
  shape as the existing `/adopt`. Audit detail is tagged
  `"flow": "adopt-pending"` so we can distinguish in-UI adoptions
  from QR-scan adoptions in the log.

- **`DELETE /api/devices/pending/{pending_id}`** — reject a pending
  row. Refuses to delete already-adopted rows (their
  `outbox_ciphertext` is still needed until the device polls).

## Service refactor

Pulled the inner body of `adopt_device` into a shared
`_perform_adoption(pending, …)` that works from a locked
`PendingRegistration` object. Both `adopt_device(pairing_secret=…)`
and the new `adopt_pending_by_id(pending_id=…)` call it.

Also renamed `_lock_pending_for_adoption` →
`_lock_pending_by_hash` (back-compat alias kept) and added
`_lock_pending_by_id`, `list_pending_registrations`,
`delete_pending`.

## What is **not** in this PR

- **UI** — the `devices.html` "Pending Devices" section + JS polling
  land in A.5b as a separate PR so the backend can be independently
  verified in prod first.
- **QR-scan / pairing-secret-typing flow** — stays as-is. Both paths
  coexist.

## Tests

14 new tests across 3 classes added to `tests/test_bootstrap_endpoints.py`:

- `TestListPending` — auth, empty, single row, newest-first, adopted
  rows excluded, sensitive fields not leaked.
- `TestAdoptPending` — happy path (decrypts outbox with device key to
  prove end-to-end correctness), missing auth, unknown/malformed id,
  already-adopted 409, unknown profile 404.
- `TestRejectPending` — auth, delete happy path, unknown/malformed id,
  refusal to delete adopted rows.

Local: **42 passed in 53s** (`pytest tests/test_bootstrap_endpoints.py -p no:timeout`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
