### PR TITLE
feat(devices): Pending Devices UI — one-click adopt (A.5b)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1057,6 +1057,78 @@ function showBootstrapAdoptModal(groups, profiles) {
 }
 window.bootstrapAdoptDevice = bootstrapAdoptDevice;
 
+
+// Adopt a device by pending-id — one-click from the Pending Devices list
+// on the /devices page.  No pairing secret needed; the backend keys the
+// adoption off the row's primary key.  See bootstrap redesign A.5 and
+// `POST /api/devices/adopt-pending`.
+async function adoptPendingDevice(pendingId, deviceIdAdvisory) {
+    const groups = window._adoptionGroups || [];
+    const profiles = window._adoptionProfiles || [];
+    const suggested = deviceIdAdvisory || "";
+    const result = await showAdoptModal(suggested, groups, profiles);
+    if (!result) return;
+    const body = {
+        pending_id: pendingId,
+        name: result.name || null,
+        profile_id: result.profile_id,
+    };
+    if (result.location) body.location = result.location;
+    if (result.group_id) body.group_id = result.group_id;
+    const resp = await apiCall("POST", "/api/devices/adopt-pending", body);
+    if (resp && resp.ok) {
+        showToast("Device adopted");
+        if (typeof window.refreshDevices === 'function') window.refreshDevices();
+        if (typeof window._refreshPending === 'function') window._refreshPending();
+        return;
+    }
+    if (resp) {
+        let msg = "Failed to adopt device";
+        const err = await resp.json().catch(() => null);
+        const detail = err?.detail;
+        if (resp.status === 404 && detail === "pending_not_found") {
+            msg = "That pending device is no longer in the list — refresh and try again.";
+        } else if (resp.status === 404 && detail === "group_not_found") {
+            msg = "Selected group no longer exists — refresh and try again.";
+        } else if (resp.status === 404 && detail === "profile_not_found") {
+            msg = "Selected encoder profile no longer exists — refresh and try again.";
+        } else if (resp.status === 409) {
+            msg = "That device has already been adopted.";
+        } else if (resp.status === 429) {
+            msg = "Too many adoption attempts — please wait a moment.";
+        } else if (typeof detail === "string") {
+            msg = detail;
+        }
+        showToast(msg, true);
+        if (typeof window._refreshPending === 'function') window._refreshPending();
+    }
+}
+window.adoptPendingDevice = adoptPendingDevice;
+
+
+// Reject a pending registration — removes it from the list without
+// adopting.  Useful for cleaning up bogus or duplicate registrations.
+async function rejectPendingDevice(pendingId, deviceIdAdvisory) {
+    const label = deviceIdAdvisory || "this pending registration";
+    const ok = await showConfirm(
+        `Reject ${label}?\n\nThe device will have to re-register if it's reconnected.`,
+    );
+    if (!ok) return;
+    const resp = await apiCall("DELETE", `/api/devices/pending/${pendingId}`);
+    if (resp && resp.ok) {
+        showToast("Pending registration rejected");
+        if (typeof window._refreshPending === 'function') window._refreshPending();
+        return;
+    }
+    if (resp) {
+        const err = await resp.json().catch(() => null);
+        showToast(err?.detail || "Failed to reject pending device", true);
+        if (typeof window._refreshPending === 'function') window._refreshPending();
+    }
+}
+window.rejectPendingDevice = rejectPendingDevice;
+
+
 function showAdoptModal(defaultName, groups, profiles) {
     _closeOpenPopovers();
     return new Promise((resolve) => {

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -264,6 +264,29 @@
 
 {% set th_row_compact %}{{ macros.th_row_compact() }}{% endset %}
 
+{# ── Pending Devices (unadopted registrations) ── #}
+{% if 'devices:manage' in user_perms %}
+<div class="card" id="pending-devices-card" style="display: none;">
+    <h2 style="margin: 0 0 0.5rem 0;">Pending Devices</h2>
+    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
+        Devices that have registered with the CMS but haven't been adopted yet.
+        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Device ID</th>
+                <th>Firmware</th>
+                <th>IP</th>
+                <th>Registered</th>
+                <th style="width: 1%; white-space: nowrap;">Actions</th>
+            </tr>
+        </thead>
+        <tbody id="pending-devices-tbody"></tbody>
+    </table>
+</div>
+{% endif %}
+
 {# ── All Devices ── #}
 <div class="card">
     <div style="display: flex; gap: 0.25rem; align-items: center;">
@@ -576,6 +599,11 @@ window._adoptionProfiles = [
 
     setInterval(pollDevicesOnce, 5000);
     setInterval(pollGroupsOnce, 5000);
+    {% if 'devices:manage' in user_perms %}
+    setInterval(pollPendingOnce, 5000);
+    // Kick an immediate fetch on load so the card appears without a 5s wait.
+    pollPendingOnce();
+    {% endif %}
 
     // Keep the /devices Device Groups card in sync across replicas without
     // a full page reload. Added as part of #87: when session A creates or
@@ -663,6 +691,76 @@ window._adoptionProfiles = [
             }
         } catch (e) { /* ignore */ }
     }
+
+    {% if 'devices:manage' in user_perms %}
+    // ── Pending Devices card (bootstrap redesign A.5) ──
+    // Poll /api/devices/pending every 5s and render one row per unadopted
+    // registration.  The card is hidden when the list is empty.
+    function _escHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+    function _fmtRelativeAge(iso) {
+        if (!iso) return '—';
+        const t = Date.parse(iso);
+        if (isNaN(t)) return '—';
+        const secs = Math.max(0, Math.floor((Date.now() - t) / 1000));
+        if (secs < 60) return secs + 's ago';
+        const mins = Math.floor(secs / 60);
+        if (mins < 60) return mins + 'm ago';
+        const hrs = Math.floor(mins / 60);
+        if (hrs < 24) return hrs + 'h ago';
+        const days = Math.floor(hrs / 24);
+        return days + 'd ago';
+    }
+    async function pollPendingOnce() {
+        // Don't swap the table while the user has a modal open — they could
+        // be in the middle of adopting one of these rows.
+        if (isModalOpen()) return;
+        const tbody = document.getElementById('pending-devices-tbody');
+        const card = document.getElementById('pending-devices-card');
+        if (!tbody || !card) return;
+        let items = [];
+        try {
+            const resp = await fetch('/api/devices/pending');
+            if (!resp.ok) return;
+            const data = await resp.json();
+            items = data.items || [];
+        } catch (e) { return; }
+        if (!items.length) {
+            card.style.display = 'none';
+            tbody.innerHTML = '';
+            return;
+        }
+        card.style.display = '';
+        const rows = items.map(p => {
+            const devId = _escHtml(p.device_id || p.id);
+            const fw = _escHtml((p.metadata && p.metadata.firmware_version) || '—');
+            const ip = _escHtml(p.ip_address || '—');
+            const age = _escHtml(_fmtRelativeAge(p.created_at));
+            const advisoryJs = (p.device_id || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+            return (
+                '<tr>' +
+                '<td>' + devId + '</td>' +
+                '<td>' + fw + '</td>' +
+                '<td>' + ip + '</td>' +
+                '<td title="' + _escHtml(p.created_at || '') + '">' + age + '</td>' +
+                '<td style="white-space: nowrap;">' +
+                    '<button type="button" class="btn btn-primary" ' +
+                    'onclick="adoptPendingDevice(\'' + p.id + '\', \'' + advisoryJs + '\')">Adopt</button> ' +
+                    '<button type="button" class="btn" ' +
+                    'onclick="rejectPendingDevice(\'' + p.id + '\', \'' + advisoryJs + '\')">Reject</button>' +
+                '</td>' +
+                '</tr>'
+            );
+        }).join('');
+        tbody.innerHTML = rows;
+    }
+    // Expose for action handlers (adopt/reject) to request an immediate
+    // repopulate instead of waiting up to 5s for the next poll cycle.
+    window._refreshPending = () => pollPendingOnce();
+    {% endif %}
 })();
 
 async function checkForUpdates(menuItem) {

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -264,29 +264,6 @@
 
 {% set th_row_compact %}{{ macros.th_row_compact() }}{% endset %}
 
-{# ── Pending Devices (unadopted registrations) ── #}
-{% if 'devices:manage' in user_perms %}
-<div class="card" id="pending-devices-card" style="display: none;">
-    <h2 style="margin: 0 0 0.5rem 0;">Pending Devices</h2>
-    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
-        Devices that have registered with the CMS but haven't been adopted yet.
-        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
-    </p>
-    <table>
-        <thead>
-            <tr>
-                <th>Device ID</th>
-                <th>Firmware</th>
-                <th>IP</th>
-                <th>Registered</th>
-                <th style="width: 1%; white-space: nowrap;">Actions</th>
-            </tr>
-        </thead>
-        <tbody id="pending-devices-tbody"></tbody>
-    </table>
-</div>
-{% endif %}
-
 {# ── All Devices ── #}
 <div class="card">
     <div style="display: flex; gap: 0.25rem; align-items: center;">
@@ -311,6 +288,31 @@
         </tbody>
     </table>
 </div>
+
+{# ── Pending Devices (unadopted registrations) ── #}
+{# Rendered after the main Devices card so the Devices <h2> remains the #}
+{# first heading on the page — the e2e page-load test keys off that.   #}
+{% if 'devices:manage' in user_perms %}
+<div class="card" id="pending-devices-card" style="display: none;">
+    <h2 style="margin: 0 0 0.5rem 0;">Pending Devices</h2>
+    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
+        Devices that have registered with the CMS but haven't been adopted yet.
+        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Device ID</th>
+                <th>Firmware</th>
+                <th>IP</th>
+                <th>Registered</th>
+                <th style="width: 1%; white-space: nowrap;">Actions</th>
+            </tr>
+        </thead>
+        <tbody id="pending-devices-tbody"></tbody>
+    </table>
+</div>
+{% endif %}
 
 {# ── Device Groups (expandable) ── #}
 {% if 'groups:read' in user_perms %}


### PR DESCRIPTION
## Stage A.5b — Pending Devices UI (bootstrap redesign)

Surfaces a **Pending Devices** card on the `/devices` page so admins can adopt
newly-registered devices with a single click — no pairing secret ever typed
into, or surfaced in, the UI.

Companion frontend to the A.5a backend (PR #430) that added
`GET /api/devices/pending`, `POST /api/devices/adopt-pending`, and
`DELETE /api/devices/pending/{id}`.

### What's in this PR

**`cms/templates/devices.html`**
- New **Pending Devices** card above the main Devices card, gated by
  `devices:manage`. Hidden when the list is empty. Columns: Device ID,
  Firmware, IP, Registered (relative age), Actions.
- `pollPendingOnce()` fetches `/api/devices/pending` every 5 s alongside
  the existing devices/groups pollers. Kicks an immediate fetch on load so
  the card appears without a visible 5 s delay.
- Exposes `window._refreshPending()` so action handlers can force an
  immediate re-fetch after adopt/reject.
- Polling pauses while any modal is open (same guard pattern as
  `pollDevicesOnce`/`pollGroupsOnce`) to avoid swapping out a row the
  admin is mid-way through adopting.

**`cms/static/app.js`**
- `adoptPendingDevice(pendingId, deviceIdAdvisory)` — reuses the existing
  `showAdoptModal()` (Name / Profile / Location / Group), then POSTs to
  `/api/devices/adopt-pending` with `{ pending_id, name, profile_id,
  location, group_id }`. Maps backend error codes (`pending_not_found`,
  `group_not_found`, `profile_not_found`, 409, 429) to friendly toasts.
- `rejectPendingDevice(pendingId, deviceIdAdvisory)` — confirm prompt
  then `DELETE /api/devices/pending/{id}`.
- Both exposed via `window.*` so the template's inline `onclick`
  handlers can call them.

### What's unchanged

The existing **Adopt Device** button (pairing-secret modal / QR scanner)
stays as-is. It becomes a fallback path for the "I still have the secret
printed somewhere" case; the pending-list flow is the primary UX. This
mirrors the split on the backend where `/adopt` (pairing-secret) and
`/adopt-pending` (pending-id) are both supported.

### Validation

- Local: `pytest tests/test_bootstrap_endpoints.py -p no:timeout -q` →
  **42 passed** (no backend change; sanity-checked the shared modules
  still import cleanly).
- Jinja parse check of the edited template.
- Prod verification after auto-merge: open `/devices` with a pending
  registration in the queue, click Adopt, confirm it moves to the main
  Devices table.

### Follow-ups (out of scope)

- B.3 (firmware service wiring to the redesigned register/poll/claim
  endpoints) is unblocked once this lands.
- Playwright coverage for the pending-list flow — repo currently has no
  playwright harness; defer until we add one.

Closes part of #420.
