### PR TITLE
feat(devices): surface per-HDMI-port display_ports (#350)

### DIFF
--- a/alembic/versions/0014_devices_display_ports.py
+++ b/alembic/versions/0014_devices_display_ports.py
@@ -1,0 +1,40 @@
+"""devices.display_ports column for per-HDMI-port state
+
+Issue #350.  Firmware (sslivins/agora #117) reports per-port HDMI
+connection state on every STATUS heartbeat as a ``display_ports``
+array.  Today the CMS silently drops the field (Pydantic ``extra``
+ignored at the schema, and there's no column to write to).  This
+migration adds a JSON column so :func:`device_presence.update_status`
+can persist the per-port list alongside the legacy ``display_connected``
+flag.
+
+JSON portability: ``sa.JSON`` resolves to ``JSONB`` on Postgres and
+``TEXT`` on SQLite (with the JSON1 extension auto-loaded by aiosqlite),
+matching the pattern already used for ``pending_registrations.connection_metadata``
+in migration 0010.
+
+Revision ID: 0014
+Revises: 0013
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "devices",
+        sa.Column("display_ports", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0014 is not supported")

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum as PyEnum
 
-from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy import JSON, Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -132,6 +132,14 @@ class Device(Base):
     ssh_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     local_api_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     display_connected: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    # Per-HDMI-port connection state from the most recent STATUS heartbeat.
+    # Multi-port boards (Pi 5, Pi 4) report each port independently here;
+    # the legacy ``display_connected`` is kept for backward compatibility
+    # and tracks ``display_ports[0].connected`` on the device side.
+    # Stored as a list of {"name": str, "connected": bool} dicts; ``None``
+    # means the device hasn't reported per-port state yet (older firmware
+    # or single-port boards).  See issue #350.
+    display_ports: Mapped[list | None] = mapped_column(JSON, nullable=True)
     # Last-known IP address written by whichever replica processed the
     # most recent register.  None when no registering replica has written
     # yet (or the device is only reachable via WPS, which has no IP).

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -87,6 +87,7 @@ _DEVICE_OUT_OVERLAP_COLUMNS = {
     "ssh_enabled",
     "local_api_enabled",
     "display_connected",
+    "display_ports",
     "ip_address",
 }
 
@@ -215,6 +216,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             playback_asset=_resolve_asset_name(d.id),
             pipeline_state=live_states[d.id]["pipeline_state"] if d.id in live_states else None,
             display_connected=live_states[d.id]["display_connected"] if d.id in live_states else None,
+            display_ports=live_states[d.id]["display_ports"] if d.id in live_states else None,
             cpu_temp_c=live_states[d.id]["cpu_temp_c"] if d.id in live_states else None,
             ip_address=(
                 live_states[d.id]["ip_address"]
@@ -272,6 +274,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         playback_asset=raw_asset,
         pipeline_state=live_states[device.id]["pipeline_state"] if device.id in live_states else None,
         display_connected=live_states[device.id]["display_connected"] if device.id in live_states else None,
+        display_ports=live_states[device.id]["display_ports"] if device.id in live_states else None,
         cpu_temp_c=live_states[device.id]["cpu_temp_c"] if device.id in live_states else None,
         ip_address=(
             live_states[device.id]["ip_address"]

--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -33,6 +33,9 @@ class DeviceOut(BaseModel):
     playback_asset: Optional[str] = None
     pipeline_state: Optional[str] = None
     display_connected: Optional[bool] = None
+    # Per-HDMI-port state — see issue #350.  ``None`` for older firmware
+    # or single-port boards that don't surface per-port detail.
+    display_ports: Optional[list[dict]] = None
     has_active_schedule: bool = False
     # Live state fields from device_manager
     cpu_temp_c: Optional[float] = None

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -104,6 +104,23 @@ class StatusMessage(BaseMessage):
     ssh_enabled: Optional[bool] = None
     local_api_enabled: Optional[bool] = None
     display_connected: Optional[bool] = None
+    # Per-HDMI-port connection state (issue #350).  Multi-port boards
+    # report one entry per port; ``display_connected`` mirrors port 0
+    # for backward compat with single-port readers.  Older firmware
+    # omits this field entirely.
+    display_ports: Optional[list["PortStatus"]] = None
+
+
+class PortStatus(BaseModel):
+    """One HDMI port's connection state — element of ``display_ports``."""
+
+    name: str
+    connected: bool
+
+
+# ``StatusMessage.display_ports`` is declared with a forward reference
+# above; resolve it now that ``PortStatus`` is defined.
+StatusMessage.model_rebuild()
 
 
 class AssetAckMessage(BaseMessage):

--- a/cms/services/device_presence.py
+++ b/cms/services/device_presence.py
@@ -48,6 +48,7 @@ _STATE_COLUMNS = (
     Device.ssh_enabled,
     Device.local_api_enabled,
     Device.display_connected,
+    Device.display_ports,
     Device.connection_id,
     Device.online,
     Device.ip_address,
@@ -84,6 +85,7 @@ def _row_to_state(row: Any) -> dict[str, Any]:
         "ssh_enabled": row.ssh_enabled,
         "local_api_enabled": row.local_api_enabled,
         "display_connected": row.display_connected,
+        "display_ports": row.display_ports,
         "connection_id": row.connection_id,
         "online": bool(row.online),
     }
@@ -308,6 +310,12 @@ async def update_status(
     # as-is (including None, which means "unknown on this device").
     if "display_connected" in status:
         values["display_connected"] = status["display_connected"]
+    # ``display_ports`` is the per-HDMI-port array reported by Pi 5 / Pi 4
+    # firmware (issue #350).  Same passthrough policy: persist whatever
+    # the device sent, including None / missing-key (no overwrite when
+    # absent so a malformed STATUS doesn't blow away a known-good list).
+    if "display_ports" in status and status["display_ports"] is not None:
+        values["display_ports"] = status["display_ports"]
 
     result = await db.execute(
         update(Device)

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -185,7 +185,11 @@
             <div class="detail-item">
                 <span class="detail-label">Display</span>
                 <span class="detail-value" data-live-display="{{ d.id }}">
-                    {% if d.display_connected is none %}
+                    {% if d.display_ports and d.display_ports | length > 1 %}
+                        {% for p in d.display_ports %}
+                            <span class="badge {% if p.connected %}badge-online{% else %}badge-offline{% endif %}" title="{{ p.name }}: {{ 'connected' if p.connected else 'disconnected' }}">{{ p.name }}{% if p.connected %} ✓{% else %} ✗{% endif %}</span>
+                        {% endfor %}
+                    {% elif d.display_connected is none %}
                         <span class="text-muted">—</span>
                     {% elif d.display_connected %}
                         <span class="badge badge-online">Connected</span>
@@ -552,7 +556,16 @@ window._adoptionProfiles = [
             // ── Detail panel: display, pipeline, asset ──
             const displayEl = document.querySelector(`[data-live-display="${d.id}"]`);
             if (displayEl) {
-                if (d.display_connected === null || d.display_connected === undefined) displayEl.innerHTML = '<span class="text-muted">—</span>';
+                if (Array.isArray(d.display_ports) && d.display_ports.length > 1) {
+                    displayEl.innerHTML = d.display_ports.map(p => {
+                        const cls = p.connected ? 'badge-online' : 'badge-offline';
+                        const mark = p.connected ? ' ✓' : ' ✗';
+                        const label = `${p.name}: ${p.connected ? 'connected' : 'disconnected'}`;
+                        const safeName = String(p.name).replace(/[<>&]/g, '');
+                        return `<span class="badge ${cls}" title="${label}">${safeName}${mark}</span>`;
+                    }).join(' ');
+                }
+                else if (d.display_connected === null || d.display_connected === undefined) displayEl.innerHTML = '<span class="text-muted">—</span>';
                 else if (d.display_connected) displayEl.innerHTML = '<span class="badge badge-online">Connected</span>';
                 else displayEl.innerHTML = '<span class="badge badge-offline">Disconnected</span>';
             }

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -720,6 +720,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             "error": state["error"] if state else None,
             "error_since": state["error_since"] if state else None,
             "display_connected": state["display_connected"] if state else None,
+            "display_ports": state["display_ports"] if state else None,
         })
 
     # Upcoming schedules (next 24h)
@@ -929,6 +930,7 @@ async def dashboard_json(request: Request, db: AsyncSession = Depends(get_db)):
             "cpu_temp_c": live_states[did]["cpu_temp_c"] if did in live_states else None,
             "error": live_states[did]["error"] if did in live_states else None,
             "display_connected": live_states[did]["display_connected"] if did in live_states else None,
+            "display_ports": live_states[did]["display_ports"] if did in live_states else None,
         }
         for did in all_device_ids
     ]

