### PR TITLE
feat(telemetry): metrics registry + WPS transport counters (Pillar B1)

### DIFF
--- a/cms/metrics.py
+++ b/cms/metrics.py
@@ -1,0 +1,98 @@
+"""Custom OpenTelemetry metric registry for the Agora CMS.
+
+Issue #474, Phase 0 / Pillar B (custom metrics) — first slice.
+
+Defining all counter/histogram/gauge handles in **one place** has two
+benefits:
+
+* No metric-name string literals at call sites — typos at the call
+  site become ``AttributeError`` at import time, not silently-wrong
+  metric names that nobody notices for weeks.
+* The registry doubles as a catalog: ``grep`` ``cms/metrics.py`` and
+  you can see every custom metric the CMS emits.
+
+Runtime behaviour:
+
+* When ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is set and
+  :func:`cms.observability.setup_observability` has run, the OTel SDK
+  installed by ``azure-monitor-opentelemetry`` becomes the global
+  ``MeterProvider`` and these counters export to App Insights as
+  custom metrics.
+* When telemetry is disabled (local dev, unit tests, ``docker-compose``,
+  CI without the env var), OTel's default no-op
+  ``MeterProvider`` is in effect.  ``Counter.add(...)`` then resolves
+  to a cheap no-op call — there is no need to gate any call site on
+  "is telemetry enabled?".
+
+The ``opentelemetry`` API package is a transitive dependency of
+``azure-monitor-opentelemetry`` (a hard dep in ``requirements.txt``),
+so the imports below are always available in any supported install
+profile.
+
+Naming convention
+-----------------
+
+Per the telemetry plan we use ``agora.<subsystem>.<event>`` for
+counters.  Bounded, low-cardinality attribute keys carry the dimensions
+(e.g. ``reason`` for WPS send failures).  See the constants below for
+the bounded value sets.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from opentelemetry import metrics
+
+_meter = metrics.get_meter("agora.cms")
+
+
+# ----------------------------------------------------------------------
+# WPS transport (cms/services/wps_transport.py)
+# ----------------------------------------------------------------------
+#
+# Failure-rate model:
+#   failure_rate = wps.send.failure / wps.send.attempt
+#   success_rate = wps.send.success / wps.send.attempt
+# The attempt counter is incremented unconditionally before the send
+# so the denominator covers every code path including unexpected
+# exceptions.  ``success`` and ``failure`` are mutually exclusive and
+# together always sum to ``attempt``.
+
+wps_send_attempt_total: Final = _meter.create_counter(
+    "agora.wps.send.attempt",
+    description=(
+        "Total number of WPS send_to_device calls attempted, including "
+        "those that ultimately failed.  Forms the denominator of the "
+        "WPS send failure rate."
+    ),
+)
+
+wps_send_success_total: Final = _meter.create_counter(
+    "agora.wps.send.success",
+    description=(
+        "WPS send_to_device calls that returned successfully (HTTP 2xx)."
+    ),
+)
+
+wps_send_failed_total: Final = _meter.create_counter(
+    "agora.wps.send.failure",
+    description=(
+        "WPS send_to_device calls that failed for any reason.  The "
+        "``reason`` attribute distinguishes 404 (device offline), 429 "
+        "(throttled by WPS), other HTTP errors, and unexpected "
+        "exceptions."
+    ),
+)
+
+
+# Bounded value set for the ``reason`` attribute on WPS failure
+# counters.  Keep this list short — every distinct value is a separate
+# series in App Insights.
+
+ATTR_REASON: Final[str] = "reason"
+
+WPS_REASON_404: Final[str] = "404"
+WPS_REASON_429: Final[str] = "429"
+WPS_REASON_HTTP_ERROR: Final[str] = "http_error"
+WPS_REASON_UNEXPECTED: Final[str] = "unexpected"

--- a/cms/services/wps_transport.py
+++ b/cms/services/wps_transport.py
@@ -26,6 +26,7 @@ from typing import Any
 from azure.core.exceptions import HttpResponseError
 from azure.messaging.webpubsubservice.aio import WebPubSubServiceClient
 
+from cms import metrics
 from cms.services import device_presence
 from cms.services.transport import DeviceTransport, _session
 
@@ -94,12 +95,14 @@ class WPSTransport(DeviceTransport):
                 device_id,
             )
 
+        metrics.wps_send_attempt_total.add(1)
         try:
             await self._client.send_to_user(
                 device_id,
                 json.dumps(message),
                 content_type="application/json",
             )
+            metrics.wps_send_success_total.add(1)
             return True
         except HttpResponseError as e:
             status = getattr(e, "status_code", None)
@@ -117,13 +120,23 @@ class WPSTransport(DeviceTransport):
                         )
                 except Exception:
                     logger.exception("Failed to clear presence after 404 send")
+                metrics.wps_send_failed_total.add(
+                    1, {metrics.ATTR_REASON: metrics.WPS_REASON_404},
+                )
                 return False
             logger.warning(
                 "send_to_device(%s) failed: %s (status=%s)", device_id, e, status,
             )
+            reason = (
+                metrics.WPS_REASON_429 if status == 429 else metrics.WPS_REASON_HTTP_ERROR
+            )
+            metrics.wps_send_failed_total.add(1, {metrics.ATTR_REASON: reason})
             return False
         except Exception:
             logger.exception("send_to_device(%s) unexpected error", device_id)
+            metrics.wps_send_failed_total.add(
+                1, {metrics.ATTR_REASON: metrics.WPS_REASON_UNEXPECTED},
+            )
             return False
 
     # ---- presence (DB-backed) -----------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,94 @@
+"""Tests for the central metrics registry (``cms.metrics``).
+
+The registry is intentionally lightweight — its job is to provide
+process-wide OpenTelemetry counter handles that the rest of the CMS can
+import and call ``.add()`` on without each call site having to know
+whether telemetry is wired up.
+
+These tests verify the *behavioural* contract:
+
+* importing the module never raises (even with no SDK configured),
+* every documented handle is present and exposes ``.add()``, and
+* calling ``.add()`` is safe under the default no-op MeterProvider that
+  applies when ``configure_azure_monitor`` has not run.
+
+We deliberately avoid asserting anything about the *type* of the
+returned counter objects — OTel changes those classes between minor
+versions, and pinning to a concrete class would cause spurious
+breakage on every dependency bump.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_module_imports_without_telemetry_configured():
+    # Smoke test.  ``cms.metrics`` is imported at module-load by every
+    # subsystem that emits a counter; if it ever throws on import we
+    # break all of them at once.
+    import importlib
+
+    import cms.metrics as m
+
+    importlib.reload(m)
+
+
+def test_wps_counter_handles_exposed():
+    from cms import metrics
+
+    for name in (
+        "wps_send_attempt_total",
+        "wps_send_success_total",
+        "wps_send_failed_total",
+    ):
+        handle = getattr(metrics, name)
+        assert hasattr(handle, "add"), (
+            f"{name} should expose an OTel-style .add() method"
+        )
+
+
+def test_wps_failure_reason_constants_are_strings():
+    from cms import metrics
+
+    # Bounded value set for the ``reason`` attribute — every distinct
+    # value is a series in App Insights, so this list deliberately
+    # short.  Pin it so a future PR adding a new reason has to update
+    # this test (and the workbook KQL alongside).
+    assert metrics.ATTR_REASON == "reason"
+    assert {
+        metrics.WPS_REASON_404,
+        metrics.WPS_REASON_429,
+        metrics.WPS_REASON_HTTP_ERROR,
+        metrics.WPS_REASON_UNEXPECTED,
+    } == {"404", "429", "http_error", "unexpected"}
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["wps_send_attempt_total", "wps_send_success_total"],
+)
+def test_unattributed_add_is_safe(name):
+    from cms import metrics
+
+    handle = getattr(metrics, name)
+    # Under the default no-op MeterProvider this is a no-op; under a
+    # real SDK it records.  Either way it must not raise.
+    handle.add(1)
+
+
+def test_failure_add_with_reason_attribute_is_safe():
+    from cms import metrics
+
+    metrics.wps_send_failed_total.add(
+        1, {metrics.ATTR_REASON: metrics.WPS_REASON_404},
+    )
+    metrics.wps_send_failed_total.add(
+        1, {metrics.ATTR_REASON: metrics.WPS_REASON_429},
+    )
+    metrics.wps_send_failed_total.add(
+        1, {metrics.ATTR_REASON: metrics.WPS_REASON_HTTP_ERROR},
+    )
+    metrics.wps_send_failed_total.add(
+        1, {metrics.ATTR_REASON: metrics.WPS_REASON_UNEXPECTED},
+    )

