### PR TITLE
infra: bump CMS container app to N=2 replicas

### DIFF
--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -258,15 +258,17 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 1
-        // Pinned to 1 until multi-replica architecture lands (issue #344).
-        // CMS is not multi-replica safe today: in-memory device manager,
-        // scheduler caches, singleton background loops, and the
-        // `_upgrading` guard all assume a single process. Scaling > 1
-        // silently drops device traffic and double-schedules work. See
-        // docs/multi-replica-architecture.md for the staged plan to
-        // lift this restriction.
-        maxReplicas: 1
+        minReplicas: 2
+        // Multi-replica safe as of issue #344 completion (April 2026).
+        // All singleton state has been moved to DB-backed or leader-gated
+        // paths: device presence, confirmed-playing, missed-schedule state,
+        // temp-alert state, scheduler lease, log-request flow, WPS
+        // transport fan-out.  Pinned to N=2 rather than letting autoscale
+        // decide so the multi-replica paths are always exercised and we
+        // learn about regressions before they surface at higher scale.
+        // Next step (post-stability): lift maxReplicas and gate scaling
+        // on CPU/HTTP metrics.
+        maxReplicas: 2
       }
     }
   }


### PR DESCRIPTION
## Summary

Bumps the CMS container app from `minReplicas=1, maxReplicas=1` to `minReplicas=2, maxReplicas=2`. This is the replica-flip-bicep todo from `files/multi-replica-fix-plan.md`.

**Opened as draft** — do not merge until the current smoke → prod deploy cycle completes on `main` and you're ready to take the N=2 step.

## N>1 correctness fixes already on main

All blockers from the multi-replica audit have landed:

| Issue | PR |
|---|---|
| `startup-transport-ordering` | #426 |
| `logs-rpc-retire` | #429 |
| `temp-alert-state-dbback` | #431 |
| `missed-schedule-state-dbback` + `confirmed-playing-dbback` (combined) | #435 |
| `device-purge-race` | #437 |

State that was previously held in replica-local dicts is now DB-backed with CAS / `RETURNING` guards across the board: device presence, confirmed-playing, temp-alert state, missed-schedule dedupe, log-request flow, scheduler leader lease, WPS transport fan-out.

## Why pinned 2/2 instead of autoscale

Pinning `min=max=2` forces the multi-replica code paths to execute continuously in prod, so any regression surfaces immediately rather than hiding behind a cold autoscaler that only wakes under load. Once we have a couple of weeks of clean runtime we can lift `maxReplicas` and gate scaling on CPU/HTTP metrics.

## Merge checklist

- [ ] Current deploy of `main` (post-#437) is healthy in prod.
- [ ] Both test Pis still showing online and playing scheduled content.
- [ ] No new alerts on CMS error rate / WPS connection count.
- [ ] Ready to mark PR ready-for-review and squash-merge.

## Rollback

If something goes sideways after the flip, revert is safe: set `maxReplicas: 1` → next deploy drains one replica → back to N=1 behaviour. No data migrations involved.
