### PR TITLE
Exclude slideshow assets from splash dropdown

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -533,7 +533,7 @@
             {% if 'groups:write' in user_perms %}
             <select class="inline-edit inline-edit-sm" onchange="setGroupDefaultAsset('{{ g.id }}', this.value)">
                 <option value="">No default asset</option>
-                {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
+                {% for a in assets if a.asset_type.value not in ('webpage', 'stream', 'slideshow') %}
                 <option value="{{ a.id }}" {% if g.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
                 {% endfor %}
             </select>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -48,7 +48,7 @@
         {% if 'devices:write' in user_perms %}
         <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
             <option value="">None (use group)</option>
-            {% for a in assets if a.asset_type.value not in ('webpage', 'stream') %}
+            {% for a in assets if a.asset_type.value not in ('webpage', 'stream', 'slideshow') %}
             <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
             {% endfor %}
         </select>


### PR DESCRIPTION
Slideshows showed up in the group+device 'Splash Screen' dropdowns, but the player's _show_splash / _find_splash path only handles single-file image/video splashes — there is no slideshow sequencer for splash mode. Picking a slideshow as the splash silently fell back to default.png.

Hides slideshow-typed assets from both selects:
- cms/templates/_macros.html (group splash dropdown)
- cms/templates/devices.html (device splash dropdown)

Backend slideshow_v1 capability gate is left intact for now (it's not user-facing once the dropdown stops offering slideshows). Note: cms_client/service.py also writes default_asset desired state without asset_type, so even an API-level POST of a slideshow id won't actually render — that's a separate latent bug not addressed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>