--- a/tests/test_wps_transport.py
+++ b/tests/test_wps_transport.py
@@ -145,6 +145,116 @@ class TestSendToDevice:
         assert ok is False
 
 
+@pytest.mark.asyncio
+class TestSendToDeviceMetrics:
+    """Verify cms.metrics counters are incremented on each branch.
+
+    The metric registry is module-level so we monkeypatch the ``add``
+    method of each counter with a Mock for the duration of the test.
+    """
+
+    @pytest.fixture
+    def counters(self, monkeypatch):
+        from cms import metrics as m
+
+        attempt = MagicMock()
+        success = MagicMock()
+        failed = MagicMock()
+        monkeypatch.setattr(m.wps_send_attempt_total, "add", attempt)
+        monkeypatch.setattr(m.wps_send_success_total, "add", success)
+        monkeypatch.setattr(m.wps_send_failed_total, "add", failed)
+        return SimpleNamespace(
+            attempt=attempt, success=success, failed=failed,
+        )
+
+    async def test_success_increments_attempt_and_success(self, counters):
+        t, c, _ = _make_transport()
+        await t.send_to_device("pi-1", {"type": "ping"})
+        counters.attempt.assert_called_once_with(1)
+        counters.success.assert_called_once_with(1)
+        counters.failed.assert_not_called()
+
+    async def test_404_increments_failure_with_404_reason(
+        self, counters, monkeypatch,
+    ):
+        from azure.core.exceptions import HttpResponseError
+        from cms import metrics as m
+
+        t, c, _ = _make_transport()
+        err = HttpResponseError(message="not connected")
+        err.status_code = 404
+        c.send_to_user.side_effect = err
+
+        # Stub session + offline-alert helper so we don't reach the DB.
+        class _DummySession:
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return None
+            async def execute(self, _stmt):
+                return SimpleNamespace(scalar_one_or_none=lambda: None)
+            async def commit(self): return None
+
+        monkeypatch.setattr(
+            "cms.services.wps_transport._session", lambda: _DummySession(),
+        )
+
+        async def _noop(*a, **kw):
+            return True
+
+        monkeypatch.setattr(
+            "cms.services.wps_transport.device_presence."
+            "mark_offline_and_alert",
+            _noop,
+        )
+
+        await t.send_to_device("pi-1", {"type": "ping"})
+        counters.attempt.assert_called_once_with(1)
+        counters.success.assert_not_called()
+        counters.failed.assert_called_once_with(
+            1, {m.ATTR_REASON: m.WPS_REASON_404},
+        )
+
+    async def test_429_increments_failure_with_429_reason(self, counters):
+        from azure.core.exceptions import HttpResponseError
+        from cms import metrics as m
+
+        t, c, _ = _make_transport()
+        err = HttpResponseError(message="throttled")
+        err.status_code = 429
+        c.send_to_user.side_effect = err
+
+        await t.send_to_device("pi-1", {"type": "ping"})
+        counters.failed.assert_called_once_with(
+            1, {m.ATTR_REASON: m.WPS_REASON_429},
+        )
+
+    async def test_other_http_error_uses_http_error_reason(self, counters):
+        from azure.core.exceptions import HttpResponseError
+        from cms import metrics as m
+
+        t, c, _ = _make_transport()
+        err = HttpResponseError(message="boom")
+        err.status_code = 500
+        c.send_to_user.side_effect = err
+
+        await t.send_to_device("pi-1", {"type": "ping"})
+        counters.failed.assert_called_once_with(
+            1, {m.ATTR_REASON: m.WPS_REASON_HTTP_ERROR},
+        )
+
+    async def test_unexpected_exception_uses_unexpected_reason(
+        self, counters,
+    ):
+        from cms import metrics as m
+
+        t, c, _ = _make_transport()
+        c.send_to_user.side_effect = RuntimeError("network died")
+
+        await t.send_to_device("pi-1", {"type": "ping"})
+        counters.failed.assert_called_once_with(
+            1, {m.ATTR_REASON: m.WPS_REASON_UNEXPECTED},
+        )
+
+
 class TestPresenceDelegates:
     # Stage 2c: WPS transport presence now reads from the ``devices``
     # table via ``device_presence`` helpers, which require a live session


