### PR TITLE
fix(device_purge): atomic guarded DELETE prevents adopt-vs-purge race

### DIFF
--- a/cms/services/device_purge.py
+++ b/cms/services/device_purge.py
@@ -4,11 +4,10 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.models.device import Device, DeviceStatus
-from cms.services import device_presence
 
 logger = logging.getLogger("agora.cms.device_purge")
 
@@ -17,33 +16,68 @@ async def purge_stale_pending_devices(db: AsyncSession, ttl_hours: int) -> list[
     """Delete pending devices not seen for longer than *ttl_hours*.
 
     Returns a list of purged device IDs.
+
+    Concurrency / N>1 safety
+    ------------------------
+    The purge runs under a session-advisory lock so only one replica's
+    loop fires at a time, but a user adopting a device on a *different*
+    replica can still race with this call between the candidate SELECT
+    and the DELETE.  To prevent silently nuking an in-flight adopt, the
+    DELETE statement re-checks ``status == PENDING`` and ``online == false``
+    in SQL: if the row was flipped to ADOPTED (or the device just
+    reconnected) between the two steps, the WHERE clause excludes it
+    and the row survives.  We use ``RETURNING id`` to learn which rows
+    actually got deleted.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(hours=ttl_hours)
 
+    # Step 1 — gather candidates.  Cutoff comparison is done in Python
+    # because SQLAlchemy + SQLite ``DateTime(timezone=True)`` round-trips
+    # can drop tzinfo, making a SQL ``<= cutoff`` predicate fragile across
+    # backends.  Postgres handles it natively, but the same code runs in
+    # tests against SQLite, so we keep this part backend-agnostic.
     result = await db.execute(
-        select(Device).where(
-            Device.status == DeviceStatus.PENDING,
-        )
+        select(Device.id, Device.last_seen, Device.registered_at, Device.online)
+        .where(Device.status == DeviceStatus.PENDING)
     )
-    candidates = result.scalars().all()
-    purged: list[str] = []
 
-    for device in candidates:
-        # Skip devices that are currently connected (DB-backed presence).
-        if await device_presence.is_online(db, device.id):
+    candidate_ids: list[str] = []
+    for did, last_seen, registered_at, online in result.all():
+        if online:
             continue
-
-        # Use last_seen, fall back to registered_at
-        seen_at = device.last_seen or device.registered_at
-        # Ensure both sides are comparable (SQLite strips tzinfo)
+        seen_at = last_seen or registered_at
         if seen_at.tzinfo is None:
             seen_at = seen_at.replace(tzinfo=timezone.utc)
         if seen_at <= cutoff:
-            logger.info("Purging stale pending device %s (last seen %s)", device.id, seen_at)
-            await db.delete(device)
-            purged.append(device.id)
+            candidate_ids.append(did)
+
+    if not candidate_ids:
+        return []
+
+    # Step 2 — atomic guarded DELETE.  Even though candidates were
+    # filtered above, the SQL guards re-validate at DELETE time so a
+    # concurrent adopt or reconnect on another replica wins the race.
+    stmt = (
+        delete(Device)
+        .where(
+            Device.id.in_(candidate_ids),
+            Device.status == DeviceStatus.PENDING,
+            Device.online == False,  # noqa: E712 — SQLAlchemy comparator
+        )
+        .returning(Device.id)
+    )
+    res = await db.execute(stmt)
+    purged: list[str] = [row[0] for row in res.all()]
 
     if purged:
+        for did in purged:
+            logger.info("Purged stale pending device %s (cutoff %s)", did, cutoff)
+        skipped = set(candidate_ids) - set(purged)
+        if skipped:
+            logger.info(
+                "Skipped %d candidate(s) racing with adopt/reconnect: %s",
+                len(skipped), sorted(skipped),
+            )
         await db.commit()
 
     return purged

--- a/tests/test_pending_staleness.py
+++ b/tests/test_pending_staleness.py
@@ -151,6 +151,104 @@ async def test_purge_skips_connected_pending_devices(db_session):
 
 
 @pytest.mark.asyncio
+async def test_purge_does_not_delete_devices_adopted_during_purge(db_session):
+    """N>1 race regression: if a device is selected as a purge candidate
+    on replica A but adopted on replica B between the SELECT and DELETE,
+    the DELETE's ``status == PENDING`` guard must exclude it so the
+    adopt wins.
+
+    Simulated by hooking the session's ``execute`` so that immediately
+    after the candidate-selection query returns we flip one row's
+    status to ADOPTED (mimicking another replica's commit), then let the
+    DELETE proceed.  The adopted row must survive.
+    """
+    from sqlalchemy import update as sa_update
+
+    from cms.models.device import Device, DeviceStatus
+    from cms.services.device_purge import purge_stale_pending_devices
+
+    stale = datetime.now(timezone.utc) - timedelta(hours=48)
+    await _create_pending_device(db_session, "racy-pending", last_seen=stale)
+    await _create_pending_device(db_session, "stable-pending", last_seen=stale)
+
+    real_execute = db_session.execute
+    call_count = {"n": 0}
+
+    async def hooked_execute(stmt, *a, **kw):
+        result = await real_execute(stmt, *a, **kw)
+        call_count["n"] += 1
+        # The first execute is the candidate SELECT.  Flip racy-pending
+        # to ADOPTED before the DELETE runs.
+        if call_count["n"] == 1:
+            await real_execute(
+                sa_update(Device)
+                .where(Device.id == "racy-pending")
+                .values(status=DeviceStatus.ADOPTED)
+            )
+        return result
+
+    db_session.execute = hooked_execute  # type: ignore[method-assign]
+    try:
+        purged = await purge_stale_pending_devices(db_session, ttl_hours=24)
+    finally:
+        db_session.execute = real_execute  # type: ignore[method-assign]
+
+    assert "racy-pending" not in purged, (
+        "DELETE missing status guard — concurrent adopt was nuked"
+    )
+    assert "stable-pending" in purged
+
+    # racy-pending row still exists, now ADOPTED.
+    result = await real_execute(select(Device).where(Device.id == "racy-pending"))
+    dev = result.scalar_one_or_none()
+    assert dev is not None
+    assert dev.status == DeviceStatus.ADOPTED
+
+
+@pytest.mark.asyncio
+async def test_purge_does_not_delete_devices_that_came_online_during_purge(db_session):
+    """N>1 race regression: if a candidate device's ``online`` flag
+    flipped to true between SELECT and DELETE (the device just
+    reconnected on another replica), the DELETE's ``online == false``
+    guard must exclude it.
+    """
+    from sqlalchemy import update as sa_update
+
+    from cms.models.device import Device, DeviceStatus
+    from cms.services.device_purge import purge_stale_pending_devices
+
+    stale = datetime.now(timezone.utc) - timedelta(hours=48)
+    await _create_pending_device(db_session, "reconnecting", last_seen=stale)
+
+    real_execute = db_session.execute
+    call_count = {"n": 0}
+
+    async def hooked_execute(stmt, *a, **kw):
+        result = await real_execute(stmt, *a, **kw)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            await real_execute(
+                sa_update(Device)
+                .where(Device.id == "reconnecting")
+                .values(online=True)
+            )
+        return result
+
+    db_session.execute = hooked_execute  # type: ignore[method-assign]
+    try:
+        purged = await purge_stale_pending_devices(db_session, ttl_hours=24)
+    finally:
+        db_session.execute = real_execute  # type: ignore[method-assign]
+
+    assert "reconnecting" not in purged
+    result = await real_execute(select(Device).where(Device.id == "reconnecting"))
+    dev = result.scalar_one_or_none()
+    assert dev is not None
+    assert dev.status == DeviceStatus.PENDING
+    assert dev.online is True
+
+
+@pytest.mark.asyncio
 async def test_purge_config_ttl(app, db_session):
     """TTL setting from config should be respected."""
     from cms.auth import get_settings


### PR DESCRIPTION
## Summary

Fixes the last known N>1 correctness blocker for the CMS replica flip: an adopt-vs-purge race in `device_purge.py`.

The purge job runs under a session-advisory lock so only one replica fires the loop at a time, but a user adopting a device on another replica can still race with the purge between the candidate `SELECT` and the per-row Python-side `db.delete()`. Sequence:

1. Replica A (purge): `SELECT` picks device X (status=PENDING, offline).
2. Replica B (adopt): user hits `POST /api/devices/X/adopt` → sets status=ADOPTED, name, owner.
3. Replica A: `db.delete(X)` → adopted device wiped, audit claims it was purged.

Purge runs hourly with a 24h+ TTL so the window is narrow but non-zero, and becomes a real risk at N≥2.

## Fix

Replace the per-row Python check + `db.delete()` loop with a **single guarded DELETE** that re-validates `status = PENDING` AND `online = false` in SQL, using `RETURNING id` to learn which rows actually got deleted. If a concurrent adopt or reconnect on another replica flipped either column between the candidate SELECT and the DELETE, the WHERE clause excludes that row and it survives.

The candidate SELECT still happens in Python so the staleness cutoff stays backend-agnostic — SQLite + SQLAlchemy `DateTime(timezone=True)` round-trips can drop tzinfo, making a SQL `<= cutoff` predicate fragile. Postgres handles it natively, but the same code runs against SQLite in tests.

## Tests

Two new race regression tests hook `AsyncSession.execute` to mutate the candidate row mid-purge:

- `test_purge_does_not_delete_devices_adopted_during_purge` — flip status to ADOPTED between SELECT and DELETE; verify row survives.
- `test_purge_does_not_delete_devices_that_came_online_during_purge` — flip `online=True` between SELECT and DELETE; verify row survives.

All 9 tests in `test_pending_staleness.py` pass locally.

## Closes the N>1 blocker list

Per `files/multi-replica-fix-plan.md`, this was the last open MEDIUM. With #429, #431, #432, #434, #435, and this PR landed, the CMS is ready for `replica-flip-bicep`.