--- a/tests/test_device_presence.py
+++ b/tests/test_device_presence.py
@@ -82,6 +82,10 @@ class TestUpdateStatus:
                 "ssh_enabled": True,
                 "local_api_enabled": True,
                 "display_connected": True,
+                "display_ports": [
+                    {"name": "HDMI-1", "connected": True},
+                    {"name": "HDMI-2", "connected": False},
+                ],
             },
         )
         assert ok is True
@@ -96,7 +100,27 @@ class TestUpdateStatus:
         assert row.playback_position_ms == 1234
         assert row.ssh_enabled is True
         assert row.display_connected is True
+        assert row.display_ports == [
+            {"name": "HDMI-1", "connected": True},
+            {"name": "HDMI-2", "connected": False},
+        ]
         assert row.last_status_ts is not None
+
+    @pytest.mark.asyncio
+    async def test_display_ports_absent_does_not_clobber(self, db_session, _device):
+        # First STATUS reports two ports.
+        await device_presence.update_status(
+            db_session, _device.id,
+            {"display_ports": [{"name": "HDMI-1", "connected": True}]},
+        )
+        # Second STATUS omits the field — must NOT wipe the previous list.
+        await device_presence.update_status(
+            db_session, _device.id, {"mode": "play"},
+        )
+        row = (await db_session.execute(
+            select(Device.display_ports).where(Device.id == _device.id)
+        )).scalar_one()
+        assert row == [{"name": "HDMI-1", "connected": True}]
 
     @pytest.mark.asyncio
     async def test_monotonic_guard_rejects_older_status(self, db_session, _device):
