### PR TITLE
feat(ui): add 'Report an issue' button to topbar

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -206,7 +206,7 @@ jobs:
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
               wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
               fleetRegisterSecrets='${{ steps.fleet_secrets.outputs.map }}' \
-              githubIssuesToken='${{ secrets.GITHUB_ISSUES_TOKEN }}' \
+              githubIssuesToken='${{ secrets.AGORA_CMS_ISSUES_TOKEN }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -206,6 +206,7 @@ jobs:
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
               wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
               fleetRegisterSecrets='${{ steps.fleet_secrets.outputs.map }}' \
+              githubIssuesToken='${{ secrets.GITHUB_ISSUES_TOKEN }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \
               cmsImage="$CMS_REF" \

--- a/cms/config.py
+++ b/cms/config.py
@@ -111,3 +111,13 @@ class Settings(SharedSettings):
     bootstrap_nonce_ttl_seconds: int = 600
     # WPS JWT lifetime for tokens issued via /connect-token and /adopt.
     bootstrap_wps_jwt_minutes: int = 60
+
+    # "Report an issue" feature.  When ``github_issues_token`` is set,
+    # the topbar exposes a button that opens a modal letting the signed-
+    # in user file a GitHub issue against ``github_issues_repo`` with
+    # the supplied title + description plus auto-captured context (page
+    # URL, user agent, app version, user, timestamp).  When the token
+    # is unset (e.g. dev/local without a PAT), the button is hidden.
+    github_issues_token: str | None = None
+    github_issues_repo: str = "sslivins/agora-cms"
+    github_issues_label: str = "user-reported"

--- a/cms/main.py
+++ b/cms/main.py
@@ -825,6 +825,7 @@ from cms.routers.roles import router as roles_router  # noqa: E402
 from cms.routers.stream_probe import router as stream_probe_router  # noqa: E402
 from cms.routers.users import router as users_router  # noqa: E402
 from cms.routers.bootstrap import router as bootstrap_router  # noqa: E402
+from cms.routers.issue_report import router as issue_report_router  # noqa: E402
 from cms.ui import router as ui_router  # noqa: E402
 
 app.include_router(bootstrap_router)
@@ -847,6 +848,7 @@ app.include_router(device_events_router)
 app.include_router(users_router)
 app.include_router(roles_router)
 app.include_router(stream_probe_router)
+app.include_router(issue_report_router)
 # /ws/device is only mounted in local transport mode. In WPS mode, devices
 # reach the CMS via Azure Web PubSub, and exposing a direct websocket is a
 # security/confusion risk (devices that connect there appear "online" but

