### PR TITLE
fix(audit): name device by serial in pending-reject log entries

### DIFF
--- a/cms/routers/bootstrap.py
+++ b/cms/routers/bootstrap.py
@@ -558,13 +558,13 @@ async def reject_pending(
         raise HTTPException(status_code=404, detail="pending_not_found")
 
     try:
-        deleted = await device_bootstrap.delete_pending(db, pending_uuid)
+        device_id = await device_bootstrap.delete_pending(db, pending_uuid)
     except Exception:
         await db.rollback()
         logger.exception("/pending delete internal error")
         raise HTTPException(status_code=500, detail="internal_error")
 
-    if not deleted:
+    if device_id is None:
         await db.rollback()
         raise HTTPException(status_code=404, detail="pending_not_found")
 
@@ -572,10 +572,10 @@ async def reject_pending(
         db,
         user=getattr(request.state, "user", None),
         action="device.pending.reject",
-        resource_type="pending_registration",
-        resource_id=str(pending_uuid),
-        description="Rejected pending device registration from UI",
-        details={"pending_id": str(pending_uuid)},
+        resource_type="device",
+        resource_id=device_id,
+        description=f"Rejected pending registration for device '{device_id}'",
+        details={"pending_id": str(pending_uuid), "device_id": device_id},
         request=request,
     )
     await db.commit()

--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -379,9 +379,11 @@ async def list_pending_registrations(
 
 async def delete_pending(
     db: AsyncSession, pending_id: uuid.UUID,
-) -> bool:
-    """Delete an un-adopted pending row.  Returns True if a row was
-    removed, False otherwise (missing or already adopted).
+) -> str | None:
+    """Delete an un-adopted pending row.
+
+    Returns the ``device_id`` (Pi serial) of the deleted row on
+    success, or ``None`` if the row is missing or already adopted.
 
     Refuses to delete adopted rows — those still carry the outbox
     ciphertext that the device picks up on its next /bootstrap-status
@@ -389,10 +391,13 @@ async def delete_pending(
     """
     pending = await _lock_pending_by_id(db, pending_id)
     if pending is None or pending.adopted_at is not None:
-        return False
+        return None
+    # Capture before delete so we don't read off a deleted ORM
+    # instance after flush.
+    device_id = pending.device_id
     await db.delete(pending)
     await db.flush()
-    return True
+    return device_id
 
 
 async def _perform_adoption(

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -902,6 +902,37 @@ class TestRejectPending:
         r = await client.delete(f"/api/devices/pending/{pending_id}")
         assert r.status_code == 404
 
+    async def test_audit_row_uses_device_id(
+        self, client, unauthed_client, fleet_secret_enabled, db_session,
+    ):
+        """Reject of a pending row writes an audit entry that names
+        the physical device by its serial in description, resource_id,
+        and details — not the disposable pending UUID alone.
+        """
+        from sqlalchemy import select
+
+        from cms.models.audit_log import AuditLog
+
+        await _register_one(unauthed_client, device_id="pi-audit-name")
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+
+        r = await client.delete(f"/api/devices/pending/{pending_id}")
+        assert r.status_code == 204
+
+        result = await db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.action == "device.pending.reject")
+            .order_by(AuditLog.created_at.desc())
+        )
+        entry = result.scalars().first()
+        assert entry is not None, "no audit row written for reject"
+        assert entry.resource_type == "device"
+        assert entry.resource_id == "pi-audit-name"
+        assert "pi-audit-name" in (entry.description or "")
+        assert entry.details["pending_id"] == pending_id
+        assert entry.details["device_id"] == "pi-audit-name"
+
 
 # ---------------------------------------------------------------------
 # /connect-token


### PR DESCRIPTION
## Summary

Tiny audit-log polish. Rejecting a pending device registration was the lone `audit_log()` call site in `cms/` that didn't name the device by its friendly identifier — the row read:

> description: "Rejected pending device registration from UI"
> resource_type: "pending_registration"
> resource_id: "<disposable pending-row UUID>"

…which makes "who got rejected" unanswerable from the audit log unless you already happened to capture the pending UUID elsewhere.

## Change

- `delete_pending()` in `cms/services/device_bootstrap.py` now returns the deleted row's `device_id` (Pi serial) on success, or `None` on missing/already-adopted, instead of `bool`. The serial is captured **before** `db.delete()/flush()` so we don't read off a detached ORM instance.
- `reject_pending` in `cms/routers/bootstrap.py` uses that serial as the audit description (`Rejected pending registration for device '<serial>'`), resource_id, and a new `device_id` key in details. Resource type is now `device` to match the rest of the audit log. The pending UUID is preserved in details for forensics.

## Test

Added `TestRejectPending::test_audit_row_uses_device_id` in `tests/test_bootstrap_endpoints.py` asserting all four fields.

Local: `pytest tests/test_bootstrap_endpoints.py::TestRejectPending -p no:timeout -q` → 6 passed.

## Risk

Very low. `delete_pending` has exactly one caller. Audit rows are append-only and only consumed by humans + the audit page; no machine consumer cares about `resource_type`.
