### PR TITLE
test(#344): WPS multi-replica smoke CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -254,13 +254,75 @@ jobs:
           docker compose -f tests/integration/docker-compose.integration.yml \
             down -v --remove-orphans || true
 
+  # Multi-replica + WPS-transport smoke. Same harness as
+  # ``multireplica-smoke`` but layered with the WPS overlay so both
+  # cms replicas run ``AGORA_CMS_DEVICE_TRANSPORT=wps`` against a
+  # local-broker pinned at cms-0. Closes the Stage-4 coverage gap:
+  # prod runs N=2 + WPS, but the existing smoke job only exercises
+  # N=2 + direct-WS. Runs the same ``-m smoke`` cluster-health gate
+  # under WPS plus the dedicated ``-m smoke_wps`` synthetic
+  # cross-replica webhook tests in
+  # ``tests/integration/test_multireplica_wps_smoke.py``.
+  multireplica-wps-smoke:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install host-side test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+
+      - name: Run multi-replica WPS smoke tests
+        env:
+          AGORA_RUN_INTEGRATION: "1"
+          # conftest reads this and layers the WPS overlay on top of
+          # the base integration compose file (local-broker + cms env
+          # flips). Without it the harness comes up direct-WS.
+          AGORA_INTEGRATION_TRANSPORT: "wps"
+        run: |
+          # Single pytest invocation so the session-scoped compose
+          # fixture brings the stack up exactly once. ``smoke``
+          # re-validates cluster health under WPS (catches transport-
+          # specific boot/auth/leader regressions); ``smoke_wps`` runs
+          # the cross-replica synthetic webhook coverage.
+          pytest tests/integration/ \
+            --run-integration \
+            -m "smoke or smoke_wps" \
+            -p no:xdist -p no:timeout \
+            -v --tb=short
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          docker compose \
+            -f tests/integration/docker-compose.integration.yml \
+            -f tests/integration/docker-compose.integration.wps.yml \
+            logs --no-color --tail=500 || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose \
+            -f tests/integration/docker-compose.integration.yml \
+            -f tests/integration/docker-compose.integration.wps.yml \
+            down -v --remove-orphans || true
+
   # Umbrella check that branch protection requires. Runs on every PR so
   # it always reports a status. Passes iff every upstream job is either
   # success or skipped (path-filtered out); fails on failure/cancelled.
   # Keeps tests-only PRs unblocked while still catching real breakage.
   ci-gate:
     name: ci-gate
-    needs: [changes, test, e2e, broker-test, multireplica-smoke]
+    needs: [changes, test, e2e, broker-test, multireplica-smoke, multireplica-wps-smoke]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -272,8 +334,9 @@ jobs:
           echo "e2e=${{ needs.e2e.result }}"
           echo "broker-test=${{ needs.broker-test.result }}"
           echo "multireplica-smoke=${{ needs.multireplica-smoke.result }}"
+          echo "multireplica-wps-smoke=${{ needs.multireplica-wps-smoke.result }}"
           fail=0
-          for r in "${{ needs.changes.result }}" "${{ needs.test.result }}" "${{ needs.e2e.result }}" "${{ needs.broker-test.result }}" "${{ needs.multireplica-smoke.result }}"; do
+          for r in "${{ needs.changes.result }}" "${{ needs.test.result }}" "${{ needs.e2e.result }}" "${{ needs.broker-test.result }}" "${{ needs.multireplica-smoke.result }}" "${{ needs.multireplica-wps-smoke.result }}"; do
             case "$r" in
               success|skipped) ;;
               *) fail=1 ;;

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ timeout = 60
 timeout_method = signal
 markers =
     smoke: multi-replica smoke subset gated by ci-gate (required check)