--- a/cms/routers/issue_report.py
+++ b/cms/routers/issue_report.py
@@ -1,0 +1,112 @@
+"""Router for the topbar "Report an issue" feature.
+
+POST /api/issues/report — create a GitHub issue with the user-supplied
+title and description plus server-merged context (current user, app
+version, timestamp).  Available to any authenticated user.  Returns
+503 when no GitHub token is configured.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from cms import __version__ as cms_version
+from cms.auth import get_current_user, get_settings
+from cms.config import Settings
+from cms.models.user import User
+from cms.services import issue_reporter
+
+router = APIRouter(prefix="/api/issues")
+
+_MAX_TITLE_LEN = 200
+_MAX_BODY_LEN = 8000
+_MAX_FIELD_LEN = 500
+
+
+class ReportIssueRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=_MAX_TITLE_LEN)
+    description: str = Field(..., min_length=1, max_length=_MAX_BODY_LEN)
+    page_url: Optional[str] = Field(default=None, max_length=_MAX_FIELD_LEN)
+    user_agent: Optional[str] = Field(default=None, max_length=_MAX_FIELD_LEN)
+
+
+class ReportIssueResponse(BaseModel):
+    ok: bool
+    number: int
+    html_url: str
+
+
+def _build_body(req: ReportIssueRequest, user: User) -> str:
+    """Compose the GitHub issue body from the user description plus context."""
+    description = req.description.strip()
+    page_url = (req.page_url or "").strip() or "(unknown)"
+    user_agent = (req.user_agent or "").strip() or "(unknown)"
+    submitter = user.display_name or user.email or "(unknown)"
+    submitter_email = user.email or "(unknown)"
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    return (
+        f"{description}\n\n"
+        "---\n"
+        "**Reported from Agora CMS**\n\n"
+        f"- **User:** {submitter} ({submitter_email})\n"
+        f"- **CMS version:** {cms_version}\n"
+        f"- **Page:** {page_url}\n"
+        f"- **User agent:** {user_agent}\n"
+        f"- **Timestamp:** {now}\n"
+    )
+
+
+@router.get("/report/config")
+async def report_config(user: User = Depends(get_current_user)) -> dict:
+    """Tell the UI whether the report-issue feature is enabled.
+
+    The button is rendered server-side via a template flag, but this
+    endpoint is useful for diagnostics and lets the modal guard the
+    submit if the token is removed mid-session.
+    """
+    return {"enabled": issue_reporter.is_enabled()}
+
+
+@router.post("/report", response_model=ReportIssueResponse)
+async def report_issue(
+    payload: ReportIssueRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
+) -> ReportIssueResponse:
+    if not issue_reporter.is_enabled():
+        raise HTTPException(status_code=503, detail="Issue reporting is not configured")
+
+    # Prefer a client-supplied page URL (with hash/path) but fall back to
+    # the Referer header so the issue body has *something* useful even
+    # when the JS forgets to send it.
+    if not payload.page_url:
+        ref = request.headers.get("referer")
+        if ref:
+            payload.page_url = ref[:_MAX_FIELD_LEN]
+    if not payload.user_agent:
+        ua = request.headers.get("user-agent")
+        if ua:
+            payload.user_agent = ua[:_MAX_FIELD_LEN]
+
+    body = _build_body(payload, user)
+    label = settings.github_issues_label
+    labels = [label] if label else None
+
+    try:
+        result = await issue_reporter.create_issue(
+            payload.title.strip(), body, labels=labels
+        )
+    except issue_reporter.IssueReporterError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    return ReportIssueResponse(
+        ok=True,
+        number=int(result.get("number", 0)),
+        html_url=str(result.get("html_url", "")),
+    )

--- a/cms/services/issue_reporter.py
+++ b/cms/services/issue_reporter.py
@@ -1,0 +1,107 @@
+"""GitHub issue reporter — file an issue from the topbar "Report" modal.
+
+Wraps the GitHub Issues REST API.  Requires a fine-grained PAT with
+``Issues: Read and Write`` scoped to the configured repo.  The token is
+read from settings (``github_issues_token``); when absent the feature
+is disabled at the UI layer (button hidden) and any direct API call
+returns 503.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import httpx
+
+from cms.auth import get_settings
+
+logger = logging.getLogger("agora.cms.issue_reporter")
+
+_TIMEOUT = 15.0
+
+
+class IssueReporterError(Exception):
+    """Raised when issue creation fails."""
+
+    def __init__(self, message: str, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def is_enabled() -> bool:
+    """Return True if a GitHub token is configured."""
+    return bool(get_settings().github_issues_token)
+
+
+async def create_issue(
+    title: str,
+    body: str,
+    *,
+    labels: Optional[list[str]] = None,
+) -> dict:
+    """Create a GitHub issue.
+
+    Returns the parsed JSON response from the GitHub API on success.
+    Raises :class:`IssueReporterError` with an appropriate ``status_code``
+    when the token is missing, the API rejects the request, or the
+    network call fails.
+    """
+    settings = get_settings()
+    token = settings.github_issues_token
+    if not token:
+        raise IssueReporterError("GitHub issues integration is not configured", status_code=503)
+
+    repo = settings.github_issues_repo
+    if "/" not in repo:
+        raise IssueReporterError(f"Invalid github_issues_repo: {repo!r}", status_code=500)
+
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload: dict = {"title": title, "body": body}
+    if labels:
+        payload["labels"] = labels
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+    except httpx.HTTPError as exc:
+        logger.warning("GitHub issue create failed: network error: %s", exc)
+        raise IssueReporterError("Failed to reach GitHub", status_code=502) from exc
+
+    if resp.status_code == 201:
+        data = resp.json()
+        logger.info(
+            "Created GitHub issue #%s in %s: %s",
+            data.get("number"), repo, data.get("html_url"),
+        )
+        return data
+
+    # Surface the GitHub error message when available
+    detail = ""
+    try:
+        detail = resp.json().get("message", "") or ""
+    except Exception:
+        pass
+    logger.warning(
+        "GitHub issue create returned %d: %s", resp.status_code, detail or resp.text[:200]
+    )
+    if resp.status_code in (401, 403):
+        raise IssueReporterError(
+            "GitHub rejected the request — check the configured PAT scopes",
+            status_code=502,
+        )
+    if resp.status_code == 404:
+        raise IssueReporterError(
+            f"Repo {repo!r} not found or the PAT does not have access",
+            status_code=502,
+        )
+    raise IssueReporterError(
+        f"GitHub returned {resp.status_code}: {detail or 'unknown error'}",
+        status_code=502,
+    )

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -59,6 +59,9 @@
             {% if 'settings:write' in user_perms %}
             <a href="/settings" class="header-icon has-tooltip" aria-label="Settings"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg><span class="tooltip">Settings</span></a>
             {% endif %}
+            {% if request.state.user is defined and request.state.user and report_issue_enabled() %}
+            <button type="button" class="header-icon has-tooltip" id="report-issue-btn" aria-label="Report an issue" onclick="openReportIssueModal()"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><span class="tooltip">Report an issue</span></button>
+            {% endif %}
             <a href="/logout" class="header-icon has-tooltip" aria-label="Logout"><svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M7.5 17.5H4.17a1.67 1.67 0 0 1-1.67-1.67V4.17A1.67 1.67 0 0 1 4.17 2.5H7.5M13.33 14.17 17.5 10l-4.17-4.17M17.5 10H7.5"/></svg><span class="tooltip">Logout</span></a>
         </div>
     </header>
@@ -262,6 +265,89 @@
     }
     pollSystemHealth();
     setInterval(pollSystemHealth, 30000);
