### PR TITLE
fix(audit): show device name not GUID in end-now description (#443)

### DIFF
--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -506,7 +506,12 @@ async def end_schedule_now(
             row.skip_until = end_today
             db.add(row)
 
-    scope = "all devices" if device_id is None else f"device {device_id}"
+    if device_id is None:
+        scope = "all devices"
+    else:
+        dev = await db.get(Device, device_id)
+        label = dev.name if dev and dev.name else device_id
+        scope = f"device '{label}'"
     await audit_log(
         db, user=getattr(request.state, "user", None),
         action="schedule.end_now", resource_type="schedule",

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -770,6 +770,95 @@ class TestEndNowPerDevice:
         )).scalars().all()
         assert sorted(rows) == [dev_a]
 
+    async def test_end_now_audit_description_uses_device_name(
+        self, client, db_session,
+    ):
+        """Issue #443: end-now audit description should include device name, not GUID."""
+        from cms.models.audit_log import AuditLog
+        from sqlalchemy import select
+
+        group_id, asset_id, dev_a, _ = await self._seed_two_devices(db_session)
+        # dev_a's friendly name is "A" (set by _seed_two_devices).
+
+        created = await client.post("/api/schedules", json={
+            "name": "Audit Name Test",
+            "group_id": group_id,
+            "asset_id": asset_id,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        sched_id = created.json()["id"]
+
+        resp = await client.post(
+            f"/api/schedules/{sched_id}/end-now",
+            json={"device_id": dev_a},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db_session.expire_all()
+        rows = (await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "schedule.end_now")
+        )).scalars().all()
+        assert rows, "expected an audit entry for schedule.end_now"
+        descriptions = [r.description for r in rows]
+        assert any("device 'A'" in d for d in descriptions), (
+            f"Expected friendly device name in audit description, got: {descriptions}"
+        )
+        # Must NOT contain the raw device id in the description.
+        assert all(dev_a not in d for d in descriptions), (
+            f"Audit description should not contain raw device id; got: {descriptions}"
+        )
+        # But the structured details must still carry the device_id GUID.
+        assert any(
+            (r.details or {}).get("device_id") == dev_a for r in rows
+        ), "details.device_id should remain the GUID for machine consumers"
+
+    async def test_end_now_audit_description_falls_back_to_id_if_unnamed(
+        self, client, db_session,
+    ):
+        """If a device row has no friendly name, fall back to the device_id."""
+        from cms.models.asset import Asset, AssetType
+        from cms.models.audit_log import AuditLog
+        from cms.models.device import Device, DeviceGroup, DeviceStatus
+        from sqlalchemy import select
+
+        group = DeviceGroup(name="Unnamed Device Group")
+        dev = Device(id="pi-no-name", name=None, status=DeviceStatus.ADOPTED)
+        asset = Asset(
+            filename="p.mp4", asset_type=AssetType.VIDEO, size_bytes=1, checksum="c",
+        )
+        db_session.add_all([group, dev, asset])
+        await db_session.flush()
+        dev.group_id = group.id
+        await db_session.commit()
+        # Capture ids before any expire/refresh so later assertions don't lazy-load.
+        dev_id = dev.id
+        group_id_str = str(group.id)
+        asset_id_str = str(asset.id)
+
+        created = await client.post("/api/schedules", json={
+            "name": "Unnamed Device Test",
+            "group_id": group_id_str,
+            "asset_id": asset_id_str,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        sched_id = created.json()["id"]
+
+        resp = await client.post(
+            f"/api/schedules/{sched_id}/end-now",
+            json={"device_id": dev_id},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db_session.expire_all()
+        rows = (await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "schedule.end_now")
+        )).scalars().all()
+        assert any(f"device '{dev_id}'" in r.description for r in rows), (
+            f"Expected fallback to device id, got: {[r.description for r in rows]}"
+        )
+
     async def test_end_now_without_body_still_schedule_wide(self, client, db_session):
         """Back-compat: POST with no body skips all devices on the schedule."""
         from cms.models.schedule_device_skip import ScheduleDeviceSkip


### PR DESCRIPTION
Fixes #443.

### Problem

The `schedule.end_now` audit description embedded the raw `device_id`
GUID:

> Ended schedule 'Test (4)' early for device dee8ed3d-2a0b-453b-af11-ab138dbc17a6 (resumes at 2026-04-24T17:49:00)

Operators had to cross-reference the GUID against the devices list to
figure out which Pi was affected.

### Fix

`cms/routers/schedules.py` — when a per-device end-now is logged, look
up the `Device` row and render the friendly name in single quotes:

> Ended schedule 'Test (4)' early for device 'Living Room Pi' (resumes at 2026-04-24T17:49:00)

If the device has no name or was deleted between the call and the audit
write, fall back to the GUID. The structured `details.device_id` is
unchanged so machine-parsing audit consumers are unaffected.

### Tests

- `test_end_now_audit_description_uses_device_name` — friendly name
  appears, raw GUID does not appear in the description, but
  `details.device_id` still carries the GUID.
- `test_end_now_audit_description_falls_back_to_id_if_unnamed` — when
  `Device.name` is `NULL`, description falls back to the device id.
- Existing 3 end-now-per-device tests still pass.

Local: 5 passed.