@@ -229,7 +253,7 @@ class TestListStates:
         for key in (
             "device_id", "mode", "asset", "pipeline_state", "connected_at",
             "cpu_temp_c", "ip_address", "ssh_enabled", "local_api_enabled",
-            "display_connected", "error", "error_since", "uptime_seconds",
+            "display_connected", "display_ports", "error", "error_since", "uptime_seconds",
         ):
             assert key in s, f"missing key: {key}"
         assert s["device_id"] == _device.id


### PR DESCRIPTION
Closes #350.

## Summary

Plumb per-HDMI-port `display_ports` from the device STATUS heartbeat all
the way through to the `/devices` UI.  Multi-port boards (Pi 5, Pi 4)
already report each port independently in firmware (sslivins/agora #117);
the CMS was silently dropping the field.

## What changed

- **`devices.display_ports` JSON column** + alembic 0014 migration
  (downgrade raises `NotImplementedError` per repo policy).
- **`device_presence.update_status`** persists `display_ports` when
  present.  Sticky semantics — absent / `None` won't clobber the
  previous value.
- **`StatusMessage` schema** gains `PortStatus` + `display_ports`
  (contract hygiene; runtime path is the raw dict).
- **`DeviceOut` + `cms/routers/devices.py` + `cms/ui.py`** thread the
  field through to API and SSR.
- **`cms/templates/devices.html`** renders one chip per port for
  multi-port boards in both the Jinja initial render and the JS live
  update path.  Single-port boards keep the existing single
  Connected/Disconnected badge unchanged.

## Deferred (intentional, will follow up)

- **Banner/alert semantics** in `dashboard.html` and the
  `DISPLAY_CONNECTED`/`DISPLAY_DISCONNECTED` event paths still key off
  `display_connected` (which firmware sets to port-0's state).  Doing
  `any(port.connected)` for the banner / `all()` for "no display"
  alerting is a real product decision and is out of scope for this PR.

## Tests

- `tests/test_device_presence.py`:
  - extends `test_applies_telemetry_fields` to round-trip a 2-port list
  - new `test_display_ports_absent_does_not_clobber` for the sticky
    overwrite policy
  - extends `test_state_shape_contains_ui_contract_keys` with the new
    key

`pytest tests/test_device_presence.py tests/test_devices.py
tests/test_migration_policy.py -p no:timeout` → 124 passed locally.
