### PR TITLE
infra: fix workbook tile KQL to use classic schema

### DIFF
--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -295,7 +295,7 @@ var workbookContent = {
       type: 3
       content: {
         version: 'KqlItem/1.0'
-        query: 'AppRequests\n| where Name !contains "/health" and Name !contains "/metrics"\n| summarize Total = count(), Errors = countif(toint(ResultCode) >= 500) by bin(TimeGenerated, 5m)\n| order by TimeGenerated asc'
+        query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| summarize Total = count(), Errors = countif(toint(resultCode) >= 500) by bin(timestamp, 5m)\n| order by timestamp asc'
         size: 0
         title: 'Request volume & 5xx errors (5-min bins)'
         timeContext: {
@@ -311,7 +311,7 @@ var workbookContent = {
       type: 3
       content: {
         version: 'KqlItem/1.0'
-        query: 'AppRequests\n| where Name !contains "/health" and Name !contains "/metrics"\n| summarize P50 = percentile(DurationMs, 50), P95 = percentile(DurationMs, 95), P99 = percentile(DurationMs, 99) by bin(TimeGenerated, 5m)\n| order by TimeGenerated asc'
+        query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| summarize P50 = percentile(duration, 50), P95 = percentile(duration, 95), P99 = percentile(duration, 99) by bin(timestamp, 5m)\n| order by timestamp asc'
         size: 0
         title: 'Request latency p50/p95/p99 (ms)'
         timeContext: {
@@ -327,7 +327,7 @@ var workbookContent = {
       type: 3
       content: {
         version: 'KqlItem/1.0'
-        query: 'AppDependencies\n| where OperationName !contains "/health" and OperationName !contains "/metrics"\n| summarize Total = count(), Failures = countif(Success == false) by bin(TimeGenerated, 5m), Type\n| order by TimeGenerated asc'
+        query: 'dependencies\n| where operation_Name !contains "/health" and operation_Name !contains "/metrics"\n| summarize Total = count(), Failures = countif(success == false) by bin(timestamp, 5m), type\n| order by timestamp asc'
         size: 0
         title: 'Dependency calls & failures by type'
         timeContext: {
@@ -343,7 +343,7 @@ var workbookContent = {
       type: 3
       content: {
         version: 'KqlItem/1.0'
-        query: 'AppExceptions\n| where OperationName !contains "/health" and OperationName !contains "/metrics"\n| summarize Count = count() by bin(TimeGenerated, 5m), ProblemId\n| order by TimeGenerated asc'
+        query: 'exceptions\n| where operation_Name !contains "/health" and operation_Name !contains "/metrics"\n| summarize Count = count() by bin(timestamp, 5m), problemId\n| order by timestamp asc'
         size: 0
         title: 'Exceptions by problem id'
         timeContext: {


### PR DESCRIPTION
## Workbook tile schema fix

The "Agora CMS — Telemetry triage" workbook tiles were authored against the
**workspace-based** Application Insights schema (`AppRequests`,
`AppDependencies`, `AppExceptions`) but the tiles are scoped to
`resourceType: 'microsoft.insights/components'`, which queries the AI
component endpoint. That endpoint only understands the **classic** schema.

Result: every tile rendered with
`'where' operator: Failed to resolve table or column expression named 'AppRequests'`.

The 5 scheduled-query alert rules in the same module are unaffected — they
target `scopes: [appInsights.id]` which routes through the workspace
endpoint, where the workspace-based names work correctly.

## Fix

Translate all 4 workbook tile queries to the classic schema:

| Workspace-based      | Classic               |
|----------------------|-----------------------|
| `AppRequests`        | `requests`            |
| `AppDependencies`    | `dependencies`        |
| `AppExceptions`      | `exceptions`          |
| `Name`               | `name`                |
| `ResultCode`         | `resultCode`          |
| `DurationMs`         | `duration`            |
| `OperationName`      | `operation_Name`      |
| `Success`            | `success`             |
| `Type`               | `type`                |
| `ProblemId`          | `problemId`           |
| `TimeGenerated`      | `timestamp`           |

## Validation

Verified each renamed query against the live `agoracms-env-ai` component
via `az monitor app-insights query`. Returns rows for `requests` and
`dependencies` (driven by health-check/login traffic during validation);
`exceptions` returns 0 (none yet).

## Risk

Bicep-only change. Workbook redeploy on container-app deployment is a
no-op for the alert rules (they're untouched). Tiles will start
populating from existing data the moment the new content is uploaded.
