### PR TITLE
fix(#406): fire OFFLINE alert when CMS-to-device send fails

### DIFF
--- a/cms/services/device_presence.py
+++ b/cms/services/device_presence.py
@@ -152,6 +152,83 @@ async def mark_offline(
     return (result.rowcount or 0) > 0
 
 
+async def mark_offline_and_alert(
+    db: AsyncSession,
+    device_id: str,
+    *,
+    expected_connection_id: str | None,
+) -> bool:
+    """CAS-flip presence offline AND fire ``alert_service.device_disconnected``.
+
+    Designed for transport send-failure paths and the WPS
+    ``sys.disconnected`` webhook — anywhere we need to react to "this
+    device just dropped" by both clearing presence and emitting the
+    OFFLINE alert.
+
+    *expected_connection_id* must be the ``connection_id`` snapshotted
+    at the moment we last knew the connection was good (send-time for
+    transports, the CloudEvent header for the webhook).  The flip uses
+    that token as a CAS guard so a stale failure can't knock a fresh
+    connection on another replica offline (issue #406 + Stage 4 of
+    #344).
+
+    Pass ``None`` only when the caller has no trustworthy token.  In
+    that case the flip is best-effort (unconditional) and **no alert is
+    fired** — failing closed on alerts is safer than producing duplicate
+    OFFLINE events when we can't tell the stale case from the real one.
+
+    Returns ``True`` iff this call performed the transition (and
+    therefore dispatched the alert).
+    """
+    if expected_connection_id is None:
+        await mark_offline(db, device_id)
+        return False
+
+    # Atomic CAS that returns the alert payload from the same row in
+    # one round-trip — avoids a TOCTOU between read-then-flip.
+    result = await db.execute(
+        update(Device)
+        .where(Device.id == device_id)
+        .where(Device.connection_id == expected_connection_id)
+        .values(online=False, connection_id=None)
+        .returning(Device.name, Device.group_id, Device.status)
+    )
+    row = result.first()
+    await db.commit()
+    if row is None:
+        logger.info(
+            "Send-failure offline flip suppressed for %s "
+            "(connection_id replaced)", device_id,
+        )
+        return False
+
+    group_name = ""
+    if row.group_id is not None:
+        g = await db.execute(
+            select(DeviceGroup.name).where(DeviceGroup.id == row.group_id)
+        )
+        group_name = g.scalar_one_or_none() or ""
+
+    try:
+        from cms.services.alert_service import alert_service
+        alert_service.device_disconnected(
+            device_id,
+            device_name=row.name or device_id,
+            group_id=str(row.group_id) if row.group_id else None,
+            group_name=group_name,
+            status=(
+                row.status.value
+                if hasattr(row.status, "value")
+                else str(row.status)
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to dispatch disconnect alert for %s", device_id,
+        )
+    return True
+
+
 def _parse_timestamp(value: Any) -> datetime | None:
     """Best-effort parse of an ISO-8601 timestamp from the device wire."""
     if value is None:

--- a/cms/services/transport.py
+++ b/cms/services/transport.py
@@ -126,13 +126,27 @@ class LocalDeviceTransport(DeviceTransport):
         self._manager = manager
 
     async def send_to_device(self, device_id: str, message: dict[str, Any]) -> bool:
+        # Snapshot the local socket's connection_id before the send so a
+        # stale failure (the device just reconnected via another path or
+        # replica) can't flip the fresh session offline — used as the
+        # CAS token in ``mark_offline_and_alert`` (issue #406).  When
+        # the in-process registry holds no entry for this device the
+        # snapshot is None, in which case the helper performs an
+        # unconditional flip with no alert.
+        conn = self._manager.get(device_id) if hasattr(self._manager, "get") else None
+        snapshot_cid: str | None = getattr(conn, "connection_id", None) if conn else None
+
         ok = await self._manager.send_to_device(device_id, message)
         # If the send blew up and the local socket was dropped, clear
-        # the presence flag in the DB too — otherwise stale online=true
-        # can persist across replicas until the next heartbeat loop.
+        # the presence flag in the DB and fire the OFFLINE alert via
+        # the shared helper — otherwise stale online=true can persist
+        # across replicas until the next heartbeat loop, and the alert
+        # path was missing entirely (#406).
         if not ok and not self._manager.is_connected(device_id):
             async with _session() as db:
-                await device_presence.mark_offline(db, device_id)
+                await device_presence.mark_offline_and_alert(
+                    db, device_id, expected_connection_id=snapshot_cid,
+                )
         return ok
 
     async def is_connected(self, device_id: str) -> bool:

--- a/cms/services/wps_transport.py
+++ b/cms/services/wps_transport.py
@@ -64,7 +64,36 @@ class WPSTransport(DeviceTransport):
         distinction between "unknown device" and "known but offline" —
         both are "can't reach it").  All other errors are logged and
         swallowed into ``False`` for the same reason.
+
+        On 404, snapshots the device's ``connection_id`` *before* the
+        send so a stale failure (the device just reconnected on another
+        replica) can't flip the fresh session offline — the snapshot is
+        used as the CAS token in
+        :func:`device_presence.mark_offline_and_alert`, which also fires
+        the OFFLINE alert when the flip wins.  Without the pre-send
+        snapshot we'd race with the new ``register`` event and
+        potentially knock out the new connection.
         """
+        # Snapshot the current connection_id so we can use it as a CAS
+        # token if the send fails (issue #406).  Doing this before the
+        # send means a reconnect on another replica between the snapshot
+        # and our 404 will simply suppress our offline flip / alert — we
+        # see the stale token, the DB has the new one, the CAS misses.
+        snapshot_cid: str | None = None
+        try:
+            from sqlalchemy import select
+            from cms.models.device import Device
+            async with _session() as db:
+                row = await db.execute(
+                    select(Device.connection_id).where(Device.id == device_id)
+                )
+                snapshot_cid = row.scalar_one_or_none()
+        except Exception:
+            logger.exception(
+                "send_to_device(%s): connection_id snapshot failed",
+                device_id,
+            )
+
         try:
             await self._client.send_to_user(
                 device_id,
@@ -76,11 +105,16 @@ class WPSTransport(DeviceTransport):
             status = getattr(e, "status_code", None)
             if status == 404:
                 logger.debug("send_to_device(%s): user has no active connections", device_id)
-                # WPS says "no connections" — clear the DB presence flag
-                # so the next readerl sees the device as offline.
+                # WPS says "no connections" — clear DB presence and fire
+                # the OFFLINE alert.  CAS-guarded with the pre-send
+                # connection_id so a fresh connection on another replica
+                # is left alone.
                 try:
                     async with _session() as db:
-                        await device_presence.mark_offline(db, device_id)
+                        await device_presence.mark_offline_and_alert(
+                            db, device_id,
+                            expected_connection_id=snapshot_cid,
+                        )
                 except Exception:
                     logger.exception("Failed to clear presence after 404 send")
                 return False

--- a/tests/test_device_presence.py
+++ b/tests/test_device_presence.py
@@ -274,3 +274,170 @@ class TestSetFlags:
         )).one()
         assert row.name == "Test Device"
         assert row.ssh_enabled is True
+
+
+class TestMarkOfflineAndAlert:
+    """Issue #406 — CAS-flip presence offline AND fire OFFLINE alert.
+
+    The helper is the single source of truth for "device just dropped"
+    side-effects: presence flip + alert dispatch.  These tests pin the
+    contract so every transport's send-failure path produces the same
+    behaviour.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cas_hit_flips_offline_and_fires_alert(
+        self, db_session, _device, monkeypatch,
+    ):
+        from cms.services import alert_service as alert_mod
+
+        await device_presence.mark_online(
+            db_session, _device.id, connection_id="cid-good",
+        )
+
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            alert_mod.alert_service,
+            "device_disconnected",
+            lambda did, **kw: calls.append({"device_id": did, **kw}),
+        )
+
+        ok = await device_presence.mark_offline_and_alert(
+            db_session, _device.id, expected_connection_id="cid-good",
+        )
+
+        assert ok is True
+        row = (await db_session.execute(
+            select(Device.online, Device.connection_id)
+            .where(Device.id == _device.id)
+        )).one()
+        assert row.online is False
+        assert row.connection_id is None
+        assert len(calls) == 1
+        assert calls[0]["device_id"] == _device.id
+        assert calls[0]["device_name"] == "Test Device"
+
+    @pytest.mark.asyncio
+    async def test_cas_miss_keeps_fresh_session_and_skips_alert(
+        self, db_session, _device, monkeypatch,
+    ):
+        """A stale failure must NOT knock the new session offline.
+
+        Simulates: replica A's send fails after a re-register on
+        replica B replaced ``connection_id``.  We pass A's stale token,
+        but the row already holds B's fresh token — the CAS misses.
+        """
+        from cms.services import alert_service as alert_mod
+
+        await device_presence.mark_online(
+            db_session, _device.id, connection_id="cid-fresh",
+        )
+
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            alert_mod.alert_service,
+            "device_disconnected",
+            lambda did, **kw: calls.append({"device_id": did, **kw}),
+        )
+
+        ok = await device_presence.mark_offline_and_alert(
+            db_session, _device.id, expected_connection_id="cid-stale",
+        )
+
+        assert ok is False
+        row = (await db_session.execute(
+            select(Device.online, Device.connection_id)
+            .where(Device.id == _device.id)
+        )).one()
+        # Fresh session left intact.
+        assert row.online is True
+        assert row.connection_id == "cid-fresh"
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_none_token_unconditional_flip_no_alert(
+        self, db_session, _device, monkeypatch,
+    ):
+        """Caller without a trustworthy token: flip best-effort, no alert.
+
+        We fail closed on alerts when we can't tell the stale case from
+        the real one, to avoid duplicate OFFLINE notifications.
+        """
+        from cms.services import alert_service as alert_mod
+
+        await device_presence.mark_online(
+            db_session, _device.id, connection_id="cid-1",
+        )
+
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            alert_mod.alert_service,
+            "device_disconnected",
+            lambda did, **kw: calls.append({"device_id": did, **kw}),
+        )
+
+        ok = await device_presence.mark_offline_and_alert(
+            db_session, _device.id, expected_connection_id=None,
+        )
+
+        assert ok is False  # No alert fired — see docstring.
+        row = (await db_session.execute(
+            select(Device.online, Device.connection_id)
+            .where(Device.id == _device.id)
+        )).one()
+        assert row.online is False
+        assert row.connection_id is None
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_device_is_noop(self, db_session, monkeypatch):
+        from cms.services import alert_service as alert_mod
+
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            alert_mod.alert_service,
+            "device_disconnected",
+            lambda did, **kw: calls.append({"device_id": did, **kw}),
+        )
+
+        ok = await device_presence.mark_offline_and_alert(
+            db_session, "ghost-device", expected_connection_id="anything",
+        )
+
+        assert ok is False
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_alert_dispatch_failure_does_not_revert_flip(
+        self, db_session, _device, monkeypatch,
+    ):
+        """Alert subsystem blowing up must not unwind the presence flip.
+
+        The presence flip is committed before the alert call, and we
+        swallow any alert exception (logged) so a single bad listener
+        can't cascade into "device stuck online".
+        """
+        from cms.services import alert_service as alert_mod
+
+        await device_presence.mark_online(
+            db_session, _device.id, connection_id="cid-z",
+        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("alerts down")
+
+        monkeypatch.setattr(
+            alert_mod.alert_service, "device_disconnected", _boom,
+        )
+
+        ok = await device_presence.mark_offline_and_alert(
+            db_session, _device.id, expected_connection_id="cid-z",
+        )
+
+        assert ok is True  # CAS won — caller view unchanged.
+        row = (await db_session.execute(
+            select(Device.online, Device.connection_id)
+            .where(Device.id == _device.id)
+        )).one()
+        assert row.online is False
+        assert row.connection_id is None

--- a/tests/test_wps_transport.py
+++ b/tests/test_wps_transport.py
@@ -76,6 +76,57 @@ class TestSendToDevice:
         ok = await t.send_to_device("pi-ghost", {"type": "ping"})
         assert ok is False
 
+    async def test_404_dispatches_offline_alert_via_helper(self, monkeypatch):
+        """Issue #406 — 404 on send must trigger the offline-alert path.
+
+        We assert that ``mark_offline_and_alert`` is invoked with the
+        snapshotted ``connection_id`` (the CAS token).  Don't go all
+        the way to a real DB here — coverage for the helper's own
+        contract lives in ``tests/test_device_presence.py``.
+        """
+        from azure.core.exceptions import HttpResponseError
+
+        t, c, _ = _make_transport()
+        err = HttpResponseError(message="not connected")
+        err.status_code = 404
+        c.send_to_user.side_effect = err
+
+        # Stub the snapshot lookup to return a known cid.
+        class _DummySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def execute(self, _stmt):
+                return SimpleNamespace(scalar_one_or_none=lambda: "cid-pre")
+
+            async def commit(self):
+                return None
+
+        monkeypatch.setattr(
+            "cms.services.wps_transport._session", lambda: _DummySession(),
+        )
+
+        called: list[dict] = []
+
+        async def _fake_helper(db, did, *, expected_connection_id):
+            called.append({"db": db, "did": did, "cid": expected_connection_id})
+            return True
+
+        monkeypatch.setattr(
+            "cms.services.wps_transport.device_presence."
+            "mark_offline_and_alert",
+            _fake_helper,
+        )
+
+        ok = await t.send_to_device("pi-ghost", {"type": "ping"})
+        assert ok is False
+        assert len(called) == 1
+        assert called[0]["did"] == "pi-ghost"
+        assert called[0]["cid"] == "cid-pre"
+
     async def test_other_http_error_returns_false(self):
         from azure.core.exceptions import HttpResponseError
 


### PR DESCRIPTION
## Summary

Fixes #406 — when a CMS-to-device send fails (WPS 404 or local socket
drop), we now both flip presence offline AND fire the
`alert_service.device_disconnected` OFFLINE alert.  Previously only the
WPS `sys.disconnected` webhook fired alerts, which left the local
transport (single-instance / dev-mode) silently un-alerted, and gave
the WPS transport a half-finished cleanup that was easy to forget.

