### PR TITLE
infra: source alertEmail from GH repo var ALERT_EMAIL

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -210,7 +210,8 @@ jobs:
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \
               mcpImage="$MCP_REF" \
-              workerImage="$WORKER_REF"
+              workerImage="$WORKER_REF" \
+              alertEmail='${{ vars.ALERT_EMAIL }}'
 
       - name: Bind custom domains (if configured)
         if: vars.CMS_CUSTOM_DOMAIN != '' || vars.MCP_CUSTOM_DOMAIN != ''

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -88,13 +88,13 @@ Driven by env vars on the Container Apps deployment:
 ## Alerts and workbook (A1.5)
 
 Provisioned by `infra/modules/alerts.bicep` and wired in from
-`infra/main.bicep`.  Recipient is set per-environment via the
-`alertEmail` bicepparam; production currently goes to
-`sslivins+agora_alerts@gmail.com`.  Setting `alertEmail` to an empty
-string in a `.bicepparam` disables the action group and all alert
-rules, useful for short-lived dev environments.  The workbook is
-always provisioned regardless of `alertEmail` so dashboards remain
-available even when paging is off.
+`infra/main.bicep`.  Recipient is supplied by the CD pipeline from the
+GitHub repo variable `ALERT_EMAIL` and forwarded to the bicep
+`alertEmail` parameter; the address itself is **not** committed to
+this repo.  Setting `ALERT_EMAIL` to an empty string disables the
+action group and all alert rules, useful for short-lived dev
+environments.  The workbook is always provisioned regardless of
+`alertEmail` so dashboards remain available even when paging is off.
 
 The five alert rules all query the workspace-based App Insights tables
 (`AppRequests`, `AppDependencies`, `AppExceptions`).  Signal-based

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -17,9 +17,9 @@ param cmsAdminUsername = 'admin'
 
 param adminPrincipalId = '224d9903-ad74-4629-982b-1db94580d901'
 
-// Telemetry alert recipient (Phase 0 / A1.5 — issue #474). Same address as
-// prod for now; flip to a dev-only alias if dev starts paging too much.
-param alertEmail = 'sslivins+agora_alerts@gmail.com'
+// Telemetry alert recipient (Phase 0 / A1.5 — issue #474) is supplied by the
+// CD pipeline from the GitHub repo variable ALERT_EMAIL. Leave the default
+// empty here so we don't commit a routable address.
 
 // Use smaller resources for dev
 param cmsCpu = '0.5'

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -29,8 +29,9 @@ param cmsAdminUsername = 'admin'
 
 param adminPrincipalId = '224d9903-ad74-4629-982b-1db94580d901'
 
-// Telemetry alert recipient (Phase 0 / A1.5 — issue #474)
-param alertEmail = 'sslivins+agora_alerts@gmail.com'
+// Telemetry alert recipient (Phase 0 / A1.5 — issue #474) is supplied by the
+// CD pipeline from the GitHub repo variable ALERT_EMAIL. Leave the default
+// empty here so we don't commit a routable address.
 
 // Container images — set by CD pipeline via --parameters override:
 // param cmsImage = 'agoracmsacr.azurecr.io/agora-cms:latest'


### PR DESCRIPTION
## Summary

A1.5 alerts shipped silently disabled. `publish-image.yml` passes
parameters inline and never references `infra/parameters/*.bicepparam`,
so `alertEmail` defaulted to `''` in `main.bicep`, which makes
`alertsEnabled = !empty(alertEmail)` in `alerts.bicep` evaluate
false — gating off the action group and all five scheduled-query
rules. Only the unconditional workbook resource landed in prod.

## Fix

Source the recipient from the GitHub repo variable `ALERT_EMAIL`
instead of committing it to a bicepparam:

- Drop `param alertEmail = '...'` from `infra/parameters/dev.bicepparam`
  and `prod.bicepparam`.
- Add `alertEmail='${{ vars.ALERT_EMAIL }}'` to the inline
  `--parameters` block in `.github/workflows/publish-image.yml`,
  matching how `AZURE_RESOURCE_GROUP` / `INFRA_PREFIX` are already
  plumbed via `vars.*`.
- Update `docs/observability.md` to describe the new sourcing.

The repo variable `ALERT_EMAIL` has already been set on
`sslivins/agora-cms` to the same address that was previously hard-coded.

## Verification (post-deploy)

```
az monitor action-group list -g agoracms-cms-rg
# expect: agora-cms-alerts (plus pre-existing Smart Detection)
az monitor scheduled-query list -g agoracms-cms-rg
# expect: 5 rules
```

Refs #474.
