### PR TITLE
infra: wire fleet register secrets through bicep + CD (per-fleet GH secrets)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -177,6 +177,7 @@ jobs:
               cmsSecretKey='${{ secrets.CMS_SECRET_KEY }}' \
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
               wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
+              fleetRegisterSecrets='${{ secrets.FLEET_REGISTER_SECRETS }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -159,6 +159,34 @@ jobs:
       #     (no more "same tag, stale revision" failures).
       #   * A mutated/overwritten tag can never cause an unexpected image
       #     to be deployed.
+      # Assemble FLEET_REGISTER_SECRETS from zero-or-more GH Actions secrets
+      # named FLEET_REGISTER_SECRET_<FLEET_ID> (fleet-id uppercased, '-' -> '_').
+      # Adding a new fleet is: add one repo secret; no YAML edit needed.
+      - name: Build fleetRegisterSecrets JSON from per-fleet secrets
+        id: fleet_secrets
+        env:
+          ALL_SECRETS_JSON: ${{ toJSON(secrets) }}
+        run: |
+          MAP=$(printf '%s' "$ALL_SECRETS_JSON" | jq -c '
+            to_entries
+            | map(select(.key | startswith("FLEET_REGISTER_SECRET_")))
+            | map({
+                key: (.key | sub("^FLEET_REGISTER_SECRET_"; "") | ascii_downcase | gsub("_"; "-")),
+                value: .value
+              })
+            | from_entries
+          ')
+          if [ -z "$MAP" ] || [ "$MAP" = "null" ]; then MAP='{}'; fi
+          # Count without exposing values.
+          COUNT=$(printf '%s' "$MAP" | jq 'length')
+          echo "fleet-count=$COUNT" >> "$GITHUB_OUTPUT"
+          # Mask before writing to the step output so logs never echo the value.
+          echo "::add-mask::$MAP"
+          echo "map<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$MAP" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Assembled fleetRegisterSecrets with $COUNT fleet(s)"
+
       - name: Deploy infrastructure
         run: |
           CMS_REF='${{ env.ACR_REGISTRY }}/agora-cms@${{ needs.publish.outputs.cms_digest }}'
@@ -177,7 +205,7 @@ jobs:
               cmsSecretKey='${{ secrets.CMS_SECRET_KEY }}' \
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
               wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
-              fleetRegisterSecrets='${{ secrets.FLEET_REGISTER_SECRETS }}' \
+              fleetRegisterSecrets='${{ steps.fleet_secrets.outputs.map }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -50,6 +50,10 @@ param wpsConnectionString string = ''
 @allowed(['wps', 'local'])
 param deviceTransport string = 'wps'
 
+@description('Bootstrap v2 fleet HMAC secrets - JSON map of {fleet_id: base64_secret} used to gate the anonymous POST /api/devices/register endpoint. Empty map (default) rejects all /register calls (secure by default, v2 bootstrap disabled).')
+@secure()
+param fleetRegisterSecrets string = ''
+
 @description('CMS container image (e.g., agoracr.azurecr.io/agora-cms:latest)')
 param cmsImage string = ''
 
@@ -209,6 +213,9 @@ module containerApps 'modules/containerApps.bicep' = {
     // Device transport (Azure Web PubSub)
     wpsConnectionString: wpsConnectionString
     deviceTransport: deviceTransport
+
+    // Bootstrap v2 fleet secrets (JSON map)
+    fleetRegisterSecrets: fleetRegisterSecrets
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -62,6 +62,10 @@ param wpsConnectionString string = ''
 @allowed(['wps', 'local'])
 param deviceTransport string = 'wps'
 
+@description('Bootstrap v2 fleet HMAC secrets - JSON map of {fleet_id: base64_secret} used to gate POST /api/devices/register. Empty (default) disables v2 registration end-to-end (secure by default).')
+@secure()
+param fleetRegisterSecrets string = ''
+
 // ── Container Apps Environment ──
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: '${environmentName}-logs'
@@ -161,6 +165,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'wps-connection-string'
           value: wpsConnectionString
         }
+        {
+          name: 'fleet-register-secrets'
+          value: fleetRegisterSecrets
+        }
       ]
     }
     template: {
@@ -228,6 +236,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'AGORA_CMS_WPS_CONNECTION_STRING'
               secretRef: 'wps-connection-string'
+            }
+            {
+              name: 'FLEET_REGISTER_SECRETS'
+              secretRef: 'fleet-register-secrets'
             }
           ]
           volumeMounts: [


### PR DESCRIPTION
## Bootstrap v2 - wire `FLEET_REGISTER_SECRETS` through bicep / CD

Adds the plumbing for the v2 bootstrap fleet-HMAC credential (gates
`POST /api/devices/register`). The CMS code already reads
`FLEET_REGISTER_SECRETS` via `cms/config.py::fleet_register_secrets`;
this PR just makes it possible to set the value in prod without a
manual `az containerapp` patch.

### What this changes
- `infra/main.bicep` - new top-level `@secure` param `fleetRegisterSecrets` (default `''`), piped into the containerApps module.
- `infra/modules/containerApps.bicep` - matching `@secure` param, new `fleet-register-secrets` entry in the CMS app's `secrets[]`, new `FLEET_REGISTER_SECRETS` env var referencing the secret.
- `.github/workflows/publish-image.yml` - new step that assembles the JSON map at deploy time from zero-or-more GH Actions secrets matching `FLEET_REGISTER_SECRET_<FLEET_ID>`, then passes the result to `az deployment group create`.

### Secret-naming convention
One GH Actions secret per fleet. Name format:

    FLEET_REGISTER_SECRET_<FLEET_ID>

where `<FLEET_ID>` is the fleet id uppercased with `-` replaced by `_`.

| Fleet id         | GH secret name                          |
|------------------|-----------------------------------------|
| `test-fleet-1`   | `FLEET_REGISTER_SECRET_TEST_FLEET_1`    |
| `prod-fleet-1`   | `FLEET_REGISTER_SECRET_PROD_FLEET_1`    |

Adding a new fleet is "create one secret in the repo settings and re-run
the deploy" - no YAML edit, no "what was the old value" problem from
clobbering a single aggregate secret.

### What this does NOT change
- `deviceTransport` is already `wps` in prod. No transport flip here.
- Default value is `''` (empty map at deploy time when no
  `FLEET_REGISTER_SECRET_*` secrets exist), which the CMS interprets
  as empty JSON. All `/register` calls are rejected with 401.
  Secure-by-default.
- No Pi firmware or client code changes.

### Activation
Two things must happen for v2 bootstrap to accept a real device registration:

1. At least one GH Actions secret named `FLEET_REGISTER_SECRET_<FLEET_ID>`.
2. A device boots with `AGORA_BOOTSTRAP_V2=1`, `AGORA_FLEET_ID=<fleet-id>`,
   `AGORA_FLEET_SECRET_HEX=<hex-of-same-bytes>` in its environment.

Neither of those lands in this PR. Today's fleet still runs legacy mode
until the test Pi is re-provisioned with v2 env vars.

### Validation
- `az bicep build` passes on both modules.
- When no `FLEET_REGISTER_SECRET_*` secrets exist, the assembled map is
  `{}`, which serializes to an empty dict in `cms/config.py` - the
  router fast-paths to 401, identical to today.
- Secret values are never echoed: they enter via `${{ toJSON(secrets) }}`
  (already masked by GH), are piped directly into `jq`, and the
  assembled map is re-masked via `::add-mask::` before being written
  to the step output.
