### PR TITLE
fix(e2e): click .expand-toggle directly to avoid stopPropagation children

### DIFF
--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -81,11 +81,15 @@ def expand_group_panel(group_panel, timeout: int = 5000):
     if panel_handle and "expanded" in (panel_handle.get_attribute("class") or ""):
         return group_panel.locator(".group-body")
 
+    # Click the expand-toggle arrow specifically — clicking the .group-header
+    # itself can land on inner spans (the name, kebab, splash dropdown) that
+    # call event.stopPropagation(), so toggleGroup() never fires. The
+    # .expand-toggle ▶ on the left has no children and bubbles up cleanly.
     attempts = 5
     last_err = None
     for _ in range(attempts):
         try:
-            group_panel.locator(".group-header").click(timeout=2000)
+            group_panel.locator(".group-header .expand-toggle").click(timeout=2000)
             expect(group_panel).to_have_class(
                 re.compile(r"(^|\s)expanded(\s|$)"),
                 timeout=timeout // attempts,


### PR DESCRIPTION
## Summary

PR #452 added a retry-loop `expand_group_panel()` helper but the underlying click was still hitting children of `.group-header` that call `event.stopPropagation()` (editable name, group-actions kebab, splash dropdown). Five retries didn't help — every click landed on the same swallowing child.

Click `.expand-toggle` directly. It's a leaf `<span>▶</span>` with no handlers, so the click bubbles up to the header's `onclick="toggleGroup(this)"` cleanly.

## Why this is the real fix

The PR #447 e2e job kept failing with:

```
AssertionError: Group panel never reached expanded state after 5 clicks
locator resolved to <div class="group-panel" ...>  (no `expanded`)
```

If polling were the cause, at least one of the 5 clicks would have stuck. The class never appeared because `toggleGroup` wasn't running at all.

## Test plan

- Local e2e for `test_ui_group_remove.py` should pass deterministically.
- Pre-existing `tests/nightly/test_04_groups.py` still uses `.group-header` directly — not touched (it's the nightly suite, lower-frequency, and could be migrated separately).