### PR TITLE
telemetry(B-presence): leader-lease claim/claim_lost/heartbeat_late counters

### DIFF
--- a/cms/metrics.py
+++ b/cms/metrics.py
@@ -153,3 +153,73 @@ ATTR_OUTCOME: Final[str] = "outcome"
 SCHEDULER_OUTCOME_EVALUATED: Final[str] = "evaluated"
 SCHEDULER_OUTCOME_SKIPPED_NOT_LEADER: Final[str] = "skipped_not_leader"
 SCHEDULER_OUTCOME_ERROR: Final[str] = "error"
+
+
+# ----------------------------------------------------------------------
+# Presence / leader-lease (cms/services/leader.py)
+# ----------------------------------------------------------------------
+#
+# The ``LeaderLease`` heartbeat task drives a small state machine for
+# each loop (scheduler, alert_sweep, …).  Three counters expose the
+# state-change events we care about during incidents:
+#
+# * ``agora.presence.claim`` — this replica's lease state flipped to
+#   leader.  Sums to roughly N over the cluster's lifetime where N is
+#   the number of leadership transitions; under steady state with no
+#   restarts you should see one increment per replica per
+#   ``(loop_name)`` cluster-wide.  A sustained spike means leadership
+#   is flapping.
+# * ``agora.presence.claim_lost`` — this replica observed that it lost
+#   the lease (heartbeat returned False after previously being True).
+#   Graceful shutdown (``stop()``) is intentionally NOT counted — only
+#   involuntary loss (lease takeover, heartbeat exception, etc.).  The
+#   delta between ``claim`` and ``claim_lost`` cluster-wide should
+#   stay near zero in steady state.
+# * ``agora.presence.heartbeat_late`` — the heartbeat raised an
+#   exception (DB unreachable, transient network issue, …).  Treated
+#   as a missed renewal in the lease state machine; the loop will
+#   recover on the next heartbeat.  Frequent ticks here are an early
+#   warning that the lease is at risk of TTL'ing out.
+#
+# Dimension: ``loop_name`` (bounded enum — currently "scheduler"; will
+# expand as alert_sweep / log_drainer / rollout adopt the lease).  We
+# deliberately do NOT use ``replica_id`` / ``holder_id`` as a
+# dimension — the holder UUID rotates every process restart and would
+# produce unbounded series in App Insights.
+#
+# Non-Postgres backends (SQLite tests, local dev with no DB) bypass
+# the heartbeat entirely and report ``is_leader=True`` unconditionally.
+# In that mode no presence counters are emitted — there is no real
+# state machine to instrument and any signal would be noise.
+
+presence_claim_total: Final = _meter.create_counter(
+    "agora.presence.claim",
+    description=(
+        "Leader lease state flipped to leader on this replica "
+        "(state True after previously being False, or won on first "
+        "acquire).  Dimension: ``loop_name``."
+    ),
+)
+
+presence_claim_lost_total: Final = _meter.create_counter(
+    "agora.presence.claim_lost",
+    description=(
+        "Leader lease state flipped to non-leader on this replica "
+        "(heartbeat returned False after previously being True). "
+        "Graceful shutdown via ``stop()`` is not counted.  "
+        "Dimension: ``loop_name``."
+    ),
+)
+
+presence_heartbeat_late_total: Final = _meter.create_counter(
+    "agora.presence.heartbeat_late",
+    description=(
+        "Leader lease heartbeat raised an exception (treated as a "
+        "missed renewal).  Dimension: ``loop_name``."
+    ),
+)
+
+
+# Attribute key for the lease-loop name on presence counters.
+
+ATTR_LOOP_NAME: Final[str] = "loop_name"

--- a/cms/services/leader.py
+++ b/cms/services/leader.py
@@ -44,6 +44,13 @@ from typing import AsyncIterator, Optional
 
 from sqlalchemy import text
 
