### PR TITLE
feat(telemetry): scheduler tick + missed_emitted counters (Pillar B2)

### DIFF
--- a/cms/metrics.py
+++ b/cms/metrics.py
@@ -96,3 +96,60 @@ WPS_REASON_404: Final[str] = "404"
 WPS_REASON_429: Final[str] = "429"
 WPS_REASON_HTTP_ERROR: Final[str] = "http_error"
 WPS_REASON_UNEXPECTED: Final[str] = "unexpected"
+
+
+# ----------------------------------------------------------------------
+# Scheduler (cms/services/scheduler.py)
+# ----------------------------------------------------------------------
+#
+# Two counters cover the operational questions operators actually ask
+# about the scheduler:
+#
+# 1. "Is the scheduler running?"  ``agora.scheduler.tick`` with
+#    ``outcome`` ∈ {evaluated, skipped_not_leader, error} answers this.
+#    Under N replicas, total tick rate scales with replica count, but
+#    ``outcome=evaluated`` count ≈ global tick rate (one leader at a
+#    time).  ``outcome=skipped_not_leader`` is a positive liveness
+#    signal for follower replicas and verifies the leader lease is
+#    gating correctly.
+# 2. "Are devices missing scheduled playback?"
+#    ``agora.scheduler.missed_emitted`` increments once per MISSED
+#    ScheduleLog row that is durably committed.  We deliberately do
+#    NOT increment for CAS-claim losses (normal under multi-replica
+#    dedup) or for log-write failures (the CAS claim is reverted so
+#    the next tick retries).  The increment happens AFTER the outer
+#    ``db.commit()`` succeeds so a commit failure cannot produce
+#    false-positive telemetry.
+
+scheduler_tick_total: Final = _meter.create_counter(
+    "agora.scheduler.tick",
+    description=(
+        "Scheduler loop iterations, attributed by ``outcome``: "
+        "``evaluated`` (leader ran ``evaluate_schedules`` to "
+        "completion), ``skipped_not_leader`` (replica without the "
+        "scheduler lease), or ``error`` (unexpected exception in the "
+        "loop body — does NOT include task cancellation)."
+    ),
+)
+
+scheduler_missed_emitted_total: Final = _meter.create_counter(
+    "agora.scheduler.missed_emitted",
+    description=(
+        "MISSED schedule events that were durably committed to "
+        "``schedule_logs`` in the current tick.  Increments only "
+        "after ``db.commit()`` succeeds and only for events whose "
+        "ScheduleLog row was actually written (CAS-claim losses and "
+        "log-write failures are not counted)."
+    ),
+)
+
+
+# Bounded value set for the ``outcome`` attribute on
+# ``agora.scheduler.tick``.  Keep this list short — every distinct
+# value is a separate series in App Insights.
+
+ATTR_OUTCOME: Final[str] = "outcome"
+
+SCHEDULER_OUTCOME_EVALUATED: Final[str] = "evaluated"
+SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER: Final[str] = "skipped_not_leader"
+SCHEDULER_OUTCOME_ERROR: Final[str] = "error"

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -22,6 +22,7 @@ from cms.models.schedule_missed_event import ScheduleMissedEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import ScheduleEntry, SyncMessage
 from cms.services.transport import get_transport
+from cms import metrics as _metrics
 
 logger = logging.getLogger("agora.cms.scheduler")
 
@@ -1282,6 +1283,13 @@ async def evaluate_schedules() -> None:
         from sqlalchemy.exc import IntegrityError
 
         grace_cutoff = utc_now - timedelta(seconds=MISSED_GRACE_SECONDS)
+        # Accumulator for ``agora.scheduler.missed_emitted``.  We only
+        # increment the counter AFTER the outer ``db.commit()`` below
+        # succeeds, so a commit failure cannot produce false-positive
+        # telemetry.  Per-event ``log_written=True`` is necessary but
+        # not sufficient — the commit at line ~1383 is the durability
+        # boundary.
+        missed_emitted_count = 0
         for (_sid_str, did), ctx in active_offline_context.items():
             # CAS claim.
             claim_result = await db.execute(
@@ -1375,11 +1383,20 @@ async def evaluate_schedules() -> None:
                     )
                     .values(emitted_at=None)
                 )
