### PR TITLE
fix(devices): return 409 (not 500) on duplicate group name

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -6,6 +6,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import func, or_, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -741,7 +742,18 @@ async def create_group(data: DeviceGroupCreate, request: Request, db: AsyncSessi
 
     group = DeviceGroup(name=data.name, description=data.description, default_asset_id=data.default_asset_id)
     db.add(group)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Unique constraint on ``device_groups.name`` — surface as 409
+        # so callers (UI, e2e tests, scripts) can distinguish a
+        # duplicate from a real server error.  Race-safe: we let the
+        # DB enforce uniqueness rather than do a TOCTOU pre-check.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"Device group named '{data.name}' already exists",
+        )
 
     # Auto-add non-admin creator to the new group. Without this, the list_groups
     # endpoint (which filters by user_groups for non-admins) would hide the

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -580,6 +580,13 @@ class TestDeviceGroups:
         assert data["name"] == "Lobby Screens"
         assert data["device_count"] == 0
 
+    async def test_create_group_duplicate_name_returns_409(self, client):
+        resp = await client.post("/api/devices/groups/", json={"name": "Dup Name"})
+        assert resp.status_code == 201
+        resp = await client.post("/api/devices/groups/", json={"name": "Dup Name"})
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"].lower()
+
     async def test_list_groups(self, client):
         await client.post("/api/devices/groups/", json={"name": "Group A"})
         await client.post("/api/devices/groups/", json={"name": "Group B"})


### PR DESCRIPTION
## Summary

`POST /api/devices/groups/` raised SQLAlchemy `IntegrityError` on the unique constraint over `device_groups.name`, which FastAPI surfaced as **500 Internal Server Error**. Callers (UI, e2e tests, scripts) couldn't distinguish a benign "name already taken" from a real server fault.

This came up in PR #447 fixture work — the seeding helper had to GET-then-POST as a workaround. Server-side fix removes that footgun.

## Change

- `cms/routers/devices.py`: catch `IntegrityError` on flush, roll back, return `409` with `detail="Device group named '<name>' already exists"`.
- Race-safe: DB enforces uniqueness, no TOCTOU pre-check.
- New unit test `test_create_group_duplicate_name_returns_409` in `tests/test_devices.py`.

## Tests

`TestDeviceGroups` group: 11 passed locally (was 10 + 1 new).

Proactive bug fix found via PR #447 fixture work.
