### PR TITLE
feat(alerts): stale-presence sweep + heartbeat self-heal

### DIFF
--- a/alembic/versions/0013_devices_stale_check_index.py
+++ b/alembic/versions/0013_devices_stale_check_index.py
@@ -1,0 +1,41 @@
+"""partial index on devices(last_seen) WHERE online = true
+
+PR #440 — supports the leader-gated stale-presence sweep
+(:func:`alert_service.stale_presence_sweep_once`). The sweep claims
+devices whose ``last_seen`` is older than a threshold while still
+marked ``online = TRUE``; this partial index keeps the claim fast on
+fleets where most devices are healthy (the index only contains rows
+that are *currently* online, which is the only set the sweep ever
+scans).
+
+Both Postgres and SQLite (3.8+) support partial indexes via the
+``WHERE`` clause; alembic surfaces it via ``postgresql_where`` /
+``sqlite_where``.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_devices_stale_check",
+        "devices",
+        ["last_seen"],
+        postgresql_where="online = true AND last_seen IS NOT NULL",
+        sqlite_where="online = 1 AND last_seen IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0013 is not supported")

--- a/cms/main.py
+++ b/cms/main.py
@@ -301,12 +301,48 @@ async def _offline_sweep_loop() -> None:
             try:
                 if lease.is_leader:
                     async for db in get_db():
-                        emitted = await alert_service.offline_sweep_once(db)
-                        if emitted:
-                            logger.info(
-                                "Offline sweep: emitted %d offline notification(s)",
-                                emitted,
-                            )
+                        # Stale-presence sweep first (PR #440): flip
+                        # devices.online=false for rows whose last
+                        # heartbeat is older than the threshold so the
+                        # offline-alert pipeline below can claim them.
+                        # Wrapped in its own try/rollback so an error
+                        # here doesn't poison the session for the
+                        # offline sweep.
+                        try:
+                            flipped = await alert_service.stale_presence_sweep_once(db)
+                            if flipped:
+                                logger.info(
+                                    "Stale-presence sweep: flipped %d device(s) offline",
+                                    flipped,
+                                )
+                        except asyncio.CancelledError:
+                            return
+                        except Exception:
+                            logger.exception("Error in stale-presence sweep")
+                            try:
+                                await db.rollback()
+                            except Exception:
+                                logger.exception(
+                                    "Rollback after stale-presence sweep failed",
+                                )
+
+                        try:
+                            emitted = await alert_service.offline_sweep_once(db)
+                            if emitted:
+                                logger.info(
+                                    "Offline sweep: emitted %d offline notification(s)",
+                                    emitted,
+                                )
+                        except asyncio.CancelledError:
+                            return
+                        except Exception:
+                            logger.exception("Error in offline sweep")
+                            try:
+                                await db.rollback()
+                            except Exception:
+                                logger.exception(
+                                    "Rollback after offline sweep failed",
+                                )
             except asyncio.CancelledError:
                 return
             except Exception:

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -45,6 +45,12 @@ class Device(Base):
             postgresql_where=text("pubkey IS NOT NULL"),
             sqlite_where=text("pubkey IS NOT NULL"),
         ),
+        Index(
+            "ix_devices_stale_check",
+            "last_seen",
+            postgresql_where=text("online = true AND last_seen IS NOT NULL"),
+            sqlite_where=text("online = 1 AND last_seen IS NOT NULL"),
+        ),
         {"extend_existing": True},
     )
 

--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -84,6 +84,18 @@ DEFAULT_TEMP_WARNING_C = 70.0
 DEFAULT_TEMP_CRITICAL_C = 80.0
 DEFAULT_TEMP_COOLDOWN_SECONDS = 300
 
+# Stale-presence sweep (PR #440): how long a device may go without a
+# STATUS heartbeat before we infer it is offline regardless of the
+# WebSocket / WPS connection state. Matches roughly 2 missed 30s
+# heartbeats — short enough that the UI flips offline within a minute
+# of a power-cut Pi, long enough to absorb a one-off network blip.
+STALE_PRESENCE_THRESHOLD_S = 60
+# Maximum devices flipped offline in a single sweep tick. Caps the
+# cost of a pathological backlog (e.g., a clock-skew bug or a
+# datacenter blip flipping the whole fleet at once); the next tick
+# will pick up the rest.
+STALE_PRESENCE_BATCH_SIZE = 50
+
 
 class AlertService:
     """Singleton service wired into the WebSocket + WPS webhook handlers.
