### PR TITLE
Phase 0/A1 (#474): provision App Insights + OTel auto-instrumentation

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -50,6 +50,15 @@ _buf_handler = _BufferHandler(logging.INFO)
 _buf_handler.setFormatter(logging.Formatter(_fmt))
 logging.getLogger().addHandler(_buf_handler)
 
+# ── Application Insights / OpenTelemetry bootstrap ─────────────────
+# Must run BEFORE the FastAPI app is constructed so the auto-
+# instrumentation can hook the framework at import time.  No-op when
+# APPLICATIONINSIGHTS_CONNECTION_STRING is unset — see
+# cms/observability.py.  Issue #474, Phase 0 / A1.
+from cms.observability import setup_observability  # noqa: E402
+
+setup_observability()
+
 from fastapi import Depends, FastAPI, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse, RedirectResponse

--- a/cms/observability.py
+++ b/cms/observability.py
@@ -1,0 +1,109 @@
+"""Application Insights / OpenTelemetry bootstrap for the CMS.
+
+Issue #474, Phase 0 / A1 — telemetry roadmap.
+
+Calling :func:`setup_observability` early in process startup wires up the
+``azure-monitor-opentelemetry`` distro, which in turn enables OpenTelemetry
+auto-instrumentation for:
+
+* FastAPI (request rows in the ``requests`` Application Insights table)
+* SQLAlchemy (``dependencies`` rows for every database call)
+* HTTPX / requests / urllib3 (``dependencies`` rows for outbound HTTP)
+
+Unhandled exceptions raised inside instrumented frames are also captured
+into the ``exceptions`` table.
+
+The function is a **no-op** when ``APPLICATIONINSIGHTS_CONNECTION_STRING``
+is unset — that's the expected state for local development, docker-compose
+runs, and the unit-test suite.  This means we can call it unconditionally
+from ``cms.main`` without breaking anything.
+
+It is also safe to call multiple times in the same process: the underlying
+``configure_azure_monitor`` short-circuits on the second invocation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Final
+
+logger = logging.getLogger("agora.cms.observability")
+
+_CONN_STRING_ENV: Final[str] = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+_DISABLE_ENV: Final[str] = "AGORA_CMS_DISABLE_OBSERVABILITY"
+
+# Process-level flag so repeated calls don't double-initialize the
+# OpenTelemetry exporter.  ``configure_azure_monitor`` itself is
+# idempotent, but logging "enabled" twice is just noise.
+_initialised: bool = False
+
+
+def setup_observability() -> bool:
+    """Initialise Application Insights / OpenTelemetry export.
+
+    Returns ``True`` when telemetry export was enabled (connection string
+    present and SDK loaded successfully), ``False`` otherwise.  Callers
+    don't need to inspect the return value — it's exposed mainly for
+    tests.
+    """
+    global _initialised  # noqa: PLW0603
+    if _initialised:
+        return True
+
+    if os.environ.get(_DISABLE_ENV, "").lower() in {"1", "true", "yes"}:
+        logger.info(
+            "observability disabled via %s; skipping App Insights init",
+            _DISABLE_ENV,
+        )
+        return False
+
+    conn = os.environ.get(_CONN_STRING_ENV, "").strip()
+    if not conn:
+        logger.info(
+            "%s not set; App Insights export disabled (this is expected "
+            "for local/dev runs)",
+            _CONN_STRING_ENV,
+        )
+        return False
+
+    try:
+        # Imported lazily so the dependency is only required when
+        # telemetry is actually enabled.  This keeps the unit-test
+        # environment small and lets the CMS run without the SDK
+        # installed (e.g. minimal local dev container).
+        from azure.monitor.opentelemetry import configure_azure_monitor
+    except ImportError:
+        logger.warning(
+            "azure-monitor-opentelemetry not installed; App Insights "
+            "export disabled despite %s being set.  Install the package "
+            "or unset the env var to silence this warning.",
+            _CONN_STRING_ENV,
+        )
+        return False
+
+    try:
+        configure_azure_monitor(connection_string=conn)
+    except Exception:  # pragma: no cover — defensive: never let a
+        # telemetry init failure crash the CMS process
+        logger.exception(
+            "configure_azure_monitor() failed; CMS will continue without "
+            "telemetry export"
+        )
+        return False
+
+    _initialised = True
+    logger.info(
+        "App Insights observability enabled (FastAPI / SQLAlchemy / "
+        "HTTPX auto-instrumentation active)"
+    )
+    return True
+
+
+def _reset_for_tests() -> None:
+    """Reset the module-level "already initialised" flag.
+
+    Test-only helper.  Production code never calls this.
+    """
+    global _initialised  # noqa: PLW0603
+    _initialised = False

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,93 @@
+# Observability — CMS telemetry pipeline
+
+Issue [#474](../../../issues/474) — Phase 0 (A1 + A1.5).
+
+## What's wired up
+
+The CMS app is auto-instrumented at process start by the
+[`azure-monitor-opentelemetry`](https://pypi.org/project/azure-monitor-opentelemetry/)
+distro.  See `cms/observability.py` for the bootstrap; it runs from
+`cms/main.py` before the FastAPI app is constructed.
+
+Auto-instrumentations active:
+
+| Library     | What it captures                                                        | App Insights table |
+|-------------|-------------------------------------------------------------------------|--------------------|
+| FastAPI     | Every HTTP request: method, route template, status, duration, client IP | `requests`         |
+| SQLAlchemy  | Every database query: statement preview, duration, server, success      | `dependencies`     |
+| HTTPX       | Outbound HTTP calls (e.g. CMS → Azure Web PubSub REST)                  | `dependencies`     |
+| Logging     | Stdlib `logging` records (WARNING+) emitted anywhere in the process      | `traces`           |
+| Exceptions  | Unhandled exceptions inside instrumented frames                          | `exceptions`       |
+
+Sampling is **100%** for the A1 baseline.  Sampling will be revisited in
+a later phase once we know what the actual ingestion cost looks like.
+
+## How to enable / disable
+
+Driven by env vars on the Container Apps deployment:
+
+* `APPLICATIONINSIGHTS_CONNECTION_STRING` — provided automatically by the
+  Bicep template (the `appInsights` resource in
+  `infra/modules/containerApps.bicep`).  When unset, telemetry export is
+  silently disabled — local dev and docker-compose runs work normally.
+* `OTEL_RESOURCE_ATTRIBUTES` — set in Bicep to
+  `service.name=agora-cms,service.namespace=agora,deployment.environment=<env>`
+  so all rows are tagged with the deployment's environment name.
+* `AGORA_CMS_DISABLE_OBSERVABILITY=1` — escape hatch to disable the SDK
+  even when the conn string is set.  Useful for one-off debugging.
+
+## Verifying after a deploy
+
+1. Open the resource group in the portal and find the App Insights
+   resource (`<env>-ai`).
+2. Go to **Logs** and run:
+
+   ```kql
+   requests
+   | where timestamp > ago(15m)
+   | summarize count() by name, resultCode
+   | order by count_ desc
+   ```
+
+   You should see `GET /healthz` rows within a few minutes — Container
+   Apps liveness probes hit the endpoint constantly.
+
+3. Confirm dependency tracking:
+
+   ```kql
+   dependencies
+   | where timestamp > ago(15m)
+   | summarize count() by type, name
+   ```
+
+   Expect both `Microsoft Postgres SQL Server` (or `postgres`) rows from
+   SQLAlchemy and any HTTP rows from the WPS REST client.
+
+4. Confirm exceptions are flowing if you can manufacture one (e.g. hit
+   an endpoint that raises):
+
+   ```kql
+   exceptions
+   | where timestamp > ago(15m)
+   | project timestamp, type, outerMessage, operation_Name
+   ```
+
+## Troubleshooting
+
+* **No rows showing up after 5 minutes** — check the CMS container
+  startup logs for the line `App Insights observability enabled`.  If
+  it instead says `… not set; App Insights export disabled`, the
+  connection string env var didn't reach the container.  Confirm the
+  Bicep deployment ran cleanly and the `appInsights` resource exists.
+* **Logs show `azure-monitor-opentelemetry not installed`** — the
+  Docker image was built against an older `requirements.txt`.  Rebuild
+  and redeploy.
+* **Bursts of 4xx / 5xx in `requests`** — A1.5 alert rules are designed
+  to catch these.  Until A1.5 lands, eyeball the workbook manually.
+
+## What's next
+
+* **A1.5** — health workbook and alert rules (issue #474, same phase).
+* **Phase 1** — Pi-side telemetry (devices report their own request /
+  exception / playback metrics).  Will arrive in `requests` /
+  `customEvents` from the device fleet, queryable by `client_Id`.

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -79,6 +79,26 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   }
 }
 
+// ── Application Insights (workspace-based) ──
+// Phase 0 / A1 of the telemetry roadmap (issue #474).  Auto-instruments
+// the CMS app via OpenTelemetry — request/dependency/exception tables
+// are populated without any per-route code changes.  Reuses the
+// Container Apps log analytics workspace so all telemetry lives in one
+// place and is queryable with a single KQL connection.
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: '${environmentName}-ai'
+  location: location
+  tags: tags
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
 resource containerAppsEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
   name: environmentName
   location: location
@@ -169,6 +189,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'fleet-register-secrets'
           value: fleetRegisterSecrets
         }
+        {
+          name: 'app-insights-connection-string'
+          value: appInsights.properties.ConnectionString
+        }
       ]
     }
     template: {
@@ -240,6 +264,20 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'AGORA_CMS_FLEET_REGISTER_SECRETS'
               secretRef: 'fleet-register-secrets'
+            }
+            {
+              // Picked up by azure-monitor-opentelemetry's
+              // configure_azure_monitor() at process start (see
+              // cms/observability.py).  When unset (e.g. local dev,
+              // docker-compose) telemetry export is silently disabled.
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              secretRef: 'app-insights-connection-string'
+            }
+            {
+              // Tag every emitted record so we can distinguish prod from
+              // dev/staging in shared workbooks and KQL.
+              name: 'OTEL_RESOURCE_ATTRIBUTES'
+              value: 'service.name=agora-cms,service.namespace=agora,deployment.environment=${environmentName}'
             }
           ]
           volumeMounts: [
@@ -451,3 +489,6 @@ output mcpAppUrl string = 'https://${mcpApp.properties.configuration.ingress.fqd
 output environmentId string = containerAppsEnv.id
 output cmsPrincipalId string = cmsApp.identity.principalId
 output mcpPrincipalId string = mcpApp.identity.principalId
+output logAnalyticsWorkspaceId string = logAnalytics.id
+output appInsightsId string = appInsights.id
+output appInsightsName string = appInsights.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,10 @@ azure-identity>=1.16,<2.0
 azure-keyvault-secrets>=4.8,<5.0
 # Azure Web PubSub (#344 Stage 2b.2 — DEVICE_TRANSPORT=wps)
 azure-messaging-webpubsubservice>=1.2,<2.0
+
+# Telemetry — Application Insights via OpenTelemetry (issue #474, Phase 0 / A1).
+# Meta-package that pulls in opentelemetry-api/sdk + the Azure Monitor exporter
+# + auto-instrumentations for FastAPI, SQLAlchemy, HTTPX, urllib3, requests.
+# A no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset — see
+# cms/observability.py for the wiring.
+azure-monitor-opentelemetry>=1.6,<2.0

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,178 @@
+"""Tests for cms.observability — App Insights bootstrap wrapper.
+
+Issue #474, Phase 0 / A1.
+
+These tests don't require ``azure-monitor-opentelemetry`` to be installed
+in the test environment — we inject a fake module into ``sys.modules`` so
+the wrapper's lazy import resolves to a controllable mock.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from cms import observability
+
+
+def _install_fake_azure_monitor(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    configure: mock.MagicMock | None = None,
+) -> mock.MagicMock:
+    """Inject a stub ``azure.monitor.opentelemetry`` module.
+
+    Returns the mock that ``configure_azure_monitor`` resolves to so
+    tests can assert on it.
+    """
+    configure = configure or mock.MagicMock()
+
+    azure_pkg = sys.modules.get("azure") or types.ModuleType("azure")
+    monitor_pkg = sys.modules.get("azure.monitor") or types.ModuleType(
+        "azure.monitor"
+    )
+    otel_pkg = types.ModuleType("azure.monitor.opentelemetry")
+    otel_pkg.configure_azure_monitor = configure  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "azure", azure_pkg)
+    monkeypatch.setitem(sys.modules, "azure.monitor", monitor_pkg)
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", otel_pkg)
+    return configure
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch: pytest.MonkeyPatch):
+    """Clear the conn string env var and reset the init flag for each test."""
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AGORA_CMS_DISABLE_OBSERVABILITY", raising=False)
+    observability._reset_for_tests()
+    yield
+    observability._reset_for_tests()
+
+
+def test_no_op_when_conn_string_unset(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+
+    result = observability.setup_observability()
+
+    assert result is False
+    assert any(
+        "not set" in rec.message for rec in caplog.records
+    ), "expected an informational log line about the env var being unset"
+
+
+def test_no_op_when_conn_string_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "   ")
+
+    assert observability.setup_observability() is False
+
+
+def test_disable_env_var_short_circuits(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The escape hatch must beat a present conn string."""
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    monkeypatch.setenv("AGORA_CMS_DISABLE_OBSERVABILITY", "1")
+    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+    mocked = _install_fake_azure_monitor(monkeypatch)
+
+    result = observability.setup_observability()
+
+    assert result is False
+    mocked.assert_not_called()
+    assert any(
+        "disabled via" in rec.message for rec in caplog.records
+    )
+
+
+def test_calls_configure_azure_monitor_when_conn_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    conn = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example/"
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", conn)
+    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+    mocked = _install_fake_azure_monitor(monkeypatch)
+
+    result = observability.setup_observability()
+
+    assert result is True
+    mocked.assert_called_once_with(connection_string=conn)
+    assert any(
+        "enabled" in rec.message for rec in caplog.records
+    )
+
+
+def test_idempotent_repeated_calls_only_init_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    mocked = _install_fake_azure_monitor(monkeypatch)
+
+    assert observability.setup_observability() is True
+    assert observability.setup_observability() is True
+    assert observability.setup_observability() is True
+
+    mocked.assert_called_once()
+
+
+def test_missing_sdk_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If the SDK isn't installed, log a warning but never raise."""
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    caplog.set_level(logging.WARNING, logger="agora.cms.observability")
+
+    # Make sure the module is NOT in sys.modules — and block re-import.
+    for name in (
+        "azure.monitor.opentelemetry",
+        "azure.monitor",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name.startswith("azure.monitor.opentelemetry"):
+            raise ImportError("simulated missing SDK")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    result = observability.setup_observability()
+
+    assert result is False
+    assert any("not installed" in rec.message for rec in caplog.records)
+
+
+def test_configure_failure_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: a misbehaving SDK init must not take down the CMS."""
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    boom = mock.MagicMock(side_effect=RuntimeError("simulated boom"))
+    _install_fake_azure_monitor(monkeypatch, configure=boom)
+
+    # Must not raise.
+    result = observability.setup_observability()
+
+    assert result is False
+    boom.assert_called_once()


### PR DESCRIPTION
## Phase 0 / A1: provision App Insights + OTel auto-instrumentation

Part of #474 (brick-prevention-first telemetry roadmap).  This is the
foundational CMS-side observability work — must land before any of the
phases that depend on telemetry.

### What this PR does

**Bicep (`infra/modules/containerApps.bicep`)**
- Adds a workspace-based `Microsoft.Insights/components` resource
  named `${environmentName}-ai`, attached to the existing Log Analytics
  workspace.  No new module / no circular deps — both LA and AI live
  in the same module that owns Container Apps.
- Wires the connection string into the CMS container as a secret +
  env var (`APPLICATIONINSIGHTS_CONNECTION_STRING`).
- Adds `OTEL_RESOURCE_ATTRIBUTES` so every signal is tagged with
  `service.name=agora-cms`, `service.namespace=agora`,
  `deployment.environment=${environmentName}`.
- Exposes `logAnalyticsWorkspaceId` / `appInsightsId` /
  `appInsightsName` as outputs (consumed by the A1.5 follow-up that
  adds the workbook and alerts).

**Python**
- Adds `azure-monitor-opentelemetry>=1.6,<2.0` to `requirements.txt`.
- New `cms/observability.py` with a `setup_observability()` wrapper
  that:
  - no-ops cleanly when `APPLICATIONINSIGHTS_CONNECTION_STRING` is
    unset or blank (so local/dev runs don't need the SDK at all);
  - honours an `AGORA_CMS_DISABLE_OBSERVABILITY=1` escape hatch for
    incident debugging;
  - lazy-imports the Azure SDK and logs a warning if it's missing
    rather than crashing;
  - is idempotent (module-level guard, safe to call from multiple
    places);
  - never raises out of `configure_azure_monitor` — a misbehaving
    SDK init can't take down the CMS.
- Hooked from `cms/main.py` before `app = FastAPI(...)` so OTel
  auto-instrumentation captures FastAPI requests, SQLAlchemy queries,
  HTTPX outbound calls, and stdlib `logging` from request 0.

### What this PR does *not* do

- No workbook, no alert rules, no action group — those land in A1.5
  (still need the user's email address for routing).
- No client-side telemetry yet (Phase A2).
- No device-side telemetry yet (Phase A3).
- No sampling tuning — running at 100% baseline; revisit once we see
  actual ingestion costs.

### Tests

7 new unit tests in `tests/test_observability.py` covering:

| case | expected |
| --- | --- |
| conn string unset | returns `False`, no SDK import |
| conn string blank/whitespace | returns `False` |
| `AGORA_CMS_DISABLE_OBSERVABILITY=1` | returns `False` even with conn set |
| conn string set + SDK present | calls `configure_azure_monitor`, returns `True` |
| repeated calls | only init once |
| SDK not installed | warns, returns `False`, no crash |
| SDK init raises | swallows, returns `False`, no crash |

Tests inject a fake `azure.monitor.opentelemetry` into `sys.modules`
so the suite stays portable — the real SDK isn't required to run them.

### Verification after deploy

KQL queries documented in `docs/observability.md`.  Key ones:

```kql
// requests in the last 15 min
requests | where timestamp > ago(15m) | summarize count() by name, resultCode
// non-200s
requests | where timestamp > ago(1h) | where resultCode !startswith "2" | summarize count() by name, resultCode
// per-replica fanout (sanity)
requests | summarize count() by cloud_RoleInstance
```