+    smoke_wps: multi-replica + WPS-transport smoke subset (gates ci-gate)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,7 +27,15 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 COMPOSE_FILE = Path(__file__).parent / "docker-compose.integration.yml"
+COMPOSE_FILE_WPS = Path(__file__).parent / "docker-compose.integration.wps.yml"
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# When ``AGORA_INTEGRATION_TRANSPORT=wps`` is set in the env, we layer
+# the WPS overlay on top of the base compose file so the same harness
+# spins up local-broker + flips both replicas to WPS transport. The
+# ``multireplica-wps-smoke`` CI job sets it; the existing
+# ``multireplica-smoke`` job leaves it unset (direct-WS path).
+INTEGRATION_TRANSPORT = os.environ.get("AGORA_INTEGRATION_TRANSPORT", "local").strip().lower()
 
 CMS_A_URL = "http://127.0.0.1:8080"
 CMS_B_URL = "http://127.0.0.1:8081"
@@ -45,7 +53,10 @@ LEADER_TIMEOUT_SEC = 60
 
 
 def _compose_cmd(*args: str) -> list[str]:
-    return ["docker", "compose", "-f", str(COMPOSE_FILE), *args]
+    files = ["-f", str(COMPOSE_FILE)]
+    if INTEGRATION_TRANSPORT == "wps":
+        files += ["-f", str(COMPOSE_FILE_WPS)]
+    return ["docker", "compose", *files, *args]
 
 
 def _port_open(host: str, port: int, timeout: float = 1.0) -> bool:

--- a/tests/integration/docker-compose.integration.wps.yml
+++ b/tests/integration/docker-compose.integration.wps.yml
@@ -1,0 +1,86 @@
+# WPS-transport overlay for the multi-replica integration harness
+# (issue #344, post-Stage-4 parity coverage).
+#
+# Layered on top of ``docker-compose.integration.yml`` so the same
+# two-replica + shared-Postgres topology runs through the local WPS
+# broker instead of the direct-WS path. Used by the
+# ``multireplica-wps-smoke`` CI job to lock in N>=2 + WPS coverage —
+# the exact combination prod runs since the Stage 4 flip but that the
+# default integration stack still tests under direct-WS only.
+#
+# Usage (from repo root):
+#
+#   docker compose \
+#     -f tests/integration/docker-compose.integration.yml \
+#     -f tests/integration/docker-compose.integration.wps.yml \
+#     up -d --build --wait
+#
+# The WPS transport bits (env on cms-0 / cms-1, local-broker service)
+# are listed below; everything else (db, ports, volumes, healthchecks)
+# is inherited from the base file.
+#
+# Cross-replica coverage gap this overlay closes:
+#   * The base stack runs ``AGORA_CMS_DEVICE_TRANSPORT=local`` so the
+#     ``/internal/wps/events`` receiver, signature-verify path, and
+#     ``device_presence.mark_online/mark_offline_and_alert`` CAS guards
+#     are never exercised under N>=2 in CI. Stage 4 surfaced bugs in
+#     each (#445 IP persistence, #406 stale-disconnect race) — this
+#     overlay re-runs the same smoke gate against those code paths.
+#
+# What this overlay deliberately does NOT do:
+#   * Pin ``WPS_UPSTREAM_URL`` at a load-balancer in front of both
+#     replicas. Real ACA ingress round-robins; we don't have that
+#     locally and adding nginx just to mimic it adds moving parts the
+#     bug surface doesn't actually need (cross-replica reads are
+#     DB-backed; whichever replica receives the webhook is enough to
+#     prove the read coherence). The dedicated cross-replica synthetic
+#     tests in ``test_multireplica_wps_smoke.py`` POST signed events
+#     directly at *both* replicas to cover the case where webhooks for
+#     the same device land on different replicas.
+
+services:
+  cms-0:
+    environment:
+      - AGORA_CMS_DATABASE_URL=postgresql+asyncpg://agora:agora@db:5432/agora_cms
+      - AGORA_CMS_SECRET_KEY=integration-test-secret
+      - AGORA_CMS_ADMIN_USERNAME=admin
+      - AGORA_CMS_ADMIN_PASSWORD=integration-testpass
+      - AGORA_CMS_DEVICE_TRANSPORT=wps
+      - AGORA_CMS_WPS_CONNECTION_STRING=Endpoint=http://local-broker:7080;AccessKey=integration-wps-key;Version=1.0;
+      - AGORA_CMS_WPS_HUB=agora
+    depends_on:
+      db:
+        condition: service_healthy
+      local-broker:
+        condition: service_started
+
+  cms-1:
+    environment:
+      - AGORA_CMS_DATABASE_URL=postgresql+asyncpg://agora:agora@db:5432/agora_cms
+      - AGORA_CMS_SECRET_KEY=integration-test-secret
+      - AGORA_CMS_ADMIN_USERNAME=admin
+      - AGORA_CMS_ADMIN_PASSWORD=integration-testpass
+      - AGORA_CMS_DEVICE_TRANSPORT=wps
+      - AGORA_CMS_WPS_CONNECTION_STRING=Endpoint=http://local-broker:7080;AccessKey=integration-wps-key;Version=1.0;
+      - AGORA_CMS_WPS_HUB=agora
+    depends_on:
+      db:
+        condition: service_healthy
+      local-broker:
+        condition: service_started
+      cms-0:
+        condition: service_healthy
+
+  local-broker:
+    build:
+      context: ../../local-broker
+      dockerfile: Dockerfile
+    restart: "no"
+    environment:
+      - WPS_ACCESS_KEY=integration-wps-key
+      - WPS_HUB=agora
+      # Pinned at cms-0 for the broker's own webhook fan-out. The
+      # synthetic cross-replica race tests in
+      # ``test_multireplica_wps_smoke.py`` POST signed events directly
+      # at both replicas, so the pinned upstream is fine here.
+      - WPS_UPSTREAM_URL=http://cms-0:8080/internal/wps/events

