### PR TITLE
fix(#436): persist LAN IP + clear upgrade-claim on WPS register

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -27,7 +27,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, Request, Response
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.auth import get_settings
@@ -229,7 +229,30 @@ async def events_receiver(
         # still bootstrap over direct-WS — they can't hit connect-token
         # without an API key and a device row.
         if msg.get("type") == "register":
+            # Capture pre-register firmware AND upgrade-claim token
+            # before ``register_known_device`` mutates them.  Used
+            # below to gate (and CAS-protect) clearing the
+            # upgrade-in-progress claim on a real firmware-change.
+            pre_register_fw = device.firmware_version or ""
+            pre_register_upgrade_claim = device.upgrade_started_at
             reg_result = await register_known_device(device, msg, db)
+            # Persist the device's LAN IP from the register payload.
+            # ``sys.connected`` (handled above) has no body, so it can't
+            # carry the IP — and the webhook origin we'd see at the HTTP
+            # layer is Azure Web PubSub's egress, not the device's LAN
+            # address.  The ``register`` user-message is the first hop
+            # where the device itself reports ``ip_address``.  Calling
+            # ``mark_online`` again is idempotent (it tolerates an
+            # already-current ``connection_id``) and only writes
+            # ``Device.ip_address`` when the value is non-empty.
+            client_ip = msg.get("ip_address") or None
+            if client_ip:
+                from cms.services import device_presence
+                await device_presence.mark_online(
+                    db, ce_user_id,
+                    connection_id=ce_connection_id,
+                    ip_address=client_ip,
+                )
             if reg_result.orphaned:
                 # Over direct-WS we'd close 4004.  Over WPS we can't
                 # close the WPS connection from here; the device is
@@ -248,6 +271,35 @@ async def events_receiver(
                     logger.exception(
                         "Failed to push auth_assigned to WPS device %s", ce_user_id,
                     )
+            # Clear any stale upgrade-in-progress claim so the device
+            # can be upgraded again on a future request — but only
+            # when this register represents an actual completed
+            # upgrade (mirrors ``ws.py`` Stage-4 logic):
+            #   - there was a claim at register time
+            #     (``pre_register_upgrade_claim``),
+            #   - both prior and reported firmware are non-empty, and
+            #   - they differ (so the device booted into a new version).
+            # The UPDATE uses compare-and-swap on
+            # ``upgrade_started_at`` equal to the pre-register value,
+            # so a successor upgrade claim written between our SELECT
+            # and our clear isn't wiped.  Transient reconnects during
+            # an upgrade (same firmware) leave the claim in place;
+            # the upgrade-endpoint TTL is the safety net that releases
+            # the claim if no firmware change is ever reported.
+            if pre_register_upgrade_claim is not None:
+                reported_fw = (msg.get("firmware_version") or "").strip()
+                prior_fw = (pre_register_fw or "").strip()
+                if reported_fw and prior_fw and reported_fw != prior_fw:
+                    await db.execute(
+                        update(Device)
+                        .where(
+                            Device.id == ce_user_id,
+                            Device.upgrade_started_at == pre_register_upgrade_claim,
+                        )
+                        .values(upgrade_started_at=None)
+                        .execution_options(synchronize_session=False)
+                    )
+                    await db.commit()
             # Notify alert service of reconnection — mirrors ws.py's
             # direct-WS register path.  This is what emits the ONLINE
             # device_event, clears ``offline_notified`` on

--- a/cms/services/device_presence.py
+++ b/cms/services/device_presence.py
@@ -101,9 +101,11 @@ async def mark_online(
     the UI is immediately accurate after reconnect.  ``connection_id``
     is persisted when the caller has one (WPS webhook path); direct-WS
     connections don't expose a stable id and pass ``None``.
-    ``ip_address`` is persisted when the caller has it (direct-WS path);
-    WPS-only connections pass ``None`` and the column keeps its
-    previous value (so the last-known IP survives an offline blip).
+    ``ip_address`` is persisted when the caller has it (direct-WS
+    register and WPS ``register`` user-message paths); the system
+    ``sys.connected`` event has no body to source one from and passes
+    ``None``, in which case the column keeps its previous value (so
+    the last-known IP survives an offline blip).
     """
     now = datetime.now(timezone.utc)
     values: dict[str, Any] = {

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -552,6 +552,233 @@ class TestUserEvents:
         assert r.status_code == 204
         fake_transport.send_to_device.assert_not_called()
 
+    async def test_register_over_wps_persists_ip_address(
+        self, client, app_and_session,
+    ):
+        """``register`` user-message must persist ``ip_address`` to the
+        device row.  ``sys.connected`` has no body so it can't carry
+        the IP, and the webhook origin we'd see at the HTTP layer is
+        Azure WPS's egress, not the device's LAN address.  This is a
+        regression test for #436 — the LAN IP only landed in the DB
+        on direct-WS deployments before this fix.
+        """
+        app, session = app_and_session
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg-ip"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.services.device_presence.mark_online",
+            new=AsyncMock(),
+        ) as mock_mark, patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "valid-token",
+                    "ip_address": "192.168.1.53",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_mark.assert_awaited_once()
+        _, kwargs = mock_mark.call_args
+        assert kwargs.get("ip_address") == "192.168.1.53"
+        assert kwargs.get("connection_id") == cid
+
+    async def test_register_over_wps_no_ip_address_skips_mark_online(
+        self, client, app_and_session,
+    ):
+        """If the firmware omits ``ip_address`` (older builds) we don't
+        call ``mark_online`` from the register handler — the
+        ``sys.connected`` event already flipped presence and we don't
+        want to overwrite a previously-known IP with ``None``."""
+        app, session = app_and_session
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.20",
+            upgrade_started_at=None,
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg-noip"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.services.device_presence.mark_online",
+            new=AsyncMock(),
+        ) as mock_mark, patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "valid-token",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_mark.assert_not_called()
+
+    async def test_register_over_wps_clears_upgrade_claim_on_fw_change(
+        self, client, app_and_session,
+    ):
+        """When register reports a different firmware than the device row
+        held *and* an upgrade claim was set at register time, the WPS
+        path must clear ``Device.upgrade_started_at`` via a CAS UPDATE.
+        Otherwise the device is permanently stuck with
+        ``is_upgrading=true`` and can't be upgraded again.  Mirrors the
+        Stage-4 logic in ``cms/routers/ws.py:204-217``.
+        """
+        from datetime import datetime, timezone
+
+        app, session = app_and_session
+        prior_claim = datetime.now(timezone.utc)
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.7",
+            upgrade_started_at=prior_claim,
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg-fwchg"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.11.20",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        # Confirm an UPDATE statement was issued targeting upgrade_started_at.
+        update_stmts = [
+            str(s) for s in session.executed
+            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+        ]
+        assert update_stmts, (
+            f"Expected CAS UPDATE clearing upgrade_started_at, "
+            f"got {[str(s) for s in session.executed]}"
+        )
+
+    async def test_register_over_wps_keeps_upgrade_claim_on_same_fw(
+        self, client, app_and_session,
+    ):
+        """Reconnect during an in-flight upgrade (same firmware as
+        before) must NOT clear ``upgrade_started_at`` — the upgrade
+        hasn't actually completed yet.  The upgrade-endpoint TTL is
+        the safety net that releases the claim if the device never
+        boots into the new version.
+        """
+        from datetime import datetime, timezone
+
+        app, session = app_and_session
+        prior_claim = datetime.now(timezone.utc)
+        device = MagicMock(
+            id="pi-wps", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.20",
+            upgrade_started_at=prior_claim,
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-reg-samefw"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-wps",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.11.20",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-wps",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        update_stmts = [
+            str(s) for s in session.executed
+            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+        ]
+        assert not update_stmts, (
+            f"Did not expect upgrade_started_at UPDATE for same-fw register, "
+            f"got {update_stmts}"
+        )
+
     async def test_register_over_wps_orphaned_device(self, client, app_and_session):
         """Orphaned result returns 204 without pushing — direct-WS path
         would close 4004 but over WPS we can't close from here."""


### PR DESCRIPTION
## Problem

WPS-only / N=2 transition left two parity gaps in the WPS register handler vs the direct-WS handler in `cms/routers/ws.py`. Both fall on the same code path so they're shipped together.

### 1. `Device.ip_address` never written under WPS  *(closes #436 properly)*

The shared `register_known_device` helper only refreshes firmware/codecs/storage/last_seen. Direct-WS additionally calls `device_presence.mark_online(..., ip_address=client_ip)` from `ws.py:175-188`; the WPS handler did not. `sys.connected` carries no body, and the HTTP webhook origin is Azure WPS's egress (useless), so the `register` user-message is the first hop where the device reports its own LAN IP.

### 2. `upgrade_started_at` never cleared under WPS

`ws.py:204-217` runs a CAS UPDATE clearing the claim when (a) a claim was set at register time, (b) prior and reported firmware are both non-empty, and (c) they differ. WPS path was missing this entirely, so devices that completed an OTA over WPS stayed flagged `is_upgrading=true` until the upgrade-endpoint TTL expired. **Observed in prod today**: both Pis on v1.11.20 still showing `is_upgrading: true` post-upgrade.

## Fix

Mirrors the direct-WS structure:
- Capture `pre_register_fw` and `pre_register_upgrade_claim` **before** `register_known_device` mutates them.
- After register: conditional `mark_online` with IP (only when non-empty so legacy firmware doesn't clobber a known IP with None).
- Then the same CAS UPDATE on `upgrade_started_at` gated on the pre-register claim, compare-and-swap on the column value so a successor upgrade claim isn't wiped.

## Tests (4 new in `tests/test_wps_webhook.py`)

- `test_register_over_wps_persists_ip_address`
- `test_register_over_wps_no_ip_address_skips_mark_online`
- `test_register_over_wps_clears_upgrade_claim_on_fw_change`
- `test_register_over_wps_keeps_upgrade_claim_on_same_fw`

28/28 webhook tests pass.

## Risk

Tiny. Two extra DB writes per register, both gated on conditions that are False for the no-op cases. CAS guard prevents wiping a successor upgrade claim. `mark_online` is idempotent on the same connection_id.

## Manual cleanup needed (one-shot)

The two prod Pis are currently stuck with `upgrade_started_at` set even though they completed v1.11.20. They'll auto-clear on the next upgrade attempt (TTL guard releases the stale claim) or via direct DB UPDATE; not part of this PR.