+from cms.metrics import (
+    ATTR_LOOP_NAME,
+    presence_claim_lost_total,
+    presence_claim_total,
+    presence_heartbeat_late_total,
+)
+
 log = logging.getLogger("agora.leader")
 
 
@@ -158,6 +165,13 @@ class LeaderLease:
                 "LeaderLease[%s] start: is_leader=%s holder=%s",
                 self.loop_name, self._is_leader, self.holder_id,
             )
+            if self._is_leader:
+                # First acquire won — count this as a state flip into
+                # leader.  Initial state was implicitly False before
+                # ``start()`` was called.
+                presence_claim_total.add(
+                    1, {ATTR_LOOP_NAME: self.loop_name}
+                )
         except Exception as e:
             log.warning(
                 "LeaderLease[%s] initial acquire failed: %s (will retry)",
@@ -199,12 +213,28 @@ class LeaderLease:
                         "LeaderLease[%s] heartbeat failed: %s",
                         self.loop_name, e,
                     )
+                    presence_heartbeat_late_total.add(
+                        1, {ATTR_LOOP_NAME: self.loop_name}
+                    )
                     new_state = False
                 if new_state != self._is_leader:
                     log.info(
                         "LeaderLease[%s] state change: is_leader=%s",
                         self.loop_name, new_state,
                     )
+                    if new_state:
+                        presence_claim_total.add(
+                            1, {ATTR_LOOP_NAME: self.loop_name}
+                        )
+                    else:
+                        # Involuntary loss — graceful shutdown goes
+                        # through stop()/_release() which sets
+                        # _is_leader=False without going through this
+                        # heartbeat loop, so anything we see here is a
+                        # genuine takeover or backend hiccup.
+                        presence_claim_lost_total.add(
+                            1, {ATTR_LOOP_NAME: self.loop_name}
+                        )
                 self._is_leader = new_state
         except asyncio.CancelledError:
             raise

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -139,3 +139,35 @@ def test_scheduler_missed_emitted_add_is_safe():
     from cms import metrics
 
     metrics.scheduler_missed_emitted_total.add(3)
+
+
+def test_presence_counter_handles_exposed():
+    from cms import metrics
+
+    for name in (
+        "presence_claim_total",
+        "presence_claim_lost_total",
+        "presence_heartbeat_late_total",
+    ):
+        handle = getattr(metrics, name)
+        assert hasattr(handle, "add"), (
+            f"{name} should expose an OTel-style .add() method"
+        )
+
+
+def test_presence_loop_name_attribute_constant():
+    from cms import metrics
+
+    assert metrics.ATTR_LOOP_NAME == "loop_name"
+
+
+def test_presence_add_with_loop_name_is_safe():
+    from cms import metrics
+
+    for handle_name in (
+        "presence_claim_total",
+        "presence_claim_lost_total",
+        "presence_heartbeat_late_total",
+    ):
+        handle = getattr(metrics, handle_name)
+        handle.add(1, {metrics.ATTR_LOOP_NAME: "scheduler"})

