### PR TITLE
ui(dashboard): stretch fleet tiles to row width (auto-fill -> auto-fit)

### DIFF
--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -9,7 +9,7 @@
 <style>
 .stat-tile-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 0.6rem;
     margin: 0 0 1rem 0;
 }


### PR DESCRIPTION
Tiles were stuck at min 140px when only Healthy was visible. `auto-fit` collapses empty grid tracks so the remaining tiles grow to fill the container, matching the panel widths below.