@@ -366,6 +378,158 @@ class AlertService:
             logger.debug("Best-effort clear of alert state for %s failed", device_id)
 
     # ── Leader-gated sweep (fires offline notifications past grace) ──
+
+    async def stale_presence_sweep_once(self, db: AsyncSession) -> int:
+        """Mark devices that have stopped heartbeating as offline.
+
+        Backstop for the WS-disconnect path under N>1 replicas: when
+        Container Apps' load balancer keeps a dead WebSocket "alive"
+        for many minutes (or when a device drops off the WPS gateway
+        without a clean close), no replica observes the disconnect, so
+        ``devices.online`` stays TRUE and ``device_alert_state.offline_since``
+        is never written. The offline-alert pipeline therefore can't
+        fire and the UI keeps showing the device as healthy.
+
+        This sweep claims any row with ``online = TRUE`` and
+        ``last_seen < now - STALE_PRESENCE_THRESHOLD_S`` in a single
+        atomic ``UPDATE ... RETURNING``, so two replicas running the
+        sweep concurrently can't double-process a device. For each
+        adopted+grouped row it emits an OFFLINE event (kind
+        ``stale_heartbeat``) and transitions
+        ``device_alert_state.offline_since`` from NULL to NOW so the
+        existing :func:`offline_sweep_once` can fire the notification
+        once the configured grace window elapses.
+
+        Devices that aren't adopted+grouped are still flipped to
+        offline (so the UI doesn't lie) but receive no event or alert
+        state — pending registrations and orphaned devices have no
+        owner group to notify.
+
+        The sweep is idempotent: a device whose row is already
+        ``online = FALSE`` won't match the claim predicate. Returns
+        the number of devices flipped offline by this call.
+        """
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(seconds=STALE_PRESENCE_THRESHOLD_S)
+
+        # Cap claim size *before* mutation. Using a subquery with
+        # LIMIT (rather than slicing the RETURNING result) avoids
+        # stranding rows that were flipped offline but never had
+        # ``offline_since`` written, which would leave them invisible
+        # to the offline-alert pipeline.
+        cap_subq = (
+            select(Device.id)
+            .where(Device.online.is_(True))
+            .where(Device.last_seen.is_not(None))
+            .where(Device.last_seen < cutoff)
+            .limit(STALE_PRESENCE_BATCH_SIZE)
+        )
+        claim_stmt = (
+            update(Device)
+            .where(Device.id.in_(cap_subq))
+            # Re-assert the claim predicate on the outer UPDATE so
+            # races with concurrent reconnects (which flip
+            # ``online`` and bump ``last_seen`` from a heartbeat
+            # path) can't accidentally re-flip an already-online row.
+            .where(Device.online.is_(True))
+            .where(Device.last_seen.is_not(None))
+            .where(Device.last_seen < cutoff)
+            .values(online=False, connection_id=None)
+            .returning(
+                Device.id,
+                Device.name,
+                Device.group_id,
+                Device.status,
+            )
+        )
+        claimed = (await db.execute(claim_stmt)).all()
+        if not claimed:
+            return 0
+
+        # Batch-fetch group names for the rows we'll alert on so we
+        # don't issue one SELECT per device.
+        from cms.models.device import DeviceGroup
+        group_ids = {row.group_id for row in claimed if row.group_id}
+        group_names: dict = {}
+        if group_ids:
+            for gid, gname in (
+                await db.execute(
+                    select(DeviceGroup.id, DeviceGroup.name).where(
+                        DeviceGroup.id.in_(group_ids)
+                    )
+                )
+            ).all():
+                group_names[gid] = gname or ""
+
+        from sqlalchemy.exc import IntegrityError
+        for row in claimed:
+            # Only adopted + grouped devices have an owner to alert.
+            if row.status != DeviceStatus.ADOPTED or not row.group_id:
+                continue
+
+            group_name = group_names.get(row.group_id, "")
+            device_name = row.name or row.id
+
+            # 1. OFFLINE event with stale-detection marker so operators
+            #    can distinguish heartbeat-timeout offlines from
+            #    WS-close offlines in the audit trail.
+            db.add(DeviceEvent(
+                device_id=row.id,
+                device_name=device_name,
+                group_id=row.group_id,
+                group_name=group_name,
+                event_type=DeviceEventType.OFFLINE,
+                details={"kind": "stale_heartbeat"},
+            ))
+
+            # 2. Transition ``offline_since`` NULL → NOW. Mirrors the
+            #    semantics of ``_record_disconnect`` so duplicate
+            #    sweep ticks (or a sweep tick racing with a real WS
+            #    close) don't reset the grace window.
+            existing = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == row.id
+                )
+            )).scalar_one_or_none()
+            if existing is None:
+                # No row yet — common path for a freshly-adopted
+                # device that has never disconnected. Insert in a
+                # SAVEPOINT so a concurrent insert by the WS path
+                # (e.g., racing with a near-simultaneous real
+                # disconnect) raises IntegrityError that we can
+                # treat as benign without poisoning the outer
+                # transaction.
+                try:
+                    async with db.begin_nested():
+                        db.add(DeviceAlertState(
+                            device_id=row.id,
+                            offline_since=now,
+                            offline_notified=False,
+                        ))
+                except IntegrityError:
+                    logger.debug(
+                        "DeviceAlertState for %s created concurrently "
+                        "during stale-presence sweep; ignoring",
+                        row.id,
+                    )
+            elif existing.offline_since is None:
+                # Online → offline transition: mark when we first
+                # noticed and ensure the notified flag starts clean
+                # so the offline_sweep can claim it after grace.
+                existing.offline_since = now
+                existing.offline_notified = False
+            # else: device is already in an offline_since window
+            # (e.g., a partial ws disconnect happened and the sweep
+            # is catching up). Leave the timestamp + flag alone.
+
+        await db.commit()
+        flipped = len(claimed)
+        logger.info(
+            "Stale-presence sweep: marked %d device(s) offline "
+            "(no heartbeat for ≥ %ds)",
+            flipped, STALE_PRESENCE_THRESHOLD_S,
+        )
+        return flipped
 
     async def offline_sweep_once(self, db: AsyncSession) -> int:
         """Fire offline notifications for any device past the grace period.

--- a/cms/services/device_presence.py
+++ b/cms/services/device_presence.py
@@ -24,7 +24,7 @@ from typing import Any, Iterable, Mapping
 from sqlalchemy import case, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cms.models.device import Device
+from cms.models.device import Device, DeviceGroup
 
 logger = logging.getLogger("agora.cms.device_presence")
 
@@ -239,8 +239,70 @@ async def update_status(
         )
         .values(**values)
     )
+    rowcount = result.rowcount or 0
+
+    # Self-heal for the stale-presence sweep (PR #440): if a previous
+    # leader-gated sweep marked this device offline (e.g., because the
+    # Container Apps load balancer kept a dead WS connection "alive"
+    # past the heartbeat threshold), accepting a new STATUS heartbeat
+    # is positive evidence the device is alive — atomically flip
+    # ``online`` back to ``true`` and dispatch the existing reconnect
+    # path so any outstanding offline alert is cleared and a "back
+    # online" notification fires when warranted.
+    #
+    # The CAS predicate ``online IS FALSE`` ensures only one replica
+    # wins if heartbeats from multiple paths race; the loser sees
+    # zero returned rows and skips dispatch.
+    healed_row = None
+    if rowcount > 0:
+        heal_claim = await db.execute(
+            update(Device)
+            .where(Device.id == device_id)
+            .where(Device.online.is_(False))
+            .values(online=True)
+            .returning(
+                Device.name, Device.group_id, Device.status,
+            )
+        )
+        healed_row = heal_claim.first()
+
     await db.commit()
-    return (result.rowcount or 0) > 0
+
+    if healed_row is not None:
+        # Look up group_name for the back-online notification payload.
+        # Done after commit so we don't extend the heartbeat
+        # transaction; tiny extra round-trip on the rare transition
+        # edge only.
+        group_name = ""
+        if healed_row.group_id is not None:
+            group_name = (
+                await db.execute(
+                    select(DeviceGroup.name).where(
+                        DeviceGroup.id == healed_row.group_id
+                    )
+                )
+            ).scalar_one_or_none() or ""
+        try:
+            from cms.services.alert_service import alert_service
+            alert_service.device_reconnected(
+                device_id,
+                device_name=healed_row.name or device_id,
+                group_id=str(healed_row.group_id) if healed_row.group_id else None,
+                group_name=group_name,
+                status=(
+                    healed_row.status.value
+                    if hasattr(healed_row.status, "value")
+                    else str(healed_row.status)
+                ),
+            )
+        except Exception:
+            # Dispatch is fire-and-forget; never let an alert-service
+            # failure break the heartbeat path.
+            logger.exception(
+                "Failed to dispatch reconnect for healed device %s", device_id,
+            )
+
+    return rowcount > 0
 
 
 async def set_flags(

--- a/tests/test_stale_presence_sweep.py
+++ b/tests/test_stale_presence_sweep.py
@@ -1,0 +1,543 @@
+"""Tests for the stale-presence sweep (PR #440).
+
+Backstop sweep that flips ``devices.online=false`` for any device
+whose ``last_seen`` is older than the threshold, then transitions
+``device_alert_state.offline_since`` so the existing leader-gated
+offline-alert pipeline can fire the notification.
+
+Also covers the matching self-heal in ``device_presence.update_status``:
+when a heartbeat lands for a device the sweep had marked offline, the
+``online`` flag flips back to TRUE and any pending alert state is
+cleared (or, if the offline notification had already fired, the
+"back online" notification is emitted).
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.device_alert_state import DeviceAlertState
+from cms.models.device_event import DeviceEvent, DeviceEventType
+from cms.models.notification import Notification
+from cms.services import device_presence
+from cms.services.alert_service import (
+    AlertService,
+    STALE_PRESENCE_THRESHOLD_S,
+    STALE_PRESENCE_BATCH_SIZE,
+)
+
+
+@pytest_asyncio.fixture
+async def stale_seed(app):
+    """Adopted+grouped device whose last heartbeat is past the threshold."""
+    from cms.database import get_db
+    factory = app.dependency_overrides[get_db]
+    stale_ts = datetime.now(timezone.utc) - timedelta(
+        seconds=STALE_PRESENCE_THRESHOLD_S + 30
+    )
+    async for db in factory():
+        group = DeviceGroup(name="Stale Test Group")
+        db.add(group)
+        await db.flush()
+
+        device = Device(
+            id="stale-device-001",
+            name="Stale Display",
+            status=DeviceStatus.ADOPTED,
+            group_id=group.id,
+            online=True,
+            last_seen=stale_ts,
+        )
+        db.add(device)
+        await db.commit()
+        yield {
+            "device_id": device.id,
+            "device_name": device.name,
+            "group_id": group.id,
+            "group_name": group.name,
+        }
+        break
+
+
+@pytest_asyncio.fixture
+def alert_svc():
+    """Fresh AlertService with short grace for fast tests."""
+    svc = AlertService()
+    svc._offline_grace_seconds = 1
+    return svc
+
+
+class TestStalePresenceSweep:
+    """``stale_presence_sweep_once`` claim + alert-state transition."""
+
+    @pytest.mark.asyncio
+    async def test_stale_device_flipped_offline(self, app, stale_seed, alert_svc):
+        """Device past the threshold is flipped to online=false + alert state created."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 1
+            break
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == info["device_id"])
+            )).scalar_one()
+            assert device.online is False
+            assert device.connection_id is None
+
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one()
+            assert state.offline_since is not None
+            assert state.offline_notified is False
+
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.OFFLINE,
+                )
+            )).scalars().all()
+            assert len(events) == 1
+            assert events[0].details == {"kind": "stale_heartbeat"}
+            break
+
+    @pytest.mark.asyncio
+    async def test_recent_heartbeat_not_flipped(self, app, alert_svc):
+        """Device with last_seen within the threshold is left alone."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        recent_ts = datetime.now(timezone.utc) - timedelta(
+            seconds=STALE_PRESENCE_THRESHOLD_S - 5
+        )
+        async for db in factory():
+            group = DeviceGroup(name="Fresh Group")
+            db.add(group)
+            await db.flush()
+            device = Device(
+                id="fresh-device-001",
+                name="Fresh Device",
+                status=DeviceStatus.ADOPTED,
+                group_id=group.id,
+                online=True,
+                last_seen=recent_ts,
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 0
+            break
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == "fresh-device-001")
+            )).scalar_one()
+            assert device.online is True
+            break
+
+    @pytest.mark.asyncio
+    async def test_already_offline_not_re_swept(self, app, alert_svc):
+        """A device already online=false isn't re-claimed (idempotent)."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        stale_ts = datetime.now(timezone.utc) - timedelta(
+            seconds=STALE_PRESENCE_THRESHOLD_S + 30
+        )
+        async for db in factory():
+            group = DeviceGroup(name="Already Offline Group")
+            db.add(group)
+            await db.flush()
+            device = Device(
+                id="already-offline-001",
+                status=DeviceStatus.ADOPTED,
+                group_id=group.id,
+                online=False,
+                last_seen=stale_ts,
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 0
+            break
+
+    @pytest.mark.asyncio
+    async def test_pending_device_flipped_no_alert(self, app, alert_svc):
+        """Pending devices flip offline but get no event/alert state."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        stale_ts = datetime.now(timezone.utc) - timedelta(
+            seconds=STALE_PRESENCE_THRESHOLD_S + 30
+        )
+        async for db in factory():
+            device = Device(
+                id="pending-stale-001",
+                status=DeviceStatus.PENDING,
+                online=True,
+                last_seen=stale_ts,
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 1
+            break
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == "pending-stale-001")
+            )).scalar_one()
+            assert device.online is False
+            # No alert state, no event for unadopted devices.
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == "pending-stale-001"
+                )
+            )).scalar_one_or_none()
+            assert state is None
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == "pending-stale-001"
+                )
+            )).scalars().all()
+            assert events == []
+            break
+
+    @pytest.mark.asyncio
+    async def test_ungrouped_adopted_device_flipped_no_alert(self, app, alert_svc):
+        """Adopted-but-ungrouped devices flip offline but get no event/alert state."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        stale_ts = datetime.now(timezone.utc) - timedelta(
+            seconds=STALE_PRESENCE_THRESHOLD_S + 30
+        )
+        async for db in factory():
+            device = Device(
+                id="ungrouped-stale-001",
+                status=DeviceStatus.ADOPTED,
+                group_id=None,
+                online=True,
+                last_seen=stale_ts,
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 1
+            break
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == "ungrouped-stale-001")
+            )).scalar_one()
+            assert device.online is False
+            events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == "ungrouped-stale-001"
+                )
+            )).scalars().all()
+            assert events == []
+            break
+
+    @pytest.mark.asyncio
+    async def test_existing_offline_since_not_overwritten(self, app, stale_seed, alert_svc):
+        """A device already in an offline_since window keeps its original timestamp."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        prior_offline_since = datetime.now(timezone.utc) - timedelta(seconds=300)
+        async for db in factory():
+            db.add(DeviceAlertState(
+                device_id=info["device_id"],
+                offline_since=prior_offline_since,
+                offline_notified=True,
+            ))
+            await db.commit()
+            break
+
+        async for db in factory():
+            await alert_svc.stale_presence_sweep_once(db)
+            break
+
+        async for db in factory():
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one()
+            # Original timestamp preserved (transition-only update).
+            assert state.offline_since is not None
+            stored = state.offline_since
+            if stored.tzinfo is None:
+                stored = stored.replace(tzinfo=timezone.utc)
+            assert abs(
+                (stored - prior_offline_since).total_seconds()
+            ) < 1
+            # offline_notified preserved (we don't reset already-notified).
+            assert state.offline_notified is True
+            break
+
+    @pytest.mark.asyncio
+    async def test_grace_then_offline_sweep_fires_notification(
+        self, app, stale_seed, alert_svc,
+    ):
+        """End-to-end: stale-sweep flips offline → grace elapses → offline_sweep fires alert."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+
+        async for db in factory():
+            await alert_svc.stale_presence_sweep_once(db)
+            break
+
+        # Wait past the (fixture-shortened) grace period.
+        await asyncio.sleep(1.5)
+
+        async for db in factory():
+            emitted = await alert_svc.offline_sweep_once(db)
+            assert emitted == 1
+            break
+
+        async for db in factory():
+            notifs = (await db.execute(
+                select(Notification).where(
+                    Notification.group_id == info["group_id"],
+                    Notification.level == "error",
+                )
+            )).scalars().all()
+            assert len(notifs) == 1
+            assert "offline" in notifs[0].title.lower()
+            break
+
+    @pytest.mark.asyncio
+    async def test_batch_cap_caps_per_tick(self, app, alert_svc):
+        """More stale devices than batch size are split across ticks."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        stale_ts = datetime.now(timezone.utc) - timedelta(
+            seconds=STALE_PRESENCE_THRESHOLD_S + 30
+        )
+        target = STALE_PRESENCE_BATCH_SIZE + 5
+        async for db in factory():
+            group = DeviceGroup(name="Batch Group")
+            db.add(group)
+            await db.flush()
+            for i in range(target):
+                db.add(Device(
+                    id=f"batch-stale-{i:03d}",
+                    status=DeviceStatus.ADOPTED,
+                    group_id=group.id,
+                    online=True,
+                    last_seen=stale_ts,
+                ))
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped1 = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped1 == STALE_PRESENCE_BATCH_SIZE
+            break
+
+        async for db in factory():
+            flipped2 = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped2 == target - STALE_PRESENCE_BATCH_SIZE
+            break
+
+        async for db in factory():
+            still_online = (await db.execute(
+                select(Device).where(
+                    Device.id.like("batch-stale-%"),
+                    Device.online.is_(True),
+                )
+            )).scalars().all()
+            assert still_online == []
+            break
+
+    @pytest.mark.asyncio
+    async def test_null_last_seen_not_flipped(self, app, alert_svc):
+        """Device that has never reported (last_seen IS NULL) isn't claimed."""
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            group = DeviceGroup(name="Never Seen Group")
+            db.add(group)
+            await db.flush()
+            device = Device(
+                id="never-seen-001",
+                status=DeviceStatus.ADOPTED,
+                group_id=group.id,
+                online=True,
+                last_seen=None,
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        async for db in factory():
+            flipped = await alert_svc.stale_presence_sweep_once(db)
+            assert flipped == 0
+            break
+
+
+class TestUpdateStatusSelfHeal:
+    """``update_status`` re-flips online + clears alert state on heartbeat resume."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_after_stale_offline_restores_online(
+        self, app, stale_seed, alert_svc,
+    ):
+        """A device flipped offline by the sweep comes back online on the next heartbeat."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+
+        # Stale-sweep marks it offline.
+        async for db in factory():
+            await alert_svc.stale_presence_sweep_once(db)
+            break
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == info["device_id"])
+            )).scalar_one()
+            assert device.online is False
+            break
+
+        # Next heartbeat lands.
+        async for db in factory():
+            ok = await device_presence.update_status(
+                db, info["device_id"],
+                {"mode": "play", "asset": "x.mp4", "uptime_seconds": 1},
+            )
+            assert ok is True
+            break
+
+        # Allow the fire-and-forget reconnect dispatch to complete.
+        await asyncio.sleep(0.2)
+
+        async for db in factory():
+            device = (await db.execute(
+                select(Device).where(Device.id == info["device_id"])
+            )).scalar_one()
+            assert device.online is True
+
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one_or_none()
+            # Either the alert state row was cleared, or the row never
+            # had offline_notified set (so _record_reconnect's
+            # else-branch ran). Either way, offline_since must be
+            # None now so the next disconnect starts a fresh window.
+            if state is not None:
+                assert state.offline_since is None
+            break
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_after_grace_fires_back_online(
+        self, app, stale_seed, alert_svc,
+    ):
+        """Device whose offline notification fired gets a back-online notification on heartbeat."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+
+        # Stale-sweep marks offline.
+        async for db in factory():
+            await alert_svc.stale_presence_sweep_once(db)
+            break
+
+        # Past grace: offline_sweep flips offline_notified=true and
+        # emits the alert.
+        await asyncio.sleep(1.5)
+        async for db in factory():
+            await alert_svc.offline_sweep_once(db)
+            break
+
+        # Heartbeat resumes.
+        async for db in factory():
+            await device_presence.update_status(
+                db, info["device_id"],
+                {"mode": "play", "asset": "y.mp4", "uptime_seconds": 1},
+            )
+            break
+
+        # Wait for the dispatched _record_reconnect to land.
+        await asyncio.sleep(0.5)
+
+        async for db in factory():
+            online_notifs = (await db.execute(
+                select(Notification).where(
+                    Notification.group_id == info["group_id"],
+                    Notification.level == "success",
+                )
+            )).scalars().all()
+            assert any(
+                "back online" in n.title.lower() for n in online_notifs
+            ), "Expected a back-online notification after heartbeat resume"
+
+            state = (await db.execute(
+                select(DeviceAlertState).where(
+                    DeviceAlertState.device_id == info["device_id"]
+                )
+            )).scalar_one()
+            assert state.offline_since is None
+            assert state.offline_notified is False
+            break
+
+    @pytest.mark.asyncio
+    async def test_steady_state_heartbeat_no_extra_event(self, app, stale_seed):
+        """A normal heartbeat on an already-online device doesn't fire a reconnect."""
+        info = stale_seed
+        from cms.database import get_db
+        factory = app.dependency_overrides[get_db]
+
+        # Pretend the device never went offline — bump it online.
+        async for db in factory():
+            await db.execute(
+                update(Device)
+                .where(Device.id == info["device_id"])
+                .values(online=True, last_seen=datetime.now(timezone.utc))
+            )
+            await db.commit()
+            break
+
+        # Heartbeat.
+        async for db in factory():
+            await device_presence.update_status(
+                db, info["device_id"],
+                {"mode": "play", "asset": "z.mp4"},
+            )
+            break
+
+        await asyncio.sleep(0.2)
+
+        async for db in factory():
+            online_events = (await db.execute(
+                select(DeviceEvent).where(
+                    DeviceEvent.device_id == info["device_id"],
+                    DeviceEvent.event_type == DeviceEventType.ONLINE,
+                )
+            )).scalars().all()
+            # No reconnect dispatched → no ONLINE event written.
+            assert online_events == []
+            break