+            else:
+                missed_emitted_count += 1
 
         # Commit the claim + log (or revert) as a single atomic unit per
         # tick.  If this commit itself fails the whole batch rolls back
         # and the next tick will retry every claim it attempted here.
         await db.commit()
+
+        # Telemetry: only after the commit above has durably persisted
+        # the claim+log rows do we record the MISSED counter.  If the
+        # commit raised, this line is unreachable and the metric is
+        # not incremented — matching the on-disk reality.
+        if missed_emitted_count:
+            _metrics.scheduler_missed_emitted_total.add(missed_emitted_count)
 
         # Cleanup: drop dedup rows whose (schedule, device) combo is no
         # longer in the active-offline set for today (device reconnected
@@ -1480,15 +1497,32 @@ async def scheduler_loop() -> None:
     try:
         await lease.start()
         while True:
+            outcome: str | None = None
             try:
                 if lease.is_leader:
                     await evaluate_schedules()
+                    outcome = _metrics.SCHEDULER_OUTCOME_EVALUATED
                 else:
+                    outcome = _metrics.SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER
                     logger.debug("scheduler_loop: not leader, skipping tick")
             except asyncio.CancelledError:
+                # Cancellation is the normal shutdown path — leave
+                # ``outcome`` as ``None`` and re-raise straight away so
+                # the ``finally`` block deliberately skips recording.
                 raise
             except Exception:
                 logger.exception("Scheduler evaluation error")
+                outcome = _metrics.SCHEDULER_OUTCOME_ERROR
+            finally:
+                # ``outcome is None`` only on cancellation; in every
+                # other path one of the three constants has been
+                # assigned above.  Per-replica: total tick rate ≈
+                # replica count × (1 / EVAL_INTERVAL_SECONDS).  Filter
+                # by ``outcome=evaluated`` for the global eval rate.
+                if outcome is not None:
+                    _metrics.scheduler_tick_total.add(
+                        1, {_metrics.ATTR_OUTCOME: outcome},
+                    )
             try:
                 await asyncio.sleep(EVAL_INTERVAL_SECONDS)
             except asyncio.CancelledError:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -92,3 +92,50 @@ def test_failure_add_with_reason_attribute_is_safe():
     metrics.wps_send_failed_total.add(
         1, {metrics.ATTR_REASON: metrics.WPS_REASON_UNEXPECTED},
     )
+
+
+def test_scheduler_counter_handles_exposed():
+    from cms import metrics
+
+    for name in (
+        "scheduler_tick_total",
+        "scheduler_missed_emitted_total",
+    ):
+        handle = getattr(metrics, name)
+        assert hasattr(handle, "add"), (
+            f"{name} should expose an OTel-style .add() method"
+        )
+
+
+def test_scheduler_outcome_constants_are_bounded():
+    from cms import metrics
+
+    # Bounded value set for the ``outcome`` attribute on the scheduler
+    # tick counter.  Pin this so a future PR adding a new outcome has
+    # to update this test (and any KQL workbook tile that filters on
+    # outcome) alongside.
+    assert metrics.ATTR_OUTCOME == "outcome"
+    assert {
+        metrics.SCHEDULER_OUTCOME_EVALUATED,
+        metrics.SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER,
+        metrics.SCHEDULER_OUTCOME_ERROR,
+    } == {"evaluated", "skipped_not_leader", "error"}
+
+
+def test_scheduler_tick_add_with_outcome_is_safe():
+    from cms import metrics
+
+    for outcome in (
+        metrics.SCHEDULER_OUTCOME_EVALUATED,
+        metrics.SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER,
+        metrics.SCHEDULER_OUTCOME_ERROR,
+    ):
+        metrics.scheduler_tick_total.add(
+            1, {metrics.ATTR_OUTCOME: outcome},
+        )
+
+
+def test_scheduler_missed_emitted_add_is_safe():
+    from cms import metrics
+
+    metrics.scheduler_missed_emitted_total.add(3)

