### PR TITLE
fix(logs): use device name (not GUID) in log-bundle download audit

### DIFF
--- a/cms/routers/log_requests.py
+++ b/cms/routers/log_requests.py
@@ -288,14 +288,25 @@ async def download_log_request(
         )
 
     user = getattr(request.state, "user", None)
+    # Resolve the friendly device name for the audit log so operators
+    # see "device 'Lobby Pi'" instead of a UUID.  Falls back to the GUID
+    # if the device row was deleted between the request being created
+    # and the bundle being downloaded.
+    device_name = (
+        await db.execute(
+            select(Device.name).where(Device.id == row.device_id)
+        )
+    ).scalar_one_or_none()
+    device_label = f"'{device_name}'" if device_name else row.device_id
     await audit_log(
         db, user=user,
         action="logs.download_bundle",
         resource_type="log_request",
         resource_id=row.id,
-        description=f"Downloaded log bundle for device {row.device_id}",
+        description=f"Downloaded log bundle for device {device_label}",
         details={
             "device_id": row.device_id,
+            "device_name": device_name,
             "size_bytes": row.size_bytes,
         },
         request=request,


### PR DESCRIPTION
## Summary

Follow-up to PR #446 / #443. The audit-log entry for `logs.download_bundle` still rendered the device's GUID in its description instead of the friendly name, so operators reading the audit log saw entries like:

> Downloaded log bundle for device dee8ed3d-2a0b-453b-af11-ab138dbc17a6

Same nit class as #443 (end-now). Operators want names everywhere they look at the audit log.

## Change

`cms/routers/log_requests.py::download_log_request`:
- Resolve `Device.name` from `row.device_id` (single-column SELECT).
- Format as `'Friendly Name'` in the description; fall back to the GUID if the device row was deleted between the bundle being requested and downloaded.
- Persist `device_name` in audit `details` too so downstream tooling has both id and name.

## Tests

`TestDownloadLogRequest` and `TestRequestLogs` — 6 tests pass locally.
