### PR TITLE
fix(transport): source LocalTransport presence from DB only (N>1 fix)

### DIFF
--- a/cms/services/transport.py
+++ b/cms/services/transport.py
@@ -136,32 +136,23 @@ class LocalDeviceTransport(DeviceTransport):
         return ok
 
     async def is_connected(self, device_id: str) -> bool:
-        # Local transport is single-replica so a live socket on this
-        # process is just as authoritative as ``devices.online`` —
-        # treat the two as a union so tests that exercise the direct-WS
-        # path (``device_manager.register`` + no ``mark_online``) still
-        # see the device as connected.  Production code always pairs
-        # register with mark_online anyway.
-        if self._manager.is_connected(device_id):
-            return True
+        # Always source presence from the DB so every replica returns
+        # the same answer.  The in-memory ``device_manager`` set is
+        # only authoritative for "do *I* hold this WS so I can send to
+        # it directly?" — under N>1 a stale local entry on one replica
+        # would otherwise make ``is_online`` oscillate between True
+        # (replica holding the dead socket) and False (other replicas
+        # reading the DB) request-by-request as the LB round-robins.
         async with _session() as db:
             return await device_presence.is_online(db, device_id)
 
     async def connected_count(self) -> int:
         async with _session() as db:
-            db_count = await device_presence.count_online(db)
-            ids = await device_presence.ids_online(db)
-        local_only = [d for d in self._manager._connections if d not in ids]
-        return db_count + len(local_only)
+            return await device_presence.count_online(db)
 
     async def connected_ids(self) -> list[str]:
         async with _session() as db:
-            db_ids = await device_presence.ids_online(db)
-        merged = list(db_ids)
-        for d in self._manager._connections:
-            if d not in merged:
-                merged.append(d)
-        return merged
+            return list(await device_presence.ids_online(db))
 
     async def get_all_states(self) -> list[dict[str, Any]]:
         async with _session() as db:

--- a/tests/test_device_actions.py
+++ b/tests/test_device_actions.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from cms.models.device import Device, DeviceStatus
+from cms.services import device_presence
 from cms.services.device_manager import DeviceManager, device_manager
 
 
@@ -18,6 +19,7 @@ class TestFactoryReset:
 
         ws = AsyncMock()
         device_manager.register("fr-001", ws)
+        await device_presence.mark_online(db_session, "fr-001")
         try:
             resp = await client.post("/api/devices/fr-001/factory-reset")
             assert resp.status_code == 200
@@ -56,6 +58,7 @@ class TestLocalApiToggle:
 
         ws = AsyncMock()
         device_manager.register("la-001", ws)
+        await device_presence.mark_online(db_session, "la-001")
         try:
             resp = await client.post("/api/devices/la-001/local-api", json={"enabled": False})
             assert resp.status_code == 200
@@ -83,6 +86,7 @@ class TestLocalApiToggle:
 
         ws = AsyncMock()
         device_manager.register("la-002", ws)
+        await device_presence.mark_online(db_session, "la-002")
         try:
             resp = await client.post("/api/devices/la-002/local-api", json={"enabled": True})
             assert resp.status_code == 200
@@ -147,6 +151,7 @@ class TestSplashFix:
 
         ws = AsyncMock()
         device_manager.register("splash-001", ws)
+        await device_presence.mark_online(db_session, "splash-001")
         try:
             with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
                 resp = await client.patch(
@@ -176,6 +181,7 @@ class TestSplashFix:
 
         ws = AsyncMock()
         device_manager.register("splash-002", ws)
+        await device_presence.mark_online(db_session, "splash-002")
         try:
             with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
                 resp = await client.patch(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -773,6 +773,9 @@ class TestGroupDefaultAssetSync:
 
         device_manager.register("grp-sync-pi-1", FakeWS1())
         device_manager.register("grp-sync-pi-2", FakeWS2())
+        from cms.services import device_presence
+        await device_presence.mark_online(db_session, "grp-sync-pi-1")
+        await device_presence.mark_online(db_session, "grp-sync-pi-2")
 
         try:
             resp = await client.patch(
@@ -817,6 +820,8 @@ class TestGroupDefaultAssetSync:
                 sent.append(data)
 
         device_manager.register("grp-clear-pi", FakeWS())
+        from cms.services import device_presence
+        await device_presence.mark_online(db_session, "grp-clear-pi")
 
         try:
             resp = await client.patch(
@@ -990,6 +995,8 @@ class TestDefaultAssetVariantResolution:
                 sent_messages.append(data)
 
         device_manager.register("test-variant-pi", FakeWS())
+        from cms.services import device_presence
+        await device_presence.mark_online(db_session, "test-variant-pi")
 
         try:
             resp = await client.patch(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -537,6 +537,8 @@ class TestUpgradeGuard:
         class FakeWS:
             async def send_json(self, data): pass
         device_manager.register("up-pi-002", FakeWS())
+        from cms.services import device_presence
+        await device_presence.mark_online(db_session, "up-pi-002")
 
         try:
             resp = await client.post("/api/devices/up-pi-002/upgrade")

--- a/tests/test_pending_staleness.py
+++ b/tests/test_pending_staleness.py
@@ -55,6 +55,8 @@ async def test_pending_device_shows_online_when_connected(client, db_session, ap
     await _create_pending_device(db_session, "dev-online-pending")
     # Simulate the device being connected via WebSocket
     device_manager.register("dev-online-pending", websocket=None)
+    from cms.services import device_presence
+    await device_presence.mark_online(db_session, "dev-online-pending")
 
     try:
         resp = await client.get("/")

--- a/tests/test_scheduler_advanced.py
+++ b/tests/test_scheduler_advanced.py
@@ -1244,6 +1244,8 @@ class TestMissedGracePeriod:
             async def send_json(self, data): pass
 
         device_manager.register("grace-dev-03", FakeWS())
+        from cms.services import device_presence
+        await device_presence.mark_online(db_session, "grace-dev-03")
 
         try:
             await evaluate_schedules()


### PR DESCRIPTION
## Why

N=2 flip drill 2 surfaced this: Pi 5 was physically unplugged for 17 min, DB correctly showed `online=false`, but the API returned `is_online=true` on ~13/20 requests and `false` on the other ~7/20 — pure replica-split. Dashboard `Last Seen` flipped `'Now'` ↔ `'17 min ago'` on every refresh.

Root cause: `LocalTransport.is_connected` did a union of (in-memory `device_manager._connections`) ∪ (DB `devices.online`). Under N>1 with sticky-off, one replica with a stale local WS entry returned True while the other replica read DB and returned False.

## Change

Make `is_connected` / `connected_count` / `connected_ids` source presence exclusively from `device_presence` (DB-backed) — same pattern WpsTransport already uses. The in-memory `device_manager` map stays as the source of truth for outbound message routing (per-replica is correct there).

## Test plan

- CI runs the full suite. Tests that did `device_manager.register(...)` without also calling `device_presence.mark_online(...)` will surface here and get fixed in this PR.
- Post-deploy: re-probe `/api/devices` 20× — Pi 5 should consistently return `is_online=false`.
- Re-run drill 2 (unplug a fresh device, expect single offline alert + UI shows offline within ~grace).
