### PR TITLE
Close kebab popover when opening asset preview modal

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1470,6 +1470,7 @@ async function deleteGroup(groupId) {
 
 // ── Asset actions ──
 function previewAsset(assetId, filename, assetType) {
+    _closeOpenPopovers();
     const overlay = document.createElement("div");
     overlay.className = "modal-overlay";
     const box = document.createElement("div");
@@ -1508,6 +1509,7 @@ function previewAsset(assetId, filename, assetType) {
 }
 
 function previewVariant(variantId, filename, assetType, profileName) {
+    _closeOpenPopovers();
     const overlay = document.createElement("div");
     overlay.className = "modal-overlay";
     const box = document.createElement("div");


### PR DESCRIPTION
Opening an asset preview from the kebab menu in the asset library left the kebab visible on top of the video.`n`n`previewAsset()` and `previewVariant()` now call `_closeOpenPopovers()` before inserting the modal overlay, matching the pattern `showConfirm()` already uses.