### PR TITLE
infra(alerts): project timestamp in latency alert query

### DIFF
--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -135,7 +135,7 @@ resource alertLatency 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview
     criteria: {
       allOf: [
         {
-          query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| summarize Samples = count(), P95Ms = percentile(duration, 95)\n| where Samples >= 20\n| project P95Ms'
+          query: 'requests\n| where name !contains "/health" and name !contains "/metrics"\n| summarize Samples = count(), P95Ms = percentile(duration, 95) by bin(timestamp, 5m)\n| where Samples >= 20\n| project timestamp, P95Ms'
           timeAggregation: 'Maximum'
           metricMeasureColumn: 'P95Ms'
           operator: 'GreaterThan'


### PR DESCRIPTION
## What

Fix the `CMS slow requests (p95 > 3s)` scheduled-query alert rule so the deploy succeeds.

## Why

Post-merge `Publish & Deploy` failed with:

```
Number of evaluation periods must be 1 for queries that do not project the
'timestamp' column of type 'datetime'
```

The latency alert uses `numberOfEvaluationPeriods: 3` (intentional: 2/3 failing 5-minute windows must agree before paging, to suppress single-spike noise). When `numberOfEvaluationPeriods > 1`, ARM requires the query to project a `timestamp` column so it can bucket results into evaluation periods. The previous query's final `| project P95Ms` dropped that column.

## Fix

Bin the percentile by 5-minute windows and keep `timestamp` in the projection:

```kql
requests
| where name !contains "/health" and name !contains "/metrics"
| summarize Samples = count(), P95Ms = percentile(duration, 95) by bin(timestamp, 5m)
| where Samples >= 20
| project timestamp, P95Ms
```

The other 4 alerts already project `timestamp` (via `by bin(timestamp, 5m)`) or use `numberOfEvaluationPeriods: 1` (heartbeat), so they are unaffected.

## Test plan

Auto-merge enabled. Post-merge `Publish & Deploy` should now succeed and create all 5 alert rules in the AI alerts blade.