--- a/tests/test_presence_metrics.py
+++ b/tests/test_presence_metrics.py
@@ -1,0 +1,329 @@
+"""Behavioural tests for leader-lease presence telemetry (Pillar B).
+
+These tests verify that ``cms.services.leader.LeaderLease`` emits the
+expected :class:`opentelemetry.metrics.Counter` ``.add()`` calls when
+its lease state machine transitions between leader / non-leader.
+
+Strategy mirrors ``tests/test_scheduler_metrics.py``:
+
+* monkeypatch the counter handles' ``.add()`` methods so we capture
+  exact call arguments without coupling to the OTel SDK;
+* drive the heartbeat loop deterministically by patching
+  ``cms.services.leader.asyncio.sleep`` to return once and then raise
+  :class:`asyncio.CancelledError`, giving us exactly one body
+  iteration per test;
+* override ``_try_acquire`` on the instance so we don't need a real
+  Postgres backend.
+
+Coverage:
+
+* ``start()`` first-acquire success → exactly one ``claim``;
+* ``start()`` first-acquire failure → no emission;
+* heartbeat F→T flip → ``claim``;
+* heartbeat T→F flip → ``claim_lost``;
+* heartbeat raises → ``heartbeat_late`` (and ``claim_lost`` on the
+  T→F transition that the exception forces);
+* non-Postgres backend → no emission whatsoever (the heartbeat is
+  never spawned and there is no real state machine).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+
+from cms.services.leader import LeaderLease
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+class _FakePgEngine:
+    """Minimal stand-in for an SQLAlchemy AsyncEngine on Postgres."""
+
+    class _Dialect:
+        name = "postgresql"
+
+    dialect = _Dialect()
+
+
+def _capture_add(monkeypatch, handle_name: str) -> list[tuple]:
+    """Patch ``cms.metrics.<handle_name>.add`` to record calls.
+
+    Returns the list that will be appended to.
+    """
+    from cms import metrics
+
+    calls: list[tuple] = []
+    handle = getattr(metrics, handle_name)
+    monkeypatch.setattr(
+        handle,
+        "add",
+        lambda *a, **kw: calls.append((a, kw)),
+    )
+    return calls
+
+
+def _install_one_tick_sleep(monkeypatch) -> None:
+    """Make ``asyncio.sleep`` (as seen by leader.py) return once then cancel.
+
+    The heartbeat structure is::
+
+        while True:
+            await asyncio.sleep(...)   # sleep #1: returns
+            <body runs>                # one full iteration
+            <loop top>
+            await asyncio.sleep(...)   # sleep #2: raises CancelledError
+
+    This gives us exactly one body iteration before the loop exits.
+    """
+    import cms.services.leader as leader_mod
+
+    state = {"n": 0}
+
+    async def _fake_sleep(_):
+        state["n"] += 1
+        if state["n"] >= 2:
+            raise asyncio.CancelledError()
+        return None
+
+    monkeypatch.setattr(leader_mod.asyncio, "sleep", _fake_sleep)
+
+
+def _bind_try_acquire(lease: LeaderLease, fn) -> None:
+    """Replace ``lease._try_acquire`` with the given async function."""
+    lease._try_acquire = types.MethodType(  # type: ignore[method-assign]
+        lambda self: fn(), lease,
+    )
+
+
+# ----------------------------------------------------------------------
+# start() — first-acquire emission
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_emits_claim_on_first_acquire_success(monkeypatch):
+    from cms import metrics
+
+    monkeypatch.setattr(
+        "cms.services.leader._get_engine", lambda: _FakePgEngine(),
+    )
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    # Stop the heartbeat from doing real work after start() spawns it.
+    _install_one_tick_sleep(monkeypatch)
+
+    lease = LeaderLease("scheduler", ttl_s=30, heartbeat_s=5)
+
+    async def _acquire_true() -> bool:
+        return True
+
+    _bind_try_acquire(lease, _acquire_true)
+    # Bypass DB on shutdown.
+    lease._release = types.MethodType(  # type: ignore[method-assign]
+        lambda self: _noop_async(), lease,
+    )
+
+    await lease.start()
+    await lease.stop()
+
+    assert len(claim_calls) == 1, claim_calls
+    amount, attrs = claim_calls[0][0]
+    assert amount == 1
+    assert attrs == {metrics.ATTR_LOOP_NAME: "scheduler"}
+    assert claim_lost_calls == []
+    assert heartbeat_late_calls == []
+
+
+@pytest.mark.asyncio
+async def test_start_no_emission_on_first_acquire_failure(monkeypatch):
+    monkeypatch.setattr(
+        "cms.services.leader._get_engine", lambda: _FakePgEngine(),
+    )
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    _install_one_tick_sleep(monkeypatch)
+
+    lease = LeaderLease("scheduler", ttl_s=30, heartbeat_s=5)
+
+    async def _acquire_false() -> bool:
+        return False
+
+    _bind_try_acquire(lease, _acquire_false)
+    lease._release = types.MethodType(  # type: ignore[method-assign]
+        lambda self: _noop_async(), lease,
+    )
+
+    await lease.start()
+    await lease.stop()
+
+    # Initial state was False, first acquire returned False — no flip.
+    assert claim_calls == []
+    assert claim_lost_calls == []
+    assert heartbeat_late_calls == []
+
+
+# ----------------------------------------------------------------------
+# Heartbeat — state transitions
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_emits_claim_on_false_to_true(monkeypatch):
+    from cms import metrics
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    _install_one_tick_sleep(monkeypatch)
+
+    lease = LeaderLease("alert_sweep", ttl_s=30, heartbeat_s=5)
+    lease._enabled = True
+    lease._is_leader = False  # initial state for this tick
+
+    async def _acquire_true() -> bool:
+        return True
+
+    _bind_try_acquire(lease, _acquire_true)
+
+    with pytest.raises(asyncio.CancelledError):
+        await lease._heartbeat_run()
+
+    assert len(claim_calls) == 1
+    amount, attrs = claim_calls[0][0]
+    assert amount == 1
+    assert attrs == {metrics.ATTR_LOOP_NAME: "alert_sweep"}
+    assert claim_lost_calls == []
+    assert heartbeat_late_calls == []
+    assert lease._is_leader is True
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_emits_claim_lost_on_true_to_false(monkeypatch):
+    from cms import metrics
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    _install_one_tick_sleep(monkeypatch)
+
+    lease = LeaderLease("scheduler", ttl_s=30, heartbeat_s=5)
+    lease._enabled = True
+    lease._is_leader = True  # we were the leader at the start of this tick
+
+    async def _acquire_false() -> bool:
+        return False
+
+    _bind_try_acquire(lease, _acquire_false)
+
+    with pytest.raises(asyncio.CancelledError):
+        await lease._heartbeat_run()
+
+    assert claim_calls == []
+    assert len(claim_lost_calls) == 1
+    amount, attrs = claim_lost_calls[0][0]
+    assert amount == 1
+    assert attrs == {metrics.ATTR_LOOP_NAME: "scheduler"}
+    assert heartbeat_late_calls == []
+    assert lease._is_leader is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_emits_late_on_exception(monkeypatch):
+    from cms import metrics
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    _install_one_tick_sleep(monkeypatch)
+
+    lease = LeaderLease("scheduler", ttl_s=30, heartbeat_s=5)
+    lease._enabled = True
+    lease._is_leader = True  # was leader; the exception forces F state
+
+    async def _boom() -> bool:
+        raise RuntimeError("simulated DB outage")
+
+    _bind_try_acquire(lease, _boom)
+
+    with pytest.raises(asyncio.CancelledError):
+        await lease._heartbeat_run()
+
+    # The exception bumps heartbeat_late, and because the resulting
+    # state is False (default after exception) we *also* see
+    # claim_lost for the involuntary T→F transition.  This is the
+    # documented behaviour: heartbeat_late is the "why" and
+    # claim_lost is the "what".
+    assert len(heartbeat_late_calls) == 1
+    amount, attrs = heartbeat_late_calls[0][0]
+    assert amount == 1
+    assert attrs == {metrics.ATTR_LOOP_NAME: "scheduler"}
+    assert claim_calls == []
+    assert len(claim_lost_calls) == 1
+    assert lease._is_leader is False
+
+
+# ----------------------------------------------------------------------
+# Non-Postgres backend — heartbeat skipped, no emission
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_emission_on_non_postgres_backend(monkeypatch):
+    # ``_get_engine`` returns None (sqlite/no-DB scenario in tests).
+    monkeypatch.setattr("cms.services.leader._get_engine", lambda: None)
+
+    claim_calls = _capture_add(monkeypatch, "presence_claim_total")
+    claim_lost_calls = _capture_add(monkeypatch, "presence_claim_lost_total")
+    heartbeat_late_calls = _capture_add(
+        monkeypatch, "presence_heartbeat_late_total"
+    )
+
+    lease = LeaderLease("scheduler", ttl_s=30, heartbeat_s=5)
+    await lease.start()
+
+    # SQLite-fallback path always reports leadership but never emits.
+    assert lease.is_leader is True
+    assert lease._enabled is False
+    assert lease._task is None
+    assert claim_calls == []
+    assert claim_lost_calls == []
+    assert heartbeat_late_calls == []
+
+    await lease.stop()
+    assert claim_calls == []
+    assert claim_lost_calls == []
+    assert heartbeat_late_calls == []
+
+
+# ----------------------------------------------------------------------
+# Helpers (placed at end so test fns above read top-down)
+# ----------------------------------------------------------------------
+
+
+async def _noop_async() -> None:
+    return None


### PR DESCRIPTION
# telemetry(B-presence): leader-lease claim / claim_lost / heartbeat_late counters

Pillar B continued. After B1 (WPS) and B2 (scheduler), this adds presence telemetry for the leader-lease loops. Now we can finally answer "is some replica actually holding the lease for loop X right now?" from App Insights without tailing logs.

## Counters added

All dimensioned on `loop_name` (bounded enum: `scheduler`, `alert_sweep`, etc.) — **not** `replica_id`, which would be a UUID4 cardinality bomb.

| Metric | When it fires |
|---|---|
| `agora.presence.claim` | F→T leadership transition (we just took the lease) |
| `agora.presence.claim_lost` | involuntary T→F transition only — graceful `stop()` / `release()` is silent |
| `agora.presence.heartbeat_late` | the heartbeat body raised; lease may be stale until the next iteration |

## Instrumentation

`cms/services/leader.py`:

* `start()` first-acquire success on the Postgres path → `claim`
* `_heartbeat_run()` state-change site → `claim` (F→T) or `claim_lost` (T→F)
* `_heartbeat_run()` exception path → `heartbeat_late`, plus `claim_lost` when previously leader (the exception sets `new_state = False`, so a T→F transition is observed by the same state-change site)

SQLite / non-Postgres path emits nothing — the early-return at the top of `start()` short-circuits before any counter logic.

## Why `loop_name` and not `replica_id`

`replica_id` is a UUID4 generated on container start. With auto-scaling that's effectively unbounded cardinality — App Insights would silently drop or sample, and the metric becomes useless. `loop_name` is a small, hand-curated enum and is the dimension you'd actually `summarize by` in a workbook tile.

## Why `stop()` is silent

A clean `stop()` means the operator scaled down or restarted the replica — that's not a presence anomaly, just a normal lifecycle event. We only want `claim_lost` to fire when the loop *thought* it was leader and then discovered it wasn't, which the heartbeat-body state-change site already captures.

## Tests

* `tests/test_metrics.py` (+3) — contract tests: handles exposed, `ATTR_LOOP_NAME` constant exists, `.add()` with attrs is safe under the no-op SDK.
* `tests/test_presence_metrics.py` (NEW, 6 tests) — behavioural:
  * `start()` first-acquire success → emits `claim`
  * `start()` first-acquire failure → no emission
  * `_heartbeat_run()` F→T transition → emits `claim`
  * `_heartbeat_run()` T→F transition (still healthy) → emits `claim_lost`
  * `_heartbeat_run()` exception while leader → emits both `heartbeat_late` and `claim_lost`
  * non-Postgres backend → no emission anywhere

Same monkeypatch-based capture pattern used by the B2 scheduler tests (`tests/test_scheduler_metrics.py`).

## Verification

Local: `pytest -p no:timeout tests/test_leader.py tests/test_presence_metrics.py tests/test_metrics.py tests/test_scheduler_metrics.py` → 29 passed, 8 skipped (skips are pre-existing env-gated tests).

## Next

Working through Pillar B: `alert_sweep` is the natural next target (same shape as scheduler), then webhook/log_drainer/db pool. Once those land we'll have enough material to populate the operator-facing tile workbook (Pillar D).
