### PR TITLE
fix(e2e): make group expand robust to polling re-render

### DIFF
--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -7,13 +7,14 @@ authenticated via session cookie.
 
 import asyncio
 import os
+import re
 import socket
 import threading
 import time
 
 import pytest
 import uvicorn
-from playwright.sync_api import Browser, BrowserContext, Page, sync_playwright
+from playwright.sync_api import Browser, BrowserContext, Page, expect, sync_playwright
 
 # ── Helpers ──
 
@@ -66,6 +67,36 @@ def open_row_kebab(row):
     except Exception:
         pass
     return row
+
+
+def expand_group_panel(group_panel, timeout: int = 5000):
+    """Click a .group-header until the panel reaches the .expanded state.
+
+    The /devices page's polling loop re-renders panels asynchronously and
+    can race with a single click — the click can land before the panel is
+    fully wired, leaving the body still hidden. Retry until the
+    ``expanded`` class is present, then return the body locator.
+    """
+    panel_handle = group_panel.element_handle()
+    if panel_handle and "expanded" in (panel_handle.get_attribute("class") or ""):
+        return group_panel.locator(".group-body")
+
+    attempts = 5
+    last_err = None
+    for _ in range(attempts):
+        try:
+            group_panel.locator(".group-header").click(timeout=2000)
+            expect(group_panel).to_have_class(
+                re.compile(r"(^|\s)expanded(\s|$)"),
+                timeout=timeout // attempts,
+            )
+            return group_panel.locator(".group-body")
+        except Exception as e:
+            last_err = e
+            continue
+    raise AssertionError(
+        f"Group panel never reached expanded state after {attempts} clicks: {last_err}"
+    )
 
 
 def click_row_action(row, action_text, exact=False):

--- a/tests_e2e/test_ui_group_remove.py
+++ b/tests_e2e/test_ui_group_remove.py
@@ -3,7 +3,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests_e2e.conftest import run_async, click_row_action
+from tests_e2e.conftest import run_async, click_row_action, expand_group_panel
 from tests_e2e.fake_device import FakeDevice
 
 
@@ -80,10 +80,7 @@ class TestGroupRemoveButtons:
         # Expand the group
         group_panel = page.locator('div.group-panel[data-group-id="' + group_id + '"]')
         expect(group_panel).to_be_visible(timeout=5000)
-        group_panel.locator(".group-header").click()
-
-        # Find Device C's row within the group and click its Remove button
-        group_body = group_panel.locator(".group-body")
+        group_body = expand_group_panel(group_panel)
         expect(group_body).to_be_visible(timeout=3000)
         device_row = group_body.locator('tr[data-device-id="grp-rm-003"]')
         expect(device_row).to_be_visible(timeout=3000)
@@ -100,8 +97,7 @@ class TestGroupRemoveButtons:
 
         # Expand the group again
         group_panel = page.locator('div.group-panel[data-group-id="' + group_id + '"]')
-        group_panel.locator(".group-header").click()
-        group_body = group_panel.locator(".group-body")
+        group_body = expand_group_panel(group_panel)
         expect(group_body).to_be_visible(timeout=3000)
 
         # Device D should still be in the group
@@ -243,7 +239,7 @@ class TestGroupRemoveInPlaceMove:
 
         # Expand and click Remove (in the row kebab).
         group_panel = page.locator(f'div.group-panel[data-group-id="{group_id}"]')
-        group_panel.locator(".group-header").click()
+        expand_group_panel(group_panel)
         device_row = group_panel.locator('tr[data-device-id="inplace-001"]')
         expect(device_row).to_be_visible(timeout=3000)
         click_row_action(device_row, "Remove from group")


### PR DESCRIPTION
## Problem

Two e2e tests in `tests_e2e/test_ui_group_remove.py` flake intermittently
in CI with the same root cause:

```
expect(group_body).to_be_visible(timeout=3000)
E   AssertionError: Locator expected to be visible
E   Actual value: hidden
```

The pattern is:

```python
group_panel.locator(".group-header").click()
group_body = group_panel.locator(".group-body")
expect(group_body).to_be_visible(timeout=3000)  # FAILS
```

The `/devices` page polling loop (`devices.html` lines 627–641) re-renders
group panels asynchronously when the device set changes. If the click
lands while the panel is mid-replacement — or if the click's effect is
clobbered by a subsequent re-render — the panel ends up back at its
default state (`<div class="group-body" style="display: none;">`).

## Fix

Add an `expand_group_panel(group_panel)` helper to `tests_e2e/conftest.py`
that:

1. Returns immediately if the panel already has the `.expanded` class.
2. Otherwise clicks `.group-header` and waits for `.expanded` to be set
   on the panel.
3. Retries up to 5 times — covers the polling-cycle race window.
4. Returns the `.group-body` locator for the caller.

Updates the two affected tests (and one more pre-existing site that had
the same fragile pattern) to use the helper.

Affected:
- `test_device_remove_ungroups_single_device`
- `test_remove_moves_row_to_ungrouped_without_reload`

## Why the helper waits for the class, not the body's `display`

`toggleGroup()` in `devices.html` sets both `body.style.display = ''` and
`panel.classList.toggle('expanded', open)` in the same JS frame, so the
class is a faithful proxy for "I really did get expanded." The polling
loop also explicitly skips re-rendering panels that already carry the
`.expanded` class (line 640: `if (panel && panel.classList.contains('expanded')) continue;`),
which is what stabilizes the state once the helper succeeds.

## Test

Local run pending (the flake only reproduces in CI under load); the
helper is purely additive — if a test was passing before, it still does
the same click and the same visibility check, just with a retry loop
around it.