+
+    /* ── Report an issue modal ── */
+    function openReportIssueModal() {
+        if (typeof _closeOpenPopovers === 'function') _closeOpenPopovers();
+        const overlay = document.createElement('div');
+        overlay.className = 'modal-overlay';
+        overlay.innerHTML = `
+            <div class="modal-box" style="max-width:560px;width:100%;">
+                <h3 style="margin-top:0;">Report an issue</h3>
+                <p class="text-muted" style="margin-top:0;font-size:.9em;">
+                    Filed as a GitHub issue. Page URL, browser, app version, and your account
+                    info are included automatically.
+                </p>
+                <label style="display:block;margin-top:.75rem;font-weight:600;">Title</label>
+                <input type="text" id="report-issue-title" class="modal-input" maxlength="200"
+                       placeholder="Brief summary" style="width:100%;">
+                <label style="display:block;margin-top:.75rem;font-weight:600;">Description</label>
+                <textarea id="report-issue-body" class="modal-input" rows="6" maxlength="8000"
+                          placeholder="What happened? Steps to reproduce, what you expected, what you saw."
+                          style="width:100%;resize:vertical;font-family:inherit;"></textarea>
+                <div id="report-issue-error" style="display:none;color:var(--color-danger,#c22);margin-top:.5rem;font-size:.9em;"></div>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-secondary" id="report-issue-cancel">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="report-issue-submit">Submit</button>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(overlay);
+        const titleEl = overlay.querySelector('#report-issue-title');
+        const bodyEl = overlay.querySelector('#report-issue-body');
+        const errEl = overlay.querySelector('#report-issue-error');
+        const cancelBtn = overlay.querySelector('#report-issue-cancel');
+        const submitBtn = overlay.querySelector('#report-issue-submit');
+        const close = () => overlay.remove();
+        cancelBtn.onclick = close;
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+        document.addEventListener('keydown', function onKey(e) {
+            if (e.key === 'Escape') { document.removeEventListener('keydown', onKey); close(); }
+        });
+        titleEl.focus();
+
+        submitBtn.onclick = async () => {
+            const title = (titleEl.value || '').trim();
+            const description = (bodyEl.value || '').trim();
+            errEl.style.display = 'none';
+            errEl.textContent = '';
+            if (!title) { errEl.textContent = 'Title is required'; errEl.style.display = 'block'; titleEl.focus(); return; }
+            if (!description) { errEl.textContent = 'Description is required'; errEl.style.display = 'block'; bodyEl.focus(); return; }
+            submitBtn.disabled = true;
+            cancelBtn.disabled = true;
+            submitBtn.textContent = 'Submitting…';
+            try {
+                const resp = await fetch('/api/issues/report', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        title,
+                        description,
+                        page_url: window.location.href,
+                        user_agent: navigator.userAgent,
+                    }),
+                });
+                if (resp.ok) {
+                    close();
+                    showToast('Thanks for your feedback!');
+                } else {
+                    let detail = `Failed (${resp.status})`;
+                    try { const d = await resp.json(); if (d && d.detail) detail = d.detail; } catch {}
+                    errEl.textContent = detail;
+                    errEl.style.display = 'block';
+                    submitBtn.disabled = false;
+                    cancelBtn.disabled = false;
+                    submitBtn.textContent = 'Submit';
+                }
+            } catch (e) {
+                errEl.textContent = 'Network error — please try again';
+                errEl.style.display = 'block';
+                submitBtn.disabled = false;
+                cancelBtn.disabled = false;
+                submitBtn.textContent = 'Submit';
+            }
+        };
+    }
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -162,6 +162,15 @@ templates.env.globals["static_version"] = _static_version
 from cms import __version__ as _cms_version
 templates.env.globals["cms_version"] = _cms_version
 
+# Expose the report-issue feature flag to templates so the topbar
+# button is only rendered when a GitHub PAT is configured.
+def _report_issue_enabled() -> bool:
+    try:
+        return bool(get_settings().github_issues_token)
+    except Exception:
+        return False
+templates.env.globals["report_issue_enabled"] = _report_issue_enabled
+
 router = APIRouter()
 
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -46,6 +46,10 @@ param cmsAdminPassword string
 @secure()
 param wpsConnectionString string = ''
 
+@description('GitHub personal access token used by the "Report an issue" feature to file issues against the configured repo. When empty, the report-issue button is hidden.')
+@secure()
+param githubIssuesToken string = ''
+
 @description('Device transport mode: "wps" (multi-replica safe, routes via Azure Web PubSub) or "local" (direct CMS→device websockets, single-replica only).')
 @allowed(['wps', 'local'])
 param deviceTransport string = 'wps'
@@ -216,6 +220,9 @@ module containerApps 'modules/containerApps.bicep' = {
     // Device transport (Azure Web PubSub)
     wpsConnectionString: wpsConnectionString
     deviceTransport: deviceTransport
+
+    // Report-issue feature (GitHub)
+    githubIssuesToken: githubIssuesToken
 
     // Bootstrap v2 fleet secrets (JSON map)
     fleetRegisterSecrets: fleetRegisterSecrets

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -66,6 +66,10 @@ param deviceTransport string = 'wps'
 @secure()
 param fleetRegisterSecrets string = ''
 
+@description('GitHub personal access token used by the CMS "Report an issue" feature. When empty, the report-issue button is hidden.')
+@secure()
+param githubIssuesToken string = ''
+
 // ── Container Apps Environment ──
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: '${environmentName}-logs'
@@ -190,6 +194,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
           value: fleetRegisterSecrets
         }
         {
+          name: 'github-issues-token'
+          value: githubIssuesToken
+        }
+        {
           name: 'app-insights-connection-string'
           value: appInsights.properties.ConnectionString
         }
@@ -264,6 +272,10 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'AGORA_CMS_FLEET_REGISTER_SECRETS'
               secretRef: 'fleet-register-secrets'
+            }
+            {
+              name: 'AGORA_CMS_GITHUB_ISSUES_TOKEN'
+              secretRef: 'github-issues-token'
             }
             {
               // Picked up by azure-monitor-opentelemetry's

--- a/tests/test_issue_report.py
+++ b/tests/test_issue_report.py
@@ -1,0 +1,268 @@
+"""Tests for the "Report an issue" feature."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Service-level tests: cms/services/issue_reporter.py
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def with_token(monkeypatch):
+    """Patch get_settings() inside issue_reporter to return a token-enabled settings object."""
+    from cms.services import issue_reporter
+
+    fake_settings = MagicMock()
+    fake_settings.github_issues_token = "ghp_test"
+    fake_settings.github_issues_repo = "owner/repo"
+    fake_settings.github_issues_label = "user-reported"
+
+    monkeypatch.setattr(issue_reporter, "get_settings", lambda: fake_settings)
+    return fake_settings
+
+
+@pytest.fixture
+def without_token(monkeypatch):
+    from cms.services import issue_reporter
+
+    fake_settings = MagicMock()
+    fake_settings.github_issues_token = None
+    fake_settings.github_issues_repo = "owner/repo"
+    fake_settings.github_issues_label = "user-reported"
+    monkeypatch.setattr(issue_reporter, "get_settings", lambda: fake_settings)
+    return fake_settings
+
+
+def _patched_async_client(handler):
+    """Build an httpx.AsyncClient that uses a MockTransport via patch context manager."""
+    transport = httpx.MockTransport(handler)
+    # Use the unmonkey-patched AsyncClient class so this works even when
+    # the test has replaced ``issue_reporter.httpx.AsyncClient``.
+    return _ORIG_ASYNC_CLIENT(transport=transport, timeout=15)
+
+
+_ORIG_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def test_is_enabled_true(with_token):
+    from cms.services import issue_reporter
+    assert issue_reporter.is_enabled() is True
+
+
+def test_is_enabled_false(without_token):
+    from cms.services import issue_reporter
+    assert issue_reporter.is_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_create_issue_success(with_token, monkeypatch):
+    from cms.services import issue_reporter
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        import json
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            201,
+            json={"number": 42, "html_url": "https://github.com/owner/repo/issues/42"},
+        )
+
+    # Replace AsyncClient(...) call with one bound to our mock transport
+    def fake_client_factory(*args, **kwargs):
+        return _patched_async_client(handler)
+
+    monkeypatch.setattr(issue_reporter.httpx, "AsyncClient", fake_client_factory)
+
+    result = await issue_reporter.create_issue(
+        "hi", "body text", labels=["user-reported"]
+    )
+    assert result["number"] == 42
+    assert captured["url"] == "https://api.github.com/repos/owner/repo/issues"
+    assert captured["body"]["title"] == "hi"
+    assert captured["body"]["body"] == "body text"
+    assert captured["body"]["labels"] == ["user-reported"]
+    assert captured["headers"]["authorization"] == "Bearer ghp_test"
+
+
+@pytest.mark.asyncio
+async def test_create_issue_no_token_raises_503(without_token):
+    from cms.services import issue_reporter
+
+    with pytest.raises(issue_reporter.IssueReporterError) as exc_info:
+        await issue_reporter.create_issue("t", "b")
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_create_issue_unauthorized(with_token, monkeypatch):
+    from cms.services import issue_reporter
+
+    def handler(request):
+        return httpx.Response(401, json={"message": "Bad credentials"})
+
+    monkeypatch.setattr(
+        issue_reporter.httpx, "AsyncClient", lambda *a, **kw: _patched_async_client(handler)
+    )
+
+    with pytest.raises(issue_reporter.IssueReporterError) as exc_info:
+        await issue_reporter.create_issue("t", "b")
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_create_issue_network_error(with_token, monkeypatch):
+    from cms.services import issue_reporter
+
+    def handler(request):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(
+        issue_reporter.httpx, "AsyncClient", lambda *a, **kw: _patched_async_client(handler)
+    )
+
+    with pytest.raises(issue_reporter.IssueReporterError) as exc_info:
+        await issue_reporter.create_issue("t", "b")
+    assert exc_info.value.status_code == 502
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Endpoint tests: POST /api/issues/report
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_disabled_returns_503(client, monkeypatch):
+    """When no token is configured, the endpoint refuses with 503."""
+    from cms.services import issue_reporter
+
+    monkeypatch.setattr(issue_reporter, "is_enabled", lambda: False)
+
+    resp = await client.post(
+        "/api/issues/report",
+        json={"title": "t", "description": "d"},
+    )
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_creates_issue(client, monkeypatch):
+    from cms.services import issue_reporter
+
+    monkeypatch.setattr(issue_reporter, "is_enabled", lambda: True)
+
+    create_mock = AsyncMock(
+        return_value={"number": 7, "html_url": "https://github.com/owner/repo/issues/7"}
+    )
+    monkeypatch.setattr(issue_reporter, "create_issue", create_mock)
+
+    resp = await client.post(
+        "/api/issues/report",
+        json={
+            "title": "Bug on schedules tab",
+            "description": "Stuff broke",
+            "page_url": "http://localhost/schedules",
+            "user_agent": "Mozilla/5.0 test",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["number"] == 7
+    assert data["html_url"].endswith("/issues/7")
+
+    create_mock.assert_awaited_once()
+    args, kwargs = create_mock.await_args
+    assert args[0] == "Bug on schedules tab"
+    body = args[1]
+    # Body should include description and the captured context block
+    assert "Stuff broke" in body
+    assert "http://localhost/schedules" in body
+    assert "Mozilla/5.0 test" in body
+    assert "**CMS version:**" in body
+    assert kwargs.get("labels") == ["user-reported"]
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_validates_input(client, monkeypatch):
+    from cms.services import issue_reporter
+
+    monkeypatch.setattr(issue_reporter, "is_enabled", lambda: True)
+
+    # Missing description
+    resp = await client.post("/api/issues/report", json={"title": "t"})
+    assert resp.status_code == 422
+
+    # Empty title
+    resp = await client.post("/api/issues/report", json={"title": "", "description": "d"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_requires_auth(unauthed_client):
+    resp = await unauthed_client.post(
+        "/api/issues/report",
+        json={"title": "t", "description": "d"},
+    )
+    assert resp.status_code in (401, 403, 302)
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_falls_back_to_request_headers(client, monkeypatch):
+    """When client doesn't supply page_url/user_agent, server uses Referer + User-Agent headers."""
+    from cms.services import issue_reporter
+
+    monkeypatch.setattr(issue_reporter, "is_enabled", lambda: True)
+
+    create_mock = AsyncMock(
+        return_value={"number": 1, "html_url": "https://github.com/owner/repo/issues/1"}
+    )
+    monkeypatch.setattr(issue_reporter, "create_issue", create_mock)
+
+    resp = await client.post(
+        "/api/issues/report",
+        json={"title": "t", "description": "d"},
+        headers={"Referer": "http://test/devices", "User-Agent": "ServerPickedUA"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = create_mock.await_args.args[1]
+    assert "http://test/devices" in body
+    assert "ServerPickedUA" in body
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Topbar button visibility (template integration)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_topbar_button_visible_when_token_configured(client, monkeypatch):
+    """The 'Report an issue' button renders in the topbar when a token is set."""
+    from cms import ui as cms_ui
+
+    fake_settings = MagicMock()
+    fake_settings.github_issues_token = "ghp_test"
+    monkeypatch.setattr(cms_ui, "get_settings", lambda: fake_settings)
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert 'id="report-issue-btn"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_topbar_button_hidden_when_token_missing(client, monkeypatch):
+    """The 'Report an issue' button is hidden when no GitHub token is configured."""
+    from cms import ui as cms_ui
+
+    fake_settings = MagicMock()
+    fake_settings.github_issues_token = None
+    monkeypatch.setattr(cms_ui, "get_settings", lambda: fake_settings)
+
+    resp = await client.get("/")
+    assert resp.status_code == 200
+    assert 'id="report-issue-btn"' not in resp.text


### PR DESCRIPTION
## Summary

Adds a **Report an issue** button to the CMS topbar. Logged-in users can file a GitHub issue against `sslivins/agora-cms` from anywhere in the app. The CMS automatically captures the page URL, browser, app version, username, and timestamp into the issue body so reports are actionable without back-and-forth.

## UX

- Triangle warning icon appears in the topbar between system-health and the settings gear
- Click → modal with title + description fields
- Submit → toast: "Thanks for your feedback!" and modal closes
- Issue is filed server-side using a single shared GitHub PAT — end users do not need a GitHub account

The button is **hidden entirely** when `AGORA_CMS_GITHUB_ISSUES_TOKEN` is unset, so the feature stays dark until you explicitly turn it on.

## Implementation

| Layer | File | Notes |
|---|---|---|
| Settings | `cms/config.py` | `github_issues_token` / `github_issues_repo` / `github_issues_label` |
| Service | `cms/services/issue_reporter.py` | httpx-based GitHub Issues API client; `is_enabled()` + `create_issue()` |
| API | `cms/routers/issue_report.py` | `POST /api/issues/report`, `GET /api/issues/report/config` |
| Template global | `cms/ui.py` | `report_issue_enabled()` Jinja global |
| UI | `cms/templates/base.html` | Topbar button + modal JS |
| Infra | `infra/main.bicep`, `infra/modules/containerApps.bicep` | New `@secure() param githubIssuesToken` wired to `AGORA_CMS_GITHUB_ISSUES_TOKEN` env var on the CMS container |
| CI | `.github/workflows/publish-image.yml` | Passes `secrets.GITHUB_ISSUES_TOKEN` into the Bicep deploy |

## Required Repo Setup (for prod)

Add a new repo Action secret named **`GITHUB_ISSUES_TOKEN`** containing a fine-grained PAT scoped to `sslivins/agora-cms` with **Issues: Read and Write**.
Until that secret exists, prod deploys will pass an empty string and the button stays hidden — no breakage.

## Tests

14 new unit tests in `tests/test_issue_report.py`:

- Service: `is_enabled` true/false, success path (asserts URL/payload/Bearer auth), no-token → 503, 401 → 502, network error → 502
- Endpoint: 503 when disabled, success creates issue with full context body, 422 validation, auth required, fallback to `Referer` / `User-Agent` headers when client omits them
- Topbar: button rendered when token configured, hidden when not

All passing locally (`pytest tests/test_issue_report.py`).

## Manual smoke test

Verified locally via `docker compose up cms db` with the token configured: button appears, modal submits, real issue gets created, success toast renders, modal closes cleanly.
