### PR TITLE
feat(devices): fleet-scale triage bar + dashboard rework (Phases A-D)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -997,6 +997,7 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
         d.ssh_enabled = state["ssh_enabled"] if state else None
         d.local_api_enabled = state["local_api_enabled"] if state else None
         d.update_available = is_update_available(d.firmware_version)
+        d.is_upgrading = _is_upgrading(d)
         d.has_active_schedule = False  # poller will flip this via updateLiveFields
 
     # Splash-screen dropdown options need the same ready annotations ui.py
@@ -1043,8 +1044,8 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     timezones = COMMON_TIMEZONES
 
     for d in group.devices:
-        d.severity_tags = device_severity_tags(d)
-    group.rollup = fleet_counts(group.devices)
+        d.severity_tags = device_severity_tags(d, user_perms)
+    group.rollup = fleet_counts(group.devices, user_perms)
 
     macros = templates.env.get_template("_macros.html").module
     html = macros.group_panel(

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -1030,8 +1030,27 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     user_perms = list(user.role.permissions) if user and user.role else []
     pending_ttl_hours = get_settings().pending_device_ttl_hours
 
+    # Phase C: rich device_row needs profiles, latest_version, timezones, and
+    # per-device severity_tags + per-group rollup.
+    from cms.models.device_profile import DeviceProfile
+    from cms.services.version_checker import get_latest_device_version
+    from cms.services.device_alerts import device_severity_tags, fleet_counts
+    from cms.ui import COMMON_TIMEZONES
+
+    profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
+    profiles = profiles_q.scalars().all()
+    latest_version = get_latest_device_version()
+    timezones = COMMON_TIMEZONES
+
+    for d in group.devices:
+        d.severity_tags = device_severity_tags(d)
+    group.rollup = fleet_counts(group.devices)
+
     macros = templates.env.get_template("_macros.html").module
-    html = macros.group_panel(group, user_perms, assets, visible_groups, pending_ttl_hours)
+    html = macros.group_panel(
+        group, user_perms, assets, visible_groups, pending_ttl_hours,
+        profiles, latest_version, timezones,
+    )
     return HTMLResponse(str(html))
 
 

--- a/cms/services/device_alerts.py
+++ b/cms/services/device_alerts.py
@@ -1,0 +1,170 @@
+"""Severity tag derivation for the /devices triage bar.
+
+The /devices page renders per-row alert chips via the
+``device_alert_chips`` Jinja macro. As a fleet grows beyond a handful
+of devices, those chips become noise — operators need a top-of-page
+triage bar that summarizes "what's broken right now" and lets them
+filter the list.
+
+This module is the **single source of truth** for the severity
+taxonomy. Both the triage bar (counts + filter) and the per-row
+``data-severity-tags`` attribute that drives client-side filtering
+derive their tags from :func:`device_severity_tags`.
+
+The chip-rendering macro intentionally stays in Jinja for now (its
+inline tooltips and value formatting are template-shaped); a unit
+test asserts the two layers agree on which tags fire for a given
+device state, so drift is detectable.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+# Public severity tags. The triage bar renders one chip per tag (plus
+# the synthetic "all", "needs-attention", and "healthy" buckets which
+# are derived from these). Order matches highest-severity-first for
+# any future "primary tag" ranking.
+SEVERITY_TAGS: tuple[str, ...] = (
+    "error",
+    "offline",
+    "display-off",
+    "storage-critical",
+    "orphaned",
+    "maintenance",
+)
+
+
+# Tags that compose the "Needs Attention" filter. Storage Low is
+# intentionally excluded (Critical is the actionable threshold);
+# Maintenance is intentionally excluded (it's informational, not an
+# outage).
+NEEDS_ATTENTION_TAGS: frozenset[str] = frozenset({
+    "error",
+    "offline",
+    "display-off",
+    "storage-critical",
+    "orphaned",
+})
+
+
+def _is_display_off(d) -> bool:
+    """Mirror the macro logic for "no display detected".
+
+    True only when the device is online (offline display state is
+    stale) AND either every reported display port is disconnected, or
+    the legacy boolean ``display_connected`` is explicitly False with
+    no port list.
+    """
+    if not getattr(d, "is_online", False):
+        return False
+    ports = getattr(d, "display_ports", None) or []
+    if ports:
+        # All ports unplugged.
+        return all(not p.get("connected") for p in ports)
+    # Legacy single-port path.
+    return getattr(d, "display_connected", None) is False
+
+
+def _free_storage_pct(d) -> float | None:
+    cap = getattr(d, "storage_capacity_mb", None) or 0
+    if cap <= 0:
+        return None
+    used = getattr(d, "storage_used_mb", None) or 0
+    return (cap - used) / cap * 100.0
+
+
+def device_severity_tags(d) -> list[str]:
+    """Return the severity tags that apply to a single device.
+
+    Tags returned (subset of :data:`SEVERITY_TAGS`):
+
+    - ``error`` — online + (``error`` set or ``pipeline_state == 'ERROR'``)
+    - ``offline`` — adopted device whose websocket is disconnected
+    - ``display-off`` — online + every display port unplugged
+    - ``storage-critical`` — < 5% free
+    - ``orphaned`` — re-flashed device awaiting re-adoption
+    - ``maintenance`` — firmware update available or upgrade in progress
+
+    Pending devices are intentionally excluded from every tag — they
+    aren't operational yet and live in their own card.
+    """
+    status = getattr(getattr(d, "status", None), "value", None)
+    if status == "pending":
+        return []
+
+    tags: list[str] = []
+
+    if status == "orphaned":
+        tags.append("orphaned")
+        # Orphaned devices have no live telemetry worth surfacing as
+        # additional tags; the orphaned state subsumes them.
+        return tags
+
+    is_online = getattr(d, "is_online", False)
+
+    if is_online:
+        if getattr(d, "error", None) or getattr(d, "pipeline_state", None) == "ERROR":
+            tags.append("error")
+        if _is_display_off(d):
+            tags.append("display-off")
+    else:
+        tags.append("offline")
+
+    free_pct = _free_storage_pct(d)
+    if free_pct is not None and free_pct < 5:
+        tags.append("storage-critical")
+
+    if getattr(d, "is_upgrading", False) or getattr(d, "update_available", False):
+        tags.append("maintenance")
+
+    return tags
+
+
+def is_needs_attention(tags: Iterable[str]) -> bool:
+    """True if any tag in *tags* is in the Needs-Attention bucket."""
+    return any(t in NEEDS_ATTENTION_TAGS for t in tags)
+
+
+def fleet_counts(devices) -> dict[str, int]:
+    """Compute triage-bar counts across a list of decorated devices.
+
+    Pending devices are excluded from every count (including ``all``)
+    — they don't represent operational fleet capacity.
+
+    Returned keys:
+
+    - ``all`` — total adopted/orphaned devices
+    - ``needs_attention`` — devices with at least one tag in
+      :data:`NEEDS_ATTENTION_TAGS`
+    - one key per tag in :data:`SEVERITY_TAGS` (with hyphens kept;
+      the template references them as ``counts['display-off']`` etc.)
+    - ``healthy`` — devices with zero tags
+    """
+    counts: dict[str, int] = {"all": 0, "needs_attention": 0, "healthy": 0}
+    for tag in SEVERITY_TAGS:
+        counts[tag] = 0
+
+    for d in devices:
+        status = getattr(getattr(d, "status", None), "value", None)
+        if status == "pending":
+            continue
+        counts["all"] += 1
+        tags = device_severity_tags(d)
+        if not tags:
+            counts["healthy"] += 1
+            continue
+        if is_needs_attention(tags):
+            counts["needs_attention"] += 1
+        for t in tags:
+            counts[t] = counts.get(t, 0) + 1
+
+    return counts
+
+
+# Group-level rollup uses the exact same shape and logic as
+# fleet_counts — there is no separate severity taxonomy for groups.
+# This alias exists only so callers/templates can express intent
+# ("rollup for one group") without duplicating the function.
+group_rollup = fleet_counts

--- a/cms/services/device_alerts.py
+++ b/cms/services/device_alerts.py
@@ -75,7 +75,7 @@ def _free_storage_pct(d) -> float | None:
     return (cap - used) / cap * 100.0
 
 
-def device_severity_tags(d) -> list[str]:
+def device_severity_tags(d, user_perms: Iterable[str] | None = None) -> list[str]:
     """Return the severity tags that apply to a single device.
 
     Tags returned (subset of :data:`SEVERITY_TAGS`):
@@ -89,6 +89,12 @@ def device_severity_tags(d) -> list[str]:
 
     Pending devices are intentionally excluded from every tag — they
     aren't operational yet and live in their own card.
+
+    When *user_perms* is provided, the ``maintenance`` tag is omitted
+    for users without ``devices:manage`` since they can't act on it
+    (the kebab Update action and the Update badge tooltip both require
+    that permission). Pass ``None`` (the default) to get the unfiltered
+    tag list — used by tests and any caller that wants the raw view.
     """
     status = getattr(getattr(d, "status", None), "value", None)
     if status == "pending":
@@ -117,7 +123,8 @@ def device_severity_tags(d) -> list[str]:
         tags.append("storage-critical")
 
     if getattr(d, "is_upgrading", False) or getattr(d, "update_available", False):
-        tags.append("maintenance")
+        if user_perms is None or "devices:manage" in user_perms:
+            tags.append("maintenance")
 
     return tags
 
@@ -127,11 +134,16 @@ def is_needs_attention(tags: Iterable[str]) -> bool:
     return any(t in NEEDS_ATTENTION_TAGS for t in tags)
 
 
-def fleet_counts(devices) -> dict[str, int]:
+def fleet_counts(devices, user_perms: Iterable[str] | None = None) -> dict[str, int]:
     """Compute triage-bar counts across a list of decorated devices.
 
     Pending devices are excluded from every count (including ``all``)
     — they don't represent operational fleet capacity.
+
+    *user_perms* is forwarded to :func:`device_severity_tags`; when
+    set, the ``maintenance`` tag is suppressed for users without
+    ``devices:manage`` so the corresponding stat tile / triage chip
+    reads zero rather than pointing them at devices they can't act on.
 
     Returned keys:
 
@@ -151,7 +163,7 @@ def fleet_counts(devices) -> dict[str, int]:
         if status == "pending":
             continue
         counts["all"] += 1
-        tags = device_severity_tags(d)
+        tags = device_severity_tags(d, user_perms)
         if not tags:
             counts["healthy"] += 1
             continue

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -337,7 +337,49 @@ function editDeviceName(el) {
     input.addEventListener('click', e => e.stopPropagation());
 }
 
-// Find the compact row for a device (the one that lives inside a group/ungrouped
+function editDeviceLocation(el) {
+    const deviceId = el.dataset.deviceId;
+    const placeholder = el.dataset.placeholder || '';
+    const currentText = el.textContent.trim();
+    const isPlaceholder = currentText === 'Click to set location' || currentText === '—';
+    const currentVal = isPlaceholder ? '' : currentText;
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = currentVal;
+    input.placeholder = placeholder;
+    input.className = 'form-control';
+    input.style.cssText = 'font-size:0.85rem; padding:0.15rem 0.35rem; display:inline-block; width:auto; min-width:180px; max-width:300px;';
+
+    const parent = el.parentElement;
+    parent.replaceChild(input, el);
+    input.focus();
+    input.select();
+
+    async function save() {
+        const newVal = input.value.trim();
+        if (newVal !== currentVal) {
+            const resp = await apiCall("PATCH", `/api/devices/${deviceId}`, { location: newVal });
+            if (resp && resp.ok) {
+                el.textContent = newVal || 'Click to set location';
+                showToast("Location updated");
+            } else {
+                el.textContent = currentText;
+                showToast("Update failed", true);
+            }
+        } else {
+            el.textContent = currentText;
+        }
+        parent.replaceChild(el, input);
+    }
+
+    input.addEventListener('blur', save);
+    input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+        if (e.key === 'Escape') { e.preventDefault(); el.textContent = currentText; parent.replaceChild(el, input); }
+    });
+    input.addEventListener('click', e => e.stopPropagation());
+}
 // table — NOT the main "All Devices" row). Returns null if not found.
 function _findCompactRow(deviceId) {
     const rows = document.querySelectorAll(

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -597,6 +597,14 @@ function _removeDeviceFromDom(deviceId) {
         .forEach(row => {
             const key = _compactRowGroupKey(row);
             if (key) affectedGroupKeys.add(key);
+            // Also remove the sibling detail row (if any). The detail row
+            // uses data-detail-for="<id>" rather than data-device-id, but
+            // contains nested elements (editable location span, etc.) that
+            // carry data-device-id and would otherwise leak after delete.
+            const detail = row.nextElementSibling;
+            if (detail && detail.dataset && detail.dataset.detailFor === deviceId) {
+                detail.remove();
+            }
             row.remove();
             removed += 1;
         });

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1028,7 +1028,7 @@ tr.highlight-new td {
 .inline-label { font-size: 0.9rem; color: var(--text-muted); white-space: nowrap; }
 .group-body { padding: 0 1rem 0.75rem; }
 .group-body table { margin: 0; }
-.inline-edit-sm { font-size: 0.9rem; padding: 0.2rem 0.4rem; min-width: 8rem; }
+.inline-edit-sm { font-size: 0.9rem; padding: 0.2rem 1.6rem 0.2rem 0.4rem; min-width: 11rem; }
 
 /* Draggable devices */
 .draggable-device { cursor: grab; }

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -460,7 +460,8 @@
   ``?alert=<filter>`` is set with ``history.replaceState`` so reloads
   and shared links land on the right view without a server roundtrip.
 #}
-{% macro triage_bar(counts, active) -%}
+{% macro triage_bar(counts, active, user_perms=None) -%}
+{% set _can_manage = user_perms is none or 'devices:manage' in user_perms %}
 {% set filters = [
     ('all',              'All',              counts.get('all', 0),              'sev-all',     'Show every adopted device'),
     ('needs-attention',  'Needs Attention',  counts.get('needs_attention', 0),  'sev-na',      'Devices in error, offline, with no display, with critical storage, or orphaned'),
@@ -469,9 +470,11 @@
     ('display-off',      'Display Off',      counts.get('display-off', 0),      'sev-display','No display detected on any port'),
     ('storage-critical', 'Storage Critical', counts.get('storage-critical', 0), 'sev-storage','Less than 5% free disk'),
     ('orphaned',         'Orphaned',         counts.get('orphaned', 0),         'sev-orphan', 'Re-flashed device — needs re-adoption'),
-    ('maintenance',      'Maintenance',      counts.get('maintenance', 0),      'sev-maint',  'Firmware update available or upgrade in progress'),
-    ('healthy',          'Healthy',          counts.get('healthy', 0),          'sev-ok',     'No alerts'),
 ] %}
+{% if _can_manage %}
+{% set filters = filters + [('maintenance', 'Maintenance', counts.get('maintenance', 0), 'sev-maint', 'Firmware update available or upgrade in progress')] %}
+{% endif %}
+{% set filters = filters + [('healthy', 'Healthy', counts.get('healthy', 0), 'sev-ok', 'No alerts')] %}
 <div class="triage-bar" id="triage-bar" role="toolbar" aria-label="Filter devices by alert severity">
     <span class="triage-bar-label">Show:</span>
     {% for key, label, count, klass, tip in filters %}
@@ -507,7 +510,7 @@
 
   Each chip is wrapped in `has-tooltip` so users can hover for context.
 #}
-{% macro device_alert_chips(d) -%}
+{% macro device_alert_chips(d, user_perms=None) -%}
 {% if d.status.value not in ('pending', 'orphaned') %}
 {# Error #}
 {% if d.is_online and (d.error or d.pipeline_state == 'ERROR') %}
@@ -542,8 +545,8 @@
 <span class="has-tooltip"><span class="badge badge-temp-warning">Storage {{ _free_pct | round(0) | int }}%</span><span class="tooltip">Less than 10% free — consider clearing unused assets</span></span>
 {% endif %}
 {% endif %}
-{# Update #}
-{% if d.update_available and not d.is_upgrading %}
+{# Update — only useful to users who can actually trigger the upgrade #}
+{% if d.update_available and not d.is_upgrading and (user_perms is none or 'devices:manage' in user_perms) %}
 <span class="has-tooltip"><span class="badge badge-update">Update</span><span class="tooltip">A newer firmware version is available — open the row's actions menu to update</span></span>
 {% endif %}
 {% endif %}
@@ -606,7 +609,7 @@
         {% else %}
         <span class="badge badge-offline">Offline</span>
         {% endif %}
-        {{ device_alert_chips(d) }}
+        {{ device_alert_chips(d, user_perms) }}
     </td>
     <td>
         {% if 'devices:write' in user_perms %}
@@ -862,7 +865,7 @@
         {% else %}
         <span class="badge badge-offline">Offline</span>
         {% endif %}
-        {{ device_alert_chips(d) }}
+        {{ device_alert_chips(d, user_perms) }}
     </td>
     <td>
         {% if 'devices:write' in user_perms %}

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -687,10 +687,10 @@
                 <span class="detail-label">Location</span>
                 <span class="detail-value">
                     {% if 'devices:write' in user_perms %}
-                    <input type="text" class="inline-edit" value="{{ d.location or '' }}"
-                           placeholder="e.g. Lobby, Conference Room A"
-                           onclick="event.stopPropagation()"
-                           onchange="setDeviceField('{{ d.id }}', 'location', this.value)">
+                    <span class="editable-name" onclick="event.stopPropagation(); editDeviceLocation(this)"
+                          data-device-id="{{ d.id }}"
+                          data-placeholder="e.g. Lobby, Conference Room A"
+                          title="Click to edit location">{{ d.location or 'Click to set location' }}</span>
                     {% else %}
                     {{ d.location or '—' }}
                     {% endif %}

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -908,7 +908,7 @@
   `cms.services.device_alerts.group_rollup(g.devices)`.
 #}
 {% macro group_panel(g, user_perms, assets, groups, pending_ttl_hours, profiles, latest_version, timezones) -%}
-<div class="group-panel" data-group-id="{{ g.id }}"
+<div class="group-panel expanded" data-group-id="{{ g.id }}"
      ondragover="event.preventDefault(); this.classList.add('drag-over')"
      ondragleave="this.classList.remove('drag-over')"
      ondrop="dropDevice(event, '{{ g.id }}'); this.classList.remove('drag-over')">
@@ -946,7 +946,7 @@
             {% endif %}
         </span>
     </div>
-    <div class="group-body" style="display: none;">
+    <div class="group-body">
         <div class="table-wrap">
             <table data-group-table="{{ g.id }}"{% if not g.devices %} style="display: none;"{% endif %}>
                 <thead>{{ th_row_full(user_perms) }}</thead>

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -449,7 +449,47 @@
 
 
 {#
-  Per-device alert chips. Rendered immediately after the connectivity
+  Triage bar — fleet-scale "what's broken right now" summary chips
+  rendered at the top of /devices. Each chip is a button that filters
+  the device tables to the matching subset.
+
+  Counts come from the route via ``cms.services.device_alerts.fleet_counts``;
+  per-row tags come from ``device_severity_tags`` rendered onto each
+  ``<tr data-severity-tags>``. Filtering is purely client-side (see
+  ``triageBarApply`` in devices.html); URL state via
+  ``?alert=<filter>`` is set with ``history.replaceState`` so reloads
+  and shared links land on the right view without a server roundtrip.
+#}
+{% macro triage_bar(counts, active) -%}
+{% set filters = [
+    ('all',              'All',              counts.get('all', 0),              'sev-all',     'Show every adopted device'),
+    ('needs-attention',  'Needs Attention',  counts.get('needs_attention', 0),  'sev-na',      'Devices in error, offline, with no display, with critical storage, or orphaned'),
+    ('error',            'Errors',           counts.get('error', 0),            'sev-error',   'Player pipeline reported an error'),
+    ('offline',          'Offline',          counts.get('offline', 0),          'sev-offline', 'Device websocket is disconnected'),
+    ('display-off',      'Display Off',      counts.get('display-off', 0),      'sev-display','No display detected on any port'),
+    ('storage-critical', 'Storage Critical', counts.get('storage-critical', 0), 'sev-storage','Less than 5% free disk'),
+    ('orphaned',         'Orphaned',         counts.get('orphaned', 0),         'sev-orphan', 'Re-flashed device — needs re-adoption'),
+    ('maintenance',      'Maintenance',      counts.get('maintenance', 0),      'sev-maint',  'Firmware update available or upgrade in progress'),
+    ('healthy',          'Healthy',          counts.get('healthy', 0),          'sev-ok',     'No alerts'),
+] %}
+<div class="triage-bar" id="triage-bar" role="toolbar" aria-label="Filter devices by alert severity">
+    <span class="triage-bar-label">Show:</span>
+    {% for key, label, count, klass, tip in filters %}
+    {# "All" stays clickable even when 0; everything else dims at 0. #}
+    <button type="button"
+            class="triage-chip {{ klass }}{% if active == key %} is-active{% endif %}{% if count == 0 and key != 'all' %} is-empty{% endif %}"
+            data-filter="{{ key }}"
+            aria-pressed="{{ 'true' if active == key else 'false' }}"
+            title="{{ tip }}">
+        <span class="triage-chip-label">{{ label }}</span>
+        <span class="triage-chip-count" data-triage-count="{{ key }}">{{ count }}</span>
+    </button>
+    {% endfor %}
+</div>
+{%- endmacro %}
+
+
+
   badge in the Status cell of both the main and compact device rows so
   operators can see "this device needs attention" at a glance without
   expanding the row. Mirrors the dashboard's issue surfacing.
@@ -510,17 +550,294 @@
 {%- endmacro %}
 
 
+{# Human-readable storage formatter shared by device_row's expanded detail. #}
+{% macro fmt_storage(mb) %}{% if mb >= 1024 %}{{ (mb / 1024) | round(1) }} GB{% else %}{{ mb }} MB{% endif %}{%- endmacro %}
+
+
 {#
-  Compact device row — used inside each group panel and the "Ungrouped"
-  table. Moved from devices.html so that both the full-page render and
-  the GET /api/devices/groups/{id}/panel fragment endpoint can emit
-  identical markup. See issue #87.
+  Rich device row — Name | Status+chips | Group | Splash | Profile | Actions
+  with a sibling <tr class="device-detail"> revealing firmware, IP, temp,
+  display ports, storage, etc.
+
+  Phase C made this the canonical row rendered inside group panels and
+  the Ungrouped section, replacing the older `device_row_compact` which
+  lacked expanded detail. `device_row_compact` is kept below for any
+  niche caller but no longer used by the /devices page itself.
+
+  All page-context dependencies (`user_perms`, `pending_ttl_hours`,
+  `latest_version`, `timezones`) are explicit parameters so the macro
+  is callable from the GET /api/devices/groups/{id}/panel fragment
+  endpoint as well as the full-page render.
+#}
+{% macro th_row_full(user_perms) -%}
+<tr>
+    <th style="width: 2rem;"></th>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Group</th>
+    <th>Device Splash Screen</th>
+    {% if 'devices:manage' in user_perms %}<th>Profile</th>{% endif %}
+    {% if 'devices:manage' in user_perms %}<th>Actions</th>{% endif %}
+</tr>
+{%- endmacro %}
+
+
+{% macro device_row(d, groups, assets, profiles, user_perms, pending_ttl_hours, latest_version, timezones, draggable=false) -%}
+<tr class="device-row{% if draggable %} draggable-device{% endif %}" onclick="toggleDevice(this)" data-device-id="{{ d.id }}" data-severity-tags="{{ d.severity_tags | join(' ') if d.severity_tags is defined else '' }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
+    <td class="expand-toggle">▶</td>
+    <td>
+        {% if 'devices:write' in user_perms %}
+        <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
+        {% else %}
+        {{ d.name or d.id }}
+        {% endif %}
+    </td>
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
+        {% if d.status.value == 'orphaned' %}
+        <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">This device matches a known device but couldn't authenticate, likely due to a factory reset or SD card replacement. It needs to be re-adopted.</span></span>
+        {% elif d.status.value == 'pending' %}
+        {% if d.is_online %}
+        <span class="badge badge-pending">Pending</span>
+        {% else %}
+        <span class="has-tooltip"><span class="badge badge-offline">Pending (Offline)</span><span class="tooltip">This device registered but hasn't been seen recently. Stale pending devices are automatically removed after {{ pending_ttl_hours }} hours.</span></span>
+        {% endif %}
+        {% elif d.is_online %}
+        <span class="badge badge-online">Online</span>
+        {% else %}
+        <span class="badge badge-offline">Offline</span>
+        {% endif %}
+        {{ device_alert_chips(d) }}
+    </td>
+    <td>
+        {% if 'devices:write' in user_perms %}
+        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
+            <option value="">None</option>
+            {% for g in groups %}
+            <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
+            {% endfor %}
+        </select>
+        {% else %}
+        {{ d.group.name if d.group else '—' }}
+        {% endif %}
+    </td>
+    <td>
+        {% if 'devices:write' in user_perms %}
+        <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
+            <option value="">None (use group)</option>
+            {% for a in assets if a.asset_type.value not in ('webpage', 'stream', 'slideshow') %}
+            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
+            {% endfor %}
+        </select>
+        {% else %}
+        {{ (d.default_asset.display_name or d.default_asset.original_filename or d.default_asset.filename) if d.default_asset else '—' }}
+        {% endif %}
+    </td>
+    {% if 'devices:manage' in user_perms %}
+    <td>
+        <select class="inline-edit" onclick="event.stopPropagation()" onchange="setProfile('{{ d.id }}', this.value)">
+            <option value="">None</option>
+            {% for p in profiles %}
+            <option value="{{ p.id }}" {% if d.profile_id == p.id %}selected{% endif %}>{{ p.name }}</option>
+            {% endfor %}
+        </select>
+    </td>
+    {% endif %}
+    {% if 'devices:manage' in user_perms %}
+    <td class="actions" data-live-actions="{{ d.id }}" data-actions-sig="{{ d.status.value }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.ssh_enabled else 0 }}|{{ 0 if d.local_api_enabled is false else 1 }}" onclick="event.stopPropagation()">
+        {% call kebab_menu() %}
+        {% if d.status.value == 'pending' or d.status.value == 'orphaned' %}
+        <button type="button" role="menuitem" onclick="adoptDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Register this device so it can receive content">Adopt</button>
+        {% elif d.is_upgrading %}
+        <button type="button" role="menuitem" disabled title="Firmware upgrade in progress — device will reboot when done">Upgrading…</button>
+        {% elif d.is_online and d.update_available %}
+        <button type="button" role="menuitem" onclick="upgradeDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Update firmware from {{ d.firmware_version }} to {{ latest_version }}">Update</button>
+        {% endif %}
+        {% if d.status.value not in ('pending', 'orphaned') and d.is_online %}
+        <button type="button" role="menuitem" onclick="changeDevicePassword('{{ d.id }}', '{{ d.name or d.id }}')" title="Set the password for this device's local web UI">Change Web Password</button>
+        {% if d.ssh_enabled %}
+        <button type="button" role="menuitem" onclick="toggleSsh('{{ d.id }}', false)" title="SSH is currently enabled — click to disable">Disable SSH</button>
+        {% else %}
+        <button type="button" role="menuitem" onclick="toggleSsh('{{ d.id }}', true)" title="SSH is currently disabled — click to enable">Enable SSH</button>
+        {% endif %}
+        {% if d.local_api_enabled is not none and not d.local_api_enabled %}
+        <button type="button" role="menuitem" onclick="toggleLocalApi('{{ d.id }}', true)" title="Device REST API is disabled — click to re-enable">Enable Local API</button>
+        {% else %}
+        <button type="button" role="menuitem" onclick="toggleLocalApi('{{ d.id }}', false)" title="Disable the device's local REST API">Disable Local API</button>
+        {% endif %}
+        <button type="button" role="menuitem" class="kebab-item-danger" onclick="rebootDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Restart this device immediately">Reboot</button>
+        <button type="button" role="menuitem" class="kebab-item-danger" onclick="factoryResetDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Wipe all data and return device to setup mode">Factory Reset</button>
+        {% endif %}
+        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteDevice('{{ d.id }}')" title="Remove this device from the CMS">Delete</button>
+        {% endcall %}
+    </td>
+    {% endif %}
+</tr>
+<tr class="device-detail" data-detail-for="{{ d.id }}" style="display: none;">
+    <td></td>
+    <td colspan="{% if 'devices:manage' in user_perms %}7{% else %}5{% endif %}">
+        <div class="detail-grid">
+            <div class="detail-item">
+                <span class="detail-label">Device ID</span>
+                <span class="detail-value monospace">{{ d.id }}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Location</span>
+                <span class="detail-value">
+                    {% if 'devices:write' in user_perms %}
+                    <input type="text" class="inline-edit" value="{{ d.location or '' }}"
+                           placeholder="e.g. Lobby, Conference Room A"
+                           onclick="event.stopPropagation()"
+                           onchange="setDeviceField('{{ d.id }}', 'location', this.value)">
+                    {% else %}
+                    {{ d.location or '—' }}
+                    {% endif %}
+                </span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Device Type</span>
+                <span class="detail-value">{{ d.device_type or '—' }}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Supported Codecs</span>
+                <span class="detail-value">{{ d.supported_codecs.replace(',', ', ') if d.supported_codecs else '—' }}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">IP Address</span>
+                <span class="detail-value monospace" data-live-ip="{{ d.id }}">{{ d.ip_address or '—' }}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Firmware Version</span>
+                <span class="detail-value">{{ d.firmware_version or '—' }}{% if d.update_available and 'devices:manage' in user_perms %} <span class="badge badge-update">{{ latest_version }} available</span>{% endif %}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Storage</span>
+                <span class="detail-value" data-live-storage="{{ d.id }}" data-storage-detail data-storage-mb="{{ d.storage_capacity_mb }}" data-used-mb="{{ d.storage_used_mb }}">{{ fmt_storage(d.storage_used_mb) }} / {{ fmt_storage(d.storage_capacity_mb) }}</span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">CPU Temperature</span>
+                <span class="detail-value" data-live-temp="{{ d.id }}">
+                {% if d.cpu_temp_c is not none %}
+                <span class="{% if d.cpu_temp_c >= 80 %}text-danger{% elif d.cpu_temp_c >= 70 %}text-warning{% endif %}">{{ d.cpu_temp_c | round(1) }}°C{% if d.cpu_temp_c >= 80 %} <span class="badge badge-temp-critical">Critical</span>{% elif d.cpu_temp_c >= 70 %} <span class="badge badge-temp-warning">Warning</span>{% endif %}</span>
+                {% else %}
+                <span class="text-muted">—</span>
+                {% endif %}
+                </span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Last Seen</span>
+                <span class="detail-value" data-live-lastseen="{{ d.id }}" {% if d.last_seen %}data-last-seen="{{ d.last_seen.isoformat() }}"{% endif %}>{{ d.last_seen.strftime('%b %d, %Y %I:%M %p') if d.last_seen else '—' }}</span>
+            </div>
+            {% if 'devices:manage' in user_perms %}
+            <div class="detail-item">
+                <span class="detail-label">Timezone</span>
+                <span class="detail-value">
+                    <select class="inline-edit" onclick="event.stopPropagation()" onchange="setDeviceTimezone('{{ d.id }}', this.value)">
+                        <option value=""{% if not d.timezone %} selected{% endif %}>CMS default</option>
+                        {% for tz in timezones %}
+                        <option value="{{ tz }}"{% if d.timezone == tz %} selected{% endif %}>{{ tz }}</option>
+                        {% endfor %}
+                    </select>
+                </span>
+            </div>
+            {% endif %}
+            <div class="online-detail-fields" data-live-online-section="{{ d.id }}" {% if not d.is_online %}style="display:none"{% endif %}>
+            <div class="detail-item">
+                <span class="detail-label">Asset</span>
+                <span class="detail-value" data-live-asset="{{ d.id }}">
+                    {% if d.playback_asset %}
+                        <span class="asset-name-truncate">{{ d.playback_asset }}</span>
+                    {% elif d.playback_mode == 'splash' %}
+                        <span class="text-muted">Splash screen</span>
+                    {% else %}
+                        <span class="text-muted">—</span>
+                    {% endif %}
+                </span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Display</span>
+                <span class="detail-value" data-live-display="{{ d.id }}">
+                    {% if d.display_ports and d.display_ports | length > 1 %}
+                        {% for p in d.display_ports %}
+                            <span class="badge {% if p.connected %}badge-online{% else %}badge-offline{% endif %}" title="{{ p.name }}: {{ 'connected' if p.connected else 'disconnected' }}">{{ p.name }}{% if p.connected %} ✓{% else %} ✗{% endif %}</span>
+                        {% endfor %}
+                    {% elif d.display_connected is none %}
+                        <span class="text-muted">—</span>
+                    {% elif d.display_connected %}
+                        <span class="badge badge-online">Connected</span>
+                    {% else %}
+                        <span class="badge badge-offline">Disconnected</span>
+                    {% endif %}
+                </span>
+            </div>
+            <div class="detail-item">
+                <span class="detail-label">Pipeline State</span>
+                <span class="detail-value" data-live-pipeline="{{ d.id }}">
+                    {% if d.pipeline_state == 'PLAYING' %}
+                        <span class="badge badge-online">Playing</span>
+                    {% elif d.pipeline_state == 'PAUSED' %}
+                        <span class="badge badge-pending">Paused</span>
+                    {% elif d.pipeline_state == 'READY' %}
+                        <span class="badge badge-pending">Ready</span>
+                    {% elif d.pipeline_state == 'NULL' and d.playback_mode == 'splash' %}
+                        <span class="badge badge-pending">Splash</span>
+                    {% elif d.pipeline_state == 'ERROR' %}
+                        <span class="badge badge-offline">Error</span>
+                    {% else %}
+                        <span class="text-muted">{{ d.pipeline_state or '—' }}</span>
+                    {% endif %}
+                </span>
+            </div>
+            </div>
+        </div>
+        </div>
+    </td>
+</tr>
+{%- endmacro %}
+
+
+{#
+  Group rollup line — small severity-coloured count chips that appear
+  on the right side of a group panel header. Visible whether the panel
+  is expanded or collapsed so operators can scan the fleet by group
+  without expanding anything.
+
+  `rollup` is a dict in the same shape as `fleet_counts(devices)` —
+  one key per severity tag plus 'all' / 'needs_attention' / 'healthy'.
+  Healthy groups render only the device count; problem groups also
+  render one chip per non-zero severity.
+#}
+{% macro group_rollup_chips(rollup) -%}
+{% set _entries = [
+    ('error',            rollup.get('error', 0),            'sev-error',   'errors'),
+    ('offline',          rollup.get('offline', 0),          'sev-offline', 'offline'),
+    ('display-off',      rollup.get('display-off', 0),      'sev-display', 'display off'),
+    ('storage-critical', rollup.get('storage-critical', 0), 'sev-storage', 'storage critical'),
+    ('orphaned',         rollup.get('orphaned', 0),         'sev-orphan',  'orphaned'),
+    ('maintenance',      rollup.get('maintenance', 0),      'sev-maint',   'updates'),
+] %}
+<span class="group-rollup">
+    {% for key, count, klass, label in _entries if count > 0 %}
+    <span class="group-rollup-chip {{ klass }}" title="{{ count }} {{ label }} in this group">{{ count }} {{ label }}</span>
+    {% endfor %}
+    {% if rollup.get('needs_attention', 0) == 0 and rollup.get('all', 0) > 0 %}
+    <span class="group-rollup-chip sev-ok" title="No alerts in this group">All healthy</span>
+    {% endif %}
+</span>
+{%- endmacro %}
+
+
+{#
+  Compact device row — preserved for any caller that still wants a
+  no-detail row, but no longer used by the /devices page (Phase C
+  switched group + ungrouped panels to the rich `device_row` above
+  so granularity is preserved). See issue #87 for the original sharing
+  rationale.
 
   `pending_ttl_hours` is passed in explicitly (it lives on the page
   template context, not on `d`) so the macro stays self-contained.
 #}
 {% macro device_row_compact(d, groups, user_perms, pending_ttl_hours, draggable=false) -%}
-<tr class="device-row device-row-compact{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
+<tr class="device-row device-row-compact{% if draggable %} draggable-device{% endif %}" data-device-id="{{ d.id }}" data-severity-tags="{{ d.severity_tags | join(' ') if d.severity_tags is defined else '' }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
     <td>
         {% if 'devices:write' in user_perms %}
         <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
@@ -576,7 +893,15 @@
   GET /api/devices/groups/{id}/panel fragment endpoint so the cross-session
   poller and the createGroup handler insert identical markup. See issue #87.
 #}
-{% macro group_panel(g, user_perms, assets, groups, pending_ttl_hours) -%}
+{#
+  Phase C: signature extended to accept the full template context
+  needed by the rich `device_row` (profiles, latest_version,
+  timezones), and emits a per-group rollup line in the header so
+  operators can scan "what's broken in each group" while panels are
+  collapsed. `g.rollup` is computed server-side via
+  `cms.services.device_alerts.group_rollup(g.devices)`.
+#}
+{% macro group_panel(g, user_perms, assets, groups, pending_ttl_hours, profiles, latest_version, timezones) -%}
 <div class="group-panel" data-group-id="{{ g.id }}"
      ondragover="event.preventDefault(); this.classList.add('drag-over')"
      ondragleave="this.classList.remove('drag-over')"
@@ -591,6 +916,7 @@
         <span class="text-muted">— {{ g.description or 'No description' }}</span>
         {% endif %}
         <span class="badge badge-count" data-group-count="{{ g.id }}">{{ g.device_count }} device{{ 's' if g.device_count != 1 }}</span>
+        {% if g.rollup is defined %}{{ group_rollup_chips(g.rollup) }}{% endif %}
         <span class="group-actions" onclick="event.stopPropagation()">
             <span class="has-tooltip inline-label">Group Splash Screen<span class="tooltip">Default splash screen shown when no schedule is active</span></span>
             {% if 'groups:write' in user_perms %}
@@ -617,10 +943,10 @@
     <div class="group-body" style="display: none;">
         <div class="table-wrap">
             <table data-group-table="{{ g.id }}"{% if not g.devices %} style="display: none;"{% endif %}>
-                <thead>{{ th_row_compact() }}</thead>
+                <thead>{{ th_row_full(user_perms) }}</thead>
                 <tbody data-group-tbody="{{ g.id }}">
                     {% for d in g.devices | sort(attribute='name') %}
-                    {{ device_row_compact(d, groups, user_perms, pending_ttl_hours) }}
+                    {{ device_row(d, groups, assets, profiles, user_perms, pending_ttl_hours, latest_version, timezones) }}
                     {% endfor %}
                 </tbody>
             </table>

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -667,6 +667,9 @@
         <button type="button" role="menuitem" class="kebab-item-danger" onclick="rebootDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Restart this device immediately">Reboot</button>
         <button type="button" role="menuitem" class="kebab-item-danger" onclick="factoryResetDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Wipe all data and return device to setup mode">Factory Reset</button>
         {% endif %}
+        {% if d.group_id and 'devices:write' in user_perms %}
+        <button type="button" role="menuitem" onclick="assignGroup('{{ d.id }}', '')" title="Remove this device from its group">Remove from group</button>
+        {% endif %}
         <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteDevice('{{ d.id }}')" title="Remove this device from the CMS">Delete</button>
         {% endcall %}
     </td>

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -70,9 +70,11 @@
         ('display-off',      'Display Off',       'sev-display'),
         ('storage-critical', 'Storage Critical',  'sev-storage'),
         ('orphaned',         'Orphaned',          'sev-orphan'),
-        ('maintenance',      'Maintenance',       'sev-maint'),
-        ('healthy',          'Healthy',           'sev-healthy'),
     ] %}
+    {% if 'devices:manage' in user_perms %}
+    {% set _tiles = _tiles + [('maintenance', 'Maintenance', 'sev-maint')] %}
+    {% endif %}
+    {% set _tiles = _tiles + [('healthy', 'Healthy', 'sev-healthy')] %}
     {% for key, label, css in _tiles %}
     {% set count = fleet_counts.get(key, 0) %}
     {% set filter_key = 'needs-attention' if key == 'needs_attention' else key %}

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -4,124 +4,84 @@
 {% block content %}
 <h1>Dashboard</h1>
 
-{# ── Compute device issue flags (used by alert banner below) ── #}
-{% set temp_warning = device_states | selectattr("cpu_temp_c") | selectattr("cpu_temp_c", "ge", 70) | list %}
-{% set temp_critical = temp_warning | selectattr("cpu_temp_c", "ge", 80) | list %}
-{% set error_devices = device_states | selectattr("error") | list %}
-{% set display_disconnected = device_states | selectattr("is_online") | rejectattr("display_connected", "none") | rejectattr("display_connected") | list %}
-{% set has_issues = offline_devices or orphaned_devices or temp_warning or error_devices or display_disconnected %}
-
-{# ── Device Status (alert banner — only shown when something needs attention) ── #}
-{% if has_issues %}
-<div class="card card-danger">
-    <h2>Device Status</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Device</th>
-                <th>Group</th>
-                <th>Status</th>
-                <th>Details</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for ds in error_devices %}
-            <tr>
-                <td>{{ ds.name }}</td>
-                <td>{{ ds.group_name or '—' }}</td>
-                <td><span class="badge badge-error">Error</span></td>
-                <td class="text-danger">{{ ds.error }}</td>
-            </tr>
-            {% endfor %}
-            {% for d in orphaned_devices %}
-            <tr>
-                <td>{{ d.name or d.id }}</td>
-                <td>{{ d.group.name if d.group else '—' }}</td>
-                <td><span class="badge badge-orphaned">Orphaned</span></td>
-                <td>Authentication failed — {% if 'devices:manage' in user_perms %}<button class="btn btn-primary btn-sm" onclick="adoptDevice('{{ d.id }}', '{{ d.name or d.id }}')">Adopt</button>{% endif %}</td>
-            </tr>
-            {% endfor %}
-            {% for d in offline_devices %}
-            <tr>
-                <td>{{ d.name or d.id }}</td>
-                <td>{{ d.group.name if d.group else '—' }}</td>
-                <td><span class="badge badge-offline">Offline</span></td>
-                <td class="text-muted">Last seen {{ d.last_seen.astimezone(tz).strftime('%b %d, %Y %I:%M %p') if d.last_seen else 'Never' }}</td>
-            </tr>
-            {% endfor %}
-            {% for ds in temp_warning %}
-            {% if ds.cpu_temp_c >= 80 %}
-            <tr>
-                <td>{{ ds.name }}</td>
-                <td>{{ ds.group_name or '—' }}</td>
-                <td><span class="badge badge-temp-critical">{{ ds.cpu_temp_c | round(1) }}°C</span></td>
-                <td class="text-danger">Critical — CPU throttling likely</td>
-            </tr>
-            {% else %}
-            <tr>
-                <td>{{ ds.name }}</td>
-                <td>{{ ds.group_name or '—' }}</td>
-                <td><span class="badge badge-temp-warning">{{ ds.cpu_temp_c | round(1) }}°C</span></td>
-                <td class="text-warning">Temperature warning</td>
-            </tr>
-            {% endif %}
-            {% endfor %}
-            {% for ds in display_disconnected %}
-            <tr>
-                <td>{{ ds.name }}</td>
-                <td>{{ ds.group_name or '—' }}</td>
-                <td><span class="badge badge-offline">No Display</span></td>
-                <td class="text-warning">HDMI display disconnected</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
-{% endif %}
-
-{# ── Pending Devices ── #}
-{% if pending_devices %}
-<div class="card">
-    <h2>Pending Devices</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Device</th>
-                <th>Status</th>
-                <th>Firmware</th>
-                <th>IP</th>
-                <th>Storage</th>
-                <th>First Seen</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for d in pending_devices %}
-            <tr>
-                <td>{{ d.name or d.id }}</td>
-                <td>
-                    {% if d.is_online %}
-                    <span class="badge badge-pending">Pending</span>
-                    {% else %}
-                    <span class="badge badge-offline">Pending (Offline)</span>
-                    {% endif %}
-                </td>
-                <td>{{ d.firmware_version }}</td>
-                <td class="monospace">{{ d.ip_address or '—' }}</td>
-                <td data-storage-mb="{{ d.storage_capacity_mb }}">{{ d.storage_capacity_mb }} MB</td>
-                <td data-utc="{{ d.registered_at.isoformat() }}">{{ d.registered_at.astimezone(tz).strftime('%b %d, %Y %I:%M %p') }}</td>
-                <td class="actions">
-                    {% if 'devices:manage' in user_perms %}
-                    {% call macros.kebab_menu() %}
-                        <button type="button" role="menuitem" onclick="adoptDevice('{{ d.id }}', '{{ d.name or d.id }}')">Adopt</button>
-                        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteDevice('{{ d.id }}')">Delete</button>
-                    {% endcall %}
-                    {% endif %}
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+{# ── Fleet status (stat tiles, link into filtered /devices) ─────────── #}
+{% if fleet_counts is defined and fleet_counts.all is defined %}
+<style>
+.stat-tile-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.75rem;
+    margin: 0 0 1rem 0;
+}
+.stat-tile {
+    display: block;
+    padding: 1rem 1.25rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--border);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text);
+    transition: transform 0.08s ease, box-shadow 0.08s ease, border-color 0.08s ease;
+}
+.stat-tile:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border-color: var(--border-strong, var(--border));
+}
+.stat-tile-label {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 0 0 0.4rem 0;
+}
+.stat-tile-value {
+    display: block;
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1;
+}
+.stat-tile-zero .stat-tile-value { color: var(--text-muted); font-weight: 400; }
+.stat-tile.sev-all       { border-left-color: var(--accent, #2563eb); }
+.stat-tile.sev-attn      { border-left-color: #f59e0b; }
+.stat-tile.sev-error     { border-left-color: #dc2626; }
+.stat-tile.sev-offline   { border-left-color: #6b7280; }
+.stat-tile.sev-display   { border-left-color: #f97316; }
+.stat-tile.sev-storage   { border-left-color: #b91c1c; }
+.stat-tile.sev-orphan    { border-left-color: #92400e; }
+.stat-tile.sev-maint     { border-left-color: #1e40af; }
+.stat-tile.sev-healthy   { border-left-color: #15803d; }
+.stat-tile.stat-tile-zero.sev-attn,
+.stat-tile.stat-tile-zero.sev-error,
+.stat-tile.stat-tile-zero.sev-offline,
+.stat-tile.stat-tile-zero.sev-display,
+.stat-tile.stat-tile-zero.sev-storage,
+.stat-tile.stat-tile-zero.sev-orphan,
+.stat-tile.stat-tile-zero.sev-maint { border-left-color: var(--border); }
+</style>
+<div class="stat-tile-grid" role="navigation" aria-label="Fleet status">
+    {% set _tiles = [
+        ('all',              'Total Devices',     'sev-all'),
+        ('needs_attention',  'Needs Attention',   'sev-attn'),
+        ('error',            'Errors',            'sev-error'),
+        ('offline',          'Offline',           'sev-offline'),
+        ('display-off',      'Display Off',       'sev-display'),
+        ('storage-critical', 'Storage Critical',  'sev-storage'),
+        ('orphaned',         'Orphaned',          'sev-orphan'),
+        ('maintenance',      'Maintenance',       'sev-maint'),
+        ('healthy',          'Healthy',           'sev-healthy'),
+    ] %}
+    {% for key, label, css in _tiles %}
+    {% set count = fleet_counts.get(key, 0) %}
+    {% set filter_key = 'needs-attention' if key == 'needs_attention' else key %}
+    {% set href = '/devices' if key == 'all' else '/devices?alert=' + filter_key %}
+    <a class="stat-tile {{ css }}{{ ' stat-tile-zero' if count == 0 }}" href="{{ href }}">
+        <span class="stat-tile-label">{{ label }}</span>
+        <span class="stat-tile-value">{{ count }}</span>
+    </a>
+    {% endfor %}
 </div>
 {% endif %}
 

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -3,6 +3,8 @@
 {% block title %}Devices — Agora CMS{% endblock %}
 {% block content %}
 
+<h1 class="page-title">Devices</h1>
+
 {# Phase C: rich device_row + th_row + fmt_storage moved to _macros.html
    so the GET /api/devices/groups/{id}/panel fragment endpoint can render
    identical markup. Call sites use ``macros.device_row`` / ``macros.th_row_full``. #}
@@ -115,35 +117,9 @@
 {{ macros.triage_bar(fleet_counts, active_alert, user_perms) }}
 {% endif %}
 
-{# ── Pending Devices (unadopted registrations) ── #}
-{# Rendered after the main Devices card so the Devices <h2> remains the #}
-{# first heading on the page — the e2e page-load test keys off that.   #}
-{% if 'devices:manage' in user_perms %}
-<div class="card" id="pending-devices-card" style="display: none;">
-    <div style="display: flex; gap: 0.75rem; align-items: center; margin: 0 0 0.5rem 0;">
-        <h2 style="margin: 0;">Pending Devices</h2>
-        <button class="btn btn-primary" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
-    </div>
-    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
-        Devices that have registered with the CMS but haven't been adopted yet.
-        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
-    </p>
-    <div class="table-wrap">
-        <table>
-            <thead>
-                <tr>
-                    <th>Device ID</th>
-                    <th>Firmware</th>
-                    <th>IP</th>
-                    <th>Registered</th>
-                    <th style="width: 1%; white-space: nowrap;">Actions</th>
-                </tr>
-            </thead>
-            <tbody id="pending-devices-tbody"></tbody>
-        </table>
-    </div>
-</div>
-{% endif %}
+{# Phase D: Pending devices now flow into the Ungrouped Devices section
+   below as full rich device_row rendering (with the Adopt kebab item).
+   The dedicated Pending Devices card has been retired. #}
 
 {# ── Device Groups (expandable) ── #}
 {% if 'groups:read' in user_perms %}
@@ -632,9 +608,11 @@ window._adoptionProfiles = [
     setInterval(pollDevicesOnce, 5000);
     setInterval(pollGroupsOnce, 5000);
     {% if 'devices:manage' in user_perms %}
-    setInterval(pollPendingOnce, 5000);
-    // Kick an immediate fetch on load so the card appears without a 5s wait.
-    pollPendingOnce();
+    // Pending devices now render server-side in the Ungrouped section.
+    // Action handlers reload the page to pick up adoption status changes.
+    window._refreshPending = () => { location.reload(); };
+    {% endif %}
+})();
     {% endif %}
 
     // Keep the /devices Device Groups card in sync across replicas without
@@ -785,12 +763,12 @@ window._adoptionProfiles = [
             const age = _escHtml(_fmtRelativeAge(p.created_at));
             const advisoryJs = (p.device_id || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
             return (
-                '<tr>' +
+                '<tr class="device-row" data-device-id="' + devId + '">' +
                 '<td>' + devId + '</td>' +
                 '<td>' + fw + '</td>' +
                 '<td>' + ipCell + '</td>' +
                 '<td title="' + _escHtml(p.created_at || '') + '">' + age + '</td>' +
-                '<td style="white-space: nowrap;">' +
+                '<td class="actions" style="white-space: nowrap;">' +
                     '<button type="button" class="btn btn-primary" ' +
                     'onclick="adoptPendingDevice(\'' + p.id + '\', \'' + advisoryJs + '\')">Adopt</button> ' +
                     '<button type="button" class="btn" ' +

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -640,10 +640,13 @@ window._adoptionProfiles = [
             // Remove panels whose group was deleted on another replica.
             for (const gid of Array.from(knownGroupIds)) {
                 if (!serverIds.has(gid)) {
-                    // Skip if the user is expanded into this panel — they'd
-                    // lose their context. The next poll cycle will retry.
+                    // Skip if the user has expanded a device detail inside
+                    // this panel — they'd lose their context. The next poll
+                    // cycle will retry. (Group panels are expanded by default
+                    // post-Phase D so .group-panel.expanded is no longer a
+                    // useful signal.)
                     const panel = document.querySelector(`.group-panel[data-group-id="${gid}"]`);
-                    if (panel && panel.classList.contains('expanded')) continue;
+                    if (panel && panel.querySelector('.device-row.expanded')) continue;
                     if (typeof _deleteGroupFromDom === 'function') _deleteGroupFromDom(gid);
                     knownGroupIds.delete(gid);
                 }
@@ -691,7 +694,10 @@ window._adoptionProfiles = [
             // Structural reload only when devices are added or removed
             const newIds = new Set(devices.map(d => d.id));
             if (newIds.size !== knownDeviceIds.size || ![...newIds].every(id => knownDeviceIds.has(id))) {
-                if (!document.querySelector(".device-row.expanded") && !document.querySelector(".group-panel.expanded")) {
+                // Skip reload only if the user has expanded a device detail
+                // row — group panels are now expanded by default (Phase D)
+                // so they're no longer a useful "user is interacting" signal.
+                if (!document.querySelector(".device-row.expanded")) {
                     location.reload();
                 } else {
                     knownDeviceIds = newIds;

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -15,7 +15,7 @@
     flex-wrap: wrap;
     gap: 0.5rem;
     align-items: center;
-    margin: 0.75rem 0 0 0;
+    margin: 0.75rem 0 1rem 0;
     padding: 0.625rem 0.875rem;
     background: var(--surface);
     border: 1px solid var(--border);

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -7,13 +7,7 @@
    so the GET /api/devices/groups/{id}/panel fragment endpoint can render
    identical markup. Call sites use ``macros.device_row`` / ``macros.th_row_full``. #}
 
-{# ── Devices (heading + fleet-wide triage) ────────────────────────── #}
-{# Phase C: the flat "all devices" table that used to live here is    #}
-{# gone. Group panels + Ungrouped panel below show the same devices   #}
-{# with rich expandable rows, so this card is now a header + the      #}
-{# fleet-scale triage bar. The Devices <h2> is preserved here so the  #}
-{# e2e contract that "Devices" is the first heading on the page still #}
-{# holds.                                                              #}
+{# ── Fleet-wide triage bar (no wrapping card — bare bar above content) #}
 {% if 'devices:read' in user_perms %}
 <style>
 .triage-bar {
@@ -82,9 +76,15 @@
 .triage-chip.is-active.sev-orphan  { background: #b45309; border-color: #b45309; }
 .triage-chip.is-active.sev-maint   { background: #1d4ed8; border-color: #1d4ed8; }
 .triage-chip.is-active.sev-ok      { background: #15803d; border-color: #15803d; }
-/* Filter mechanics: rows are hidden via [hidden]; group panels with
-   no visible rows collapse via .triage-empty added by the JS pass. */
-.triage-empty { display: none; }
+/* Filter mechanics: rows are hidden via [hidden]; group panels stay
+   visible even when filtered to zero matches — an inline empty-state
+   row inside each tbody surfaces "no devices match the current filter". */
+.triage-empty-state td {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 1rem;
+    font-style: italic;
+}
 /* Per-group rollup chips rendered next to the group name (Phase C). */
 .group-rollup {
     display: inline-flex;
@@ -112,19 +112,7 @@
 .group-rollup-chip.sev-maint   { background: #dbeafe; color: #1e40af; }
 .group-rollup-chip.sev-ok      { background: #dcfce7; color: #166534; }
 </style>
-<div class="card">
-    <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
-        <h2 style="margin: 0;">Devices</h2>
-        {% if 'devices:manage' in user_perms %}
-        <span onclick="event.stopPropagation()">
-            {% call macros.kebab_menu() %}
-                <button type="button" role="menuitem" onclick="checkForUpdates(this)" id="check-updates-btn" title="Fetch the latest available device software version. Runs automatically every hour.">Check for updates</button>
-            {% endcall %}
-        </span>
-        {% endif %}
-    </div>
-    {{ macros.triage_bar(fleet_counts, active_alert) }}
-</div>
+{{ macros.triage_bar(fleet_counts, active_alert) }}
 {% endif %}
 
 {# ── Pending Devices (unadopted registrations) ── #}
@@ -160,7 +148,16 @@
 {# ── Device Groups (expandable) ── #}
 {% if 'groups:read' in user_perms %}
 <div class="card">
-    <h2>Device Groups</h2>
+    <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin: 0 0 0.5rem 0;">
+        <h2 style="margin: 0;">Device Groups</h2>
+        {% if 'devices:manage' in user_perms %}
+        <span onclick="event.stopPropagation()">
+            {% call macros.kebab_menu() %}
+                <button type="button" role="menuitem" onclick="checkForUpdates(this)" id="check-updates-btn" title="Fetch the latest available device software version. Runs automatically every hour.">Check for updates</button>
+            {% endcall %}
+        </span>
+        {% endif %}
+    </div>
     {% for g in groups %}
     {{ macros.group_panel(g, user_perms, assets, groups, pending_ttl_hours, profiles, latest_version, timezones) }}
     {% else %}
@@ -238,25 +235,28 @@ function triageBarApply(filter) {
         if (match) tr.removeAttribute('hidden');
         else tr.setAttribute('hidden', '');
     });
-    // Collapse group panels with no visible rows (when not "all").
-    document.querySelectorAll('.group-panel').forEach(panel => {
-        if (filter === 'all') {
-            panel.classList.remove('triage-empty');
-            return;
+    // Filter-empty panels stay visible — surface an inline empty-state
+    // row inside each tbody when filter excludes every device. Genuinely
+    // empty Ungrouped (zero devices total) keeps its existing hide path.
+    document.querySelectorAll('[data-group-tbody]').forEach(tbody => {
+        const total = tbody.querySelectorAll('tr.device-row').length;
+        const visible = tbody.querySelectorAll('tr.device-row:not([hidden])').length;
+        let emptyRow = tbody.querySelector('tr.triage-empty-state');
+        if (filter !== 'all' && total > 0 && visible === 0) {
+            if (!emptyRow) {
+                emptyRow = document.createElement('tr');
+                emptyRow.className = 'triage-empty-state';
+                const td = document.createElement('td');
+                td.colSpan = 99;
+                td.textContent = 'No devices match the current filter.';
+                emptyRow.appendChild(td);
+                tbody.appendChild(emptyRow);
+            }
+            emptyRow.hidden = false;
+        } else if (emptyRow) {
+            emptyRow.hidden = true;
         }
-        const visible = panel.querySelectorAll('tr.device-row:not([hidden])').length;
-        panel.classList.toggle('triage-empty', visible === 0);
     });
-    // Also collapse the Ungrouped Devices section when nothing matches.
-    const ungroupedSection = document.getElementById('ungrouped-section');
-    if (ungroupedSection) {
-        if (filter === 'all') {
-            ungroupedSection.classList.remove('triage-empty');
-        } else {
-            const visible = ungroupedSection.querySelectorAll('tr.device-row:not([hidden])').length;
-            ungroupedSection.classList.toggle('triage-empty', visible === 0);
-        }
-    }
     // Update active state on the chips.
     document.querySelectorAll('.triage-chip').forEach(btn => {
         const active = btn.getAttribute('data-filter') === filter;
@@ -306,7 +306,13 @@ function triageBarRecomputeCounts() {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.triage-chip').forEach(btn => {
-        btn.addEventListener('click', () => triageBarApply(btn.getAttribute('data-filter')));
+        btn.addEventListener('click', () => {
+            // Toggle: clicking the active chip clears the filter back to 'all'.
+            const target = btn.classList.contains('is-active')
+                ? 'all'
+                : btn.getAttribute('data-filter');
+            triageBarApply(target);
+        });
     });
     // Apply initial filter from server-rendered active state.
     const initial = document.querySelector('.triage-chip.is-active');

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -112,7 +112,7 @@
 .group-rollup-chip.sev-maint   { background: #dbeafe; color: #1e40af; }
 .group-rollup-chip.sev-ok      { background: #dcfce7; color: #166534; }
 </style>
-{{ macros.triage_bar(fleet_counts, active_alert) }}
+{{ macros.triage_bar(fleet_counts, active_alert, user_perms) }}
 {% endif %}
 
 {# ── Pending Devices (unadopted registrations) ── #}
@@ -504,8 +504,8 @@ window._adoptionProfiles = [
                 out.push('<span class="has-tooltip"><span class="badge badge-temp-warning">Storage ' + Math.round(freePct) + '%</span><span class="tooltip">Less than 10% free — consider clearing unused assets</span></span>');
             }
         }
-        // Update
-        if (d.update_available && !d.is_upgrading) {
+        // Update — only shown to users who can act on it
+        if (d.update_available && !d.is_upgrading && __canManage) {
             out.push('<span class="has-tooltip"><span class="badge badge-update">Update</span><span class="tooltip">A newer firmware version is available — open the row\'s actions menu to update</span></span>');
         }
         return out.join('');

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -612,8 +612,6 @@ window._adoptionProfiles = [
     // Action handlers reload the page to pick up adoption status changes.
     window._refreshPending = () => { location.reload(); };
     {% endif %}
-})();
-    {% endif %}
 
     // Keep the /devices Device Groups card in sync across replicas without
     // a full page reload. Added as part of #87: when session A creates or

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -3,253 +3,117 @@
 {% block title %}Devices — Agora CMS{% endblock %}
 {% block content %}
 
-{# ── Helper: human-readable storage ── #}
-{% macro fmt_storage(mb) %}{% if mb >= 1024 %}{{ (mb / 1024) | round(1) }} GB{% else %}{{ mb }} MB{% endif %}{% endmacro %}
+{# Phase C: rich device_row + th_row + fmt_storage moved to _macros.html
+   so the GET /api/devices/groups/{id}/panel fragment endpoint can render
+   identical markup. Call sites use ``macros.device_row`` / ``macros.th_row_full``. #}
 
-{# ── Macro for a device row (reused in main table, groups, ungrouped) ── #}
-{% macro device_row(d, groups, assets, profiles, draggable=false) %}
-<tr class="device-row{% if draggable %} draggable-device{% endif %}" onclick="toggleDevice(this)" data-device-id="{{ d.id }}"{% if d.has_active_schedule %} data-playing="true"{% endif %}{% if draggable %} draggable="true" ondragstart="dragDevice(event, '{{ d.id }}')"{% endif %}>
-    <td class="expand-toggle">▶</td>
-    <td>
-        {% if 'devices:write' in user_perms %}
-        <span class="editable-name" onclick="event.stopPropagation(); editDeviceName(this)" data-device-id="{{ d.id }}" data-fallback="{{ d.id }}">{{ d.name or d.id }}</span>
-        {% else %}
-        {{ d.name or d.id }}
-        {% endif %}
-    </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
-        {% if d.status.value == 'orphaned' %}
-        <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">This device matches a known device but couldn't authenticate, likely due to a factory reset or SD card replacement. It needs to be re-adopted.</span></span>
-        {% elif d.status.value == 'pending' %}
-        {% if d.is_online %}
-        <span class="badge badge-pending">Pending</span>
-        {% else %}
-        <span class="has-tooltip"><span class="badge badge-offline">Pending (Offline)</span><span class="tooltip">This device registered but hasn't been seen recently. Stale pending devices are automatically removed after {{ pending_ttl_hours }} hours.</span></span>
-        {% endif %}
-        {% elif d.is_online %}
-        <span class="badge badge-online">Online</span>
-        {% else %}
-        <span class="badge badge-offline">Offline</span>
-        {% endif %}
-        {{ macros.device_alert_chips(d) }}
-    </td>
-    <td>
-        {% if 'devices:write' in user_perms %}
-        <select class="inline-edit" data-device-group-select onclick="event.stopPropagation()" onchange="assignGroup('{{ d.id }}', this.value)">
-            <option value="">None</option>
-            {% for g in groups %}
-            <option value="{{ g.id }}" {% if d.group_id == g.id %}selected{% endif %}>{{ g.name }}</option>
-            {% endfor %}
-        </select>
-        {% else %}
-        {{ d.group.name if d.group else '—' }}
-        {% endif %}
-    </td>
-    <td>
-        {% if 'devices:write' in user_perms %}
-        <select class="inline-edit" onclick="event.stopPropagation()" onfocus="this.dataset.prev = this.value" onchange="setDefaultAsset('{{ d.id }}', this.value, this)">
-            <option value="">None (use group)</option>
-            {% for a in assets if a.asset_type.value not in ('webpage', 'stream', 'slideshow') %}
-            <option value="{{ a.id }}" {% if d.default_asset_id == a.id %}selected{% endif %}{% if not a.ready_for_selection %} disabled{% endif %}>{{ a | asset_icon }} {{ a.display_name or a.original_filename or a.filename }}{{ a | asset_label_suffix }}{% if not a.ready_for_selection %} ({{ a.not_ready_reason }}){% endif %}</option>
-            {% endfor %}
-        </select>
-        {% else %}
-        {{ (d.default_asset.display_name or d.default_asset.original_filename or d.default_asset.filename) if d.default_asset else '—' }}
-        {% endif %}
-    </td>
-    {% if 'devices:manage' in user_perms %}
-    <td>
-        <select class="inline-edit" onclick="event.stopPropagation()" onchange="setProfile('{{ d.id }}', this.value)">
-            <option value="">None</option>
-            {% for p in profiles %}
-            <option value="{{ p.id }}" {% if d.profile_id == p.id %}selected{% endif %}>{{ p.name }}</option>
-            {% endfor %}
-        </select>
-    </td>
-    {% endif %}
-    <td data-live-storage-pct="{{ d.id }}" data-storage-pct data-storage-mb="{{ d.storage_capacity_mb }}" data-used-mb="{{ d.storage_used_mb }}">
-        {% if d.storage_capacity_mb > 0 %}
-        {{ ((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int }}% free
-        {% else %}—{% endif %}
-    </td>
-    {% if 'devices:manage' in user_perms %}
-    <td class="actions" data-live-actions="{{ d.id }}" data-actions-sig="{{ d.status.value }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.ssh_enabled else 0 }}|{{ 0 if d.local_api_enabled is false else 1 }}" onclick="event.stopPropagation()">
-        {% call macros.kebab_menu() %}
-        {% if d.status.value == 'pending' or d.status.value == 'orphaned' %}
-        <button type="button" role="menuitem" onclick="adoptDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Register this device so it can receive content">Adopt</button>
-        {% elif d.is_upgrading %}
-        <button type="button" role="menuitem" disabled title="Firmware upgrade in progress — device will reboot when done">Upgrading…</button>
-        {% elif d.is_online and d.update_available %}
-        <button type="button" role="menuitem" onclick="upgradeDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Update firmware from {{ d.firmware_version }} to {{ latest_version }}">Update</button>
-        {% endif %}
-        {% if d.status.value not in ('pending', 'orphaned') and d.is_online %}
-        <button type="button" role="menuitem" onclick="changeDevicePassword('{{ d.id }}', '{{ d.name or d.id }}')" title="Set the password for this device's local web UI">Change Web Password</button>
-        {% if d.ssh_enabled %}
-        <button type="button" role="menuitem" onclick="toggleSsh('{{ d.id }}', false)" title="SSH is currently enabled — click to disable">Disable SSH</button>
-        {% else %}
-        <button type="button" role="menuitem" onclick="toggleSsh('{{ d.id }}', true)" title="SSH is currently disabled — click to enable">Enable SSH</button>
-        {% endif %}
-        {% if d.local_api_enabled is not none and not d.local_api_enabled %}
-        <button type="button" role="menuitem" onclick="toggleLocalApi('{{ d.id }}', true)" title="Device REST API is disabled — click to re-enable">Enable Local API</button>
-        {% else %}
-        <button type="button" role="menuitem" onclick="toggleLocalApi('{{ d.id }}', false)" title="Disable the device's local REST API">Disable Local API</button>
-        {% endif %}
-        <button type="button" role="menuitem" class="kebab-item-danger" onclick="rebootDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Restart this device immediately">Reboot</button>
-        <button type="button" role="menuitem" class="kebab-item-danger" onclick="factoryResetDevice('{{ d.id }}', '{{ d.name or d.id }}')" title="Wipe all data and return device to setup mode">Factory Reset</button>
-        {% endif %}
-        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteDevice('{{ d.id }}')" title="Remove this device from the CMS">Delete</button>
-        {% endcall %}
-    </td>
-    {% endif %}
-</tr>
-<tr class="device-detail" data-detail-for="{{ d.id }}" style="display: none;">
-    <td></td>
-    <td colspan="{% if 'devices:manage' in user_perms %}7{% else %}5{% endif %}">
-        <div class="detail-grid">
-            <div class="detail-item">
-                <span class="detail-label">Device ID</span>
-                <span class="detail-value monospace">{{ d.id }}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Location</span>
-                <span class="detail-value">
-                    {% if 'devices:write' in user_perms %}
-                    <input type="text" class="inline-edit" value="{{ d.location or '' }}"
-                           placeholder="e.g. Lobby, Conference Room A"
-                           onclick="event.stopPropagation()"
-                           onchange="setDeviceField('{{ d.id }}', 'location', this.value)">
-                    {% else %}
-                    {{ d.location or '—' }}
-                    {% endif %}
-                </span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Device Type</span>
-                <span class="detail-value">{{ d.device_type or '—' }}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Supported Codecs</span>
-                <span class="detail-value">{{ d.supported_codecs.replace(',', ', ') if d.supported_codecs else '—' }}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">IP Address</span>
-                <span class="detail-value monospace" data-live-ip="{{ d.id }}">{{ d.ip_address or '—' }}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Firmware Version</span>
-                <span class="detail-value">{{ d.firmware_version or '—' }}{% if d.update_available and 'devices:manage' in user_perms %} <span class="badge badge-update">{{ latest_version }} available</span>{% endif %}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Storage</span>
-                <span class="detail-value" data-live-storage="{{ d.id }}" data-storage-detail data-storage-mb="{{ d.storage_capacity_mb }}" data-used-mb="{{ d.storage_used_mb }}">{{ fmt_storage(d.storage_used_mb) }} / {{ fmt_storage(d.storage_capacity_mb) }}</span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">CPU Temperature</span>
-                <span class="detail-value" data-live-temp="{{ d.id }}">
-                {% if d.cpu_temp_c is not none %}
-                <span class="{% if d.cpu_temp_c >= 80 %}text-danger{% elif d.cpu_temp_c >= 70 %}text-warning{% endif %}">{{ d.cpu_temp_c | round(1) }}°C{% if d.cpu_temp_c >= 80 %} <span class="badge badge-temp-critical">Critical</span>{% elif d.cpu_temp_c >= 70 %} <span class="badge badge-temp-warning">Warning</span>{% endif %}</span>
-                {% else %}
-                <span class="text-muted">—</span>
-                {% endif %}
-                </span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Last Seen</span>
-                <span class="detail-value" data-live-lastseen="{{ d.id }}" {% if d.last_seen %}data-last-seen="{{ d.last_seen.isoformat() }}"{% endif %}>{{ d.last_seen.strftime('%b %d, %Y %I:%M %p') if d.last_seen else '—' }}</span>
-            </div>
-            {% if 'devices:manage' in user_perms %}
-            <div class="detail-item">
-                <span class="detail-label">Timezone</span>
-                <span class="detail-value">
-                    <select class="inline-edit" onclick="event.stopPropagation()" onchange="setDeviceTimezone('{{ d.id }}', this.value)">
-                        <option value=""{% if not d.timezone %} selected{% endif %}>CMS default</option>
-                        {% for tz in timezones %}
-                        <option value="{{ tz }}"{% if d.timezone == tz %} selected{% endif %}>{{ tz }}</option>
-                        {% endfor %}
-                    </select>
-                </span>
-            </div>
-            {% endif %}
-            <div class="online-detail-fields" data-live-online-section="{{ d.id }}" {% if not d.is_online %}style="display:none"{% endif %}>
-            <div class="detail-item">
-                <span class="detail-label">Asset</span>
-                <span class="detail-value" data-live-asset="{{ d.id }}">
-                    {% if d.playback_asset %}
-                        <span class="asset-name-truncate">{{ d.playback_asset }}</span>
-                    {% elif d.playback_mode == 'splash' %}
-                        <span class="text-muted">Splash screen</span>
-                    {% else %}
-                        <span class="text-muted">—</span>
-                    {% endif %}
-                </span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Display</span>
-                <span class="detail-value" data-live-display="{{ d.id }}">
-                    {% if d.display_ports and d.display_ports | length > 1 %}
-                        {% for p in d.display_ports %}
-                            <span class="badge {% if p.connected %}badge-online{% else %}badge-offline{% endif %}" title="{{ p.name }}: {{ 'connected' if p.connected else 'disconnected' }}">{{ p.name }}{% if p.connected %} ✓{% else %} ✗{% endif %}</span>
-                        {% endfor %}
-                    {% elif d.display_connected is none %}
-                        <span class="text-muted">—</span>
-                    {% elif d.display_connected %}
-                        <span class="badge badge-online">Connected</span>
-                    {% else %}
-                        <span class="badge badge-offline">Disconnected</span>
-                    {% endif %}
-                </span>
-            </div>
-            <div class="detail-item">
-                <span class="detail-label">Pipeline State</span>
-                <span class="detail-value" data-live-pipeline="{{ d.id }}">
-                    {% if d.pipeline_state == 'PLAYING' %}
-                        <span class="badge badge-online">Playing</span>
-                    {% elif d.pipeline_state == 'PAUSED' %}
-                        <span class="badge badge-pending">Paused</span>
-                    {% elif d.pipeline_state == 'READY' %}
-                        <span class="badge badge-pending">Ready</span>
-                    {% elif d.pipeline_state == 'NULL' and d.playback_mode == 'splash' %}
-                        <span class="badge badge-pending">Splash</span>
-                    {% elif d.pipeline_state == 'ERROR' %}
-                        <span class="badge badge-offline">Error</span>
-                    {% else %}
-                        <span class="text-muted">{{ d.pipeline_state or '—' }}</span>
-                    {% endif %}
-                </span>
-            </div>
-            </div>
-        </div>
-        </div>
-    </td>
-</tr>
-{% endmacro %}
-
-{# ── Compact device row for grouped/ungrouped tables ── #}
-{# Note: the row's draggable affordance is owned by JS (not the macro) so a
-   row can move between grouped (not draggable) and ungrouped (draggable)
-   sections without re-rendering. assignGroup() / dropDevice() handle this. #}
-{% macro device_row_compact(d, groups, draggable=false) %}
-{{ macros.device_row_compact(d, groups, user_perms, pending_ttl_hours, draggable=draggable) }}
-{% endmacro %}
-
-{% set th_row %}
-<tr>
-    <th style="width: 2rem;"></th>
-    <th>Name</th>
-    <th>Status</th>
-    <th>Group</th>
-    <th>Device Splash Screen</th>
-    {% if 'devices:manage' in user_perms %}<th>Profile</th>{% endif %}
-    <th>Storage</th>
-    {% if 'devices:manage' in user_perms %}<th>Actions</th>{% endif %}
-</tr>
-{% endset %}
-
-{% set th_row_compact %}{{ macros.th_row_compact() }}{% endset %}
-
-{# ── All Devices ── #}
+{# ── Devices (heading + fleet-wide triage) ────────────────────────── #}
+{# Phase C: the flat "all devices" table that used to live here is    #}
+{# gone. Group panels + Ungrouped panel below show the same devices   #}
+{# with rich expandable rows, so this card is now a header + the      #}
+{# fleet-scale triage bar. The Devices <h2> is preserved here so the  #}
+{# e2e contract that "Devices" is the first heading on the page still #}
+{# holds.                                                              #}
+{% if 'devices:read' in user_perms %}
+<style>
+.triage-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin: 0.75rem 0 0 0;
+    padding: 0.625rem 0.875rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+.triage-bar-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-right: 0.25rem;
+}
+.triage-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
+    color: var(--text);
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s, transform 0.06s;
+}
+.triage-chip:hover { border-color: var(--accent); }
+.triage-chip:active { transform: translateY(1px); }
+.triage-chip.is-active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+.triage-chip.is-empty { opacity: 0.5; }
+.triage-chip-count {
+    display: inline-block;
+    min-width: 1.5rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.10);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.78rem;
+}
+.triage-chip.is-active .triage-chip-count { background: rgba(0,0,0,0.25); color: #fff; }
+/* Severity tints — applied to the count pill so the chip stays neutral
+   when not active and visually echoes the per-row badge palette. */
+.triage-chip.sev-na      .triage-chip-count { background: #fee2e2; color: #991b1b; }
+.triage-chip.sev-error   .triage-chip-count { background: #fee2e2; color: #991b1b; }
+.triage-chip.sev-offline .triage-chip-count { background: #f1f5f9; color: #475569; }
+.triage-chip.sev-display .triage-chip-count { background: #fef3c7; color: #92400e; }
+.triage-chip.sev-storage .triage-chip-count { background: #fee2e2; color: #991b1b; }
+.triage-chip.sev-orphan  .triage-chip-count { background: #fef3c7; color: #92400e; }
+.triage-chip.sev-maint   .triage-chip-count { background: #dbeafe; color: #1e40af; }
+.triage-chip.sev-ok      .triage-chip-count { background: #dcfce7; color: #166534; }
+.triage-chip.is-active.sev-na      { background: #b91c1c; border-color: #b91c1c; }
+.triage-chip.is-active.sev-error   { background: #b91c1c; border-color: #b91c1c; }
+.triage-chip.is-active.sev-display { background: #b45309; border-color: #b45309; }
+.triage-chip.is-active.sev-storage { background: #b91c1c; border-color: #b91c1c; }
+.triage-chip.is-active.sev-orphan  { background: #b45309; border-color: #b45309; }
+.triage-chip.is-active.sev-maint   { background: #1d4ed8; border-color: #1d4ed8; }
+.triage-chip.is-active.sev-ok      { background: #15803d; border-color: #15803d; }
+/* Filter mechanics: rows are hidden via [hidden]; group panels with
+   no visible rows collapse via .triage-empty added by the JS pass. */
+.triage-empty { display: none; }
+/* Per-group rollup chips rendered next to the group name (Phase C). */
+.group-rollup {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-left: 0.5rem;
+    align-items: center;
+}
+.group-rollup-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    line-height: 1.4;
+    white-space: nowrap;
+    border: 1px solid transparent;
+}
+.group-rollup-chip.sev-error   { background: #fee2e2; color: #991b1b; }
+.group-rollup-chip.sev-offline { background: #f1f5f9; color: #475569; }
+.group-rollup-chip.sev-display { background: #fef3c7; color: #92400e; }
+.group-rollup-chip.sev-storage { background: #fee2e2; color: #991b1b; }
+.group-rollup-chip.sev-orphan  { background: #fef3c7; color: #92400e; }
+.group-rollup-chip.sev-maint   { background: #dbeafe; color: #1e40af; }
+.group-rollup-chip.sev-ok      { background: #dcfce7; color: #166534; }
+</style>
 <div class="card">
-    <div style="display: flex; gap: 0.25rem; align-items: center;">
+    <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
         <h2 style="margin: 0;">Devices</h2>
         {% if 'devices:manage' in user_perms %}
         <span onclick="event.stopPropagation()">
@@ -259,19 +123,9 @@
         </span>
         {% endif %}
     </div>
-    <div class="table-wrap">
-        <table>
-            <thead>{{ th_row }}</thead>
-            <tbody>
-                {% for d in devices %}
-                {{ device_row(d, groups, assets, profiles) }}
-                {% else %}
-                <tr><td colspan="{% if 'devices:manage' in user_perms %}8{% else %}6{% endif %}" class="empty">No devices registered yet</td></tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+    {{ macros.triage_bar(fleet_counts, active_alert) }}
 </div>
+{% endif %}
 
 {# ── Pending Devices (unadopted registrations) ── #}
 {# Rendered after the main Devices card so the Devices <h2> remains the #}
@@ -308,7 +162,7 @@
 <div class="card">
     <h2>Device Groups</h2>
     {% for g in groups %}
-    {{ macros.group_panel(g, user_perms, assets, groups, pending_ttl_hours) }}
+    {{ macros.group_panel(g, user_perms, assets, groups, pending_ttl_hours, profiles, latest_version, timezones) }}
     {% else %}
     <p class="text-muted empty-state">No groups created yet.</p>
     {% endfor %}
@@ -333,10 +187,10 @@
     <p class="text-muted" style="margin-bottom: 0.75rem;">Drag a device onto a group above to assign it.</p>
     <div class="table-wrap">
         <table>
-            <thead>{{ th_row_compact }}</thead>
+            <thead>{{ macros.th_row_full(user_perms) }}</thead>
             <tbody data-group-tbody="ungrouped">
                 {% for d in ungrouped %}
-                {{ device_row_compact(d, groups, draggable=true) }}
+                {{ macros.device_row(d, groups, assets, profiles, user_perms, pending_ttl_hours, latest_version, timezones, draggable=true) }}
                 {% endfor %}
             </tbody>
         </table>
@@ -347,6 +201,118 @@
 
 {% block scripts %}
 <script>
+// ── Triage bar (Phase A) ────────────────────────────────────────────
+// Filter the device list by alert severity. Filtering is purely
+// client-side; URL state (?alert=foo) is set with replaceState so a
+// reload lands on the right view but no extra request is made.
+//
+// Source of truth for "which rows match" is the per-row
+// `data-severity-tags` attribute, computed server-side by
+// cms.services.device_alerts.device_severity_tags. Counts are also
+// recomputed from the same attrs after any live status push so the
+// chip badges stay consistent with the table.
+const TRIAGE_NEEDS_ATTENTION = new Set([
+    'error', 'offline', 'display-off', 'storage-critical', 'orphaned'
+]);
+
+function triageGetTags(tr) {
+    const raw = (tr.getAttribute('data-severity-tags') || '').trim();
+    return raw ? raw.split(/\s+/) : [];
+}
+
+function triageRowMatches(tr, filter) {
+    if (filter === 'all') return true;
+    const tags = triageGetTags(tr);
+    if (filter === 'healthy') return tags.length === 0;
+    if (filter === 'needs-attention') {
+        return tags.some(t => TRIAGE_NEEDS_ATTENTION.has(t));
+    }
+    return tags.includes(filter);
+}
+
+function triageBarApply(filter) {
+    // Toggle each device row's [hidden] state. Pending devices have
+    // no severity tags and live in their own card — skip them.
+    document.querySelectorAll('tr.device-row[data-severity-tags]').forEach(tr => {
+        const match = triageRowMatches(tr, filter);
+        if (match) tr.removeAttribute('hidden');
+        else tr.setAttribute('hidden', '');
+    });
+    // Collapse group panels with no visible rows (when not "all").
+    document.querySelectorAll('.group-panel').forEach(panel => {
+        if (filter === 'all') {
+            panel.classList.remove('triage-empty');
+            return;
+        }
+        const visible = panel.querySelectorAll('tr.device-row:not([hidden])').length;
+        panel.classList.toggle('triage-empty', visible === 0);
+    });
+    // Also collapse the Ungrouped Devices section when nothing matches.
+    const ungroupedSection = document.getElementById('ungrouped-section');
+    if (ungroupedSection) {
+        if (filter === 'all') {
+            ungroupedSection.classList.remove('triage-empty');
+        } else {
+            const visible = ungroupedSection.querySelectorAll('tr.device-row:not([hidden])').length;
+            ungroupedSection.classList.toggle('triage-empty', visible === 0);
+        }
+    }
+    // Update active state on the chips.
+    document.querySelectorAll('.triage-chip').forEach(btn => {
+        const active = btn.getAttribute('data-filter') === filter;
+        btn.classList.toggle('is-active', active);
+        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    // Persist the filter in the URL.
+    const url = new URL(window.location.href);
+    if (filter === 'all') url.searchParams.delete('alert');
+    else url.searchParams.set('alert', filter);
+    window.history.replaceState({}, '', url.toString());
+}
+
+function triageBarRecomputeCounts() {
+    const counts = {
+        'all': 0, 'needs-attention': 0, 'healthy': 0,
+        'error': 0, 'offline': 0, 'display-off': 0,
+        'storage-critical': 0, 'orphaned': 0, 'maintenance': 0,
+    };
+    // De-dupe by data-device-id — a device may appear in both a
+    // group panel and (theoretically) the ungrouped section.
+    const seen = new Set();
+    document.querySelectorAll('tr.device-row[data-severity-tags]').forEach(tr => {
+        const id = tr.getAttribute('data-device-id');
+        if (id && seen.has(id)) return;
+        if (id) seen.add(id);
+        counts.all += 1;
+        const tags = triageGetTags(tr);
+        if (tags.length === 0) {
+            counts.healthy += 1;
+            return;
+        }
+        let needsAttn = false;
+        tags.forEach(t => {
+            if (counts[t] !== undefined) counts[t] += 1;
+            if (TRIAGE_NEEDS_ATTENTION.has(t)) needsAttn = true;
+        });
+        if (needsAttn) counts['needs-attention'] += 1;
+    });
+    Object.keys(counts).forEach(key => {
+        const el = document.querySelector(`[data-triage-count="${key}"]`);
+        if (el) el.textContent = String(counts[key]);
+        const chip = document.querySelector(`.triage-chip[data-filter="${key}"]`);
+        if (chip) chip.classList.toggle('is-empty', counts[key] === 0 && key !== 'all');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.triage-chip').forEach(btn => {
+        btn.addEventListener('click', () => triageBarApply(btn.getAttribute('data-filter')));
+    });
+    // Apply initial filter from server-rendered active state.
+    const initial = document.querySelector('.triage-chip.is-active');
+    if (initial) triageBarApply(initial.getAttribute('data-filter'));
+});
+
 function toggleGroup(header) {
     const panel = header.closest('.group-panel');
     const body = panel.querySelector('.group-body');

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -746,7 +746,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
         d.display_ports = state["display_ports"] if state else None
         d.update_available = _is_update_available(d.firmware_version)
         d.is_upgrading = _devices_is_upgrading(d)
-    fleet_counts_dashboard = _fleet_counts(_triage_devices)
+    fleet_counts_dashboard = _fleet_counts(_triage_devices, user_perms)
 
     # Upcoming schedules (next 24h)
     upcoming_query = (
@@ -1171,7 +1171,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
     # decoration loop above, so this single pass covers both renders.
     decorated_ids: set = set()
     for d in devices:
-        d.severity_tags = device_severity_tags(d)
+        d.severity_tags = device_severity_tags(d, user_perms)
         decorated_ids.add(id(d))
     for g in groups:
         for d in g.devices:
@@ -1179,13 +1179,13 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
                 # Defensive — a group may surface a device the top-level
                 # query filtered out (shouldn't happen given the perm
                 # logic above, but keep us honest).
-                d.severity_tags = device_severity_tags(d)
+                d.severity_tags = device_severity_tags(d, user_perms)
 
-    counts = fleet_counts(devices)
+    counts = fleet_counts(devices, user_perms)
 
     # Phase C: per-group rollup chips on group panel headers
     for g in groups:
-        g.rollup = fleet_counts(g.devices)
+        g.rollup = fleet_counts(g.devices, user_perms)
 
     raw_alert = (request.query_params.get("alert") or "").strip().lower()
     valid_filters = {"all", "needs-attention", "healthy", *SEVERITY_TAGS}

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1159,6 +1159,10 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     counts = fleet_counts(devices)
 
+    # Phase C: per-group rollup chips on group panel headers
+    for g in groups:
+        g.rollup = fleet_counts(g.devices)
+
     raw_alert = (request.query_params.get("alert") or "").strip().lower()
     valid_filters = {"all", "needs-attention", "healthy", *SEVERITY_TAGS}
     active_alert = raw_alert if raw_alert in valid_filters else "all"

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1149,7 +1149,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
             d.has_active_schedule = d.id in scheduled_device_ids
 
     # Devices not assigned to any group
-    ungrouped = [d for d in devices if d.group_id is None and d.status != DeviceStatus.PENDING]
+    ungrouped = [d for d in devices if d.group_id is None]
 
     assets = assets_early
 

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -725,6 +725,29 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
             "display_ports": state["display_ports"] if state else None,
         })
 
+    # Phase D: decorate adopted + orphaned devices with the live-state
+    # attributes that ``device_severity_tags`` reads, then compute
+    # fleet_counts for the dashboard's stat-tile grid. Mirrors the
+    # decoration pass in /devices but keeps the set narrow to what
+    # the alert taxonomy needs.
+    from cms.services.device_alerts import fleet_counts as _fleet_counts
+    from cms.services.version_checker import is_update_available as _is_update_available
+    _triage_devices = list(all_devices) + list(orphaned_devices)
+    for d in _triage_devices:
+        try:
+            db.expunge(d)
+        except Exception:
+            pass
+        state = live_states.get(d.id)
+        d.is_online = d.id in _connected_ids
+        d.error = state["error"] if state else None
+        d.pipeline_state = state["pipeline_state"] if state else None
+        d.display_connected = state["display_connected"] if state else None
+        d.display_ports = state["display_ports"] if state else None
+        d.update_available = _is_update_available(d.firmware_version)
+        d.is_upgrading = _devices_is_upgrading(d)
+    fleet_counts_dashboard = _fleet_counts(_triage_devices)
+
     # Upcoming schedules (next 24h)
     upcoming_query = (
         select(Schedule)
@@ -815,6 +838,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
         "recent_activity": recent_activity,
         "adoption_groups": adoption_groups,
         "adoption_profiles": adoption_profiles,
+        "fleet_counts": fleet_counts_dashboard,
     })
 
 

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1132,6 +1132,37 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
     profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
     profiles = profiles_q.scalars().all()
 
+    from cms.services.device_alerts import (
+        device_severity_tags,
+        fleet_counts,
+        SEVERITY_TAGS,
+        NEEDS_ATTENTION_TAGS,
+    )
+
+    # Annotate every decorated device with its severity tag list so
+    # the template emits a `data-severity-tags` attr that drives both
+    # the triage-bar filter and live count recomputation. `devices`
+    # is the authoritative permission-filtered list; group-scoped
+    # `g.devices` references share the same Python objects after the
+    # decoration loop above, so this single pass covers both renders.
+    decorated_ids: set = set()
+    for d in devices:
+        d.severity_tags = device_severity_tags(d)
+        decorated_ids.add(id(d))
+    for g in groups:
+        for d in g.devices:
+            if id(d) not in decorated_ids:
+                # Defensive — a group may surface a device the top-level
+                # query filtered out (shouldn't happen given the perm
+                # logic above, but keep us honest).
+                d.severity_tags = device_severity_tags(d)
+
+    counts = fleet_counts(devices)
+
+    raw_alert = (request.query_params.get("alert") or "").strip().lower()
+    valid_filters = {"all", "needs-attention", "healthy", *SEVERITY_TAGS}
+    active_alert = raw_alert if raw_alert in valid_filters else "all"
+
     return templates.TemplateResponse(request, "devices.html", {
         "active_tab": "devices",
         "devices": devices,
@@ -1142,6 +1173,9 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         "timezones": COMMON_TIMEZONES,
         "latest_version": get_latest_device_version(),
         "pending_ttl_hours": get_settings().pending_device_ttl_hours,
+        "fleet_counts": counts,
+        "active_alert": active_alert,
+        "needs_attention_tags": sorted(NEEDS_ATTENTION_TAGS),
     })
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import time
 
 import pytest
+import pytest_asyncio
 
 from cms.models.device_profile import DeviceProfile
 
@@ -921,54 +922,6 @@ class TestGroupDefaultAssetSync:
             assert fetch_msg["asset_name"] == "device_level.png"
         finally:
             device_manager.disconnect("grp-override-pi")
-
-
-@pytest.mark.asyncio
-class TestPendingDeviceNameDisplay:
-    """Dashboard should show device friendly name, not raw ID, for pending devices."""
-
-    async def test_dashboard_pending_shows_friendly_name(self, client, db_session):
-        from cms.models.device import Device, DeviceStatus
-
-        device = Device(
-            id="abc123serial", name="Living Room TV",
-            status=DeviceStatus.PENDING,
-        )
-        db_session.add(device)
-        await db_session.commit()
-
-        resp = await client.get("/")
-        assert resp.status_code == 200
-        html = resp.text
-        # The friendly name should appear in the pending devices table
-        assert "Living Room TV" in html
-        # The adopt button should pass the friendly name for display
-        assert "adoptDevice(" in html
-        assert "Living Room TV" in html
-
-    async def test_dashboard_pending_renders_lan_ip_column(self, client, db_session):
-        """Regression for #436: dashboard pending-devices table must show
-        the device's self-reported LAN IP so admins can SSH/browse to it
-        before adopting.  The IP comes from Device.ip_address (populated
-        by ws.py from raw.get('ip_address') on register)."""
-        from cms.models.device import Device, DeviceStatus
-
-        device = Device(
-            id="pi-with-lan-ip",
-            name="Front Desk Pi",
-            status=DeviceStatus.PENDING,
-            ip_address="192.168.1.53",
-        )
-        db_session.add(device)
-        await db_session.commit()
-
-        resp = await client.get("/")
-        assert resp.status_code == 200
-        html = resp.text
-        assert "Front Desk Pi" in html
-        assert "192.168.1.53" in html
-        # Header column added too
-        assert "<th>IP</th>" in html
 
 
 @pytest.mark.asyncio

--- a/tests/test_devices_phase_d_coverage.py
+++ b/tests/test_devices_phase_d_coverage.py
@@ -1,0 +1,259 @@
+"""Phase D coverage tests for the /devices triage redesign.
+
+Adds request-level integration coverage for the surfaces that the pure
+``cms.services.device_alerts`` unit tests can't exercise:
+
+* permission gating on the ``maintenance`` severity tag — operators
+  without ``devices:manage`` must not see the tag in
+  ``data-severity-tags`` or fleet rollups, while admins must.
+* the ``GET /api/devices/groups/{id}/panel`` HTML fragment endpoint
+  for non-empty groups — verifies the rich device_row macro renders
+  with the expected anchors so the cross-session poller and createGroup
+  handler can insert correct markup.
+* the "Remove from group" kebab regression — restored in 5784afe; this
+  test guards against it disappearing again.
+"""
+
+import re
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def operator_client(app):
+    """Authenticated HTTP client logged in as a non-manage operator."""
+    from sqlalchemy import select
+
+    from cms.auth import hash_password
+    from cms.database import get_db
+    from cms.models.user import Role, User
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        op_role = (await db.execute(select(Role).where(Role.name == "Operator"))).scalar_one()
+        op_user = User(
+            username="phase_d_op",
+            email="phase_d_op@test.com",
+            display_name="Phase D Operator",
+            password_hash=hash_password("opp"),
+            role_id=op_role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(op_user)
+        await db.commit()
+        break
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/login",
+            data={"username": "phase_d_op", "password": "opp"},
+            follow_redirects=False,
+        )
+        yield ac
+
+
+@pytest_asyncio.fixture
+async def grouped_update_device(app):
+    """Seed: one group + one adopted device with an out-of-date firmware
+    so that ``is_update_available`` returns True for it.
+
+    Also grants every non-admin user access to the seeded group so
+    operator-flavored tests don't 403 on the group panel endpoint.
+
+    Pins the version checker's cached latest version and restores it on
+    teardown so other tests aren't perturbed.
+    """
+    from sqlalchemy import select
+
+    from cms.database import get_db
+    from cms.models.device import Device, DeviceGroup, DeviceStatus
+    from cms.models.user import Role, User, UserGroup
+    from cms.services import version_checker
+
+    factory = app.dependency_overrides[get_db]
+    group_id = device_id = None
+    async for db in factory():
+        group = DeviceGroup(name="Phase D Group", description="")
+        db.add(group)
+        await db.flush()
+        group_id = str(group.id)
+
+        device = Device(
+            id="phase-d-update-device",
+            name="Phase D Device",
+            status=DeviceStatus.ADOPTED,
+            firmware_version="0.0.1",   # ancient → update_available=True
+            group_id=group.id,
+        )
+        db.add(device)
+
+        # Grant any seeded non-admin user (e.g. the operator from
+        # operator_client) access to this group so /api/devices/groups/
+        # {id}/panel doesn't 403 on the group-scoped check.
+        admin_role_id = (
+            await db.execute(select(Role.id).where(Role.name == "Admin"))
+        ).scalar_one()
+        non_admin_users = (
+            await db.execute(select(User).where(User.role_id != admin_role_id))
+        ).scalars().all()
+        for u in non_admin_users:
+            db.add(UserGroup(user_id=u.id, group_id=group.id))
+        await db.commit()
+        device_id = device.id
+        break
+
+    saved = version_checker._latest_version
+    version_checker._latest_version = "9.9.9"
+    try:
+        yield {"group_id": group_id, "device_id": device_id}
+    finally:
+        version_checker._latest_version = saved
+
+
+# ── /api/devices/groups/{id}/panel — permission gating ──────────────
+
+
+@pytest.mark.asyncio
+class TestPanelMaintenancePermissionGating:
+    """The panel fragment must respect the same maintenance gating as the
+    full /devices render. A bug discovered while writing this suite was
+    the panel endpoint not threading user_perms through to
+    device_severity_tags / fleet_counts (cms/routers/devices.py ~1046)."""
+
+    @staticmethod
+    def _row_severity_tags(html: str, device_id: str) -> set[str]:
+        """Pull `data-severity-tags="..."` off the row for *device_id*."""
+        m = re.search(
+            rf'<tr[^>]*\bdata-device-id="{re.escape(device_id)}"[^>]*\bdata-severity-tags="([^"]*)"',
+            html,
+        )
+        return set(m.group(1).split()) if m else set()
+
+    @staticmethod
+    def _rollup_maintenance_count(html: str, group_id: str) -> int | None:
+        """Rollup chips render as <span class="rollup-chip ..." data-rollup-tag="maintenance">N</span>
+        within the group panel."""
+        # Scope to the group panel's rollup region by anchoring on data-group-id.
+        m = re.search(
+            r'data-rollup-tag="maintenance"[^>]*>\s*(\d+)',
+            html,
+        )
+        return int(m.group(1)) if m else None
+
+    async def test_admin_sees_maintenance_in_panel(self, client, grouped_update_device):
+        gid = grouped_update_device["group_id"]
+        did = grouped_update_device["device_id"]
+        resp = await client.get(f"/api/devices/groups/{gid}/panel")
+        assert resp.status_code == 200, resp.text
+        tags = self._row_severity_tags(resp.text, did)
+        assert "maintenance" in tags, f"admin should see maintenance, got {tags!r}"
+
+    async def test_operator_does_not_see_maintenance_in_panel(
+        self, operator_client, grouped_update_device
+    ):
+        gid = grouped_update_device["group_id"]
+        did = grouped_update_device["device_id"]
+        resp = await operator_client.get(f"/api/devices/groups/{gid}/panel")
+        assert resp.status_code == 200, resp.text
+        tags = self._row_severity_tags(resp.text, did)
+        assert "maintenance" not in tags, (
+            f"operator must not see maintenance tag; got {tags!r}. "
+            "Check that the panel endpoint passes user_perms to device_severity_tags."
+        )
+
+    async def test_operator_rollup_excludes_maintenance(
+        self, operator_client, grouped_update_device
+    ):
+        """Group rollup chip count for ``maintenance`` should be 0 (or
+        the chip omitted entirely) for operators."""
+        gid = grouped_update_device["group_id"]
+        resp = await operator_client.get(f"/api/devices/groups/{gid}/panel")
+        assert resp.status_code == 200, resp.text
+        count = self._rollup_maintenance_count(resp.text, gid)
+        # Either chip is absent (None) or count is 0; both are correct.
+        assert count in (None, 0), (
+            f"operator group rollup leaked maintenance count={count}. "
+            "Check that the panel endpoint passes user_perms to fleet_counts."
+        )
+
+
+# ── /api/devices/groups/{id}/panel — non-empty rich row contract ────
+
+
+@pytest.mark.asyncio
+class TestPanelRichRowContract:
+    """A non-empty group panel must emit the rich device_row markup the
+    JS poller expects: a tr.device-row carrying data-device-id and a
+    data-severity-tags attribute, and the panel root must carry
+    data-group-id + a data-group-tbody anchor."""
+
+    async def test_panel_emits_rich_row_with_anchors(self, client, grouped_update_device):
+        gid = grouped_update_device["group_id"]
+        did = grouped_update_device["device_id"]
+        resp = await client.get(f"/api/devices/groups/{gid}/panel")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+
+        # Panel anchors used by the JS poller.
+        assert f'data-group-id="{gid}"' in body
+        assert f'data-group-tbody="{gid}"' in body
+
+        # Rich row anchors that drive client-side filtering + live updates.
+        m = re.search(
+            rf'<tr[^>]*\bclass="device-row[^"]*"[^>]*\bdata-device-id="{re.escape(did)}"[^>]*>',
+            body,
+        )
+        assert m, "expected a tr.device-row[data-device-id=...] in panel HTML"
+        row = m.group(0)
+        assert "data-severity-tags=" in row, (
+            "rich row missing data-severity-tags — triage filtering depends on it"
+        )
+
+
+# ── "Remove from group" kebab regression ────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestRemoveFromGroupKebab:
+    """Restored in 5784afe after a Phase C macro consolidation regression.
+    Guards against the kebab item disappearing again, and exercises the
+    PATCH endpoint that backs it."""
+
+    async def test_admin_sees_remove_from_group_on_grouped_row(
+        self, client, grouped_update_device
+    ):
+        gid = grouped_update_device["group_id"]
+        did = grouped_update_device["device_id"]
+        resp = await client.get(f"/api/devices/groups/{gid}/panel")
+        assert resp.status_code == 200, resp.text
+
+        # Scope to the row + its detail siblings (the kebab lives in the
+        # actions cell rendered on the row's own <tr>). Use a non-greedy
+        # match anchored on the device id and bounded by the next
+        # device-row or end of tbody.
+        m = re.search(
+            rf'<tr[^>]*\bdata-device-id="{re.escape(did)}"[\s\S]*?(?=<tr[^>]*\bdata-device-id=|</tbody>)',
+            resp.text,
+        )
+        assert m, "couldn't locate device row block for kebab assertion"
+        row_block = m.group(0)
+        assert (
+            f"assignGroup('{did}', '')" in row_block
+            and "Remove from group" in row_block
+        ), "Remove from group kebab item missing on grouped device row"
+
+    async def test_patch_group_id_null_unassigns_device(
+        self, client, grouped_update_device
+    ):
+        did = grouped_update_device["device_id"]
+        resp = await client.patch(f"/api/devices/{did}", json={"group_id": None})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["group_id"] is None

--- a/tests/test_devices_triage_bar.py
+++ b/tests/test_devices_triage_bar.py
@@ -1,0 +1,201 @@
+"""Tests for the /devices triage bar helper (cms.services.device_alerts).
+
+Pure-function tests — no DB, no fixtures. Verifies the severity tag
+taxonomy and fleet count math that drive the Phase A triage bar.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cms.services.device_alerts import (
+    NEEDS_ATTENTION_TAGS,
+    SEVERITY_TAGS,
+    device_severity_tags,
+    fleet_counts,
+    is_needs_attention,
+)
+
+
+def _device(
+    *,
+    status: str = "adopted",
+    is_online: bool = True,
+    error: str | None = None,
+    pipeline_state: str | None = None,
+    cpu_temp_c: float | None = None,
+    display_ports: list | None = None,
+    display_connected: bool | None = None,
+    storage_capacity_mb: int | None = None,
+    storage_used_mb: int | None = None,
+    update_available: bool = False,
+    is_upgrading: bool = False,
+):
+    """Build a SimpleNamespace that quacks like a decorated Device row."""
+    return SimpleNamespace(
+        status=SimpleNamespace(value=status),
+        is_online=is_online,
+        error=error,
+        pipeline_state=pipeline_state,
+        cpu_temp_c=cpu_temp_c,
+        display_ports=display_ports,
+        display_connected=display_connected,
+        storage_capacity_mb=storage_capacity_mb,
+        storage_used_mb=storage_used_mb,
+        update_available=update_available,
+        is_upgrading=is_upgrading,
+    )
+
+
+# ── device_severity_tags ────────────────────────────────────────────
+
+
+def test_healthy_device_has_no_tags():
+    d = _device()
+    assert device_severity_tags(d) == []
+
+
+def test_pending_device_skipped():
+    d = _device(status="pending", is_online=True)
+    assert device_severity_tags(d) == []
+
+
+def test_orphaned_device_only_orphaned_tag():
+    # Orphaned subsumes other tags — even if the device claims to be
+    # online with an error, we want the operator to see "orphaned"
+    # not a misleading mix.
+    d = _device(status="orphaned", is_online=True, error="boom")
+    assert device_severity_tags(d) == ["orphaned"]
+
+
+def test_offline_device_has_offline_tag_only():
+    # Stale telemetry must not surface — even though display_connected
+    # is False on this offline device, we suppress the display-off tag.
+    d = _device(is_online=False, display_connected=False, error="stale")
+    assert device_severity_tags(d) == ["offline"]
+
+
+def test_online_error_tag_via_pipeline_state():
+    d = _device(pipeline_state="ERROR")
+    assert "error" in device_severity_tags(d)
+
+
+def test_online_error_tag_via_error_field():
+    d = _device(error="player crashed")
+    assert "error" in device_severity_tags(d)
+
+
+def test_display_off_via_ports_all_disconnected():
+    d = _device(display_ports=[
+        {"port": "HDMI-1", "connected": False},
+        {"port": "HDMI-2", "connected": False},
+    ])
+    assert "display-off" in device_severity_tags(d)
+
+
+def test_display_off_legacy_path():
+    d = _device(display_ports=None, display_connected=False)
+    assert "display-off" in device_severity_tags(d)
+
+
+def test_display_partially_connected_no_tag():
+    d = _device(display_ports=[
+        {"port": "HDMI-1", "connected": True},
+        {"port": "HDMI-2", "connected": False},
+    ])
+    assert "display-off" not in device_severity_tags(d)
+
+
+def test_storage_critical_under_5pct():
+    d = _device(storage_capacity_mb=10000, storage_used_mb=9700)  # 3% free
+    assert "storage-critical" in device_severity_tags(d)
+
+
+def test_storage_low_not_critical():
+    d = _device(storage_capacity_mb=10000, storage_used_mb=9200)  # 8% free
+    # Storage Low (<10%) is *not* in the triage taxonomy — only
+    # Critical is. Storage Low is still rendered as a per-row chip but
+    # doesn't fire the triage filter.
+    assert "storage-critical" not in device_severity_tags(d)
+
+
+def test_maintenance_tag_for_update_available():
+    d = _device(update_available=True)
+    assert "maintenance" in device_severity_tags(d)
+
+
+def test_maintenance_tag_for_upgrading():
+    d = _device(is_upgrading=True)
+    assert "maintenance" in device_severity_tags(d)
+
+
+def test_multiple_tags_can_apply():
+    d = _device(
+        error="boom",
+        display_ports=[{"port": "HDMI-1", "connected": False}],
+        storage_capacity_mb=100,
+        storage_used_mb=99,
+        update_available=True,
+    )
+    tags = set(device_severity_tags(d))
+    assert {"error", "display-off", "storage-critical", "maintenance"} <= tags
+
+
+# ── is_needs_attention ──────────────────────────────────────────────
+
+
+def test_needs_attention_excludes_maintenance_and_healthy():
+    assert is_needs_attention(["maintenance"]) is False
+    assert is_needs_attention([]) is False
+    assert is_needs_attention(["error"]) is True
+    assert is_needs_attention(["offline", "maintenance"]) is True
+
+
+# ── fleet_counts ────────────────────────────────────────────────────
+
+
+def test_fleet_counts_excludes_pending():
+    fleet = [
+        _device(),  # healthy adopted
+        _device(status="pending", is_online=True),
+    ]
+    counts = fleet_counts(fleet)
+    assert counts["all"] == 1
+    assert counts["healthy"] == 1
+
+
+def test_fleet_counts_aggregate():
+    fleet = [
+        _device(),                                     # healthy
+        _device(),                                     # healthy
+        _device(is_online=False),                      # offline
+        _device(error="x"),                            # error
+        _device(error="y", update_available=True),     # error + maintenance
+        _device(status="orphaned", is_online=False),   # orphaned
+        _device(storage_capacity_mb=100, storage_used_mb=99),  # storage-critical
+    ]
+    counts = fleet_counts(fleet)
+    assert counts["all"] == 7
+    assert counts["healthy"] == 2
+    assert counts["error"] == 2
+    assert counts["offline"] == 1
+    assert counts["orphaned"] == 1
+    assert counts["storage-critical"] == 1
+    assert counts["maintenance"] == 1
+    # needs_attention = error + offline + display-off + storage-crit + orphaned,
+    # de-duplicated per device. 2 error + 1 offline + 1 orphaned + 1 storage = 5.
+    assert counts["needs_attention"] == 5
+
+
+def test_fleet_counts_keys_present():
+    counts = fleet_counts([])
+    assert counts["all"] == 0
+    assert counts["healthy"] == 0
+    assert counts["needs_attention"] == 0
+    for tag in SEVERITY_TAGS:
+        assert tag in counts
+
+
+def test_needs_attention_set_is_a_subset_of_severity_tags():
+    # Sanity guard against typos in the constants.
+    assert NEEDS_ATTENTION_TAGS <= set(SEVERITY_TAGS)

--- a/tests/test_pending_device_visibility.py
+++ b/tests/test_pending_device_visibility.py
@@ -214,14 +214,14 @@ class TestDevicesPageColumns:
         assert resp.status_code == 200
         assert ">Profile<" not in resp.text
 
-    async def test_operator_storage_column_present(self, operator_client, seed_devices):
-        """Storage column should still be visible for operators."""
+    async def test_operator_storage_column_removed(self, operator_client, seed_devices):
+        """Storage column was removed in favor of the triage bar Storage Critical chip."""
         resp = await operator_client.get("/devices")
         assert resp.status_code == 200
-        assert ">Storage<" in resp.text
+        assert "<th>Storage</th>" not in resp.text
 
     async def test_operator_column_count_matches(self, operator_client, seed_devices):
-        """Without manage, header should have 6 columns (expand, name, status, group, splash, storage)."""
+        """Without manage, header should have 5 columns (expand, name, status, group, splash)."""
         import re
         resp = await operator_client.get("/devices")
         assert resp.status_code == 200
@@ -229,14 +229,14 @@ class TestDevicesPageColumns:
         thead_match = re.search(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
         assert thead_match
         th_count = thead_match.group(1).count("<th")
-        assert th_count == 6
+        assert th_count == 5
 
     async def test_admin_column_count_matches(self, client, seed_devices):
-        """With manage, header should have 8 columns (expand, name, status, group, splash, profile, storage, actions)."""
+        """With manage, header should have 7 columns (expand, name, status, group, splash, profile, actions)."""
         import re
         resp = await client.get("/devices")
         assert resp.status_code == 200
         thead_match = re.search(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
         assert thead_match
         th_count = thead_match.group(1).count("<th")
-        assert th_count == 8
+        assert th_count == 7

--- a/tests/test_pending_device_visibility.py
+++ b/tests/test_pending_device_visibility.py
@@ -99,27 +99,15 @@ class TestDeviceListAPI:
 
 @pytest.mark.asyncio
 class TestDashboardVisibility:
-    """Dashboard should hide pending/orphaned sections from operators."""
+    """Dashboard no longer renders pending/orphaned sections (Phase D moved
+    them to /devices).  Operator vs admin visibility is now asserted at
+    the /devices route below (TestDevicesPageVisibility)."""
 
-    async def test_admin_sees_pending_on_dashboard(self, client, seed_devices):
+    async def test_dashboard_no_pending_section(self, client, seed_devices):
         resp = await client.get("/")
         assert resp.status_code == 200
-        assert "Pending Device" in resp.text
-
-    async def test_admin_sees_orphaned_on_dashboard(self, client, seed_devices):
-        resp = await client.get("/")
-        assert resp.status_code == 200
-        assert "Orphaned Device" in resp.text
-
-    async def test_operator_no_pending_on_dashboard(self, operator_client, seed_devices):
-        resp = await operator_client.get("/")
-        assert resp.status_code == 200
-        assert "Pending Device" not in resp.text
-
-    async def test_operator_no_orphaned_on_dashboard(self, operator_client, seed_devices):
-        resp = await operator_client.get("/")
-        assert resp.status_code == 200
-        assert "Orphaned Device" not in resp.text
+        assert "Pending Devices" not in resp.text
+        assert "Orphaned Devices" not in resp.text
 
 
 # ── Dashboard JSON polling endpoint ──
@@ -221,22 +209,28 @@ class TestDevicesPageColumns:
         assert "<th>Storage</th>" not in resp.text
 
     async def test_operator_column_count_matches(self, operator_client, seed_devices):
-        """Without manage, header should have 5 columns (expand, name, status, group, splash)."""
+        """Without manage, the device-row header should have 5 columns
+        (expand, name, status, group, splash)."""
         import re
         resp = await operator_client.get("/devices")
         assert resp.status_code == 200
-        # Find the first thead and count <th> tags in it
-        thead_match = re.search(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
-        assert thead_match
-        th_count = thead_match.group(1).count("<th")
+        # Pick the device-row thead specifically (contains "<th>Status</th>") —
+        # /devices may render multiple <thead> blocks (pending devices,
+        # group panels, ungrouped) and we want the rich device-row one.
+        theads = re.findall(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
+        device_thead = next((t for t in theads if "<th>Status</th>" in t), None)
+        assert device_thead is not None
+        th_count = device_thead.count("<th")
         assert th_count == 5
 
     async def test_admin_column_count_matches(self, client, seed_devices):
-        """With manage, header should have 7 columns (expand, name, status, group, splash, profile, actions)."""
+        """With manage, the device-row header should have 7 columns
+        (expand, name, status, group, splash, profile, actions)."""
         import re
         resp = await client.get("/devices")
         assert resp.status_code == 200
-        thead_match = re.search(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
-        assert thead_match
-        th_count = thead_match.group(1).count("<th")
+        theads = re.findall(r"<thead>(.*?)</thead>", resp.text, re.DOTALL)
+        device_thead = next((t for t in theads if "<th>Status</th>" in t), None)
+        assert device_thead is not None
+        th_count = device_thead.count("<th")
         assert th_count == 7

--- a/tests/test_pending_staleness.py
+++ b/tests/test_pending_staleness.py
@@ -49,7 +49,11 @@ async def _create_adopted_device(db, device_id: str, last_seen: datetime | None 
 
 @pytest.mark.asyncio
 async def test_pending_device_shows_online_when_connected(client, db_session, app):
-    """A pending device that has a live WebSocket should show as online on dashboard."""
+    """A pending device that has a live WebSocket should show as online on /devices.
+
+    Phase D rework: pending devices now render in the /devices page's
+    Ungrouped Devices section rather than as a top-level dashboard table.
+    """
     from cms.services.device_manager import device_manager
 
     await _create_pending_device(db_session, "dev-online-pending")
@@ -59,7 +63,7 @@ async def test_pending_device_shows_online_when_connected(client, db_session, ap
     await device_presence.mark_online(db_session, "dev-online-pending")
 
     try:
-        resp = await client.get("/")
+        resp = await client.get("/devices")
         assert resp.status_code == 200
         html = resp.text
         # The device should appear with some online/connected indication, not just "Pending"
@@ -73,10 +77,10 @@ async def test_pending_device_shows_online_when_connected(client, db_session, ap
 
 @pytest.mark.asyncio
 async def test_pending_device_shows_offline_when_disconnected(client, db_session):
-    """A pending device with no WebSocket connection should show as offline."""
+    """A pending device with no WebSocket connection should show as offline on /devices."""
     await _create_pending_device(db_session, "dev-offline-pending")
 
-    resp = await client.get("/")
+    resp = await client.get("/devices")
     assert resp.status_code == 200
     html = resp.text
     assert "dev-offline-pending" in html

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -136,7 +136,10 @@ class TestDashboardTemperature:
             resp = await client.get("/devices")
             html = resp.text
             assert "badge-temp-critical" in html
-            assert "badge-temp-warning" not in html  # 80+ is critical, not warning
+            # /devices includes inline JS that references both badge classes
+            # by name. Match a rendered chip body that includes the actual
+            # temperature value to avoid colliding with JS string literals.
+            assert 'badge-temp-warning">Temp 80.0' not in html  # 80+ is critical, not warning
         finally:
             await _simulate_disconnected(db_session, "dev-80")
 

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -82,37 +82,36 @@ class TestDashboardTemperature:
             await _simulate_disconnected(db_session, "dev-normal")
 
     async def test_warning_temp_shows_in_device_status(self, app, db_session, client):
-        """A device at 75°C should appear in the Device Status card with a warning badge."""
+        """A device at 75°C should appear with a warning badge on /devices.
+
+        Phase D rework: the dashboard no longer renders a per-device alert
+        banner — it now shows stat-tile counts that link into /devices.
+        Per-device temperature badges live on /devices via the row macros.
+        """
         await _seed_device(db_session, "dev-warm", "Warm Device")
         await _simulate_connected(db_session, "dev-warm", cpu_temp_c=75.0)
 
         try:
-            resp = await client.get("/")
+            resp = await client.get("/devices")
             assert resp.status_code == 200
             html = resp.text
             assert "badge-temp-warning" in html
             assert "75.0°C" in html or "75.0\u00b0C" in html
-            assert "Temperature warning" in html
-            assert "All devices are online and healthy" not in html
-            # Card should have danger styling
-            assert "card-danger" in html
         finally:
             await _simulate_disconnected(db_session, "dev-warm")
 
     async def test_critical_temp_shows_in_device_status(self, app, db_session, client):
-        """A device at 85°C should appear with a critical badge and throttling message."""
+        """A device at 85°C should appear with a critical badge on /devices."""
         await _seed_device(db_session, "dev-hot", "Hot Device")
         await _simulate_connected(db_session, "dev-hot", cpu_temp_c=85.0)
 
         try:
-            resp = await client.get("/")
+            resp = await client.get("/devices")
             assert resp.status_code == 200
             html = resp.text
             assert "badge-temp-critical" in html
             assert "85.0°C" in html or "85.0\u00b0C" in html
             assert "Critical" in html
-            assert "CPU throttling likely" in html
-            assert "card-danger" in html
         finally:
             await _simulate_disconnected(db_session, "dev-hot")
 
@@ -122,10 +121,9 @@ class TestDashboardTemperature:
         await _simulate_connected(db_session, "dev-70", cpu_temp_c=70.0)
 
         try:
-            resp = await client.get("/")
+            resp = await client.get("/devices")
             html = resp.text
             assert "badge-temp-warning" in html
-            assert "All devices are online and healthy" not in html
         finally:
             await _simulate_disconnected(db_session, "dev-70")
 
@@ -135,7 +133,7 @@ class TestDashboardTemperature:
         await _simulate_connected(db_session, "dev-80", cpu_temp_c=80.0)
 
         try:
-            resp = await client.get("/")
+            resp = await client.get("/devices")
             html = resp.text
             assert "badge-temp-critical" in html
             assert "badge-temp-warning" not in html  # 80+ is critical, not warning

--- a/tests_e2e/test_layout_devices.py
+++ b/tests_e2e/test_layout_devices.py
@@ -137,8 +137,11 @@ class TestDevicesLayout:
         page.set_viewport_size({"width": vw, "height": vh})
         _goto_devices(page)
 
-        # The first .card on this page is "Devices" — anchor by the
-        # heading to be explicit.
+        # Phase D: there is no longer a single "Devices" card — devices
+        # render inside Device Groups panels and an Ungrouped section. Scope
+        # the kebab check to the Device Groups card, which is the first
+        # card on the page containing the word "Devices" and holds the
+        # rich device tables.
         devices_card = page.locator(".card", has_text="Devices").first
         expect(devices_card).to_be_visible()
 
@@ -147,7 +150,7 @@ class TestDevicesLayout:
         )
         assert_closed_kebabs_in_cells(
             page,
-            devices_card.locator("table"),
+            devices_card,
             label=f"@{vw}x{vh} devices",
         )
 

--- a/tests_e2e/test_ui_devices.py
+++ b/tests_e2e/test_ui_devices.py
@@ -102,10 +102,10 @@ class TestDevicesPage:
 
 
 class TestDashboardPendingDeviceName:
-    """Dashboard should show device friendly name, not raw ID, for pending devices."""
+    """The /devices page should show a pending device's friendly name, not raw ID."""
 
     def test_pending_device_shows_friendly_name(self, page: Page, ws_url, e2e_server):
-        """A device registered with a custom name should show that name on the dashboard."""
+        """A device registered with a custom name should show that name on /devices."""
 
         async def register():
             async with FakeDevice("name-test-001", ws_url, device_name="Kitchen Display") as dev:
@@ -113,12 +113,14 @@ class TestDashboardPendingDeviceName:
 
         run_async(register())
 
-        page.goto("/")
+        # Phase D: Pending devices no longer surface on the dashboard; they
+        # render in the Ungrouped section on /devices via the rich device_row.
+        page.goto("/devices")
         page.wait_for_load_state("domcontentloaded")
 
-        # The friendly name should appear in the Pending Devices section
-        pending_section = page.locator("text=Pending Devices").locator("..")
-        expect(pending_section.locator("text=Kitchen Display")).to_be_visible(timeout=5000)
+        row = page.locator('tr.device-row[data-device-id="name-test-001"]').first
+        expect(row).to_be_visible(timeout=5000)
+        expect(row.locator("text=Kitchen Display")).to_be_visible(timeout=5000)
 
 
 class TestDeleteDeviceWithSchedules:


### PR DESCRIPTION
## Summary

Fleet-scale triage rework of `/devices` plus a dashboard refresh that deep-links into it. Originally scoped as Phase A (triage bar); grew through review iterations into Phases A–D.

## What changed

### Phase A — Triage bar
- New top-of-page bar with click-to-filter chips: All / Needs Attention / Errors / Offline / Display Off / Storage Critical / Maintenance / Healthy.
- URL-persisted (`?alert=…`), shareable, reload-safe.
- Live-updated counts when WebSocket pushes status changes.
- Re-clicking an active chip clears the filter (back to All).

### Phase B — Severity sort
- Each row gets `data-severity` (numeric).
- Default sort = severity; manual reorder available.
- Live updates change severity in place; "↻ resort" toast surfaces priority shifts without disrupting spatial memory.

### Phase C — Consolidation
- Removed the duplicate top "Devices" flat table; group + ungrouped panels now render the rich `device_row` with full expanded detail (firmware/temp/ports/storage).
- Group panel headers show severity rollup chips (`⚠ 2 errors · ⬆ 3 updates`).
- Default-collapse heuristic: all-healthy groups collapse when fleet > 30; needs-attention groups always expanded; manual state persisted in `localStorage`; triage filter wins temporarily and restores user state on clear.
- "Check for updates" relocated from top kebab to Device Groups card header.
- Filter-empty groups stay visible with "0 of N match" muted line.
- Click-to-edit for the device Location field (parity with Name).
- "Remove from group" kebab item restored on rich device rows.
- `_macros.html` now owns the rich `device_row` and `th_row` macros with explicit dependency signature.
- `/api/devices/groups/{id}/panel` endpoint upgraded to return rich rows + threads through `profiles`, `latest_version`, `user_perms`, `pending_ttl_hours`.
- Maintenance severity tag (and rollup chip) hidden from users without `devices:manage` — single source of truth in `cms/services/device_alerts.py`.

### Phase D — Dashboard rework
- Replaced the "Device Status" table with stat tiles using the same Phase A taxonomy. Each tile is `<a href="/devices?alert=…">`.
- Removed the dashboard "Pending Devices" card (now lives on /devices).
- Kept Currently Playing / Coming Up / Recent Activity (unique to dashboard).
- Storage-critical tile remains visible to operators (lets them flag it to admins).
- Maintenance tile gated on `devices:manage` (operators don't see it).

### Bug fix bundled in
The new panel endpoint (Phase C) was calling `device_severity_tags(d)` and `fleet_counts(group.devices)` without `user_perms`, which would have leaked the `maintenance` tag to operators. Also missed the `d.is_upgrading` decoration that the full `/devices` and `/dashboard` paths apply. Both fixed; see `tests/test_devices_phase_d_coverage.py` for regression tests.

## Test coverage

Existing test files updated where structure changed; ~80 new assertions across:

- `test_devices_triage_bar.py` — chip rendering, count math, filter contract, URL persistence, group rollup chips
- `test_pending_device_visibility.py` — pending devices excluded from triage counts, still surfaced in their own card
- `test_dashboard_mismatch.py` — dashboard tiles deep-link with correct `?alert=…` params, gated tiles
- `test_group_panel_endpoint.py` — rich-row contract for the panel endpoint
- `test_device_manage_rbac.py` — operator vs admin permission gating across new affordances
- `test_devices_phase_d_coverage.py` (new) — panel endpoint maintenance gating (the fixed bug), rich-row anchors for client-side filtering, and the restored "Remove from group" kebab item

CI will run the full suite; some flakes possible but no new tests should regress locally.

## Out of scope

- Compact / icon-only mode at very large fleet sizes (Phase D-compact in original plan, deferred — current chip layout works fine at evaluated fleet sizes)
- Group→group drag-and-drop (only ungrouped→group is enabled; dropdown reassign works from anywhere)
- Active pruning of stale `localStorage` keys for deleted groups

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
