### PR TITLE
infra: rewrite alert KQL to classic App Insights schema

### DIFF
--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -97,7 +97,7 @@ resource alert5xx 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = 
     criteria: {
       allOf: [
         {
-          query: 'AppRequests\n| where Name !contains "/health" and Name !contains "/metrics"\n| where toint(ResultCode) >= 500\n| summarize Errors = count() by bin(TimeGenerated, 5m)'
+          query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| where toint(resultCode) >= 500\n| summarize Errors = count() by bin(timestamp, 5m)'
           timeAggregation: 'Total'
           metricMeasureColumn: 'Errors'
           operator: 'GreaterThan'
@@ -135,7 +135,7 @@ resource alertLatency 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview
     criteria: {
       allOf: [
         {
-          query: 'AppRequests\n| where Name !contains "/health" and Name !contains "/metrics"\n| summarize Samples = count(), P95Ms = percentile(DurationMs, 95)\n| where Samples >= 20\n| project P95Ms'
+          query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| summarize Samples = count(), P95Ms = percentile(duration, 95)\n| where Samples >= 20\n| project P95Ms'
           timeAggregation: 'Maximum'
           metricMeasureColumn: 'P95Ms'
           operator: 'GreaterThan'
@@ -172,7 +172,7 @@ resource alertDeps 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' =
     criteria: {
       allOf: [
         {
-          query: 'AppDependencies\n| where OperationName !contains "/health" and OperationName !contains "/metrics"\n| where Success == false\n| summarize Failures = count() by bin(TimeGenerated, 5m)'
+          query: 'dependencies\n| where operation_Name !contains "/health" and operation_Name !contains "/metrics"\n| where success == false\n| summarize Failures = count() by bin(timestamp, 5m)'
           timeAggregation: 'Total'
           metricMeasureColumn: 'Failures'
           operator: 'GreaterThan'
@@ -209,7 +209,7 @@ resource alertExceptions 'Microsoft.Insights/scheduledQueryRules@2023-03-15-prev
     criteria: {
       allOf: [
         {
-          query: 'AppExceptions\n| where OperationName !contains "/health" and OperationName !contains "/metrics"\n| summarize Exceptions = count() by bin(TimeGenerated, 5m)'
+          query: 'exceptions\n| where operation_Name !contains "/health" and operation_Name !contains "/metrics"\n| summarize Exceptions = count() by bin(timestamp, 5m)'
           timeAggregation: 'Total'
           metricMeasureColumn: 'Exceptions'
           operator: 'GreaterThan'
@@ -259,7 +259,7 @@ resource alertHeartbeat 'Microsoft.Insights/scheduledQueryRules@2023-03-15-previ
     criteria: {
       allOf: [
         {
-          query: 'AppRequests\n| count'
+          query: 'requests\n| count'
           timeAggregation: 'Total'
           metricMeasureColumn: 'Count'
           operator: 'LessThan'


### PR DESCRIPTION
## Summary

Fix the 5 scheduled-query alert rules (`infra/modules/alerts.bicep`) to use App Insights **classic** schema instead of workspace-based table names. Same root cause as PR #479 (workbook tile fix) — when a `Microsoft.Insights/scheduledQueryRules` resource is scoped to a `microsoft.insights/components` resource, ARM validates the KQL against the component endpoint, which only knows the classic schema, regardless of whether the underlying App Insights is workspace-based.

This was discovered when PR #479's post-merge `Publish & Deploy` failed at the `Deploy infrastructure` step with these errors (run 25035245829):

```
'where' operator: Failed to resolve table or column expression named 'AppExceptions'
'where' operator: Failed to resolve table or column expression named 'AppRequests' (×3)
'where' operator: Failed to resolve table or column expression named 'AppDependencies'
```

PR #476 (which originally added these alerts) deployed cleanly because at that time the App Insights component was newly created and its schema mapping wasn't yet enforced strictly enough to fail validation. After more telemetry started flowing, ARM started validating the references, and now any redeploy of these alerts blocks.

## Changes

`infra/modules/alerts.bicep` — query strings only, no logic / threshold / structural changes:

| Alert | Workspace name → Classic name | Column renames |
|-------|-------------------------------|----------------|
| 5xx errors | `AppRequests` → `requests` | `Name`→`name`, `ResultCode`→`resultCode`, `TimeGenerated`→`timestamp` |
| Slow requests | `AppRequests` → `requests` | `Name`→`name`, `DurationMs`→`duration` (already in ms) |
| Dependency failures | `AppDependencies` → `dependencies` | `OperationName`→`operation_Name`, `Success`→`success`, `TimeGenerated`→`timestamp` |
| Exceptions | `AppExceptions` → `exceptions` | `OperationName`→`operation_Name`, `TimeGenerated`→`timestamp` |
| Heartbeat | `AppRequests` → `requests` | (no columns referenced; bare `\| count`) |

## Notes

- All thresholds, evaluation windows, severities, and action groups are unchanged.
- `duration` in classic `requests` is also in milliseconds, so `percentile(duration, 95) > 3000` is still "p95 > 3 s".
- Comments and descriptions still reference "AppRequests" colloquially — left alone since they're prose, not query references.

## Verification

- After this PR merges, the post-merge `Publish & Deploy` should reach the `verify` job for the first time since A1.5 started landing.
- I'll watch the deploy run; if green, the alerts will redeploy in prod and we can finally call A1.5 done.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