### PR DESCRIPTION
### Stage B.1 — device-side bootstrap crypto + secret-file primitives

First slice of the firmware half of the bootstrap redesign
([agora-cms#420](https://github.com/sslivins/agora-cms/issues/420)).
Pure library: no HTTP, no service wiring.  Gets us a reviewable unit
before B.2 (HTTP client) and B.3 (cms_client service integration).

#### What's here

New module `shared/bootstrap_identity.py`:

- **`load_or_create_device_identity(path)`** — 32-byte Ed25519 seed on
  disk.  Returns `DeviceIdentity(seed, pubkey_b64)`.
- **`load_or_create_pairing_secret(path)`** — 26-char RFC-4648 base32
  secret.  (Scope note: UI will adopt-by-pending-id without the admin
  typing it, but we still emit it on the wire as an idempotent
  re-registration lookup key; A.5 follow-up will hide it from the UI.)
- **`pairing_secret_hash_hex`**, **`sign_connect_token_request`**,
  **`decrypt_adopt_payload`**, **`compute_fleet_hmac_hex`** — wire-format
  complements to the CMS `device_identity` module.

Every wire-format invariant is documented at the top of the module and
pinned byte-for-byte with CMS:

| thing                       | format                                                                |
|-----------------------------|-----------------------------------------------------------------------|
| device identity on disk     | raw 32-byte Ed25519 seed                                              |
| public key on the wire      | std-base64 of 32B Ed25519 pub                                         |
| `/connect-token` signing    | `f"{device_id}\|{int(ts)}\|{nonce}"` UTF-8, Ed25519                   |
| fleet HMAC                  | `register\|device_id\|pubkey_b64\|pairing_secret_hash\|fleet_id\|ts\|nonce`, HMAC-SHA256 hex |
| ECIES                       | b64(`eph_x25519_pub(32) \|\| aesgcm_nonce(12) \|\| ct \|\| tag(16)`), HKDF-SHA256 salt=None info=`agora-bootstrap-ecies-v1` |
| pairing secret              | 26 chars RFC-4648 base32 uppercase unpadded                           |
| Ed25519 seed → X25519       | RFC-8032 §5.1.5 / RFC-7748 clamp                                      |

#### File-system contract

Both secret files follow the same rules (rubber-duck caught a handful
of real issues I'd missed originally — this version incorporates all of
them):

- `O_NOFOLLOW` on every open; symlink → hard error (`ELOOP`).
- `fstat` validates: regular file, owned by current uid, perms `0o400`.
  Same-owner loose perms → repaired via `fchmod`; different-owner →
  `BootstrapKeyFileError` / `BootstrapSecretFileError`.
- Parent dir: must be a directory, owned by current uid, not
  group/world-writable; same-owner loose → repaired to `0o700`.
- **Malformed contents never trigger silent regeneration** — that would
  strand an already-adopted device whose seed looked momentarily wrong.
  Admin intervenes (delete the file explicitly to factory-reset).
- Writes: tmp → `O_CREAT | O_EXCL | O_NOFOLLOW` + random suffix → `fsync(fd)`
  → `os.replace` → `fsync(parent dir)`.  Power-loss-safe on first boot.

#### Tests

`tests/test_bootstrap_identity.py` — 21 tests, no cross-repo import.
Self-contained ECIES encrypt helper inline so we pin the device-side
wire format independently of CMS.

| section              | tests                                                                                |
|----------------------|--------------------------------------------------------------------------------------|
| device identity      | roundtrip, perm repair, owner mismatch hard-error, malformed untouched, symlink refused, parent repair, parent-not-dir, path-is-dir |
| pairing secret       | roundtrip + charset, malformed untouched, hash frozen                                |
| signing              | canonical bytes stable across int/str, Ed25519 verify roundtrip, wrong seed length   |
| ECIES                | roundtrip, AEAD tamper, nonce-mismatch short-circuit, too-short, bad base64          |
| fleet HMAC           | canonical input string, stdlib-matching digest                                       |

11 platform-agnostic tests pass on Windows + Linux; 10 POSIX-only tests
are gated on `sys.platform != "win32"` (fd-based permission checks don't
map cleanly to NTFS ACLs).

#### CI / deps

- `requirements-cms-client.txt` gains `cryptography>=44,<46` (runtime).
- `.github/workflows/tests.yml` explicitly installs the same pin so CI
  sees the new module's only extra dep.

#### What's intentionally NOT here

- B.2: HTTP client (`bootstrap_client.py` with `register`,
  `get_bootstrap_status_once`, `connect_token`).  One-shot methods only;
  retry/backoff belongs to B.3 orchestration.
- B.3: `cms_client/service.py` wiring — detect missing `api_key` at
  boot, run bootstrap loop, persist adopt payload, transition to WPS
  connect-token auth.  Also solves API-key continuity for asset
  downloads + log upload.
- QR rendering: dropped.  A.5 adds pending-devices list to CMS UI so
  admin clicks Adopt directly, no pairing-secret typing.

#### Rubber-duck findings incorporated

- fd-based I/O with `O_NOFOLLOW` + `fchmod` instead of path-based chmod
  (TOCTOU-safe).
- Parent-dir ownership/mode checks, not just the file.
- `fsync(parent dir)` after `os.replace` for power-loss safety.
- `timestamp: int` in the public API (not `str`), matching CMS's
  `str(req.timestamp)` canonicalization internally.
- `compute_fleet_hmac_hex` (not `_header`); `load_or_create_device_identity`
  (not `_keypair`) — the file only holds the seed.
- Never regenerate malformed files — `BootstrapKeyFileError` /
  `BootstrapSecretFileError` forces operator intervention.
- No auto-wipe on a single failure — that policy will live in B.3.
