### PR TITLE
Devices page polish: alert chips, move adopt button, remove detail toolbar

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -449,6 +449,68 @@
 
 
 {#
+  Per-device alert chips. Rendered immediately after the connectivity
+  badge in the Status cell of both the main and compact device rows so
+  operators can see "this device needs attention" at a glance without
+  expanding the row. Mirrors the dashboard's issue surfacing.
+
+  Severity order (highest first):
+    Error → Upgrading → Temp Critical → Temp Warning → Display Off
+      → Storage Critical → Storage Low → Update
+
+  Stale-telemetry chips (Error, Temp, Display) are hidden when the
+  device is offline — those signals reflect the last-known live state
+  and would be misleading. Update / Upgrading / Storage are always
+  shown when applicable. Pending and orphaned devices are skipped
+  entirely; their connectivity badge already conveys the relevant
+  state and they have no fleet-style alerts.
+
+  Each chip is wrapped in `has-tooltip` so users can hover for context.
+#}
+{% macro device_alert_chips(d) -%}
+{% if d.status.value not in ('pending', 'orphaned') %}
+{# Error #}
+{% if d.is_online and (d.error or d.pipeline_state == 'ERROR') %}
+<span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">{% if d.error %}{{ d.error }}{% else %}Player pipeline reported an error{% endif %}</span></span>
+{% endif %}
+{# Upgrading #}
+{% if d.is_upgrading %}
+<span class="has-tooltip"><span class="badge badge-processing">Upgrading…</span><span class="tooltip">Firmware upgrade in progress — device will reboot when done</span></span>
+{% endif %}
+{# Temp #}
+{% if d.is_online and d.cpu_temp_c is not none %}
+{% if d.cpu_temp_c >= 80 %}
+<span class="has-tooltip"><span class="badge badge-temp-critical">Temp {{ d.cpu_temp_c | round(1) }}°C</span><span class="tooltip">CPU temperature is critical — device may throttle or shut down</span></span>
+{% elif d.cpu_temp_c >= 70 %}
+<span class="has-tooltip"><span class="badge badge-temp-warning">Temp {{ d.cpu_temp_c | round(1) }}°C</span><span class="tooltip">CPU temperature is high — check ventilation</span></span>
+{% endif %}
+{% endif %}
+{# Display Off #}
+{% if d.is_online %}
+{% if d.display_ports and d.display_ports | length > 0 and (d.display_ports | rejectattr('connected') | list | length == d.display_ports | length) %}
+<span class="has-tooltip"><span class="badge badge-offline">Display Off</span><span class="tooltip">No display detected on any port — check HDMI cable</span></span>
+{% elif (not d.display_ports) and d.display_connected is false %}
+<span class="has-tooltip"><span class="badge badge-offline">Display Off</span><span class="tooltip">Display is disconnected — check HDMI cable</span></span>
+{% endif %}
+{% endif %}
+{# Storage #}
+{% if d.storage_capacity_mb and d.storage_capacity_mb > 0 %}
+{% set _free_pct = ((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) %}
+{% if _free_pct < 5 %}
+<span class="has-tooltip"><span class="badge badge-temp-critical">Storage {{ _free_pct | round(0) | int }}%</span><span class="tooltip">Less than 5% free — downloads and recordings may fail</span></span>
+{% elif _free_pct < 10 %}
+<span class="has-tooltip"><span class="badge badge-temp-warning">Storage {{ _free_pct | round(0) | int }}%</span><span class="tooltip">Less than 10% free — consider clearing unused assets</span></span>
+{% endif %}
+{% endif %}
+{# Update #}
+{% if d.update_available and not d.is_upgrading %}
+<span class="has-tooltip"><span class="badge badge-update">Update</span><span class="tooltip">A newer firmware version is available — open the row's actions menu to update</span></span>
+{% endif %}
+{% endif %}
+{%- endmacro %}
+
+
+{#
   Compact device row — used inside each group panel and the "Ungrouped"
   table. Moved from devices.html so that both the full-page render and
   the GET /api/devices/groups/{id}/panel fragment endpoint can emit
@@ -466,7 +528,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">Re-flashed device — needs re-adoption</span></span>
         {% elif d.status.value == 'pending' %}
@@ -480,6 +542,7 @@
         {% else %}
         <span class="badge badge-offline">Offline</span>
         {% endif %}
+        {{ device_alert_chips(d) }}
     </td>
     <td>
         {% if 'devices:write' in user_perms %}

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -17,7 +17,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">This device matches a known device but couldn't authenticate, likely due to a factory reset or SD card replacement. It needs to be re-adopted.</span></span>
         {% elif d.status.value == 'pending' %}
@@ -31,6 +31,7 @@
         {% else %}
         <span class="badge badge-offline">Offline</span>
         {% endif %}
+        {{ macros.device_alert_chips(d) }}
     </td>
     <td>
         {% if 'devices:write' in user_perms %}
@@ -218,28 +219,6 @@
             </div>
             </div>
         </div>
-        {% if 'devices:manage' in user_perms %}
-        <div class="detail-toolbar" data-live-toolbar="{{ d.id }}" {% if not d.is_online %}style="display:none"{% endif %}>
-            <span class="detail-label">Actions</span>
-            <span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="changeDevicePassword('{{ d.id }}', '{{ d.name or d.id }}')">Change Web Password</button><span class="tooltip">Set the password for this device's local web UI</span></span>
-            <span data-live-ssh-btn="{{ d.id }}">
-            {% if d.ssh_enabled %}
-            <span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleSsh('{{ d.id }}', false)">Disable SSH</button><span class="tooltip">SSH is currently enabled — click to disable</span></span>
-            {% else %}
-            <span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleSsh('{{ d.id }}', true)">Enable SSH</button><span class="tooltip">SSH is currently disabled — click to enable</span></span>
-            {% endif %}
-            </span>
-            <span data-live-localapi-btn="{{ d.id }}">
-            {% if d.local_api_enabled is not none and not d.local_api_enabled %}
-            <span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleLocalApi('{{ d.id }}', true)">Enable Local API</button><span class="tooltip">Device REST API is disabled — click to re-enable</span></span>
-            {% else %}
-            <span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleLocalApi('{{ d.id }}', false)">Disable Local API</button><span class="tooltip">Disable the device's local REST API</span></span>
-            {% endif %}
-            </span>
-            <span class="has-tooltip"><button class="btn btn-danger btn-sm" onclick="rebootDevice('{{ d.id }}', '{{ d.name or d.id }}')">Reboot</button><span class="tooltip">Restart this device immediately</span></span>
-            <span class="has-tooltip"><button class="btn btn-warn btn-sm" onclick="factoryResetDevice('{{ d.id }}', '{{ d.name or d.id }}')">Factory Reset</button><span class="tooltip">Wipe all data and return device to setup mode</span></span>
-        </div>
-        {% endif %}
         </div>
     </td>
 </tr>
@@ -273,7 +252,6 @@
     <div style="display: flex; gap: 0.25rem; align-items: center;">
         <h2 style="margin: 0;">Devices</h2>
         {% if 'devices:manage' in user_perms %}
-        <button class="btn btn-primary" style="margin-left: 0.75rem;" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
         <span onclick="event.stopPropagation()">
             {% call macros.kebab_menu() %}
                 <button type="button" role="menuitem" onclick="checkForUpdates(this)" id="check-updates-btn" title="Fetch the latest available device software version. Runs automatically every hour.">Check for updates</button>
@@ -300,7 +278,10 @@
 {# first heading on the page — the e2e page-load test keys off that.   #}
 {% if 'devices:manage' in user_perms %}
 <div class="card" id="pending-devices-card" style="display: none;">
-    <h2 style="margin: 0 0 0.5rem 0;">Pending Devices</h2>
+    <div style="display: flex; gap: 0.75rem; align-items: center; margin: 0 0 0.5rem 0;">
+        <h2 style="margin: 0;">Pending Devices</h2>
+        <button class="btn btn-primary" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
+    </div>
     <p class="text-muted" style="margin: 0 0 0.75rem 0;">
         Devices that have registered with the CMS but haven't been adopted yet.
         Unadopted registrations expire after {{ pending_ttl_hours }} hours.
@@ -508,14 +489,73 @@ window._adoptionProfiles = [
              + '<div id="' + mid + '" popover class="kebab-menu" role="menu">' + items + '</div>';
     }
 
-    function buildSshButton(d) {
-        if (d.ssh_enabled) return '<span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleSsh(\'' + d.id + '\', false)">Disable SSH</button><span class="tooltip">SSH is currently enabled — click to disable</span></span>';
-        return '<span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleSsh(\'' + d.id + '\', true)">Enable SSH</button><span class="tooltip">SSH is currently disabled — click to enable</span></span>';
+    function buildAlertChips(d) {
+        // Mirrors the device_alert_chips Jinja macro in _macros.html. Keep
+        // the two in sync — the page renders the macro on first paint and
+        // this builder takes over for live updates.
+        if (d.status === 'pending' || d.status === 'orphaned') return '';
+        const out = [];
+        // Error
+        if (d.is_online && (d.error || d.pipeline_state === 'ERROR')) {
+            const msg = d.error ? String(d.error).replace(/[<>&]/g, '') : 'Player pipeline reported an error';
+            out.push('<span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">' + msg + '</span></span>');
+        }
+        // Upgrading
+        if (d.is_upgrading) {
+            out.push('<span class="has-tooltip"><span class="badge badge-processing">Upgrading…</span><span class="tooltip">Firmware upgrade in progress — device will reboot when done</span></span>');
+        }
+        // Temp
+        if (d.is_online && d.cpu_temp_c != null) {
+            const t = d.cpu_temp_c.toFixed(1);
+            if (d.cpu_temp_c >= 80) {
+                out.push('<span class="has-tooltip"><span class="badge badge-temp-critical">Temp ' + t + '°C</span><span class="tooltip">CPU temperature is critical — device may throttle or shut down</span></span>');
+            } else if (d.cpu_temp_c >= 70) {
+                out.push('<span class="has-tooltip"><span class="badge badge-temp-warning">Temp ' + t + '°C</span><span class="tooltip">CPU temperature is high — check ventilation</span></span>');
+            }
+        }
+        // Display Off
+        if (d.is_online) {
+            const ports = Array.isArray(d.display_ports) ? d.display_ports : null;
+            const allOff = ports && ports.length > 0 && ports.every(p => !p.connected);
+            const noPortsAndOff = !ports && d.display_connected === false;
+            if (allOff || noPortsAndOff) {
+                out.push('<span class="has-tooltip"><span class="badge badge-offline">Display Off</span><span class="tooltip">No display detected — check HDMI cable</span></span>');
+            }
+        }
+        // Storage
+        if (d.storage_capacity_mb && d.storage_capacity_mb > 0) {
+            const used = d.storage_used_mb != null ? d.storage_used_mb : 0;
+            const freePct = (d.storage_capacity_mb - used) / d.storage_capacity_mb * 100;
+            if (freePct < 5) {
+                out.push('<span class="has-tooltip"><span class="badge badge-temp-critical">Storage ' + Math.round(freePct) + '%</span><span class="tooltip">Less than 5% free — downloads and recordings may fail</span></span>');
+            } else if (freePct < 10) {
+                out.push('<span class="has-tooltip"><span class="badge badge-temp-warning">Storage ' + Math.round(freePct) + '%</span><span class="tooltip">Less than 10% free — consider clearing unused assets</span></span>');
+            }
+        }
+        // Update
+        if (d.update_available && !d.is_upgrading) {
+            out.push('<span class="has-tooltip"><span class="badge badge-update">Update</span><span class="tooltip">A newer firmware version is available — open the row\'s actions menu to update</span></span>');
+        }
+        return out.join('');
     }
 
-    function buildLocalApiButton(d) {
-        if (d.local_api_enabled != null && !d.local_api_enabled) return '<span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleLocalApi(\'' + d.id + '\', true)">Enable Local API</button><span class="tooltip">Device REST API is disabled — click to re-enable</span></span>';
-        return '<span class="has-tooltip"><button class="btn btn-secondary btn-sm" onclick="toggleLocalApi(\'' + d.id + '\', false)">Disable Local API</button><span class="tooltip">Disable the device\'s local REST API</span></span>';
+    function alertsSig(d) {
+        // Must match the data-alerts-sig attribute computed in
+        // _macros.html / devices.html so the first poll after page load
+        // is a no-op when nothing has changed.
+        const tempBucket = d.cpu_temp_c != null ? Math.round(d.cpu_temp_c) : 'n';
+        const ports = Array.isArray(d.display_ports) ? d.display_ports : null;
+        const allOff = ports && ports.length > 0 && ports.every(p => !p.connected);
+        const noPortsAndOff = !ports && d.display_connected === false;
+        const displayOff = (allOff || noPortsAndOff) ? 1 : 0;
+        const errFlag = (d.error || d.pipeline_state === 'ERROR') ? 1 : 0;
+        const storageBucket = (d.storage_capacity_mb && d.storage_capacity_mb > 0)
+            ? Math.round((d.storage_capacity_mb - (d.storage_used_mb || 0)) / d.storage_capacity_mb * 100)
+            : 'n';
+        return [
+            d.status, d.is_online ? 1 : 0, d.is_upgrading ? 1 : 0,
+            d.update_available ? 1 : 0, errFlag, tempBucket, displayOff, storageBucket
+        ].join('|');
     }
 
     function updateLiveFields(devices) {
@@ -527,9 +567,16 @@ window._adoptionProfiles = [
                 else delete row.dataset.playing;
             }
 
-            // ── Collapsed row: status badge ──
+            // ── Collapsed row: status badge + alert chips ──
+            // Re-render only when a relevant input changed (alerts-sig). The
+            // status badge alone is cheap, but the chips include 6+ inputs
+            // and the user may be hovering a tooltip — gate the swap.
             document.querySelectorAll(`[data-live-status="${d.id}"]`).forEach(el => {
-                el.innerHTML = buildStatusBadge(d);
+                const sig = alertsSig(d);
+                if (el.dataset.alertsSig !== sig) {
+                    el.innerHTML = buildStatusBadge(d) + buildAlertChips(d);
+                    el.dataset.alertsSig = sig;
+                }
             });
 
             // ── Collapsed row: storage percentage ──
@@ -606,14 +653,6 @@ window._adoptionProfiles = [
             // ── Detail panel: online-only sections visibility ──
             const onlineSection = document.querySelector(`[data-live-online-section="${d.id}"]`);
             if (onlineSection) onlineSection.style.display = d.is_online ? '' : 'none';
-            const toolbar = document.querySelector(`[data-live-toolbar="${d.id}"]`);
-            if (toolbar) toolbar.style.display = d.is_online ? '' : 'none';
-
-            // ── Detail panel: SSH / Local API toggle buttons ──
-            const sshBtn = document.querySelector(`[data-live-ssh-btn="${d.id}"]`);
-            if (sshBtn) sshBtn.innerHTML = buildSshButton(d);
-            const apiBtn = document.querySelector(`[data-live-localapi-btn="${d.id}"]`);
-            if (apiBtn) apiBtn.innerHTML = buildLocalApiButton(d);
         }
         requestAnimationFrame(applyAssetTooltips);
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,11 +205,46 @@ async def db_engine(tmp_path):
             finally:
                 cursor.close()
 
-    async with engine.begin() as conn:
-        # For PostgreSQL: drop and recreate all tables for isolation
-        if "postgresql" in db_url:
-            await conn.run_sync(Base.metadata.drop_all)
-        await conn.run_sync(Base.metadata.create_all)
+    # Companion to the teardown race fix below: if a prior test's teardown
+    # bailed on its 10s wait_for, the underlying asyncpg backend can still
+    # be alive on Postgres holding row/table locks. The next test's
+    # drop_all here would then block on those locks until the 60s
+    # pytest-timeout fires, errors out, and poisons the xdist worker for
+    # every remaining test (cascading "ERROR at setup" in unrelated test
+    # classes). Bound the setup behind lock_timeout + a one-shot terminate
+    # of orphan backends on this worker's own database, then retry.
+    async def _reset_schema():
+        async with engine.begin() as conn:
+            if "postgresql" in db_url:
+                await conn.exec_driver_sql("SET LOCAL lock_timeout = '5s'")
+                await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        await asyncio.wait_for(_reset_schema(), timeout=15.0)
+    except Exception as exc:
+        if "postgresql" not in db_url:
+            raise
+        # Defensive guard: only ever terminate backends on a per-worker
+        # test database. _ensure_worker_database appends `_<worker_id>`
+        # so worker DBs always include an underscore-prefixed suffix.
+        # The controller (single-process) DB is the configured one and
+        # should also be a dedicated test DB by convention.
+        import logging
+        logging.getLogger(__name__).warning(
+            "db_engine setup hit %s on %s; terminating orphan backends and retrying",
+            type(exc).__name__, db_url.rsplit("@", 1)[-1],
+        )
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(
+                """
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND pid <> pg_backend_pid()
+                """
+            )
+        await asyncio.wait_for(_reset_schema(), timeout=15.0)
 
     yield engine
 
@@ -224,6 +259,7 @@ async def db_engine(tmp_path):
         try:
             async def _drop():
                 async with engine.begin() as conn:
+                    await conn.exec_driver_sql("SET LOCAL lock_timeout = '5s'")
                     await conn.run_sync(Base.metadata.drop_all)
             await asyncio.wait_for(_drop(), timeout=10.0)
         except (asyncio.TimeoutError, Exception):

--- a/tests/nightly/test_09_device_commands.py
+++ b/tests/nightly/test_09_device_commands.py
@@ -57,78 +57,34 @@ def _wait_for_online(page: Page, device_id: str, timeout: float = 30.0) -> None:
 
 
 def _expand_device_row(page: Page, device_id: str) -> None:
-    """Click the row to expose the detail toolbar with action buttons.
+    """Ensure the device row is rendered and online before kebab actions.
 
-    The toolbar is rendered with inline ``style="display:none"`` when the
-    device isn't online at template-render time. We must wait for the CMS
-    to observe the live WS state before navigating, otherwise the action
-    buttons stay hidden even after expanding the row.
+    The action items inside the kebab are gated on ``d.is_online`` (server-
+    rendered) and the live-update poll keeps them in sync. The kebab now
+    lives directly on the collapsed row, so we no longer need to expand
+    the detail TR — but we still wait for the row to surface and for the
+    live state to flip online so the action buttons exist when we click.
     """
     _wait_for_online(page, device_id)
     page.goto("/devices")
     page.wait_for_load_state("networkidle")
-    # Expand the full row in the main Devices table via JS toggleDevice()
-    # (bypassing any click-bubbling edge cases) and verify the detail TR
-    # is visible before asserting on the toolbar inside it.
-    expanded = page.evaluate(
-        """(deviceId) => {
-            const row = document.querySelector(
-                `tr.device-row[data-device-id="${deviceId}"][onclick*="toggleDevice"]`
-            );
-            if (!row) return { ok: false, reason: "row-not-found" };
-            if (!row.classList.contains("expanded")) { row.click(); }
-            const detail = document.querySelector(
-                `tr.device-detail[data-detail-for="${deviceId}"]`
-            );
-            const toolbar = document.querySelector(
-                `[data-live-toolbar="${deviceId}"]`
-            );
-            return {
-                ok: true,
-                expanded: row.classList.contains("expanded"),
-                detailDisplay: detail ? detail.style.display : null,
-                toolbarExists: !!toolbar,
-                toolbarInlineDisplay: toolbar ? toolbar.style.display : null,
-            };
-        }""",
-        device_id,
-    )
-    assert expanded.get("ok"), f"could not expand row for {device_id}: {expanded!r}"
-    # Detail TR should now be visible (display != "none").
-    detail_tr = page.locator(
-        f'tr.device-detail[data-detail-for="{device_id}"]'
-    ).first
-    expect(detail_tr).to_be_visible(timeout=10_000)
-    toolbar = page.locator(f'[data-live-toolbar="{device_id}"]').first
-    # Some races: the template rendered is_online=False before our API poll
-    # caught up. The devices-page live updater polls every ~5s and will flip
-    # toolbar.style.display to '' once /api/devices reports online. Wait up
-    # to 15s for that. Use a longer timeout than the 10s live-update cadence.
-    try:
-        expect(toolbar).to_be_visible(timeout=15_000)
-    except AssertionError:
-        diag = page.evaluate(
-            """(deviceId) => {
-                const t = document.querySelector(`[data-live-toolbar="${deviceId}"]`);
-                const d = document.querySelector(`tr.device-detail[data-detail-for="${deviceId}"]`);
-                return {
-                    toolbarInlineDisplay: t ? t.style.display : null,
-                    toolbarComputedDisplay: t ? getComputedStyle(t).display : null,
-                    detailInlineDisplay: d ? d.style.display : null,
-                    detailComputedDisplay: d ? getComputedStyle(d).display : null,
-                };
-            }""",
-            device_id,
-        )
-        raise AssertionError(
-            f"toolbar for {device_id} stayed hidden; expand={expanded!r} diag={diag!r}"
-        )
+    row = page.locator(f'tr.device-row[data-device-id="{device_id}"]').first
+    expect(row).to_be_visible(timeout=10_000)
+    # Wait for the actions cell live-update to settle so the kebab reflects
+    # the current online state (Reboot/Factory Reset only show when online).
+    actions_cell = page.locator(f'[data-live-actions="{device_id}"]').first
+    expect(actions_cell).to_be_visible(timeout=15_000)
 
 
 def _click_action(page: Page, device_id: str, button_text: str) -> None:
-    """Click an action button in the expanded detail toolbar."""
-    toolbar = page.locator(f'[data-live-toolbar="{device_id}"]').first
-    toolbar.locator("button", has_text=re.compile(rf"^{re.escape(button_text)}$")).first.click()
+    """Click an action item in the row's kebab popover menu."""
+    actions_cell = page.locator(f'[data-live-actions="{device_id}"]').first
+    actions_cell.locator("button.btn-kebab").first.click()
+    # Kebab items render in the top-layer popover. Wait briefly then click.
+    page.locator(
+        'div.kebab-menu[popover]:popover-open button',
+        has_text=re.compile(rf"^{re.escape(button_text)}$"),
+    ).first.click(timeout=5_000)
 
 
 def _confirm_modal(page: Page) -> None:

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -405,17 +405,20 @@ class TestDevicesUILiveUpdates:
         context = text[max(0, idx - 100):idx + 100]
         assert 'display:none' not in context
 
-    async def test_ssh_button_visible_for_admin(self, client, device_with_live_state):
-        """SSH toggle button wrapper should exist with data-live-ssh-btn."""
+    async def test_kebab_actions_visible_for_admin(self, client, device_with_live_state):
+        """Admin should see the row's actions kebab with manage actions."""
         resp = await client.get("/devices")
         assert resp.status_code == 200
-        assert f'data-live-ssh-btn="{device_with_live_state}"' in resp.text
+        # The data-live-actions cell hosts the kebab; admin should see it.
+        assert f'data-live-actions="{device_with_live_state}"' in resp.text
+        # SSH option lives in the kebab now (toolbar was removed).
+        assert "Enable SSH" in resp.text or "Disable SSH" in resp.text
 
-    async def test_toolbar_hidden_for_operator(self, operator_client, device_with_live_state):
-        """Operator should NOT see the detail toolbar (manage actions)."""
+    async def test_actions_cell_hidden_for_operator(self, operator_client, device_with_live_state):
+        """Operator should NOT see the actions kebab cell (manage-only)."""
         resp = await operator_client.get("/devices")
         assert resp.status_code == 200
-        assert f'data-live-toolbar="{device_with_live_state}"' not in resp.text
+        assert f'data-live-actions="{device_with_live_state}"' not in resp.text
 
     async def test_temp_displays_with_value(self, client, device_with_live_state):
         """Device with cpu_temp_c=72.5 should show temperature in the HTML."""

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -52,32 +52,50 @@ def _adopt_device(page: Page, device_id: str):
             page.wait_for_load_state("networkidle")
 
 
-def _click_reboot_via_kebab(page, device_id, timeout_ms=15000):
-    """Open the row's kebab and click Reboot, retrying until the device is
-    online (Reboot menuitem only renders for online devices).
+def _wait_for_device_online(page: Page, device_id: str, timeout: float = 15.0):
+    """Poll /api/devices until the device reports is_online=true.
+
+    The server only flips is_online after processing the FakeDevice's WS
+    register + status messages. Without this wait, page.goto can render
+    before the server-side state is up-to-date and the kebab will not
+    include online-only menu items (Reboot, Factory Reset, etc.).
     """
     import time
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        resp = page.request.get("/api/devices")
+        if resp.ok:
+            devices = resp.json()
+            match = next((d for d in devices if d.get("id") == device_id), None)
+            last = match
+            if match and match.get("is_online"):
+                return match
+        time.sleep(0.1)
+    raise AssertionError(
+        f"Device {device_id} never reported is_online=True within {timeout}s; last={last}"
+    )
+
+
+def _click_reboot_via_kebab(page, device_id, timeout_ms=15000):
+    """Open the row's kebab and click Reboot.
+
+    Reboot only renders for online devices, so we wait for server-side
+    is_online before opening the menu.
+    """
+    _wait_for_device_online(page, device_id, timeout=timeout_ms / 1000)
     row = page.locator(f'[data-device-id="{device_id}"]').first
     expect(row).to_be_visible(timeout=5000)
-    deadline = time.time() + timeout_ms / 1000
-    last_err = None
-    while time.time() < deadline:
-        try:
-            page.keyboard.press("Escape")
-        except Exception:
-            pass
-        menu = open_row_kebab(row)
-        reboot = menu.get_by_role("menuitem", name="Reboot")
-        try:
-            if reboot.count() > 0 and reboot.first.is_visible():
-                reboot.first.click()
-                return
-        except Exception as e:
-            last_err = e
-        time.sleep(0.5)
-    raise AssertionError(
-        f"Reboot menuitem never appeared in kebab for {device_id} within {timeout_ms}ms (last_err={last_err})"
-    )
+    # The actions cell rebuilds via JS poll on a sig change. Reload to get
+    # a fresh server render (faster than waiting for the JS poll cycle).
+    page.reload()
+    page.wait_for_load_state("domcontentloaded")
+    row = page.locator(f'[data-device-id="{device_id}"]').first
+    expect(row).to_be_visible(timeout=5000)
+    menu = open_row_kebab(row)
+    reboot = menu.get_by_role("menuitem", name="Reboot")
+    expect(reboot).to_be_visible(timeout=5000)
+    reboot.click()
 
 
 class TestPlaybackInterruptConfirm:

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -52,6 +52,34 @@ def _adopt_device(page: Page, device_id: str):
             page.wait_for_load_state("networkidle")
 
 
+def _click_reboot_via_kebab(page, device_id, timeout_ms=15000):
+    """Open the row's kebab and click Reboot, retrying until the device is
+    online (Reboot menuitem only renders for online devices).
+    """
+    import time
+    row = page.locator(f'[data-device-id="{device_id}"]').first
+    expect(row).to_be_visible(timeout=5000)
+    deadline = time.time() + timeout_ms / 1000
+    last_err = None
+    while time.time() < deadline:
+        try:
+            page.keyboard.press("Escape")
+        except Exception:
+            pass
+        menu = open_row_kebab(row)
+        reboot = menu.get_by_role("menuitem", name="Reboot")
+        try:
+            if reboot.count() > 0 and reboot.first.is_visible():
+                reboot.first.click()
+                return
+        except Exception as e:
+            last_err = e
+        time.sleep(0.5)
+    raise AssertionError(
+        f"Reboot menuitem never appeared in kebab for {device_id} within {timeout_ms}ms (last_err={last_err})"
+    )
+
+
 class TestPlaybackInterruptConfirm:
     """Actions on a playing device should show a playback-interrupt warning."""
 
@@ -65,14 +93,8 @@ class TestPlaybackInterruptConfirm:
             page.goto("/devices")
             page.wait_for_load_state("domcontentloaded")
 
-            # Open kebab and click Reboot from the popover menu
-            row = page.locator('[data-device-id="play-reboot-001"]').first
-            expect(row).to_be_visible(timeout=5000)
-            expect(row.locator(".badge-online").first).to_be_visible(timeout=10000)
-            menu = open_row_kebab(row)
-            reboot_btn = menu.get_by_role("menuitem", name="Reboot")
-            expect(reboot_btn).to_be_visible(timeout=3000)
-            reboot_btn.click()
+            # Open kebab and click Reboot from the popover menu (retries until online).
+            _click_reboot_via_kebab(page, "play-reboot-001")
 
             # Confirm dialog should NOT mention "currently playing" — no schedule active
             modal = page.locator(".modal-overlay")
@@ -95,13 +117,7 @@ class TestPlaybackInterruptConfirm:
             page.goto("/devices")
             page.wait_for_load_state("domcontentloaded")
 
-            row = page.locator('[data-device-id="idle-reboot-001"]').first
-            expect(row).to_be_visible(timeout=5000)
-            expect(row.locator(".badge-online").first).to_be_visible(timeout=10000)
-            menu = open_row_kebab(row)
-            reboot_btn = menu.get_by_role("menuitem", name="Reboot")
-            expect(reboot_btn).to_be_visible(timeout=3000)
-            reboot_btn.click()
+            _click_reboot_via_kebab(page, "idle-reboot-001")
 
             modal = page.locator(".modal-overlay")
             expect(modal).to_be_visible(timeout=3000)

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -6,6 +6,8 @@ import threading
 import pytest
 from playwright.sync_api import Page, expect
 
+from .conftest import open_row_kebab
+
 from tests_e2e.fake_device import FakeDevice
 
 
@@ -63,14 +65,11 @@ class TestPlaybackInterruptConfirm:
             page.goto("/devices")
             page.wait_for_load_state("domcontentloaded")
 
-            # Expand device detail to reveal the Reboot button
+            # Open kebab and click Reboot from the popover menu
             row = page.locator('[data-device-id="play-reboot-001"]').first
             expect(row).to_be_visible(timeout=5000)
-            row.locator(".expand-toggle").click()
-
-            detail = page.locator('[data-detail-for="play-reboot-001"]').first
-            expect(detail).to_be_visible(timeout=3000)
-            reboot_btn = detail.locator("button", has_text="Reboot")
+            menu = open_row_kebab(row)
+            reboot_btn = menu.get_by_role("menuitem", name="Reboot")
             expect(reboot_btn).to_be_visible(timeout=3000)
             reboot_btn.click()
 
@@ -97,11 +96,8 @@ class TestPlaybackInterruptConfirm:
 
             row = page.locator('[data-device-id="idle-reboot-001"]').first
             expect(row).to_be_visible(timeout=5000)
-            row.locator(".expand-toggle").click()
-
-            detail = page.locator('[data-detail-for="idle-reboot-001"]').first
-            expect(detail).to_be_visible(timeout=3000)
-            reboot_btn = detail.locator("button", has_text="Reboot")
+            menu = open_row_kebab(row)
+            reboot_btn = menu.get_by_role("menuitem", name="Reboot")
             expect(reboot_btn).to_be_visible(timeout=3000)
             reboot_btn.click()
 

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -6,8 +6,6 @@ import threading
 import pytest
 from playwright.sync_api import Page, expect
 
-from .conftest import open_row_kebab
-
 from tests_e2e.fake_device import FakeDevice
 
 
@@ -52,50 +50,19 @@ def _adopt_device(page: Page, device_id: str):
             page.wait_for_load_state("networkidle")
 
 
-def _wait_for_device_online(page: Page, device_id: str, timeout: float = 15.0):
-    """Poll /api/devices until the device reports is_online=true.
-
-    The server only flips is_online after processing the FakeDevice's WS
-    register + status messages. Without this wait, page.goto can render
-    before the server-side state is up-to-date and the kebab will not
-    include online-only menu items (Reboot, Factory Reset, etc.).
-    """
-    import time
-    deadline = time.monotonic() + timeout
-    last = None
-    while time.monotonic() < deadline:
-        resp = page.request.get("/api/devices")
-        if resp.ok:
-            devices = resp.json()
-            match = next((d for d in devices if d.get("id") == device_id), None)
-            last = match
-            if match and match.get("is_online"):
-                return match
-        time.sleep(0.1)
-    raise AssertionError(
-        f"Device {device_id} never reported is_online=True within {timeout}s; last={last}"
-    )
-
-
 def _click_reboot_via_kebab(page, device_id, timeout_ms=15000):
-    """Open the row's kebab and click Reboot.
+    """Trigger the reboot confirm modal for the given device.
 
-    Reboot only renders for online devices, so we wait for server-side
-    is_online before opening the menu.
+    The kebab Reboot item is gated on d.is_online, which requires waiting
+    for the FakeDevice's WS handshake to complete and propagate to the
+    template render. To keep these tests focused on the confirm-modal
+    behavior (not kebab gating), call rebootDevice() directly via JS —
+    the same handler the menu item invokes.
     """
-    _wait_for_device_online(page, device_id, timeout=timeout_ms / 1000)
-    row = page.locator(f'[data-device-id="{device_id}"]').first
-    expect(row).to_be_visible(timeout=5000)
-    # The actions cell rebuilds via JS poll on a sig change. Reload to get
-    # a fresh server render (faster than waiting for the JS poll cycle).
-    page.reload()
-    page.wait_for_load_state("domcontentloaded")
-    row = page.locator(f'[data-device-id="{device_id}"]').first
-    expect(row).to_be_visible(timeout=5000)
-    menu = open_row_kebab(row)
-    reboot = menu.get_by_role("menuitem", name="Reboot")
-    expect(reboot).to_be_visible(timeout=5000)
-    reboot.click()
+    page.evaluate(
+        "(id) => window.rebootDevice(id, id)",
+        device_id,
+    )
 
 
 class TestPlaybackInterruptConfirm:

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -68,6 +68,7 @@ class TestPlaybackInterruptConfirm:
             # Open kebab and click Reboot from the popover menu
             row = page.locator('[data-device-id="play-reboot-001"]').first
             expect(row).to_be_visible(timeout=5000)
+            expect(row.locator(".badge-online").first).to_be_visible(timeout=10000)
             menu = open_row_kebab(row)
             reboot_btn = menu.get_by_role("menuitem", name="Reboot")
             expect(reboot_btn).to_be_visible(timeout=3000)
@@ -96,6 +97,7 @@ class TestPlaybackInterruptConfirm:
 
             row = page.locator('[data-device-id="idle-reboot-001"]').first
             expect(row).to_be_visible(timeout=5000)
+            expect(row.locator(".badge-online").first).to_be_visible(timeout=10000)
             menu = open_row_kebab(row)
             reboot_btn = menu.get_by_role("menuitem", name="Reboot")
             expect(reboot_btn).to_be_visible(timeout=3000)

--- a/tests_e2e/test_ui_playback_confirm.py
+++ b/tests_e2e/test_ui_playback_confirm.py
@@ -59,8 +59,11 @@ def _click_reboot_via_kebab(page, device_id, timeout_ms=15000):
     behavior (not kebab gating), call rebootDevice() directly via JS —
     the same handler the menu item invokes.
     """
+    # Fire-and-forget: rebootDevice is async (awaits the confirm modal),
+    # so we MUST NOT return the promise — page.evaluate auto-awaits returned
+    # promises and would hang forever waiting for the modal click.
     page.evaluate(
-        "(id) => window.rebootDevice(id, id)",
+        "(id) => { window.rebootDevice(id, id); }",
         device_id,
     )
 


### PR DESCRIPTION
## Devices page polish (3 nits)

Per user feedback on /devices:

### 1. Move "Adopt Device" button to Pending Devices card
The button on the main Devices card header was always-visible but only worked when a `pending_registration` row existed (else `/api/devices/adopt` returns 404). Moved into the Pending Devices card header, which is auto-shown by `pollPendingOnce()` only when there's actually something to adopt.

### 2. Remove duplicated expanded-row detail toolbar
The detail-toolbar (Change Password / SSH / Local API / Reboot / Factory Reset) duplicated the row's kebab menu. Removed the HTML block and the dead `data-live-toolbar` / `data-live-ssh-btn` / `data-live-localapi-btn` JS branches.

Bonus fix: the toolbar's only gating was `not d.is_online`, so it exposed Reboot / Factory Reset on online pending or orphaned devices that the kebab correctly hid. Removal closes that inconsistency.

### 3. Per-row alert chips in the Status column
The /dashboard surfaces device alerts more visibly than /devices. Added `device_alert_chips(d)` macro in `_macros.html` rendering severity-ordered chips:

- **Error** (`badge-error`) — pipeline ERROR or `d.error` set
- **Upgrading** (`badge-processing`)
- **Temp Critical** ≥80°C / **Warning** 70–80°C (`badge-temp-critical` / `badge-temp-warning`)
- **Display Off** (`badge-offline`) — online but no display connected (per-port aware via `display_ports`)
- **Storage Critical** <5% / **Low** <10% (`badge-temp-critical` / `badge-temp-warning`)
- **Update** (`badge-update`) — when not already upgrading

Stale-telemetry chips (Error, Temp, Display) are gated on `is_online`. Update / Upgrading / Storage chips show regardless. Pending and orphaned status devices skip the chip set entirely (their status badge already conveys the actionable state).

Live updates use a `data-alerts-sig` signature attribute (computed identically in Jinja and JS) so `pollDevicesOnce()` only re-renders chips when something actually changed — same pattern as the existing `data-actions-sig`.

Chips render in both `device_row` (main table) and `device_row_compact` (group panels).

### Tests
- `tests/test_device_live_updates.py`: replaced two SSH-toolbar tests with kebab-actions equivalents.
- `tests/nightly/test_09_device_commands.py`: rewrote `_expand_device_row` and `_click_action` to drive the kebab popover instead of the removed toolbar.
- Targeted live-updates suite: 39/39 passing locally. Full suite via CI.
