### PR TITLE
fix(bicep): use AGORA_CMS_ env prefix for FLEET_REGISTER_SECRETS

### DIFF
--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -238,7 +238,7 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               secretRef: 'wps-connection-string'
             }
             {
-              name: 'FLEET_REGISTER_SECRETS'
+              name: 'AGORA_CMS_FLEET_REGISTER_SECRETS'
               secretRef: 'fleet-register-secrets'
             }
           ]


### PR DESCRIPTION
## What

The CMS `Settings` class is configured with `env_prefix='AGORA_CMS_'` (via `shared/config.py`), so the `fleet_register_secrets: dict[str, str]` field only picks up the env var `AGORA_CMS_FLEET_REGISTER_SECRETS`.

PR #432 wired the Container App env var as plain `FLEET_REGISTER_SECRETS`, which pydantic-settings silently ignores — leaving `settings.fleet_register_secrets` as the empty default and causing every `/register` to hit the `if not secret_b64` branch and return 401 `fleet_hmac_bad`.

## How

Rename the env var in `infra/modules/containerApps.bicep` to `AGORA_CMS_FLEET_REGISTER_SECRETS`. Secret name in the Container App (`fleet-register-secrets`) and the GH secret assembly step are unchanged.

## Validation

Reproduced against prod with a known-good HMAC payload (correct fleet_id, correct secret bytes, canonical `register|device_id|pubkey|pairing_secret_hash|fleet_id|ts|nonce` message, matching encoding) → 401 `fleet_hmac_bad`. The prod secret has the right bytes (verified via `az containerapp secret show`), so the only remaining gap was the env-var name.

## Risk

Bicep-only change. No migration, no code path change. Pure env var rename.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>