### PR TITLE
ci(integration): run nightly under both transports + skip smoke_wps under direct-WS

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,23 +32,56 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
 
-      - name: Run full multi-replica integration suite
+      - name: Run full multi-replica integration suite (direct-WS)
         env:
           AGORA_RUN_INTEGRATION: "1"
         run: |
+          # Default direct-WS harness. ``smoke_wps`` tests are auto-
+          # skipped by ``tests/integration/conftest.py`` because the
+          # ``/internal/wps/events`` route only exists when the CMS is
+          # booted with ``AGORA_CMS_DEVICE_TRANSPORT=wps``; the
+          # explicit ``-m "not smoke_wps"`` filter makes the intent
+          # visible in the workflow rather than relying on the
+          # conftest skip alone.
           pytest tests/integration/ \
             --run-integration \
+            -m "not smoke_wps" \
+            -p no:xdist -p no:timeout \
+            -v --tb=short
+
+      - name: Tear down direct-WS stack
+        if: always()
+        run: |
+          docker compose -f tests/integration/docker-compose.integration.yml \
+            down -v --remove-orphans || true
+
+      - name: Run full multi-replica integration suite (WPS transport)
+        env:
+          AGORA_RUN_INTEGRATION: "1"
+          # Layer the WPS overlay on top of the base compose. Mirrors
+          # the per-PR ``multireplica-wps-smoke`` job but runs nightly
+          # so prod's N>=2 + WPS configuration gets the full smoke
+          # surface every night, not just on PRs that touch code.
+          AGORA_INTEGRATION_TRANSPORT: "wps"
+        run: |
+          pytest tests/integration/ \
+            --run-integration \
+            -m "smoke or smoke_wps" \
             -p no:xdist -p no:timeout \
             -v --tb=short
 
       - name: Dump compose logs on failure
         if: failure()
         run: |
-          docker compose -f tests/integration/docker-compose.integration.yml logs \
-            --no-color --tail=500 || true
+          docker compose \
+            -f tests/integration/docker-compose.integration.yml \
+            -f tests/integration/docker-compose.integration.wps.yml \
+            logs --no-color --tail=500 || true
 
       - name: Tear down
         if: always()
         run: |
-          docker compose -f tests/integration/docker-compose.integration.yml \
+          docker compose \
+            -f tests/integration/docker-compose.integration.yml \
+            -f tests/integration/docker-compose.integration.wps.yml \
             down -v --remove-orphans || true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,28 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # ``multireplica-smoke`` job leaves it unset (direct-WS path).
 INTEGRATION_TRANSPORT = os.environ.get("AGORA_INTEGRATION_TRANSPORT", "local").strip().lower()
 
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip ``smoke_wps``-marked tests when the harness isn't WPS.
+
+    The ``smoke_wps`` tests POST to ``/internal/wps/events``, which the
+    CMS only registers when ``AGORA_CMS_DEVICE_TRANSPORT=wps``. Running
+    them under the direct-WS harness is guaranteed to 404. Any caller
+    that forgets ``AGORA_INTEGRATION_TRANSPORT=wps`` (e.g. the nightly
+    full-integration workflow before this fix) would otherwise see
+    those tests as real failures rather than out-of-scope. Skipping
+    here is belt-and-braces; the workflows are also updated to set the
+    env var explicitly.
+    """
+    if INTEGRATION_TRANSPORT == "wps":
+        return
+    skip_marker = pytest.mark.skip(
+        reason="smoke_wps requires AGORA_INTEGRATION_TRANSPORT=wps",
+    )
+    for item in items:
+        if "smoke_wps" in item.keywords:
+            item.add_marker(skip_marker)
+
 CMS_A_URL = "http://127.0.0.1:8080"
 CMS_B_URL = "http://127.0.0.1:8081"
 # The test process talks to Postgres on the host-exposed port; the CMS


### PR DESCRIPTION
## Why

The nightly `Integration (multi-replica full)` workflow has been red since 4/26 (4 consecutive failures). Last green was 4/25, run [24927592256](https://github.com/sslivins/agora-cms/actions/runs/24927592256). First red was the first nightly after #454 merged, which added `tests/integration/test_multireplica_wps_smoke.py`.

**Failing tests:**
- `test_connected_on_replica_a_is_visible_via_replica_b`
- `test_stale_disconnect_after_reconnect_keeps_device_online`

Both POST to `/internal/wps/events` and got `404 Not Found` instead of `204`.

**Root cause:** that route is only registered when `AGORA_CMS_DEVICE_TRANSPORT=wps` (see `cms/main.py:~483`). The nightly didn't set `AGORA_INTEGRATION_TRANSPORT=wps` and didn't filter markers, so it ran the wps-smoke tests under the direct-WS harness — guaranteed 404.

The PR-time `multireplica-wps-smoke` job in `tests.yml` already does the right thing (sets the env var, layers `docker-compose.integration.wps.yml`). #454 just never propagated that wiring into nightly.

## What

Two-part fix:

**B — Workflow:** `.github/workflows/integration.yml` now does two pytest passes:
1. Direct-WS, `-m "not smoke_wps"` (nightly's existing coverage).
2. WPS overlay (`AGORA_INTEGRATION_TRANSPORT=wps`), `-m "smoke or smoke_wps"`. Mirrors the per-PR smoke job so prod's N>=2 + WPS path gets nightly coverage on every change, not only PRs that touch the smoke set.

Teardown + dump-logs steps now reference the wps overlay file as well, and the direct-WS stack is torn down between passes so port 5434 / cms-0/1 don't collide.

**C — Conftest auto-skip:** `tests/integration/conftest.py` now installs a `pytest_collection_modifyitems` hook that auto-skips any `smoke_wps`-marked test when `AGORA_INTEGRATION_TRANSPORT != "wps"`. Belt-and-braces — any future caller that forgets the env var sees clean skips instead of mystery 404s.

## Verification

Locally (Windows host, no Docker):
```
$ pytest tests/integration/test_multireplica_wps_smoke.py --run-integration -q -p no:timeout
2 skipped, 2 warnings in 0.09s
```

Auto-skip is doing its job. The CI integration run on this PR will exercise both transport passes for real.

## Risk

Low. The direct-WS pass is unchanged in behaviour (the conftest skip just makes implicit drop-of-2-tests explicit). The wps pass replicates a job that's already passing on every PR. Workflow runtime budget is `timeout-minutes: 30`; smoke ran ~85 s previously, dual-pass should be well under budget even as the suite grows.
