### PR TITLE
feat(adopt): accept short Crockford pairing codes

### DIFF
--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -30,6 +30,49 @@ from cms.services import device_identity
 logger = logging.getLogger(__name__)
 
 
+# Crockford base32 alphabet (no I, L, O, U).  Used for short 8-char
+# pairing codes shown on the device splash screen.
+_CROCKFORD_ALPHA = frozenset("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+_SHORT_CODE_LEN = 8
+
+
+def normalize_pairing_secret(raw: str) -> str:
+    """Canonicalize a pairing secret before hashing.
+
+    The device generates an 8-char Crockford base32 code (uppercase, no
+    I/L/O/U) and shows it on screen formatted as ``XXXX-XXXX``.  Admins
+    paste/type that code into the adopt modal in any combination of:
+
+    * lowercase / uppercase
+    * with or without a separator (hyphen, space)
+    * with confusable substitutes (``I``/``L`` for ``1``, ``O`` for ``0``)
+
+    To make all of those hash to the same bytes the device sent on
+    ``/register`` we strip separators, uppercase, apply Crockford fixups,
+    and validate that the result is exactly 8 chars from the Crockford
+    alphabet.  Inputs that don't look like a short code are returned
+    unchanged so any future / non-short formats still pass through.
+    """
+    if not isinstance(raw, str):
+        return raw
+    stripped = raw.strip()
+    # Strip whitespace and hyphens (the only display separators we use).
+    candidate = "".join(ch for ch in stripped if ch not in (" ", "-", "\t"))
+    if len(candidate) != _SHORT_CODE_LEN:
+        return stripped
+    upper = candidate.upper()
+    fixed = (
+        upper.replace("I", "1")
+             .replace("L", "1")
+             .replace("O", "0")
+    )
+    if all(ch in _CROCKFORD_ALPHA for ch in fixed):
+        return fixed
+    # Looks like the right length but has out-of-alphabet chars; fall
+    # through and let the lookup miss with the user's literal input.
+    return stripped
+
+
 # ``pg_advisory_xact_lock`` key used to serialize cap-check + insert on
 # ``POST /register``.  Any 63-bit constant works; this one is picked so
 # it is trivially greppable in server-side pg_stat_activity.
@@ -515,7 +558,7 @@ async def adopt_device(
     a single transaction.  Caller is responsible for committing.
     """
     pairing_secret_hash = device_identity.sha256_hex(
-        pairing_secret.encode("utf-8"),
+        normalize_pairing_secret(pairing_secret).encode("utf-8"),
     )
     pending = await _lock_pending_by_hash(db, pairing_secret_hash)
     if pending is None:

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -700,6 +700,25 @@ function _parsePairingQr(text) {
     return t;
 }
 
+// Canonicalize an 8-char Crockford base32 pairing code so that hyphenated /
+// lowercase / I/L/O-substituted user input hashes to the same bytes as the
+// device's QR.  Mirrors normalize_pairing_secret() in cms.services.
+// device_bootstrap; backend re-normalizes for protocol robustness, but
+// doing it here too lets validateForm() reflect the canonical form.
+const _CROCKFORD_ALPHA = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+function _normalizePairingSecret(raw) {
+    if (typeof raw !== "string") return raw;
+    const stripped = raw.trim();
+    const candidate = stripped.replace(/[\s-]/g, "");
+    if (candidate.length !== 8) return stripped;
+    const upper = candidate.toUpperCase();
+    const fixed = upper.replace(/I/g, "1").replace(/L/g, "1").replace(/O/g, "0");
+    for (const ch of fixed) {
+        if (_CROCKFORD_ALPHA.indexOf(ch) === -1) return stripped;
+    }
+    return fixed;
+}
+
 let _bootstrapAdoptOpen = false;
 
 async function bootstrapAdoptDevice() {
@@ -773,7 +792,7 @@ function showBootstrapAdoptModal(groups, profiles) {
         const secretInput = document.createElement("input");
         secretInput.type = "text";
         secretInput.className = "modal-input";
-        secretInput.placeholder = "Paste pairing code or scan QR";
+        secretInput.placeholder = "e.g. 7K3Q-4M2P (or scan QR)";
         secretInput.autocomplete = "off";
         secretInput.spellcheck = false;
         secretInput.style.flex = "1";
@@ -991,7 +1010,7 @@ function showBootstrapAdoptModal(groups, profiles) {
         scanStop.addEventListener("click", stopScanner);
 
         const validateForm = () => {
-            const secret = secretInput.value.trim();
+            const secret = _normalizePairingSecret(secretInput.value);
             adoptBtn.disabled = !(secret.length >= 8 && secret.length <= 128) || !profileSelect.value;
         };
         validateForm();
@@ -1000,7 +1019,7 @@ function showBootstrapAdoptModal(groups, profiles) {
         profileSelect.addEventListener("change", validateForm);
 
         const getResult = () => ({
-            pairing_secret: secretInput.value.trim(),
+            pairing_secret: _normalizePairingSecret(secretInput.value),
             name: nameInput.value.trim() || null,
             profile_id: profileSelect.value,
             location: locInput.value.trim() || null,

--- a/tests/test_pairing_secret_normalize.py
+++ b/tests/test_pairing_secret_normalize.py
@@ -1,0 +1,73 @@
+"""Tests for normalize_pairing_secret() in cms.services.device_bootstrap.
+
+The device generates an 8-char Crockford base32 code and shows it on
+screen as ``XXXX-XXXX``.  Admins can type/paste it back in any
+combination of case, with or without separators, and with the usual
+confusable substitutes.  This normalizer canonicalizes all those forms
+to the exact 8 uppercase chars the device sent on /register so the
+sha256 lookup matches.
+"""
+
+from __future__ import annotations
+
+from cms.services.device_bootstrap import normalize_pairing_secret
+
+
+class TestNormalizePairingSecret:
+    def test_canonical_8char_passes_through(self):
+        assert normalize_pairing_secret("7K3Q4M2P") == "7K3Q4M2P"
+
+    def test_lowercase_uppercased(self):
+        assert normalize_pairing_secret("7k3q4m2p") == "7K3Q4M2P"
+
+    def test_hyphenated_stripped(self):
+        assert normalize_pairing_secret("7K3Q-4M2P") == "7K3Q4M2P"
+
+    def test_lowercase_hyphenated(self):
+        assert normalize_pairing_secret("7k3q-4m2p") == "7K3Q4M2P"
+
+    def test_spaces_stripped(self):
+        assert normalize_pairing_secret("7K3Q 4M2P") == "7K3Q4M2P"
+
+    def test_outer_whitespace_stripped(self):
+        assert normalize_pairing_secret("  7K3Q-4M2P\n") == "7K3Q4M2P"
+
+    def test_crockford_i_to_one(self):
+        # Admin types 'I' instead of '1' (visually identical in many fonts).
+        assert normalize_pairing_secret("ABCDEF1I") == "ABCDEF11"
+        assert normalize_pairing_secret("abcdef-1i") == "ABCDEF11"
+
+    def test_crockford_l_to_one(self):
+        assert normalize_pairing_secret("ABCDEFL1") == "ABCDEF11"
+
+    def test_crockford_o_to_zero(self):
+        assert normalize_pairing_secret("ABCDEF0O") == "ABCDEF00"
+
+    def test_long_legacy_secret_passes_through(self):
+        # 26-char legacy / future-format secrets must NOT be Crockford-mangled.
+        legacy = "JBSWY3DPEHPK3PXPABCDEFGHIJ"
+        assert len(legacy) == 26
+        assert normalize_pairing_secret(legacy) == legacy
+
+    def test_long_legacy_with_O_and_I_passes_through(self):
+        # Legacy RFC-4648 base32 contains O and I; must not be touched.
+        legacy = "OOOIIIJBSWY3DPEHPK3PXPABCD"
+        assert len(legacy) == 26
+        assert normalize_pairing_secret(legacy) == legacy
+
+    def test_8_chars_with_invalid_chars_returns_stripped(self):
+        # Looks like a short code by length but has out-of-alphabet chars
+        # after substitution.  Don't pretend it's canonical; let lookup miss.
+        out = normalize_pairing_secret("ABCD@EFG")
+        # Whitespace stripped, but stays as-is (no alphabet match).
+        assert out == "ABCD@EFG"
+
+    def test_non_string_input_passes_through(self):
+        assert normalize_pairing_secret(None) is None  # type: ignore[arg-type]
+
+    def test_empty_string(self):
+        assert normalize_pairing_secret("") == ""
+
+    def test_short_input_below_8_chars(self):
+        # Too short to be a short code; return stripped unchanged.
+        assert normalize_pairing_secret("abc") == "abc"


### PR DESCRIPTION
## Why

Adopt UI used to display a 26-char RFC-4648 base32 pairing secret for
"Or enter this code manually". This PR pairs with the firmware change
that switches to an 8-char Crockford-base32 pairing code (formatted
`XXXX-XXXX`). CMS needs to accept that input cleanly without rejecting
it for case, whitespace, or the visually-confusable characters
(I/L→1, O→0).

## What

- Adds `normalize_pairing_secret()` in `cms/services/device_bootstrap.py`
  that, **only when the input is shaped like an 8-char Crockford code**,
  uppercases, strips hyphens/whitespace, applies I/L→1 and O→0, and
  validates against the Crockford alphabet. Any other length passes
  through untouched (which means a normal lookup miss for bad input,
  not a crash).
- Wires it into `adopt_device()` before the sha256 lookup.
- Mirrors the same normalizer on the frontend in `cms/static/app.js`
  (`_normalizePairingSecret`) — used in `validateForm` and `getResult`
  so the QR-decoded value and the manually-typed value end up identical
  before submission.
- Updates the manual-entry placeholder to `"e.g. 7K3Q-4M2P (or scan QR)"`.
- Adds 15 unit tests covering canonical, lowercase, hyphenated, spaces,
  Crockford I/L→1 + O→0, legacy 26-char passthrough, bad-char
  passthrough, and edge cases.

## Compat

- 26-char legacy RFC-4648 secrets pass through the normalizer
  unchanged, so any pending pre-flip rows still work after merge.
  (The matching firmware PR drops legacy generation; older devices
  haven't been provisioned with the new flow yet.)

## Tests

- `tests/test_pairing_secret_normalize.py` (15 cases) — green.
- `tests/test_bootstrap_endpoints.py` (44 cases, regression) — green.