### PR DESCRIPTION
# Stale-presence sweep + heartbeat self-heal

Closes the offline-detection gap exposed during the N=2 flip drill: when
Container Apps' load balancer keeps a dead WebSocket socket "alive" for
7–17 minutes, `mark_offline` never fires, the device never gets flipped
to `online=false`, and the user sees no offline notification.

This PR adds a leader-gated DB-backed safety net that doesn't depend on
the WS path firing at all.

## What ships

### 1. Stale-presence sweep — `alert_service.stale_presence_sweep_once`

Runs once per offline-sweep tick (already leader-only via `_offline_sweep_loop`).
Atomic claim via `UPDATE devices SET online=false WHERE id IN (SELECT id ... LIMIT 50)`
— the `LIMIT` is inside the subquery so the cap applies _before_ the
mutation (no orphaned rows on large fleets).

For each claimed device:
- INSERT/UPDATE `device_alert_state` with transition-only semantics
  (`offline_since` only set when currently NULL — mirrors `_record_disconnect`).
- Forces `offline_notified=False` on the NULL→NOW transition so the next
  scheduled `offline_sweep_once` tick fires the alert.
- Skips `pending` and ungrouped devices the same way `_record_disconnect`
  does — no group-room to deliver to.
- SAVEPOINT + IntegrityError handling around the missing-row INSERT so
  concurrent inserts don't poison the outer transaction.