--- a/tests/test_scheduler_metrics.py
+++ b/tests/test_scheduler_metrics.py
@@ -1,0 +1,428 @@
+"""Behavioural tests for scheduler-side telemetry counters (Pillar B2).
+
+These tests verify that ``cms.services.scheduler`` emits the expected
+:class:`opentelemetry.metrics.Counter` ``.add()`` calls under each
+operational outcome.  The strategy is to **monkeypatch the counter's
+``add`` method** so we capture the exact call arguments without
+needing a configured OTel SDK and without coupling to the registry's
+internal types.
+
+What we cover (per the Pillar B2 plan):
+
+* ``agora.scheduler.tick`` — exactly one ``.add(1, {outcome=…})`` per
+  scheduler-loop iteration:
+  - leader, ``evaluate_schedules`` returns successfully → ``evaluated``,
+  - non-leader replica → ``skipped_not_leader``,
+  - leader, ``evaluate_schedules`` raises :class:`Exception` → ``error``,
+  - leader, ``evaluate_schedules`` raises :class:`asyncio.CancelledError`
+    → **no** ``.add()`` call (cancellation is not a tick outcome).
+
+* ``agora.scheduler.missed_emitted`` — incremented exactly once per
+  tick by the count of MISSED events whose ``ScheduleLog`` row was
+  durably committed.  Key edge cases:
+  - happy path → one ``.add(N)`` call after the commit,
+  - log-write failure → CAS claim is reverted, so **no** ``.add()``
+    call (the count stays at zero), and
+  - zero MISSED events → no ``.add(0)`` (avoids polluting App Insights
+    with zero-valued series).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, time, timedelta, timezone
+
+import pytest
+
+from cms.models.asset import Asset, AssetType
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.schedule import Schedule
+from cms.models.schedule_log import ScheduleLog
+from cms.models.schedule_missed_event import ScheduleMissedEvent
+from cms.models.setting import CMSSetting
+from cms.services.scheduler import (
+    MISSED_GRACE_SECONDS,
+    evaluate_schedules,
+    scheduler_loop,
+)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+class _FakeLease:
+    """Drop-in replacement for ``cms.services.leader.LeaderLease``.
+
+    Lets the test choose whether the replica is the leader without
+    bringing up the real lease (which requires Postgres advisory
+    locks).  ``start``/``stop`` are no-ops so the loop's
+    ``try/finally`` cleanup is happy.
+    """
+
+    def __init__(self, *_a, is_leader: bool = True, **_kw):
+        self._is_leader = is_leader
+
+    @property
+    def is_leader(self) -> bool:
+        return self._is_leader
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+async def _run_one_tick(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    is_leader: bool,
+    evaluate_side_effect=None,
+):
+    """Run exactly one iteration of ``scheduler_loop``.
+
+    The loop is an infinite ``while True``; we cancel it during the
+    post-tick ``asyncio.sleep`` so the *first* tick has fully run
+    (counter incremented in the ``finally`` block) but the loop
+    doesn't run a second time.
+    """
+    import cms.services.scheduler as scheduler_mod
+
+    # Patch the LeaderLease class used inside the function (it's
+    # imported lazily at the top of ``scheduler_loop``).
+    monkeypatch.setattr(
+        "cms.services.leader.LeaderLease",
+        lambda *a, **kw: _FakeLease(is_leader=is_leader),
+    )
+
+    # Replace ``evaluate_schedules`` with a stub so we don't need a
+    # real DB session.  These tests are about *the loop's own*
+    # outcome attribution, not about evaluate_schedules' behaviour.
+    async def _stub(*_a, **_kw):
+        if evaluate_side_effect is not None:
+            raise evaluate_side_effect
+        return None
+
+    monkeypatch.setattr(scheduler_mod, "evaluate_schedules", _stub)
+
+    # Cancel inside the post-tick sleep so the ``finally`` block has
+    # already incremented the tick counter (or, for the cancellation
+    # test, so the body's own raise propagates first).
+    async def _short_sleep(*_a, **_kw):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(scheduler_mod.asyncio, "sleep", _short_sleep)
+
+    task = asyncio.create_task(scheduler_loop())
+    try:
+        await asyncio.wait_for(task, timeout=2.0)
+    except asyncio.CancelledError:
+        pass
+    except asyncio.TimeoutError:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+# ----------------------------------------------------------------------
+# Tick counter (scheduler_loop)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_counter_records_evaluated_when_leader_succeeds(monkeypatch):
+    from cms import metrics
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        metrics.scheduler_tick_total,
+        "add",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+
+    await _run_one_tick(monkeypatch, is_leader=True)
+
+    assert len(calls) == 1, calls
+    args, _kw = calls[0]
+    amount, attrs = args
+    assert amount == 1
+    assert attrs == {metrics.ATTR_OUTCOME: metrics.SCHEDULER_OUTCOME_EVALUATED}
+
+
+@pytest.mark.asyncio
+async def test_tick_counter_records_skipped_when_not_leader(monkeypatch):
+    from cms import metrics
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        metrics.scheduler_tick_total,
+        "add",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+
+    await _run_one_tick(monkeypatch, is_leader=False)
+
+    assert len(calls) == 1
+    amount, attrs = calls[0][0]
+    assert amount == 1
+    assert attrs == {
+        metrics.ATTR_OUTCOME: metrics.SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_tick_counter_records_error_on_evaluate_exception(monkeypatch):
+    from cms import metrics
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        metrics.scheduler_tick_total,
+        "add",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+
+    await _run_one_tick(
+        monkeypatch,
+        is_leader=True,
+        evaluate_side_effect=RuntimeError("simulated scheduler boom"),
+    )
+
+    assert len(calls) == 1
+    amount, attrs = calls[0][0]
+    assert amount == 1
+    assert attrs == {metrics.ATTR_OUTCOME: metrics.SCHEDULER_OUTCOME_ERROR}
+
+
+@pytest.mark.asyncio
+async def test_tick_counter_does_not_record_on_cancelled_error(monkeypatch):
+    """``CancelledError`` must propagate without emitting a tick metric.
+
+    Cancellation is the normal shutdown path (lifespan teardown calls
+    ``task.cancel()``).  Recording it as a tick outcome would make the
+    error-rate workbook noisy at every restart.
+    """
+    from cms import metrics
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        metrics.scheduler_tick_total,
+        "add",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+
+    await _run_one_tick(
+        monkeypatch,
+        is_leader=True,
+        evaluate_side_effect=asyncio.CancelledError(),
+    )
+
+    assert calls == [], (
+        "CancelledError must NOT increment the tick counter — it is "
+        "the normal shutdown path, not a real outcome"
+    )
+
+
+# ----------------------------------------------------------------------
+# Missed-emitted counter (evaluate_schedules)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMissedEmittedCounter:
+    """Behavioural tests for ``agora.scheduler.missed_emitted``.
+
+    These run against the real ``evaluate_schedules`` and the real DB
+    fixture (same pattern as ``TestScheduleMissedEvents`` in
+    ``test_scheduler_advanced.py``) because the increment is
+    inseparable from the CAS-claim + commit boundary; a unit-style
+    stub would not exercise that boundary.
+    """
+
+    async def test_missed_emitted_increments_after_commit(
+        self, app, db_session, monkeypatch,
+    ):
+        from cms.services.device_manager import device_manager
+        from cms import metrics
+
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            metrics.scheduler_missed_emitted_total,
+            "add",
+            lambda *a, **kw: calls.append((a, kw)),
+        )
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(
+            filename="b2_metric.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum="b2metric1",
+        )
+        group = DeviceGroup(name="B2 Metric Group")
+        device = Device(
+            id="b2-metric-dev-01", name="B2 Metric Device",
+            status=DeviceStatus.ADOPTED,
+        )
+        dummy = Device(
+            id="b2-metric-dummy", name="B2 Metric Dummy",
+            status=DeviceStatus.ADOPTED,
+        )
+        db_session.add_all([setting, asset, group, device, dummy])
+        await db_session.flush()
+        device.group_id = group.id
+
+        sched = Schedule(
+            name="B2 Metric Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        class FakeWS:
+            async def send_json(self, data):
+                pass
+
+        device_manager.register("b2-metric-dummy", FakeWS())
+
+        try:
+            now = datetime.now(timezone.utc)
+            db_session.add(ScheduleMissedEvent(
+                schedule_id=sched.id,
+                device_id="b2-metric-dev-01",
+                occurrence_date=now.date(),
+                first_seen_offline_at=now - timedelta(
+                    seconds=MISSED_GRACE_SECONDS + 10,
+                ),
+                emitted_at=None,
+            ))
+            await db_session.commit()
+
+            await evaluate_schedules()
+        finally:
+            device_manager.disconnect("b2-metric-dummy")
+
+        assert len(calls) == 1, (
+            f"expected exactly one .add() call after the commit, got {calls!r}"
+        )
+        args, _kw = calls[0]
+        # The counter is a positional-only ``.add(amount, [attrs])``;
+        # for missed_emitted we deliberately pass no attributes.
+        assert args[0] == 1, (
+            f"expected one MISSED row to have been written, got count={args[0]}"
+        )
+
+    async def test_missed_emitted_not_recorded_when_log_write_fails(
+        self, app, db_session, monkeypatch,
+    ):
+        """If the ``ScheduleLog`` insert fails the CAS claim is reverted
+        and the metric MUST NOT be incremented — matching on-disk
+        reality (no log row was committed)."""
+        from cms.services.device_manager import device_manager
+        from cms import metrics
+
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            metrics.scheduler_missed_emitted_total,
+            "add",
+            lambda *a, **kw: calls.append((a, kw)),
+        )
+
+        setting = CMSSetting(key="timezone", value="UTC")
+        asset = Asset(
+            filename="b2_revert.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=1000, checksum="b2revert1",
+        )
+        group = DeviceGroup(name="B2 Revert Group")
+        device = Device(
+            id="b2-revert-dev-01", name="B2 Revert Device",
+            status=DeviceStatus.ADOPTED,
+        )
+        dummy = Device(
+            id="b2-revert-dummy", name="B2 Revert Dummy",
+            status=DeviceStatus.ADOPTED,
+        )
+        db_session.add_all([setting, asset, group, device, dummy])
+        await db_session.flush()
+        device.group_id = group.id
+
+        sched = Schedule(
+            name="B2 Revert Test",
+            group_id=group.id,
+            asset_id=asset.id,
+            start_time=time(0, 0),
+            end_time=time(23, 59, 59),
+            priority=10,
+            enabled=True,
+        )
+        db_session.add(sched)
+        await db_session.commit()
+
+        class FakeWS:
+            async def send_json(self, data):
+                pass
+
+        device_manager.register("b2-revert-dummy", FakeWS())
+
+        now = datetime.now(timezone.utc)
+        db_session.add(ScheduleMissedEvent(
+            schedule_id=sched.id,
+            device_id="b2-revert-dev-01",
+            occurrence_date=now.date(),
+            first_seen_offline_at=now - timedelta(
+                seconds=MISSED_GRACE_SECONDS + 5,
+            ),
+            emitted_at=None,
+        ))
+        await db_session.commit()
+
+        # Force every ``ScheduleLog`` instantiation to raise so the
+        # CAS-claim revert path is exercised.
+        orig_init = ScheduleLog.__init__
+
+        def _bad_init(self, *a, **kw):
+            raise RuntimeError("simulated log insert failure")
+
+        monkeypatch.setattr(ScheduleLog, "__init__", _bad_init)
+
+        try:
+            await evaluate_schedules()
+        finally:
+            monkeypatch.setattr(ScheduleLog, "__init__", orig_init)
+            device_manager.disconnect("b2-revert-dummy")
+
+        assert calls == [], (
+            "When the log insert fails the CAS claim is reverted, so "
+            "missed_emitted MUST stay at zero — counting it would "
+            "lie about durable state"
+        )
+
+    async def test_missed_emitted_silent_when_no_missed_events(
+        self, app, db_session, monkeypatch,
+    ):
+        """Tick with no MISSED events should not call ``.add(0)``.
+
+        Suppressing the no-op call avoids a flat zero-valued series in
+        App Insights which makes operator dashboards harder to scan.
+        """
+        from cms import metrics
+
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            metrics.scheduler_missed_emitted_total,
+            "add",
+            lambda *a, **kw: calls.append((a, kw)),
+        )
+
+        # No schedules, no devices, no dedup rows — evaluate_schedules
+        # is a fast no-op tick.
+        await evaluate_schedules()
+
+        assert calls == [], (
+            "missed_emitted_total.add() should not be called on ticks "
+            f"that emit zero MISSED events; got {calls!r}"
+        )


### PR DESCRIPTION
## Summary

Adds Pillar B2 of the CMS telemetry plan: two OTel counters on the
scheduler so we can answer "is the scheduler actually running per
replica?" and "are missed-event catch-ups firing?" from KQL/workbooks.

## Counters

### `agora.scheduler.tick` *(counter, dim: `outcome`)*

One emission per scheduler-loop iteration. `outcome` is one of:

| outcome | meaning |
|---|---|
| `evaluated` | this replica held the lease and ran `evaluate_schedules` |
| `skipped_not_leader` | another replica held the lease |
| `error` | `evaluate_schedules` raised |

`CancelledError` (replica drain / shutdown) is **not** counted — the
emission is skipped so a normal drain doesn't show up as an error
spike.

> Note: the raw total scales with replica count by design. For the
> global eval rate, filter `outcome == "evaluated"`.

### `agora.scheduler.missed_emitted` *(counter, no dims)*

Incremented after the MISSED-batch `db.commit()` succeeds, by the
number of `ScheduleMissedEvents` whose accompanying `ScheduleLog`
write also succeeded. Suppressed (no zero-emission) for empty batches.

## Why these two

These match the questions the B catalog actually wanted to answer
without inventing dimensions that have no code-equivalent. The
originally-planned `agora.scheduler.superseded` counter has no place
to fire in the current scheduler (we don't supersede in-flight events)
and was dropped — see the telemetry plan note. Tick-duration histogram
and a claim-failure counter are deferred until a workbook actually
needs them.

## Implementation

- `cms/metrics.py`: appended counter handles + outcome constants. B1
  WPS counters are untouched.
- `cms/services/scheduler.py`:
  - `evaluate_schedules`: accumulator inside the MISSED loop (only
    when CAS claim *and* `ScheduleLog` write succeed); single `.add()`
    after the commit.
  - `scheduler_loop`: `outcome: str | None = None`, set per branch,
    `finally: if outcome is not None: scheduler_tick_total.add(...)`
    so `CancelledError` propagates without emission.
- `tests/test_metrics.py`: 4 new contract tests (handle exists,
  outcome set, safe add).
- `tests/test_scheduler_metrics.py` *(new)*: 7 behavioural tests
  using a monkeypatched `_metrics.scheduler_*_total.add` to capture
  calls. Covers all four tick outcomes (incl. the cancellation-skip
  case) and three MISSED-emitted scenarios.

## Verification

```
pytest -p no:timeout tests/test_metrics.py tests/test_scheduler_advanced.py tests/test_scheduler_metrics.py
# 76 passed
```

`tests/test_scheduler_advanced.py` (59 tests) confirms no regression
in existing scheduler behaviour.

## Out of scope

- `agora.scheduler.superseded` (no code equivalent — see notes above).
- Tick-duration histogram / claim-failure counter (deferred).
- Workbook tile updates — once this is in prod and emitting, a
  follow-up PR adds the tiles to the telemetry-triage workbook.
