### PR TITLE
test(#444): Playwright layout/overflow tests for /schedules

### DIFF
--- a/tests_e2e/_layout.py
+++ b/tests_e2e/_layout.py
@@ -1,0 +1,171 @@
+"""Geometric layout assertions for Playwright E2E tests — issue #444.
+
+Helpers that catch the *class of bug* where UI elements visually overflow
+their container or the viewport. Intentionally narrow: three primitives,
+no clipped-text detector, no pixel diffs.
+
+See sslivins/agora-cms#444 for the full design rationale.
+"""
+
+from playwright.sync_api import Locator, Page
+
+
+# ── Constants ──
+
+# Cell-vs-button overflow: tight tolerance, sub-pixel slop.
+_CELL_TOL = 1.0
+# Viewport-vs-element overflow: looser, headless rounding can exceed 1px.
+_VIEWPORT_TOL = 3.0
+# Open-kebab anchor distance: how far menu's nearest horizontal edge can
+# sit from the trigger center before we call it un-anchored. positionKebab()
+# right-aligns by default; on small viewports it clamps to viewport - 8px.
+_ANCHOR_TOL = 64.0
+
+
+# ── Page-level overflow ──
+
+def assert_no_horizontal_overflow(page: Page, *, label: str = "") -> None:
+    """Page document must not extend past the viewport horizontally.
+
+    Catches the canonical "table is wider than the page" bug. Uses
+    ``clientWidth`` so scrollbar gutters don't cause false negatives.
+    Compares against the larger of ``html`` / ``body`` ``scrollWidth``
+    because some layouts overflow on body, others on html.
+    """
+    metrics = page.evaluate("""() => ({
+        scrollW: Math.max(
+            document.documentElement.scrollWidth,
+            document.body ? document.body.scrollWidth : 0,
+        ),
+        clientW: document.documentElement.clientWidth,
+        innerW: window.innerWidth,
+    })""")
+    overflow = metrics["scrollW"] - metrics["clientW"]
+    assert overflow <= _VIEWPORT_TOL, (
+        f"horizontal overflow {label}: scrollWidth={metrics['scrollW']} "
+        f"clientWidth={metrics['clientW']} innerWidth={metrics['innerW']} "
+        f"(overflow={overflow}px, tol={_VIEWPORT_TOL}px)"
+    )
+
+
+# ── Closed-kebab cell containment ──
+
+def assert_closed_kebabs_in_cells(
+    page: Page,
+    container: Locator,
+    *,
+    label: str = "",
+) -> None:
+    """Every closed ``.btn-kebab`` inside ``container`` must stay within
+    its own ``td``/``th`` cell horizontally.
+
+    Catches the "kebab visually pokes past the right edge of the table"
+    regression. Uses ``closest('td,th')`` so the helper is generic across
+    tables that wrap cell content in extra divs.
+    """
+    pairs = page.evaluate(
+        """(root) => {
+            const cells = [];
+            for (const btn of root.querySelectorAll('.btn-kebab')) {
+                const cell = btn.closest('td,th');
+                if (!cell) continue;
+                const b = btn.getBoundingClientRect();
+                const c = cell.getBoundingClientRect();
+                cells.push({
+                    btnLeft: b.left, btnRight: b.right,
+                    cellLeft: c.left, cellRight: c.right,
+                });
+            }
+            return cells;
+        }""",
+        container.element_handle(),
+    )
+    assert pairs, f"no .btn-kebab found inside container {label}"
+    for i, p in enumerate(pairs):
+        right_overflow = p["btnRight"] - p["cellRight"]
+        left_overflow = p["cellLeft"] - p["btnLeft"]
+        assert right_overflow <= _CELL_TOL, (
+            f"kebab #{i} {label} overflows its cell on the right: "
+            f"btn.right={p['btnRight']} cell.right={p['cellRight']} "
+            f"(overflow={right_overflow}px, tol={_CELL_TOL}px)"
+        )
+        assert left_overflow <= _CELL_TOL, (
+            f"kebab #{i} {label} overflows its cell on the left: "
+            f"btn.left={p['btnLeft']} cell.left={p['cellLeft']} "
+            f"(overflow={left_overflow}px, tol={_CELL_TOL}px)"
+        )
+
+
+# ── Open-kebab viewport containment ──
+
+def assert_open_kebab_in_viewport(
+    page: Page,
+    kebab_button: Locator,
+    *,
+    label: str = "",
+) -> None:
+    """Open the given ``.btn-kebab`` and assert the menu is fully in
+    viewport and anchored near the trigger.
+
+    Waits via ``wait_for_function`` for the menu to (a) be in
+    ``:popover-open`` state and (b) have moved off its parked
+    ``-9999px`` position before measuring — avoids flake from
+    measuring before ``positionKebab()`` runs.
+    """
+    btn_box = kebab_button.bounding_box()
+    assert btn_box is not None, f"kebab trigger {label} has no bounding box"
+    btn_center_x = btn_box["x"] + btn_box["width"] / 2
+
+    kebab_button.click()
+    # Wait for the popover to open AND for positionKebab() to lift it
+    # out of the parked off-screen position.
+    page.wait_for_function(
+        """() => {
+            const m = document.querySelector('.kebab-menu:popover-open');
+            if (!m) return false;
+            const r = m.getBoundingClientRect();
+            return r.top > -1000 && r.left > -1000;
+        }""",
+        timeout=5000,
+    )
+
+    metrics = page.evaluate("""() => {
+        const m = document.querySelector('.kebab-menu:popover-open');
+        const r = m.getBoundingClientRect();
+        return {
+            left: r.left, right: r.right, top: r.top, bottom: r.bottom,
+            innerW: window.innerWidth, innerH: window.innerHeight,
+        };
+    }""")
+
+    # Viewport containment (looser tolerance for fractional rounding).
+    for side, val, limit in (
+        ("left",   -metrics["left"],                              _VIEWPORT_TOL),
+        ("top",    -metrics["top"],                               _VIEWPORT_TOL),
+        ("right",  metrics["right"]  - metrics["innerW"],         _VIEWPORT_TOL),
+        ("bottom", metrics["bottom"] - metrics["innerH"],         _VIEWPORT_TOL),
+    ):
+        assert val <= limit, (
+            f"open kebab menu {label} overflows viewport on {side}: "
+            f"rect=(L={metrics['left']},T={metrics['top']},"
+            f"R={metrics['right']},B={metrics['bottom']}) "
+            f"viewport=({metrics['innerW']}x{metrics['innerH']}) "
+            f"(overflow={val}px, tol={limit}px)"
+        )
+
+    # Anchor proximity — distance from trigger center to *nearest*
+    # horizontal edge of the menu. positionPopover() may right- or
+    # left-align depending on viewport space; we don't pin a side.
+    edge_dist = min(
+        abs(metrics["left"]  - btn_center_x),
+        abs(metrics["right"] - btn_center_x),
+    )
+    assert edge_dist <= _ANCHOR_TOL, (
+        f"open kebab menu {label} not anchored near trigger: "
+        f"trigger center x={btn_center_x:.0f}, menu edges "
+        f"L={metrics['left']:.0f} R={metrics['right']:.0f}, "
+        f"nearest distance={edge_dist:.0f}px (tol={_ANCHOR_TOL}px)"
+    )
+
+    # Restore page state for the next assertion.
+    page.keyboard.press("Escape")

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -184,6 +184,10 @@ def e2e_server(e2e_port, tmp_path_factory):
         col = DeviceEvent.__table__.columns["details"]
         col.type = SA_JSON()
 
+        from cms.models.log_request import LogRequest
+        col = LogRequest.__table__.columns["services"]
+        col.type = SA_JSON()
+
     # Clear cached settings so they pick up the new env vars
     from cms.auth import get_settings
     get_settings.cache_clear()

--- a/tests_e2e/test_layout_schedules.py
+++ b/tests_e2e/test_layout_schedules.py
@@ -79,21 +79,18 @@ def _schedules_seed(api, ws_url):
     run_async(_register())
     api.post(f"/api/devices/{device_id}/adopt")
 
-    # Group create — handle 409 (conflict on name) by reusing the
-    # existing group.  Some 409 bodies aren't JSON, so guard ``.json()``.
-    group_resp = api.post(
-        "/api/devices/groups/", json={"name": _LONG_GROUP},
+    # Group create — sidestep the duplicate-group 500 by GET'ing first.
+    # The CMS POST raises IntegrityError on duplicate name (returns 500
+    # rather than 409), and there's no upsert endpoint, so we reuse a
+    # pre-existing group whenever possible.
+    existing_groups = api.get("/api/devices/groups/").json()
+    group = next(
+        (g for g in existing_groups if g.get("name") == _LONG_GROUP), None,
     )
-    if group_resp.status_code == 409:
-        existing = api.get("/api/devices/groups/").json()
-        group = next(
-            (g for g in existing if g.get("name") == _LONG_GROUP), None,
+    if group is None:
+        group_resp = api.post(
+            "/api/devices/groups/", json={"name": _LONG_GROUP},
         )
-        assert group is not None, (
-            f"group create returned 409 but no matching group found; "
-            f"body={group_resp.text!r}"
-        )
-    else:
         assert group_resp.status_code in (200, 201), group_resp.text
         group = group_resp.json()
     api.patch(f"/api/devices/{device_id}", json={"group_id": group["id"]})
@@ -110,9 +107,11 @@ def _schedules_seed(api, ws_url):
     # name so the Asset column is forced wider.
     api.patch(f"/api/assets/{asset['id']}", json={"display_name": _LONG_ASSET})
 
-    # Active schedule with width-stressing name.  ``priority=99`` keeps
-    # us out of the overlap check that compares schedules at the same
-    # priority on the same target.
+    # Active schedule with width-stressing name.  Distinct priorities
+    # for active vs expired keep them out of the overlap check (the
+    # check compares only same-priority schedules on the same target;
+    # date_range is ignored, so 09–17 expired would otherwise conflict
+    # with 08–20 active even though they're temporally disjoint).
     active = api.post("/api/schedules", json={
         "name": _LONG_NAME,
         "group_id": group["id"],
@@ -140,7 +139,7 @@ def _schedules_seed(api, ws_url):
         "end_time": "17:00",
         "start_date": fourteen_days_ago,
         "end_date": seven_days_ago,
-        "priority": 99,
+        "priority": 98,
     })
     assert expired.status_code == 201, expired.text
 

--- a/tests_e2e/test_layout_schedules.py
+++ b/tests_e2e/test_layout_schedules.py
@@ -51,12 +51,23 @@ def _schedules_seed(api, ws_url):
     """Seed one active + one expired schedule using width-stressing names.
 
     Returns a dict with the created entity ids so tests can clean up
-    or reference them. Cleans up any existing schedules first to keep
-    the fixture deterministic across test ordering.
+    or reference them.
+
+    Robust to leftover state from prior tests in the same session and
+    re-runs of parametrized cases:
+
+    * any schedule whose name starts with our long-name prefix is
+      deleted up-front so we don't trip the API's "overlapping time on
+      the same target at same priority" 409;
+    * group creation tolerates 409 by GET'ing the existing one;
+    * both schedules are created at ``priority=99`` so they cannot
+      conflict with anything left over at priority 0.
     """
-    # Wipe schedules from any prior test that ran in the same session.
+    # Wipe any of our previously-created schedules so a leftover at the
+    # same priority/target doesn't trigger the API's overlap check.
     for s in api.get("/api/schedules").json():
-        api.delete(f"/api/schedules/{s['id']}")
+        if s.get("name", "").startswith(_LONG_NAME):
+            api.delete(f"/api/schedules/{s['id']}")
 
     # Register + adopt a device so it can be a schedule target.
     device_id = "layout-444-device"
@@ -68,9 +79,23 @@ def _schedules_seed(api, ws_url):
     run_async(_register())
     api.post(f"/api/devices/{device_id}/adopt")
 
-    group = api.post(
+    # Group create — handle 409 (conflict on name) by reusing the
+    # existing group.  Some 409 bodies aren't JSON, so guard ``.json()``.
+    group_resp = api.post(
         "/api/devices/groups/", json={"name": _LONG_GROUP},
-    ).json()
+    )
+    if group_resp.status_code == 409:
+        existing = api.get("/api/devices/groups/").json()
+        group = next(
+            (g for g in existing if g.get("name") == _LONG_GROUP), None,
+        )
+        assert group is not None, (
+            f"group create returned 409 but no matching group found; "
+            f"body={group_resp.text!r}"
+        )
+    else:
+        assert group_resp.status_code in (200, 201), group_resp.text
+        group = group_resp.json()
     api.patch(f"/api/devices/{device_id}", json={"group_id": group["id"]})
 
     # Asset.
@@ -85,7 +110,9 @@ def _schedules_seed(api, ws_url):
     # name so the Asset column is forced wider.
     api.patch(f"/api/assets/{asset['id']}", json={"display_name": _LONG_ASSET})
 
-    # Active schedule with width-stressing name.
+    # Active schedule with width-stressing name.  ``priority=99`` keeps
+    # us out of the overlap check that compares schedules at the same
+    # priority on the same target.
     active = api.post("/api/schedules", json={
         "name": _LONG_NAME,
         "group_id": group["id"],
@@ -93,6 +120,7 @@ def _schedules_seed(api, ws_url):
         "start_time": "08:00",
         "end_time": "20:00",
         "days_of_week": [1, 2, 3, 4, 5, 6, 7],
+        "priority": 99,
     })
     assert active.status_code == 201, active.text
     active_id = active.json()["id"]
@@ -112,6 +140,7 @@ def _schedules_seed(api, ws_url):
         "end_time": "17:00",
         "start_date": fourteen_days_ago,
         "end_date": seven_days_ago,
+        "priority": 99,
     })
     assert expired.status_code == 201, expired.text
 

--- a/tests_e2e/test_layout_schedules.py
+++ b/tests_e2e/test_layout_schedules.py
@@ -1,0 +1,256 @@
+"""Layout/overflow regression tests for /schedules — issue #444.
+
+Catches the class-of-bug we hit twice in a row:
+  * Schedules → Expired Schedules: kebab visually overflows past the
+    right edge of the table.
+  * In general: tables/menus that sneak past the viewport on narrower
+    desktops.
+
+Three geometric assertions per (viewport × table) — see ``_layout.py``:
+  1. ``assert_no_horizontal_overflow``        — page-level
+  2. ``assert_closed_kebabs_in_cells``        — closed kebab in its cell
+  3. ``assert_open_kebab_in_viewport``        — open menu in viewport,
+                                                anchored near trigger
+
+We deliberately keep this narrow: no clipped-text detector, no
+overlap probe, no pixel-diff baselines (see the issue body for why).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests_e2e._layout import (
+    assert_closed_kebabs_in_cells,
+    assert_no_horizontal_overflow,
+    assert_open_kebab_in_viewport,
+)
+from tests_e2e.conftest import run_async
+from tests_e2e.fake_device import FakeDevice
+
+
+# ── Fixture: seed an active + an expired schedule with width-stressing data ──
+#
+# What stresses table width on /schedules:
+#   - long schedule name           (Name column)
+#   - long asset display name      (Asset column)
+#   - long group name              (Target column)
+#   - long days-of-week / time     (Schedule column — rendered client-side)
+# (NOT "many devices" — Target shows the *group* name, not a device list.)
+
+
+# Long-but-realistic strings drive the worst-case row width.
+_LONG_NAME = "Lobby — Marketing Loop (Daily, Wednesdays Excluded)"
+_LONG_ASSET = "Q4-2026-marketing-promo-extended-cut-v3-final-FINAL.mp4"
+_LONG_GROUP = "Building 92 / North Wing / Hallway Display Cluster"
+
+
+@pytest.fixture
+def _schedules_seed(api, ws_url):
+    """Seed one active + one expired schedule using width-stressing names.
+
+    Returns a dict with the created entity ids so tests can clean up
+    or reference them. Cleans up any existing schedules first to keep
+    the fixture deterministic across test ordering.
+    """
+    # Wipe schedules from any prior test that ran in the same session.
+    for s in api.get("/api/schedules").json():
+        api.delete(f"/api/schedules/{s['id']}")
+
+    # Register + adopt a device so it can be a schedule target.
+    device_id = "layout-444-device"
+
+    async def _register():
+        async with FakeDevice(device_id, ws_url) as dev:
+            await dev.send_status()
+
+    run_async(_register())
+    api.post(f"/api/devices/{device_id}/adopt")
+
+    group = api.post(
+        "/api/devices/groups/", json={"name": _LONG_GROUP},
+    ).json()
+    api.patch(f"/api/devices/{device_id}", json={"group_id": group["id"]})
+
+    # Asset.
+    assets = api.get("/api/assets").json()
+    if not assets:
+        api.create_asset(_LONG_ASSET)
+        assets = api.get("/api/assets").json()
+        if not assets:
+            pytest.skip("Could not create test asset")
+    asset = assets[0]
+    # If asset already exists from a prior test, give it a long display
+    # name so the Asset column is forced wider.
+    api.patch(f"/api/assets/{asset['id']}", json={"display_name": _LONG_ASSET})
+
+    # Active schedule with width-stressing name.
+    active = api.post("/api/schedules", json={
+        "name": _LONG_NAME,
+        "group_id": group["id"],
+        "asset_id": asset["id"],
+        "start_time": "08:00",
+        "end_time": "20:00",
+        "days_of_week": [1, 2, 3, 4, 5, 6, 7],
+    })
+    assert active.status_code == 201, active.text
+    active_id = active.json()["id"]
+
+    # Expired schedule — comfortably in the past so no boundary flake.
+    seven_days_ago = (
+        datetime.now(timezone.utc) - timedelta(days=7)
+    ).strftime("%Y-%m-%dT00:00:00Z")
+    fourteen_days_ago = (
+        datetime.now(timezone.utc) - timedelta(days=14)
+    ).strftime("%Y-%m-%dT00:00:00Z")
+    expired = api.post("/api/schedules", json={
+        "name": _LONG_NAME + " (archived)",
+        "group_id": group["id"],
+        "asset_id": asset["id"],
+        "start_time": "09:00",
+        "end_time": "17:00",
+        "start_date": fourteen_days_ago,
+        "end_date": seven_days_ago,
+    })
+    assert expired.status_code == 201, expired.text
+
+    return {
+        "device_id": device_id,
+        "group_id": group["id"],
+        "asset_id": asset["id"],
+        "active_id": active_id,
+        "expired_id": expired.json()["id"],
+    }
+
+
+# ── Page-load helpers ──
+
+def _goto_schedules(page: Page) -> None:
+    page.goto("/schedules")
+    page.wait_for_load_state("domcontentloaded")
+    # ``schedule-desc`` cells are populated by JS on DOMContentLoaded;
+    # wait until that JSON-driven render has actually written content
+    # before measuring widths/positions.
+    page.wait_for_function(
+        """() => {
+            const cells = document.querySelectorAll('.table-schedules .schedule-desc');
+            if (cells.length === 0) return true;
+            return Array.from(cells).every(c => c.textContent.trim().length > 0);
+        }""",
+        timeout=5000,
+    )
+
+
+# ── Viewports ──
+#
+# Three desktop viewports (no mobile — operator-only product):
+#   * 1024×768  — narrow laptop / split-screen window (where overflow
+#                 bugs surface most often)
+#   * 1366×768  — modal mid-laptop
+#   * 1440×900  — common widescreen
+# 1920×1080 is omitted: above the 1400px ``main`` cap, low signal.
+_VIEWPORTS = [
+    pytest.param(1024, 768,  id="1024x768"),
+    pytest.param(1366, 768,  id="1366x768"),
+    pytest.param(1440, 900,  id="1440x900"),
+]
+
+
+@pytest.mark.e2e
+class TestSchedulesLayout:
+    """Geometry assertions for the /schedules page."""
+
+    @pytest.mark.parametrize("vw,vh", _VIEWPORTS)
+    def test_no_overflow_active_table(
+        self, page: Page, _schedules_seed, vw, vh,
+    ):
+        """Active Schedules table must not push the page past the viewport
+        and every closed kebab must stay inside its actions cell.
+
+        Combined into one test per viewport rather than three separate
+        tests to keep the suite well under the 30s budget — three
+        assertions on the same loaded page is cheap.
+        """
+        page.set_viewport_size({"width": vw, "height": vh})
+        _goto_schedules(page)
+
+        active_card = page.locator(".card", has_text="Active Schedules")
+        expect(active_card).to_be_visible()
+
+        assert_no_horizontal_overflow(
+            page, label=f"@{vw}x{vh} active",
+        )
+        assert_closed_kebabs_in_cells(
+            page,
+            active_card.locator("table.table-schedules"),
+            label=f"@{vw}x{vh} active",
+        )
+
+    @pytest.mark.parametrize("vw,vh", _VIEWPORTS)
+    def test_no_overflow_expired_table(
+        self, page: Page, _schedules_seed, vw, vh,
+    ):
+        """Expired Schedules table — same assertions.
+
+        This is the table where the kebab-off-edge bug was first
+        noticed by an operator. We also re-check page-level overflow:
+        the expired card pushes the whole page taller and could surface
+        a different overflow path.
+        """
+        page.set_viewport_size({"width": vw, "height": vh})
+        _goto_schedules(page)
+
+        expired_card = page.locator(".card", has_text="Expired Schedules")
+        expect(expired_card).to_be_visible()
+
+        assert_no_horizontal_overflow(
+            page, label=f"@{vw}x{vh} expired",
+        )
+        assert_closed_kebabs_in_cells(
+            page,
+            expired_card.locator("table.table-schedules"),
+            label=f"@{vw}x{vh} expired",
+        )
+
+    @pytest.mark.parametrize("vw,vh", _VIEWPORTS)
+    def test_open_kebab_stays_in_viewport_active(
+        self, page: Page, _schedules_seed, vw, vh,
+    ):
+        """Open kebab on the active table — menu must stay in viewport
+        and anchor near the trigger button."""
+        page.set_viewport_size({"width": vw, "height": vh})
+        _goto_schedules(page)
+
+        active_card = page.locator(".card", has_text="Active Schedules")
+        first_kebab = active_card.locator(
+            "tbody tr .btn-kebab",
+        ).first
+        expect(first_kebab).to_be_visible()
+
+        assert_open_kebab_in_viewport(
+            page, first_kebab, label=f"@{vw}x{vh} active",
+        )
+
+    @pytest.mark.parametrize("vw,vh", _VIEWPORTS)
+    def test_open_kebab_stays_in_viewport_expired(
+        self, page: Page, _schedules_seed, vw, vh,
+    ):
+        """Open kebab on the expired table — same viewport assertion.
+
+        This is where the visual bug originally surfaced — even if
+        the closed-kebab cell-overflow check above already flags it,
+        we also confirm the open menu doesn't fall off the viewport.
+        """
+        page.set_viewport_size({"width": vw, "height": vh})
+        _goto_schedules(page)
+
+        expired_card = page.locator(".card", has_text="Expired Schedules")
+        first_kebab = expired_card.locator(
+            "tbody tr .btn-kebab",
+        ).first
+        expect(first_kebab).to_be_visible()
+
+        assert_open_kebab_in_viewport(
+            page, first_kebab, label=f"@{vw}x{vh} expired",
+        )


### PR DESCRIPTION
Refs #444.

## What this is (and isn't)

Adds Playwright E2E tests that catch the **class** of UI bug we've now hit twice in a row — kebab menus / tables visually overflowing their container or the viewport at narrower desktop widths.

This PR is **tests only**. It does not (yet) fix the kebab-off-edge bug in the Expired Schedules table. The intent is to first land an objective, runnable reproduction, then a follow-up PR can take the fix and rely on this test to lock it down.

## Approach

Three small geometric primitives in `tests_e2e/_layout.py`:

1. `assert_no_horizontal_overflow(page)` — `documentElement.scrollWidth ≤ clientWidth + 3px` (uses `Math.max(html, body)` since either can overflow first).
2. `assert_closed_kebabs_in_cells(page, table)` — every closed `.btn-kebab` must stay within its `closest('td,th')` (1px tolerance). Uses `closest()` rather than direct parent so it's robust to wrapper divs.
3. `assert_open_kebab_in_viewport(page, kebab)` — opens the kebab, waits via `wait_for_function` for the menu to be `:popover-open` AND lifted off its parked `-9999px` position, then asserts:
   - menu rect is inside the viewport (3px tolerance)
   - menu's nearest horizontal edge is ≤ 64px from the trigger button's center (i.e. anchored, not flying somewhere random). Uses `min(left-vs-center, right-vs-center)` so we don't pin a side — `positionPopover()` may right- or left-align depending on space.
   - presses Escape to restore page state for chained assertions.

Tolerances were picked deliberately: tight (1px) for cell containment because that's the visual bug we're chasing; looser (3px) for the page/viewport because headless Chromium rounds fractional widths.

## Test surface

`tests_e2e/test_layout_schedules.py` covers `/schedules` at three desktop viewports:

| Viewport | Why |
| --- | --- |
| 1024×768 | narrow laptop / split-screen (where overflow surfaces most) |
| 1366×768 | mid-laptop |
| 1440×900 | common widescreen |

Mobile and 1920×1080 are intentionally out — operator-only product, and 1920px is above the 1400px `main` cap.

For each viewport, four tests run:

* `test_no_overflow_active_table` — page-level + closed kebab cell containment for the Active Schedules card.
* `test_no_overflow_expired_table` — same, but for Expired Schedules (where the bug originally surfaced).
* `test_open_kebab_stays_in_viewport_active` — open the first active-row kebab, assert in viewport + anchored.
* `test_open_kebab_stays_in_viewport_expired` — same for expired.

12 parametrized cases total. Each test loads the page once and runs multiple assertions to stay under the 30s budget.

## Seed strategy

The `_schedules_seed` fixture stresses table width via long but realistic strings — schedule name, asset display name, group name. We deliberately don't use "many devices" because the schedules Target column shows the *group* name, not a device list, so adding devices wouldn't widen rows.

Expired schedule end_date is 7 days ago (not "barely yesterday") to avoid boundary flake.

## Conftest fix

While wiring this up, found that `LogRequest.services` (added in #384) uses raw `JSONB` and was missing from the conftest's SQLite-patch list. Added the patch — without it, e2e startup fails on SQLite with a compiler error when `Base.metadata.create_all` tries to render `JSONB`. Other JSONB columns in `cms/models/` were already patched.

## Critique

Consulted the rubber-duck before implementing. Key feedback that landed in this PR:

* tighter cell tolerance (1px) but looser page/viewport tolerance (3px)
* `wait_for_function` instead of single `requestAnimationFrame`
* `closest('td,th')` instead of pinning to a specific parent
* anchor distance via `min(left-vs-center, right-vs-center)` so we don't pin a side
* width via long names, not "many devices" (target shows group name)
* combine 3 assertions per page-load to stay under the 30s budget

## Out of scope (and why)

Per the issue's explicit non-goals:
* clipped-text detection
* z-index / overlap probes
* pixel-diff baselines
* visual responsive breakpoints below 1024px

If those become real problems, they go in a separate issue with their own scoping.