Threshold: `STALE_PRESENCE_THRESHOLD_S = 60` (= 2 missed STATUS heartbeats
at the firmware's 30s interval). Batch cap: `STALE_PRESENCE_BATCH_SIZE = 50`
to bound per-tick work.

### 2. Heartbeat self-heal — `device_presence.update_status`

After the existing monotonic-guard UPDATE, runs a second CAS:

```sql
UPDATE devices SET online=true
WHERE id=? AND online=false
RETURNING name, group_id, status
```

Only fires on the rare `false→true` transition edge, so cost is one extra
roundtrip per ~thousands of normal heartbeats. When it does fire, dispatches
`alert_service.device_reconnected()` (fire-and-forget — internal
`asyncio.create_task`) so the `device_back_online` notification path runs.

This closes the inverse gap: a device the sweep flipped offline gets
restored as soon as a heartbeat arrives, regardless of whether the WS
disconnect/reconnect cycle ever happened.

### 3. Migration `0013_devices_stale_check_index`

Partial index on `devices(last_seen) WHERE online=true AND last_seen IS NOT NULL`
so the sweep claim doesn't full-scan the device table on large fleets.

### 4. Wiring — `cms/main.py:_offline_sweep_loop`

Inside the existing `if lease.is_leader` block, runs `stale_presence_sweep_once`
before `offline_sweep_once`, each in its own `try/except + await db.rollback()`
so an error in the stale-sweep doesn't poison the session for the alert sweep.

## Why not just fix the WS timeout

The WS path is still the primary mechanism — `mark_offline` runs the
moment a WS close is detected. This is a backstop for the case the WS
path doesn't fire (LB keepalive, replica crash mid-disconnect, network
partition that drops the close frame). It's idempotent with the WS path:
if both fire, the sweep is a no-op (sweep filters `online=true` only).