--- a/tests/integration/test_multireplica_wps_smoke.py
+++ b/tests/integration/test_multireplica_wps_smoke.py
@@ -1,0 +1,268 @@
+"""Multi-replica + WPS-transport smoke tests (issue #344, post-Stage-4).
+
+These tests run only when the harness is brought up under the
+``docker-compose.integration.wps.yml`` overlay (``--profile wps`` is
+*not* what selects them — we use a separate compose file because
+profiles can't override env on existing services). The
+``multireplica-wps-smoke`` CI job sets
+``AGORA_INTEGRATION_TRANSPORT=wps``; ``conftest.py`` reads that env
+var and layers the WPS overlay onto the base compose file.
+
+Scope is deliberately tight — these tests cover the cross-replica WPS
+risks the existing ``-m smoke`` suite (which runs under direct-WS in
+the other job) cannot, namely:
+
+* ``test_connected_on_replica_a_is_visible_via_replica_b`` — POST a
+  signed ``sys.connected`` directly at cms-0's ``/internal/wps/events``
+  receiver; assert cms-1 sees the device as ``online=true`` with the
+  correct ``connection_id``. Locks in the basic Stage 4 invariant: WPS
+  presence writes by replica A are visible to replica B without any
+  cache invalidation between them (post-#344 Stage 2c presence is in
+  the ``devices`` table, not the per-replica ``device_manager``).
+
+* ``test_stale_disconnect_after_reconnect_keeps_device_online`` — the
+  scenario the CAS guard in ``mark_offline_and_alert(...
+  expected_connection_id=...)`` was added to handle (issue #406): an
+  old socket on replica A receives ``sys.disconnected`` *after* the
+  device has already reconnected on replica B. POST signed
+  ``sys.connected(conn=A)`` to cms-0, then ``sys.connected(conn=B)``
+  to cms-1, then a stale ``sys.disconnected(conn=A)`` to cms-0; assert
+  the device stays online with ``connection_id=B``. Without the CAS
+  this would fire a bogus OFFLINE alert.
+
+Why synthetic webhooks instead of a real broker round-trip:
+
+* The local-broker fan-out is exercised by the *base* ``-m smoke``
+  suite running under WPS in this same job (``cms-0`` is the broker's
+  upstream). That suite already proves "WPS boot/auth/leader work".
+* The cross-replica webhook race requires events for the same device
+  to land on *different* replicas, which the broker (single
+  ``WPS_UPSTREAM_URL``) cannot orchestrate. Direct POSTs are the
+  smallest tool that exercises the path.
+* No JWT minting or WSS plumbing — keeps the test code small and
+  decoupled from broker internals so a refactor of the broker doesn't
+  ripple into CI.
+
+Future expansion (intentionally out of scope here): a real WSS device
+fixture that connects to local-broker and asserts a REST ``:send`` from
+the *opposite* replica reaches it. That tests broker behaviour more
+than CMS multi-replica behaviour, so the cost/benefit isn't there for
+a required gate. Track as a follow-up if/when broker behaviour starts
+to drift.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from shared.wps_signature import sign_connection_id
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.smoke_wps]
+
+# Must match the value in ``docker-compose.integration.wps.yml`` —
+# kept in sync intentionally because parameterising the overlay would
+# add complexity for no benefit (the value is opaque test-only data).
+WPS_ACCESS_KEY = "integration-wps-key"
+
+CMS_A_URL = "http://127.0.0.1:8080"
+CMS_B_URL = "http://127.0.0.1:8081"
+
+
+def _ce_headers(
+    *,
+    ce_type: str,
+    connection_id: str,
+    user_id: str,
+    event_name: str = "",
+) -> dict[str, str]:
+    """Build a CloudEvents-binary-binding header dict signed for our key.
+
+    Mirrors what local-broker emits and what Azure WPS sends in prod.
+    ``ce-id`` / ``ce-time`` are populated for completeness even though
+    the receiver only checks ``ce-type``, ``ce-connectionId``, and the
+    signature.
+    """
+    headers = {
+        "ce-specversion": "1.0",
+        "ce-type": ce_type,
+        "ce-source": f"/hubs/agora/client/{connection_id}",
+        "ce-id": uuid.uuid4().hex,
+        "ce-time": datetime.now(timezone.utc).isoformat(),
+        "ce-hub": "agora",
+        "ce-connectionId": connection_id,
+        "ce-userId": user_id,
+        "ce-signature": sign_connection_id(connection_id, [WPS_ACCESS_KEY]),
+        "Content-Type": "application/json",
+    }
+    if event_name:
+        headers["ce-eventName"] = event_name
+    return headers
+
+
+async def _seed_minimal_device(engine: AsyncEngine) -> str:
+    """Insert just a ``devices`` row with no group, no schedule.
+
+    The WPS webhook ``sys.connected`` path doesn't read the group or
+    asset; it only needs the device row to exist (well, actually
+    ``mark_online`` issues an UPDATE that no-ops on a missing row, but
+    the tests assert visibility against a real row so we still need
+    one).
+    """
+    device_id = f"int-wps-{uuid.uuid4().hex[:10]}"
+    now = datetime.now(timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO devices "
+                "(id, name, location, status, firmware_version, "
+                " storage_capacity_mb, storage_used_mb, device_type, "
+                " supported_codecs, registered_at, online, "
+                " upgrade_started_at) "
+                "VALUES (:id, :name, '', 'ADOPTED', '', 0, 0, '', '', "
+                "        :now, FALSE, NULL)"
+            ),
+            {"id": device_id, "name": "wps-int-dev", "now": now},
+        )
+    return device_id
+
+
+async def _cleanup(engine: AsyncEngine, device_id: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            text("DELETE FROM devices WHERE id = :d"), {"d": device_id}
+        )
+
+
+async def _row(engine: AsyncEngine, device_id: str) -> dict[str, object]:
+    """Read the freshest copy of the device row from the shared DB."""
+    async with engine.connect() as conn:
+        r = (
+            await conn.execute(
+                text(
+                    "SELECT online, connection_id FROM devices WHERE id = :d"
+                ),
+                {"d": device_id},
+            )
+        ).first()
+    assert r is not None, f"device {device_id} disappeared"
+    return {"online": bool(r.online), "connection_id": r.connection_id}
+
+
+async def test_connected_on_replica_a_is_visible_via_replica_b(
+    engine: AsyncEngine,
+) -> None:
+    """A signed ``sys.connected`` POST to cms-0 must be visible on cms-1.
+
+    Stage 4's invariant is that presence writes go through the shared
+    Postgres row (``devices.online``, ``devices.connection_id``), so
+    replica B sees them immediately without any cache message-passing.
+    Without ``device_presence.mark_online`` (Stage 2c) this would have
+    needed the long-since-removed in-memory ``device_manager``
+    register-remote ghost entry on each replica.
+    """
+    device_id = await _seed_minimal_device(engine)
+    connection_id = f"conn-a-{uuid.uuid4().hex[:8]}"
+    try:
+        # POST signed sys.connected directly at cms-0's webhook port.
+        with httpx.Client(timeout=5.0) as c:
+            r = c.post(
+                f"{CMS_A_URL}/internal/wps/events",
+                headers=_ce_headers(
+                    ce_type="azure.webpubsub.sys.connected",
+                    connection_id=connection_id,
+                    user_id=device_id,
+                ),
+                content=b"{}",
+            )
+        assert r.status_code == 204, (
+            f"sys.connected -> {r.status_code}: {r.text[:200]}"
+        )
+
+        # Read the row through the shared DB — what cms-1 would also
+        # see when it serves /api/devices.
+        state = await _row(engine, device_id)
+        assert state["online"] is True
+        assert state["connection_id"] == connection_id
+    finally:
+        await _cleanup(engine, device_id)
+
+
+async def test_stale_disconnect_after_reconnect_keeps_device_online(
+    engine: AsyncEngine,
+) -> None:
+    """CAS guard suppresses a stale disconnect from a replaced session.
+
+    Reproduces the issue #406 scenario: an old socket on replica A
+    receives ``sys.disconnected`` *after* the device has reconnected
+    on replica B (under WPS in N>=2, both events arrive at the CMS
+    fleet but for a brief window the old session's disconnect can be
+    in flight while the new session's connect has already won). The
+    CAS in ``mark_offline_and_alert(... expected_connection_id=A)``
+    must refuse to flip the row offline because the live
+    ``connection_id`` is now B.
+    """
+    device_id = await _seed_minimal_device(engine)
+    conn_a = f"conn-a-{uuid.uuid4().hex[:8]}"
+    conn_b = f"conn-b-{uuid.uuid4().hex[:8]}"
+    try:
+        with httpx.Client(timeout=5.0) as c:
+            # 1. Original session connects, lands on replica A.
+            r = c.post(
+                f"{CMS_A_URL}/internal/wps/events",
+                headers=_ce_headers(
+                    ce_type="azure.webpubsub.sys.connected",
+                    connection_id=conn_a,
+                    user_id=device_id,
+                ),
+                content=b"{}",
+            )
+            assert r.status_code == 204, r.text[:200]
+
+            # 2. Reconnect — new session lands on replica B.
+            r = c.post(
+                f"{CMS_B_URL}/internal/wps/events",
+                headers=_ce_headers(
+                    ce_type="azure.webpubsub.sys.connected",
+                    connection_id=conn_b,
+                    user_id=device_id,
+                ),
+                content=b"{}",
+            )
+            assert r.status_code == 204, r.text[:200]
+
+            # Sanity: row should reflect the most recent connect (B).
+            state = await _row(engine, device_id)
+            assert state["online"] is True
+            assert state["connection_id"] == conn_b
+
+            # 3. Stale disconnect from the *original* session arrives —
+            # could land on either replica; pick A to mirror the bug
+            # report. Must NOT flip the row offline.
+            r = c.post(
+                f"{CMS_A_URL}/internal/wps/events",
+                headers=_ce_headers(
+                    ce_type="azure.webpubsub.sys.disconnected",
+                    connection_id=conn_a,
+                    user_id=device_id,
+                ),
+                content=b"{}",
+            )
+            assert r.status_code == 204, r.text[:200]
+
+        state = await _row(engine, device_id)
+        assert state["online"] is True, (
+            "stale disconnect from old session flipped the row offline — "
+            "CAS guard in mark_offline_and_alert is broken"
+        )
+        assert state["connection_id"] == conn_b, (
+            "stale disconnect cleared connection_id — CAS guard left "
+            "the row in an inconsistent state"
+        )
+    finally:
+        await _cleanup(engine, device_id)


### PR DESCRIPTION
## Summary

Closes the Stage-4 CI coverage gap. Prod runs N=2 replicas + WPS
transport since the flip; the existing `multireplica-smoke` CI job
only exercises N=2 + direct-WS. WPS-only code paths
(`/internal/wps/events` receiver, `device_presence` CAS guards,
WPS transport boot under multi-replica) ship to prod without a CI
gate today. This PR adds a parallel `multireplica-wps-smoke` job that
runs the same smoke harness layered with a WPS overlay.

## What's new

* **`tests/integration/docker-compose.integration.wps.yml`** — overlay
  on top of the existing two-replica integration compose. Adds a
  `local-broker` service and flips both replicas to
  `AGORA_CMS_DEVICE_TRANSPORT=wps` pointing at the broker. Broker's
  upstream pinned at `cms-0` (no LB locally; cross-replica races are
  covered via direct synthetic webhook POSTs in the new test file —
  see below).

* **`tests/integration/test_multireplica_wps_smoke.py`** — two
  `smoke_wps`-marked tests posting CloudEvents-binary signed webhooks
  directly at each replica:
  - `test_connected_on_replica_a_is_visible_via_replica_b` — Stage 4
    invariant: WPS presence writes by A are immediately visible to B
    via the shared `devices` row (post Stage 2c).
  - `test_stale_disconnect_after_reconnect_keeps_device_online` —
    issue #406 CAS guard: an old socket's `sys.disconnected` arriving
    on replica A after the device has reconnected on replica B must
    NOT flip the row offline. Without the CAS this fires a bogus
    OFFLINE alert; this test would have caught that regression.

* **`tests/integration/conftest.py`** — reads
  `AGORA_INTEGRATION_TRANSPORT=wps` and layers the overlay onto the
  base compose file for *both* `up` and `down`. Default unchanged
  (`local`).

* **`.github/workflows/tests.yml`** — new `multireplica-wps-smoke`
  job mirroring the existing one, single pytest invocation
  (`-m "smoke or smoke_wps"` so the cluster-health smoke runs under
  WPS too — catches transport-specific boot/auth/leader regressions).
  Job wired into `ci-gate` so it gates merges.

* **`pytest.ini`** — registers the `smoke_wps` marker.

## Design choices (rubber-duck-driven)

* **Overlay file, not a compose profile.** Profiles can't override
  env on existing services cleanly. An overlay is more explicit and
  the same shape we already use for prod.

* **Single broker, pinned upstream.** A real ACA-style LB in front of
  both replicas would add moving parts the bug surface doesn't need —
  cross-replica reads are DB-backed, so whichever replica receives the
  webhook is sufficient to prove read coherence. The cross-replica
  webhook race (where events for the *same* device land on *different*
  replicas) is covered by direct synthetic POSTs at both replicas in
  the test file, which a single broker can't orchestrate either.

* **Synthetic webhooks instead of WSS device fixture.** Real broker /
  device / `:send` round-trips test broker behaviour more than CMS
  multi-replica behaviour. Out of scope for this required-gate; track
  separately if broker behaviour starts to drift.

* **Single pytest invocation per job.** Running `-m smoke` and
  `-m smoke_wps` separately would stand the compose stack up twice
  (session-scoped fixture). Combined into one `-m "smoke or smoke_wps"`
  invocation.

## Test plan

* Local: `tests/integration/test_multireplica_wps_smoke.py` collects
  cleanly.
* CI: new job runs alongside the existing direct-WS smoke. Both must
  pass for `ci-gate` to be green.

## Risk

Adds ~2 min to PR build wall-time on code-affecting PRs (path-filtered
out for docs-only PRs via the existing `changes.outputs.code` gate).
No prod behaviour change — CI infra only.
