### PR TITLE
refactor(wps): webhook reuses mark_offline_and_alert helper

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -152,42 +152,13 @@ async def events_receiver(
             # ``sys.disconnected`` *after* the device has already
             # reconnected on replica B; without this guard we'd flip
             # ``online=false`` for the fresh session and fire a bogus
-            # OFFLINE alert.  ``mark_offline`` returns False when the
-            # stored ``connection_id`` no longer matches — in that case
-            # we also skip the alert-service notification.
-            was_current = await device_presence.mark_offline(
+            # OFFLINE alert.  ``mark_offline_and_alert`` does the CAS
+            # flip + ``alert_service.device_disconnected`` in one shot
+            # — same helper used by the transport send-failure paths
+            # (issue #406), so behaviour stays consistent.
+            await device_presence.mark_offline_and_alert(
                 db, ce_user_id, expected_connection_id=ce_connection_id,
             )
-            if not was_current:
-                logger.info(
-                    "WPS device %s: stale disconnect suppressed "
-                    "(connection_id replaced)", ce_user_id,
-                )
-                return Response(status_code=204)
-            # Load the device + group so alert_service has the name /
-            # group context it needs to route the OFFLINE event and
-            # (eventually, via the sweep loop) the offline notification.
-            result = await db.execute(select(Device).where(Device.id == ce_user_id))
-            device = result.scalar_one_or_none()
-            if device is not None:
-                _group_id = str(device.group_id) if device.group_id else None
-                _device_name = device.name or ce_user_id
-                _device_status = device.status.value if device.status else "pending"
-                _group_name = ""
-                if device.group_id:
-                    g = await db.execute(
-                        select(DeviceGroup.name).where(
-                            DeviceGroup.id == device.group_id,
-                        )
-                    )
-                    _group_name = g.scalar_one_or_none() or ""
-                alert_service.device_disconnected(
-                    ce_user_id,
-                    device_name=_device_name,
-                    group_id=_group_id,
-                    group_name=_group_name,
-                    status=_device_status,
-                )
         return Response(status_code=204)
 
     # ---- user events ---------------------------------------------------

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -53,6 +53,10 @@ class _FakeSession:
         row = self.device_row
         result = MagicMock()
         result.scalar_one_or_none = MagicMock(return_value=row)
+        # ``mark_offline_and_alert`` uses ``UPDATE ... RETURNING``, then
+        # reads ``result.first()`` to get the device's name/group_id/
+        # status in one round-trip.  Drive that off ``device_row`` too.
+        result.first = MagicMock(return_value=row)
         # Stage 4: mark_offline reads result.rowcount and compares to int
         # (> 0) to return a bool — make sure the mock returns an int.
         result.rowcount = 1
@@ -946,7 +950,7 @@ class TestAlertServiceHooks:
 
         cid = "cid-current"
         with patch(
-            "cms.routers.wps_webhook.alert_service"
+            "cms.services.alert_service.alert_service"
         ) as mock_alert:
             r = await client.post(
                 "/internal/wps/events",
@@ -980,23 +984,22 @@ class TestAlertServiceHooks:
         device.name = "Lobby"
         session.device_row = device
 
-        # Force the guard to reject: mark_offline returns False when
-        # rowcount == 0 (stored connection_id no longer matches).
+        # Force the guard to reject: mark_offline_and_alert checks
+        # ``result.first() is None`` (UPDATE...RETURNING returned no rows)
+        # — surface that, plus rowcount=0 for legacy mark_offline calls.
         original_execute = session.execute
 
         async def _rowcount_zero(stmt, *a, **kw):
             result = await original_execute(stmt, *a, **kw)
-            # Only the UPDATE from mark_offline is affected — SELECTs
-            # coming after would also see rowcount=0, but our code
-            # returns before issuing any SELECT when was_current is False.
             result.rowcount = 0
+            result.first = MagicMock(return_value=None)
             return result
 
         session.execute = _rowcount_zero
 
         cid = "cid-stale"
         with patch(
-            "cms.routers.wps_webhook.alert_service"
+            "cms.services.alert_service.alert_service"
         ) as mock_alert:
             r = await client.post(
                 "/internal/wps/events",
@@ -1024,7 +1027,7 @@ class TestAlertServiceHooks:
 
         cid = "cid-ghost"
         with patch(
-            "cms.routers.wps_webhook.alert_service"
+            "cms.services.alert_service.alert_service"
         ) as mock_alert:
             r = await client.post(
                 "/internal/wps/events",


### PR DESCRIPTION
## Summary

The `sys.disconnected` handler in `cms/routers/wps_webhook.py` duplicated the CAS-flip + alert-dispatch sequence that lives in `cms/services/device_presence.py::mark_offline_and_alert` (introduced in PR #448 for transport send-failure paths).

Replace the inline sequence (~45 lines) with a single helper call. Two paths now share one source of truth for "device dropped" side-effects.

## Behaviour preserved

- CAS-guarded presence flip on `connection_id`.
- `alert_service.device_disconnected` fires only on a real transition.
- Stale disconnects (CID replaced by a fresh socket on another replica) suppressed silently.
- 204 returned in all branches.

## Test fixture updates

- `_FakeSession.execute` now drives `result.first()` off `device_row` so the helper's `UPDATE...RETURNING` path resolves to the row.
- The stale-CID test sets `first()=None` alongside `rowcount=0` to model "no row affected".
- Mock patch path moves from `cms.routers.wps_webhook.alert_service` to `cms.services.alert_service.alert_service` (the helper imports from the source module).

## Tests

`test_wps_webhook.py`, `test_device_presence.py`, `test_wps_transport.py` — 56 passed locally.

Net diff: **-42 / +16** lines. Smaller, single source of truth, equivalent behaviour.