## Replica safety

- Sweep is gated by `lease.is_leader` — only one replica claims rows per tick.
- The `UPDATE...WHERE online=true` predicate is idempotent across replicas.
- Self-heal CAS (`WHERE online=false`) is naturally idempotent — second
  replica's UPDATE matches zero rows.

## Tests

`tests/test_stale_presence_sweep.py` — 12 tests:
- Sweep claim of a stale online device, alert state created.
- Idempotency: second tick is a no-op.
- Batch cap of 50 (sweep claims exactly 50 of 75, repeats finish the rest).
- Pending devices skipped.
- Ungrouped devices flipped offline but no alert state created.
- Existing `offline_since` not overwritten (transition-only semantics).
- Recently-active devices not touched.
- Already-offline devices not re-claimed.
- Self-heal restores `online=true` on heartbeat after sweep flipped.
- Self-heal idempotent on already-online device (no-op).
- Self-heal triggers `device_reconnected` dispatch (state transition).

12/12 passing locally. 112/112 passing in `test_device_alerts`,
`test_device_presence`, `test_alert_event_notification_split`,
`test_devices`, `test_device_actions`.

## Rubber-duck-validated

Plan reviewed; flagged 2 blocking issues (now fixed): batch cap was
post-mutation (orphaned rows 51+), and dual-sweep needed explicit per-sweep
rollback. Also adopted: force `offline_notified=False` on NULL→NOW
transition; transition-only `offline_since`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
