### PR TITLE
fix: surface LAN IP across device views (#436)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -215,7 +215,11 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             pipeline_state=live_states[d.id]["pipeline_state"] if d.id in live_states else None,
             display_connected=live_states[d.id]["display_connected"] if d.id in live_states else None,
             cpu_temp_c=live_states[d.id]["cpu_temp_c"] if d.id in live_states else None,
-            ip_address=live_states[d.id]["ip_address"] if d.id in live_states else None,
+            ip_address=(
+                live_states[d.id]["ip_address"]
+                if d.id in live_states and live_states[d.id]["ip_address"]
+                else d.ip_address
+            ),
             ssh_enabled=live_states[d.id]["ssh_enabled"] if d.id in live_states else None,
             local_api_enabled=live_states[d.id]["local_api_enabled"] if d.id in live_states else None,
             error=live_states[d.id]["error"] if d.id in live_states else None,
@@ -268,7 +272,11 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         pipeline_state=live_states[device.id]["pipeline_state"] if device.id in live_states else None,
         display_connected=live_states[device.id]["display_connected"] if device.id in live_states else None,
         cpu_temp_c=live_states[device.id]["cpu_temp_c"] if device.id in live_states else None,
-        ip_address=live_states[device.id]["ip_address"] if device.id in live_states else None,
+        ip_address=(
+            live_states[device.id]["ip_address"]
+            if device.id in live_states and live_states[device.id]["ip_address"]
+            else device.ip_address
+        ),
         ssh_enabled=live_states[device.id]["ssh_enabled"] if device.id in live_states else None,
         local_api_enabled=live_states[device.id]["local_api_enabled"] if device.id in live_states else None,
         error=live_states[device.id]["error"] if device.id in live_states else None,
@@ -914,10 +922,16 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     transport = get_transport()
     live_states = {s["device_id"]: s for s in await transport.get_all_states()}
     for d in group.devices:
+        # See cms/ui.py: detach before decorating with live-state attributes
+        # so display-only values (cpu_temp_c, ip_address, …) cannot autoflush
+        # back to the DB.  Some of these names collide with real columns.
+        db.expunge(d)
         d.is_online = await transport.is_connected(d.id)
         state = live_states.get(d.id)
         d.cpu_temp_c = state["cpu_temp_c"] if state else None
-        d.ip_address = state["ip_address"] if state else None
+        # #436: prefer live LAN IP, fall back to last-known persisted value.
+        live_ip = state["ip_address"] if state else None
+        d.ip_address = live_ip or d.ip_address
         d.playback_mode = state["mode"] if state else None
         d.playback_asset = state["asset"] if state else None
         d.pipeline_state = state["pipeline_state"] if state else None

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -89,6 +89,7 @@
                 <th>Device</th>
                 <th>Status</th>
                 <th>Firmware</th>
+                <th>IP</th>
                 <th>Storage</th>
                 <th>First Seen</th>
                 <th>Actions</th>
@@ -106,6 +107,7 @@
                     {% endif %}
                 </td>
                 <td>{{ d.firmware_version }}</td>
+                <td class="monospace">{{ d.ip_address or '—' }}</td>
                 <td data-storage-mb="{{ d.storage_capacity_mb }}">{{ d.storage_capacity_mb }} MB</td>
                 <td data-utc="{{ d.registered_at.isoformat() }}">{{ d.registered_at.astimezone(tz).strftime('%b %d, %Y %I:%M %p') }}</td>
                 <td class="actions">

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -739,14 +739,26 @@ window._adoptionProfiles = [
         const rows = items.map(p => {
             const devId = _escHtml(p.device_id || p.id);
             const fw = _escHtml((p.metadata && p.metadata.firmware_version) || '—');
-            const ip = _escHtml(p.ip_address || '—');
+            // Prefer device-self-reported LAN IP from metadata when present
+            // (firmware ≥ bootstrap-v2 with local_ip).  Fall back to the
+            // server-extracted origin IP (XFF) when LAN IP is unknown.
+            // When both are present and differ, render both so the operator
+            // can see LAN-IP for SSH and origin for audit.
+            const lanIp = p.metadata && p.metadata.local_ip;
+            const originIp = p.ip_address;
+            let ipCell;
+            if (lanIp && originIp && lanIp !== originIp) {
+                ipCell = 'LAN: ' + _escHtml(lanIp) + ' · Origin: ' + _escHtml(originIp);
+            } else {
+                ipCell = _escHtml(lanIp || originIp || '—');
+            }
             const age = _escHtml(_fmtRelativeAge(p.created_at));
             const advisoryJs = (p.device_id || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
             return (
                 '<tr>' +
                 '<td>' + devId + '</td>' +
                 '<td>' + fw + '</td>' +
-                '<td>' + ip + '</td>' +
+                '<td>' + ipCell + '</td>' +
                 '<td title="' + _escHtml(p.created_at || '') + '">' + age + '</td>' +
                 '<td style="white-space: nowrap;">' +
                     '<button type="button" class="btn btn-primary" ' +

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1051,7 +1051,10 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         d.is_online = d.id in _connected_ids
         state = live_states.get(d.id)
         d.cpu_temp_c = state["cpu_temp_c"] if state else None
-        d.ip_address = state["ip_address"] if state else None
+        # #436: prefer live LAN IP, but fall back to last-known persisted
+        # value when offline so the rendered IP cell isn't blank.
+        live_ip = state["ip_address"] if state else None
+        d.ip_address = live_ip or d.ip_address
         d.playback_mode = state["mode"] if state else None
         d.playback_asset = state["asset"] if state else None
         if d.playback_asset and d.playback_asset in _url_display:
@@ -1101,7 +1104,9 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
             d.is_online = d.id in _connected_ids
             state = live_states.get(d.id)
             d.cpu_temp_c = state["cpu_temp_c"] if state else None
-            d.ip_address = state["ip_address"] if state else None
+            # #436: see note in main /devices render above.
+            live_ip = state["ip_address"] if state else None
+            d.ip_address = live_ip or d.ip_address
             d.playback_mode = state["mode"] if state else None
             d.playback_asset = state["asset"] if state else None
             if d.playback_asset and d.playback_asset in _url_display:

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -215,6 +215,70 @@ class TestDeviceAPILiveFields:
         assert d["is_online"] is False
         assert d["uptime_seconds"] == 0
 
+    async def test_offline_device_falls_back_to_persisted_ip(self, client, app):
+        """Regression for #436: an offline device must surface its
+        last-known persisted ``Device.ip_address`` instead of None.
+
+        The devices page polls /api/devices every 5s and overwrites
+        the IP cell from the response.  Without this fallback, the
+        cell flips to "—" the moment the device drops offline, even
+        though we have a perfectly good last-known LAN IP in the DB.
+        """
+        from cms.database import get_db
+        from cms.models.device import Device, DeviceStatus
+
+        factory = app.dependency_overrides[get_db]
+        device_id = "offline-with-persisted-ip-001"
+
+        async for db in factory():
+            device = Device(
+                id=device_id,
+                status=DeviceStatus.ADOPTED,
+                name="Offline Device With IP",
+                firmware_version="1.0.0",
+                ip_address="192.168.1.53",
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        resp = await client.get(f"/api/devices/{device_id}")
+        assert resp.status_code == 200
+        assert resp.json()["ip_address"] == "192.168.1.53"
+
+        list_resp = await client.get("/api/devices")
+        assert list_resp.status_code == 200
+        row = next(d for d in list_resp.json() if d["id"] == device_id)
+        assert row["ip_address"] == "192.168.1.53"
+        assert row["is_online"] is False
+
+    async def test_devices_page_renders_persisted_ip_for_offline(self, client, app):
+        """Regression for #436: initial /devices server render must show
+        the persisted Device.ip_address for an offline (not in
+        live_states) adopted device — not '—' until the JS poll fixes
+        it 5s later."""
+        from cms.database import get_db
+        from cms.models.device import Device, DeviceStatus
+
+        factory = app.dependency_overrides[get_db]
+        device_id = "offline-render-test-002"
+
+        async for db in factory():
+            device = Device(
+                id=device_id,
+                status=DeviceStatus.ADOPTED,
+                name="Offline Render Pi",
+                firmware_version="1.0.0",
+                ip_address="10.20.30.40",
+            )
+            db.add(device)
+            await db.commit()
+            break
+
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        assert "10.20.30.40" in resp.text
+
 
 # ── UI rendering tests ──
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -939,6 +939,30 @@ class TestPendingDeviceNameDisplay:
         assert "adoptDevice(" in html
         assert "Living Room TV" in html
 
+    async def test_dashboard_pending_renders_lan_ip_column(self, client, db_session):
+        """Regression for #436: dashboard pending-devices table must show
+        the device's self-reported LAN IP so admins can SSH/browse to it
+        before adopting.  The IP comes from Device.ip_address (populated
+        by ws.py from raw.get('ip_address') on register)."""
+        from cms.models.device import Device, DeviceStatus
+
+        device = Device(
+            id="pi-with-lan-ip",
+            name="Front Desk Pi",
+            status=DeviceStatus.PENDING,
+            ip_address="192.168.1.53",
+        )
+        db_session.add(device)
+        await db_session.commit()
+
+        resp = await client.get("/")
+        assert resp.status_code == 200
+        html = resp.text
+        assert "Front Desk Pi" in html
+        assert "192.168.1.53" in html
+        # Header column added too
+        assert "<th>IP</th>" in html
+
 
 @pytest.mark.asyncio
 class TestDefaultAssetVariantResolution:


### PR DESCRIPTION
Fixes #436 — surface the device's LAN IP correctly across pending
and adopted device views, and avoid showing `—` when a known device
goes offline.

## Changes

- **Dashboard pending list** — added an `IP` column to the pending
  devices table so operators can see the registering Pi's IP without
  expanding the row.
- **`/api/devices` and `/api/devices/{id}`** — when a device has no
  live presence record (offline), fall back to the persisted
  `Device.ip_address` instead of returning `null`. Last-known IP is
  better than nothing — `is_online: false` is already on the payload
  so the UI can decorate.
- **`/devices` initial server render (`cms/ui.py`)** — same fallback
  for the synchronous HTML render so the IP cell is populated on
  first paint, not just after the 5s `/api/devices` poll.
- **Group panel endpoint** — added `db.expunge(d)` before mutating
  display attrs (`ip_address`, `cpu_temp_c`, etc.) on the attached
  ORM objects, plus the same offline-IP fallback. The panel macro
  doesn't render IP today, so this is preventive — closes a latent
  autoflush hazard duck flagged.
- **Pending list JS** — when bootstrap-v2 is rolled out and
  firmware reports a `local_ip` in `metadata`, prefer it over the
  origin IP. If they differ (NAT'd registration) the cell renders
  as `LAN: 10.x.x.x · Origin: 4.4.4.4` so it's obvious which is
  which.

The firmware side (adding `"local_ip": _get_local_ip()` to the
bootstrap-v2 metadata payload) ships in a separate PR against
`sslivins/agora` since auto-merge isn't enabled there.

## Tests

- `test_offline_device_falls_back_to_persisted_ip` — `/api/devices`
  returns persisted IP for an offline adopted device.
- `test_devices_page_renders_persisted_ip_for_offline` — `/devices`
  HTML page renders persisted IP in the data-live-ip cell.
- `test_dashboard_pending_renders_lan_ip_column` — dashboard pending
  table renders the new IP column.

Targeted suites (`test_device_live_updates`, `test_devices`,
`test_group_panel_endpoint`, `test_adoption_flow`,
`test_pending_device_visibility`) all green locally — 146 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
