### PR TITLE
adopt: delete stale un-adopted sibling rows for same device_id

### DIFF
--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import func, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -535,6 +535,25 @@ async def _perform_adoption(
     pending.adopted_device_id = device_row_id
     pending.updated_at = now
     await db.flush()
+
+    # Clean up stale un-adopted rows for the same physical device.  The
+    # firmware only knows one pairing secret at a time, so any other
+    # un-adopted pending rows with the same device_id are guaranteed
+    # stale (e.g. left over from earlier register cycles before a
+    # factory reset or firmware upgrade).  Without this they sit in the
+    # pending-devices list confusing the operator until the 24h TTL
+    # reaper purges them.  device_id is the Pi CPU serial — stable
+    # across reboots and firmware versions, but regenerated on
+    # complete hardware swap, so this is safe.
+    if pending.device_id:
+        await db.execute(
+            delete(PendingRegistration).where(
+                PendingRegistration.device_id == pending.device_id,
+                PendingRegistration.id != pending.id,
+                PendingRegistration.adopted_at.is_(None),
+            )
+        )
+        await db.flush()
 
     return device, pending
 

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -630,6 +630,85 @@ class TestAdopt:
         )
         assert r2.status_code == 409
 
+    async def test_adoption_cleans_up_stale_pending_rows_for_same_device(
+        self, client, fleet_secret_enabled, stub_wps_transport,
+        db_session, unauthed_client,
+    ):
+        """Regression: when a Pi cycles through register attempts (e.g.
+        before a factory reset or firmware upgrade), each fresh pairing
+        secret creates a new pending_registrations row for the same
+        device_id.  Adopting the latest one must clean up the stale
+        un-adopted siblings; otherwise they linger until the 24h TTL
+        and the operator sees the device on /devices Pending Devices
+        even after a successful adopt.
+        """
+        from cms.models.pending_registration import PendingRegistration
+        from sqlalchemy import select
+
+        # First register: stale row, never adopted (e.g. pre-reset).
+        _, _, stale_hash, _ = await _register_one(
+            unauthed_client, device_id="pi-recycled",
+        )
+
+        # Second register: different keypair + secret, same device_id
+        # (e.g. post-factory-reset).  Creates a second pending row.
+        priv2, pub_b64_2 = _gen_keypair()
+        secret2, hash2 = _pairing_pair()
+        headers2 = _fleet_headers(
+            device_id="pi-recycled", pubkey_b64=pub_b64_2,
+            pairing_secret_hash_hex=hash2,
+        )
+        r = await unauthed_client.post(
+            "/api/devices/register",
+            json={"device_id": "pi-recycled", "pubkey": pub_b64_2,
+                  "pairing_secret_hash": hash2},
+            headers=headers2,
+        )
+        assert r.status_code == 202
+
+        # Sanity: both rows exist, both un-adopted.
+        rows = (
+            await db_session.execute(
+                select(PendingRegistration).where(
+                    PendingRegistration.device_id == "pi-recycled",
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 2
+        assert all(r.adopted_at is None for r in rows)
+
+        # Adopt the second (current) one.
+        profile = await _seed_profile(db_session, name="cleanup")
+        adopt_resp = await client.post(
+            "/api/devices/adopt",
+            json={"pairing_secret": secret2,
+                  "profile_id": str(profile.id)},
+        )
+        assert adopt_resp.status_code == 200, adopt_resp.text
+
+        # Stale row must be gone; adopted row must remain with
+        # adopted_at + outbox payload intact.
+        db_session.expire_all()
+        rows = (
+            await db_session.execute(
+                select(PendingRegistration).where(
+                    PendingRegistration.device_id == "pi-recycled",
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1, (
+            f"expected stale un-adopted row to be deleted; got "
+            f"{[(str(r.id), r.adopted_at) for r in rows]}"
+        )
+        assert rows[0].pairing_secret_hash == hash2
+        assert rows[0].adopted_at is not None
+        assert rows[0].outbox_ciphertext
+
+        # And /pending must not list the device any more.
+        listed = await client.get("/api/devices/pending")
+        assert listed.status_code == 200
+        assert listed.json() == {"items": []}
+
 
 # ---------------------------------------------------------------------
 # /pending + /adopt-pending + DELETE /pending/{id}


### PR DESCRIPTION
# Bug

After OOBE, a Pi that's been factory-reset between register attempts
shows up **twice** under Pending Devices: once for each pairing secret
the firmware ever generated. Only the row matching the pairing code
the operator types gets `adopted_at` set; the others linger under
`list_pending_registrations`' `adopted_at IS NULL` filter until the 24h
TTL reaper.

This was reproduced cleanly on the test Pi (192.168.1.53):

1. Pi registers at 16:01 with pairing secret X (row A).
2. Operator factory-resets the Pi.
3. Pi registers again at 21:36 with pairing secret Y (row B).
4. Operator scans/types pairing code Y -> row B gets `adopted_at`.
5. Row A still has `adopted_at IS NULL` -> Pending Devices card keeps
   showing the device for ~24h even though it's fully adopted.

# Repro

Confirmed in prod by inspecting the `pending_registrations` table for
device `000000008e0a81a2`:

```
id                                    | device_id        | created    | adopted_at
5ebf8c7a-d9fa-4219-9539-7a0b17bfc0b7  | 000000008e0a81a2 | 16:01      | NULL        <-- stuck
b37d456b-fc79-4f21-89da-4fecc1cc0587  | 000000008e0a81a2 | 21:36      | 21:37
```

# Fix

In `_perform_adoption`, after setting `adopted_at = now` and flushing,
delete any **other** rows with the same `device_id` that are still
un-adopted:

```python
await db.execute(
    delete(PendingRegistration).where(
        PendingRegistration.device_id == pending.device_id,
        PendingRegistration.id != pending.id,
        PendingRegistration.adopted_at.is_(None),
    )
)
await db.flush()
```

Why this is safe: the Pi only knows ONE pairing secret at a time. Once
a row for `device_id=D` has been adopted, all other un-adopted rows for
the same `device_id` are guaranteed un-claimable -- their pairing
secrets and keypairs are gone from the device. `device_id` is the Pi
CPU serial: stable across reboot/firmware/factory-reset; only changes
on hardware swap.

The fix lives in the shared service helper, so both adopt paths get it
automatically:
- `adopt_device` (`/api/devices/adopt`, by pairing secret)
- `adopt_pending_by_id` (`/api/devices/adopt-pending`, by pending row id)

# Test

Added regression test
`test_adoption_cleans_up_stale_pending_rows_for_same_device` in
`TestAdopt`:

1. Register row A for `device_id="pi-recycled"`.
2. Manually `/api/devices/register` row B for the same `device_id`
   (new keypair + new pairing secret).
3. Adopt row B.
4. Assert: only one `pending_registrations` row remains, it has
   `adopted_at != NULL`, its `pairing_secret_hash` is row B's, and
   `outbox_ciphertext` is non-empty.
5. Assert: `/api/devices/pending` returns an empty list.

`tests/test_bootstrap_endpoints.py` + `tests/test_adoption_flow.py`:
74/74 passing locally.

# Manual prod cleanup

Already deleted the stuck row `5ebf8c7a-d9fa-4219-9539-7a0b17bfc0b7`
in prod via `az containerapp exec` -> python+sqlalchemy DELETE. Future
re-occurrences will self-clean on next adopt thanks to this PR.
