### PR TITLE
feat(assets): add Create sub-tab + builders hub

### DIFF
--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -5,6 +5,9 @@
 <h1>Assets</h1>
 <div class="sub-tabs">
     <a href="/assets" class="sub-tab active">Library</a>
+    {% if 'assets:write' in user_perms %}
+    <a href="/assets/new" class="sub-tab">Create</a>
+    {% endif %}
     <a href="/profiles" class="sub-tab">Playback Profiles</a>
 </div>
 
@@ -159,9 +162,6 @@
 <div class="card">
     <div style="display:flex; align-items:center; justify-content:space-between; gap:0.5rem;">
         <h2 style="margin:0;">Library</h2>
-        {% if 'assets:write' in user_perms %}
-        <a href="/assets/new/slideshow" class="btn btn-secondary" title="Create a slideshow from existing assets">🎞️ New Slideshow</a>
-        {% endif %}
     </div>
     <div class="table-wrap">
     <table>

--- a/cms/templates/assets_new.html
+++ b/cms/templates/assets_new.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% block title %}Create Asset — Agora CMS{% endblock %}
+{% block content %}
+<h1>Assets</h1>
+<div class="sub-tabs">
+    <a href="/assets" class="sub-tab">Library</a>
+    <a href="/assets/new" class="sub-tab active">Create</a>
+    <a href="/profiles" class="sub-tab">Playback Profiles</a>
+</div>
+
+<div class="card">
+    <h2 style="margin-top:0;">Build a new asset</h2>
+    <p class="text-muted" style="margin-top:0;">
+        Builders compose a new asset from existing content in your library.
+        For straightforward uploads or live streams, head to the
+        <a href="/assets">Library</a> tab.
+    </p>
+
+    <div class="builder-tiles">
+        <a href="/assets/new/slideshow" class="builder-tile">
+            <div class="builder-tile-icon" aria-hidden="true">🎞️</div>
+            <div class="builder-tile-body">
+                <h3 class="builder-tile-title">Slideshow</h3>
+                <p class="builder-tile-desc">
+                    Sequence images and videos into a single playable asset
+                    with per-slide timing.
+                </p>
+            </div>
+        </a>
+    </div>
+</div>
+
+<style>
+    .builder-tiles {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 1rem;
+        margin-top: 1rem;
+    }
+    .builder-tile {
+        display: flex;
+        gap: 0.85rem;
+        align-items: flex-start;
+        padding: 1rem;
+        border: 1px solid var(--border-color, #d0d7de);
+        border-radius: 8px;
+        background: var(--card-bg, #fff);
+        text-decoration: none;
+        color: inherit;
+        transition: border-color .12s ease, box-shadow .12s ease,
+                    transform .12s ease;
+    }
+    .builder-tile:hover,
+    .builder-tile:focus-visible {
+        border-color: var(--accent-color, #0969da);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+        transform: translateY(-1px);
+        text-decoration: none;
+    }
+    .builder-tile-icon {
+        font-size: 2rem;
+        line-height: 1;
+        flex: 0 0 auto;
+    }
+    .builder-tile-body { flex: 1 1 auto; min-width: 0; }
+    .builder-tile-title {
+        margin: 0 0 0.25rem;
+        font-size: 1.05rem;
+    }
+    .builder-tile-desc {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--text-muted, #57606a);
+    }
+</style>
+{% endblock %}

--- a/cms/templates/profiles.html
+++ b/cms/templates/profiles.html
@@ -5,6 +5,9 @@
 <h1>Assets</h1>
 <div class="sub-tabs">
     <a href="/assets" class="sub-tab">Library</a>
+    {% if 'assets:write' in user_perms %}
+    <a href="/assets/new" class="sub-tab">Create</a>
+    {% endif %}
     <a href="/profiles" class="sub-tab active">Playback Profiles</a>
 </div>
 

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -403,7 +403,7 @@
           title="You have unsaved changes">● unsaved</span>
 </h1>
 <div class="sub-tabs">
-    <a href="/assets" class="sub-tab">← Back to Assets</a>
+    <a href="{% if edit_mode %}/assets{% else %}/assets/new{% endif %}" class="sub-tab">← Back to Assets</a>
 </div>
 
 <div class="card">

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -41,7 +41,7 @@ from cms.database import get_db
 from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.slideshow_slide import SlideshowSlide
 from cms.models.device import Device, DeviceGroup, DeviceStatus
-from cms.permissions import USERS_READ, USERS_WRITE, ROLES_WRITE, DEVICES_MANAGE, has_permission
+from cms.permissions import USERS_READ, USERS_WRITE, ROLES_WRITE, DEVICES_MANAGE, ASSETS_WRITE, has_permission
 from cms.auth import get_user_group_ids
 from cms.models.device_profile import DeviceProfile
 from cms.models.schedule import Schedule
@@ -1506,9 +1506,24 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
 
 
 @router.get(
+    "/assets/new",
+    response_class=HTMLResponse,
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
+)
+async def assets_new_hub(request: Request, db: AsyncSession = Depends(get_db)):
+    """Hub page listing builders that author synthetic assets.
+
+    Today: Slideshow. Future: Composed Slide / Scene.
+    """
+    return templates.TemplateResponse(request, "assets_new.html", {
+        "active_tab": "assets",
+    })
+
+
+@router.get(
     "/assets/new/slideshow",
     response_class=HTMLResponse,
-    dependencies=[Depends(require_auth)],
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
 )
 async def slideshow_builder_new(request: Request, db: AsyncSession = Depends(get_db)):
     ctx = await _slideshow_builder_context(request, db, asset_id=None)
@@ -1518,7 +1533,7 @@ async def slideshow_builder_new(request: Request, db: AsyncSession = Depends(get
 @router.get(
     "/assets/{asset_id}/slideshow",
     response_class=HTMLResponse,
-    dependencies=[Depends(require_auth)],
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
 )
 async def slideshow_builder_edit(
     asset_id: str, request: Request, db: AsyncSession = Depends(get_db)

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -57,6 +57,36 @@ class TestSlideshowBuilderRoutes:
         assert "ss-slides-table" in body
         assert "/api/assets/slideshow" in body  # JS POST endpoint baked in
 
+    async def test_new_page_requires_write_permission(self, app, db_session):
+        """Direct nav to /assets/new/slideshow must be gated on assets:write."""
+        from tests.test_ui_overhaul import _create_user, _login_as
+        await _create_user(db_session, username="ss_viewer", role_name="Viewer")
+        ac = await _login_as(app, "ss_viewer")
+        try:
+            resp = await ac.get("/assets/new/slideshow")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await ac.aclose()
+
+    async def test_hub_renders_for_writer(self, client):
+        resp = await client.get("/assets/new")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Slideshow tile is the only builder today; must link to the
+        # existing builder route.
+        assert 'href="/assets/new/slideshow"' in body
+        assert "Slideshow" in body
+
+    async def test_hub_requires_write_permission(self, app, db_session):
+        from tests.test_ui_overhaul import _create_user, _login_as
+        await _create_user(db_session, username="hub_viewer", role_name="Viewer")
+        ac = await _login_as(app, "hub_viewer")
+        try:
+            resp = await ac.get("/assets/new")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await ac.aclose()
+
     async def test_edit_page_renders_with_existing_slides(self, client, db_session):
         asset = await _seed_slideshow(db_session, name="Editable", slides=3)
         resp = await client.get(f"/assets/{asset.id}/slideshow")
@@ -85,11 +115,15 @@ class TestSlideshowBuilderRoutes:
         resp = await client.get(f"/assets/{bogus}/slideshow", follow_redirects=False)
         assert resp.status_code in (303, 307, 302)
 
-    async def test_assets_page_shows_create_slideshow_link(self, client, db_session):
+    async def test_assets_page_links_to_create_hub(self, client, db_session):
         resp = await client.get("/assets")
         assert resp.status_code == 200
-        assert "/assets/new/slideshow" in resp.text
-        assert "New Slideshow" in resp.text
+        # Library page now links to the Create hub (sub-tab) rather than
+        # to the slideshow builder directly.
+        assert 'href="/assets/new"' in resp.text
+        # The legacy "🎞️ New Slideshow" button on the Library card has
+        # been retired in favour of the Create tab — make sure it is gone.
+        assert "🎞️ New Slideshow" not in resp.text
 
     async def test_assets_page_shows_slide_count_badge(self, client, db_session):
         await _seed_slideshow(db_session, name="Count Show", slides=3)


### PR DESCRIPTION
## Summary

Adds a third sub-tab **Create** under Assets, linking to a new hub page
at `/assets/new`. The hub presents one tile per asset builder — today
just Slideshow, with room for future builders (composed slide, scene
with widgets, etc.) without churning the IA when they land.

This replaces the old "🎞️ New Slideshow" button buried in the Library
card header. Single discoverable entry point now.

## Why a separate "Create" surface

Slideshow (and the planned composed-slide builder) are not imports —
they're *builds* from existing assets. They need full-page editor real
estate and don't fit alongside Upload/Webpage URL/Stream in the
Library's compact "Add" card.

Surveyed two alternatives (inline expanding tab, top-level Compose nav)
and rubber-ducked the design before settling on a sub-tab + hub. Key
duck pushback that's reflected in the final design:

- Tab labelled **Create**, not "Builders" — predictable for users; doesn't
  imply a workspace where existing assets are managed.
- Single tile today, no "coming soon" ghost slot for future builders.
- Route-level permissions, not just tile visibility (see below).

## Changes

- New `GET /assets/new` route gated on `assets:write`, renders new
  `cms/templates/assets_new.html` with the Slideshow tile.
- Tighten `/assets/new/slideshow` and `/assets/{id}/slideshow` from
  `require_auth` to `require_permission(ASSETS_WRITE)`. Today a Viewer
  could deep-link past the hidden CTA and reach a non-functional editor;
  now they get a 403.
- Add **Create** sub-tab to `assets.html` and `profiles.html` (gated on
  `assets:write` so Viewers don't see a tab they can't use).
- Remove the legacy "🎞️ New Slideshow" button from the Library card
  header.
- Slideshow builder's "← Back to Assets" link now returns to
  `/assets/new` in create mode (so the user lands on the Create tab),
  `/assets` in edit mode (which is reached from the Library row kebab).

## IA after this PR

```
Assets
  Library            /assets               (table; kebab → Edit slides)
  Create             /assets/new           (NEW — tile per builder)
                     /assets/new/slideshow (existing builder, untouched)
  Playback Profiles  /profiles
```

Future composed-slide builder slots in as another tile + a
`/assets/new/scene` route. No further IA churn needed.

## Tests

`tests/test_slideshow_builder_ui.py`:
- Updated `test_assets_page_links_to_create_hub` — Library now points
  at the Create hub, legacy button is gone.
- New `test_hub_renders_for_writer` — admin sees the Slideshow tile
  with the right link.
- New `test_hub_requires_write_permission` — Viewer gets 403.
- New `test_new_page_requires_write_permission` — direct nav to
  `/assets/new/slideshow` as a Viewer is now 403 (regression guard for
  the perm tightening).

All 9 slideshow-UI tests + 37 ui-overhaul tests pass locally.

## Out of scope

- Merging Upload/Webpage URL/Stream into the Create hub (bigger IA
  refactor; deferred).
- Building the composed-slide builder itself.
- Deduping the slideshow builder's internal asset library grid.
