### PR TITLE
fix(register): use X-Forwarded-For for client IP

### DIFF
--- a/cms/routers/bootstrap.py
+++ b/cms/routers/bootstrap.py
@@ -86,10 +86,29 @@ router = APIRouter(prefix="/api/devices", tags=["bootstrap"])
 _buckets: dict[Tuple[str, str], Deque[float]] = defaultdict(deque)
 
 
+def _client_ip(request: Request) -> str | None:
+    """Return the best-effort client IP for a request.
+
+    Prefers the first entry in X-Forwarded-For when present so we record
+    the real device IP instead of the Container Apps envoy ingress hop.
+    Falls back to ``request.client.host``.  Mirrors the same logic used
+    by ``audit_service._resolve_ip`` — kept local here to avoid a
+    cross-module import from the router layer.
+    """
+    xff = request.headers.get("x-forwarded-for") if hasattr(request, "headers") else None
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    if request.client:
+        return request.client.host
+    return None
+
+
 def _ip_ratelimited(
     request: Request, *, key: str, limit: int, window_sec: int,
 ) -> None:
-    ip = request.client.host if request.client else "unknown"
+    ip = _client_ip(request) or "unknown"
     bucket_key = (key, ip)
     now = time.monotonic()
     bucket = _buckets[bucket_key]
@@ -211,7 +230,7 @@ async def register(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-    client_ip = request.client.host if request.client else None
+    client_ip = _client_ip(request)
     try:
         await device_bootstrap.register_device(
             db=db,

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -160,6 +160,40 @@ class TestRegister:
         assert row.device_id == "raspberrypi-001"
         assert row.adopted_at is None
 
+    async def test_client_ip_uses_x_forwarded_for(
+        self, unauthed_client, fleet_secret_enabled, db_session,
+    ):
+        """The first entry of X-Forwarded-For must be stored as the device's
+        client IP, not the Container Apps ingress hop in request.client.host."""
+        _, pub_b64 = _gen_keypair()
+        _, pairing_hash = _pairing_pair()
+        body = {
+            "device_id": "xff-test-pi",
+            "pubkey": pub_b64,
+            "pairing_secret_hash": pairing_hash,
+        }
+        headers = _fleet_headers(
+            device_id=body["device_id"],
+            pubkey_b64=pub_b64,
+            pairing_secret_hash_hex=pairing_hash,
+        )
+        headers["X-Forwarded-For"] = "203.0.113.42, 10.0.0.5"
+        resp = await unauthed_client.post(
+            "/api/devices/register", json=body, headers=headers,
+        )
+        assert resp.status_code == 202, resp.text
+
+        from cms.models.pending_registration import PendingRegistration
+        from sqlalchemy import select
+        row = (
+            await db_session.execute(
+                select(PendingRegistration).where(
+                    PendingRegistration.device_id == "xff-test-pi",
+                )
+            )
+        ).scalar_one()
+        assert row.ip_address == "203.0.113.42"
+
     async def test_missing_fleet_headers_rejected(
         self, unauthed_client, fleet_secret_enabled,
     ):


### PR DESCRIPTION
Fixes #6

The /register endpoint was recording request.client.host as the device's IP, which in Container Apps is the envoy ingress hop (an internal 100.100.x.x address), not the device's real public IP. Add a _client_ip() helper that reads the first entry of X-Forwarded-For (mirrors the pattern already used in audit_service) with request.client.host as a fallback.

Test: new test_client_ip_uses_x_forwarded_for sends `X-Forwarded-For: 203.0.113.42, 10.0.0.5` and asserts the pending row records 203.0.113.42.