### PR TITLE
feat(events): stamp replica_id into CMS_STARTED/STOPPED event details

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -2,8 +2,28 @@
 
 import asyncio
 import logging
+import socket
 from collections import deque
 from contextlib import asynccontextmanager
+
+
+def _replica_id() -> str:
+    """Best-effort identifier for *this* process under N>1 replicas.
+
+    Used in ``CMS_STARTED`` / ``CMS_STOPPED`` event details so operators
+    can tell which replica emitted which lifecycle event during a rolling
+    deploy.  Container Apps gives each replica a unique pod-style hostname
+    via ``HOSTNAME``; falls back to ``socket.gethostname()`` for local /
+    docker-compose / unit-test environments.  Returns a non-empty string
+    even on hosts where neither is available so we never write ``None``
+    into the JSONB column.
+    """
+    import os
+    return (
+        os.environ.get("HOSTNAME")
+        or socket.gethostname()
+        or "unknown"
+    )
 
 # ── In-memory log buffer for log download feature ──
 # Per-replica ring buffer. Under multi-replica deployments each replica
@@ -566,7 +586,7 @@ async def lifespan(app: FastAPI):
                 group_id=None,
                 group_name="",
                 event_type=DeviceEventType.CMS_STARTED,
-                details={"version": __version__},
+                details={"version": __version__, "replica_id": _replica_id()},
             ))
             await db.commit()
             break
@@ -604,7 +624,7 @@ async def lifespan(app: FastAPI):
                 group_id=None,
                 group_name="",
                 event_type=DeviceEventType.CMS_STOPPED,
-                details={"version": __version__},
+                details={"version": __version__, "replica_id": _replica_id()},
             ))
             await db.commit()
             break

--- a/cms/templates/event_log.html
+++ b/cms/templates/event_log.html
@@ -112,7 +112,7 @@
                     {% elif event.event_type == 'online' %}
                     Back online
                     {% elif event.event_type in ['cms_started', 'cms_stopped'] and event.details and event.details.version %}
-                    Version {{ event.details.version }}
+                    Version {{ event.details.version }}{% if event.details.replica_id %} (replica {{ event.details.replica_id }}){% endif %}
                     {% else %}
                     {{ event.details | tojson if event.details else '—' }}
                     {% endif %}
@@ -224,7 +224,9 @@
         }
         if (ev.event_type === "online") return "Back online";
         if ((ev.event_type === "cms_started" || ev.event_type === "cms_stopped") && d.version) {
-            return `Version ${d.version}`;
+            return d.replica_id
+                ? `Version ${d.version} (replica ${d.replica_id})`
+                : `Version ${d.version}`;
         }
         return ev.details ? JSON.stringify(ev.details) : "—";
     }

--- a/tests/test_cms_lifespan_events.py
+++ b/tests/test_cms_lifespan_events.py
@@ -16,6 +16,37 @@ def test_deviceeventtype_enum_exposes_cms_started_stopped():
     assert DeviceEventType.CMS_STOPPED.value == "cms_stopped"
 
 
+# ── Replica-id helper (multi-replica diagnostics) ──
+
+
+def test_replica_id_prefers_HOSTNAME_env(monkeypatch):
+    """ACA / docker-compose set HOSTNAME per replica; we should use it verbatim."""
+    from cms import main as main_mod
+    monkeypatch.setenv("HOSTNAME", "agora-cms-rep-7-abcd1234")
+    assert main_mod._replica_id() == "agora-cms-rep-7-abcd1234"
+
+
+def test_replica_id_falls_back_to_socket_when_no_env(monkeypatch):
+    """No HOSTNAME → use socket.gethostname()."""
+    import socket as _socket
+    from cms import main as main_mod
+    monkeypatch.delenv("HOSTNAME", raising=False)
+    monkeypatch.setattr(_socket, "gethostname", lambda: "fallback-host")
+    assert main_mod._replica_id() == "fallback-host"
+
+
+def test_replica_id_never_returns_empty(monkeypatch):
+    """Even on hosts where both signals are blank we must not write None/empty."""
+    import socket as _socket
+    from cms import main as main_mod
+    monkeypatch.delenv("HOSTNAME", raising=False)
+    monkeypatch.setattr(_socket, "gethostname", lambda: "")
+    out = main_mod._replica_id()
+    assert isinstance(out, str)
+    assert out
+    assert out == "unknown"
+
+
 # ── Nullable device_id (migration behavior) ──
 
 
@@ -130,6 +161,11 @@ async def test_real_lifespan_logs_cms_started_event(app, db_session, monkeypatch
         assert evt.device_id is None
         assert evt.details is not None
         assert "version" in evt.details
+        # Replica identifier is stamped so operators can tell which
+        # replica emitted the event under N>1.
+        assert "replica_id" in evt.details
+        assert isinstance(evt.details["replica_id"], str)
+        assert evt.details["replica_id"]  # non-empty
 
     # After the context exits, CMS_STOPPED should also be logged.
     result = await db_session.execute(
@@ -141,3 +177,6 @@ async def test_real_lifespan_logs_cms_started_event(app, db_session, monkeypatch
     stopped = result.scalars().all()
     assert len(stopped) >= 1
     assert "version" in stopped[-1].details
+    assert "replica_id" in stopped[-1].details
+    assert isinstance(stopped[-1].details["replica_id"], str)
+    assert stopped[-1].details["replica_id"]


### PR DESCRIPTION
## Summary

Stamp `replica_id` into the `details` JSON of `CMS_STARTED` / `CMS_STOPPED`
device events so operators can tell which replica emitted which lifecycle
event during a rolling deploy under N>1.

Today both events are written with `details = {"version": "1.x.y"}`. At
N=2 each deploy emits two indistinguishable started+stopped pairs, plus
lone pairs on single-replica restarts. After this change:

```json
{"version": "1.37.x", "replica_id": "agora-cms-rep-7-abcd1234"}
```

The event-log row renderer (Jinja + JS) appends `(replica <id>)` after
the version when `replica_id` is present, so the timeline shows the
restarting replica inline instead of two identical-looking entries.

## Implementation

- `cms/main.py`: new `_replica_id()` helper — `os.environ["HOSTNAME"]`
  (set per-replica by ACA / docker-compose) → `socket.gethostname()` →
  `"unknown"`. Both startup + shutdown emission sites now include it.
- `cms/templates/event_log.html`: server-side Jinja and client-side JS
  description renderers both display `(replica <id>)` when present.
- `tests/test_cms_lifespan_events.py`: three new unit tests for the
  helper (env preference, socket fallback, never-empty guard) plus
  assertions in the real-lifespan test that both `version` and
  `replica_id` end up in the persisted event row.

## Why this and not the alternatives

- **Leader-gate emission** (only the leader replica writes the event)
  is brittle during rolling deploys — the lease takes time to acquire
  on boot and may hand off mid-deploy, swallowing events.
- **Rename `CMS_STARTED` → `CMS_PROCESS_STARTED`** would be honest but
  needs an enum change, an Alembic data migration, plus UI/test churn.
  Not worth it when the JSONB `details` column can carry the context.
- **UI-side dedupe** (group adjacent same-version events) is a
  nice-to-have follow-up; this PR makes the data self-describing first.

## No DB migration

`details` is a free-form JSONB column. Existing rows stay valid; the UI
gracefully omits the suffix when `replica_id` is absent.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