## Approach

A new `device_presence.mark_offline_and_alert(db, device_id, *,
expected_connection_id)` helper is the single source of truth for
"device just dropped" side-effects: presence flip + alert dispatch.
Both transports' send-failure paths and (eventually) the WPS webhook
funnel through it.

The CAS guard against a stale failure racing a fresh reconnect was the
critical design point.  `connection_id` is **snapshotted before the
send**, not after the failure — a post-read can race with the new
`register` event on another replica and read the new session's CID,
which would knock the fresh connection offline.  Pre-read snapshots
guarantee the CAS sees only the session we actually attempted on.

When the caller has no trustworthy token (no row, lookup fails) we
fall back to an unconditional flip with **no alert** — failing closed
on alerts is safer than producing duplicate OFFLINE notifications when
we can't tell the stale case from the real one.

Rubber-duck consulted on the design before implementing — caught the
post-read CAS race and the duplicate-alert risk; both addressed in the
final design.

## Changes

* `cms/services/device_presence.py` — new helper
  `mark_offline_and_alert`.  Atomic `UPDATE … WHERE id AND
  connection_id RETURNING name, group_id, status`, then commit, then
  group-name lookup, then alert dispatch.  Mirrors the semantics of
  `wps_webhook.py:147-191` but with explicit CAS.

* `cms/services/wps_transport.py` — `send_to_device` snapshots
  `Device.connection_id` from the DB before the SDK call, passes it as
  the CAS token on 404.  (Also fixed a pre-existing typo:
  "next readerl" → "next reader.")

* `cms/services/transport.py` — `LocalDeviceTransport.send_to_device`
  snapshots from the in-process `device_manager.get(device_id)
  .connection_id` and routes through the same helper.

* `tests/test_device_presence.py::TestMarkOfflineAndAlert` — five
  unit tests covering CAS hit, CAS miss (stale failure), `None` token,
  unknown device, and alert subsystem failure.

* `tests/test_wps_transport.py::test_404_dispatches_offline_alert_via_helper`
  — pins that the WPS 404 path snapshots the cid and calls the helper.

## Tests

* 5 new direct unit tests of the helper — all pass.
* 1 new transport-side dispatch test — passes.
* `tests/test_device_presence.py + test_wps_transport.py +
  test_wps_webhook.py` (full): 56 passed locally on Windows.

## Notes

* `wps_webhook.py:147-191` could now be DRY'd to call this helper.
  Skipped this PR to keep the diff focused on the bug fix; can do
  follow-up later if useful.

Closes #406.
