### PR TITLE
fix(dashboard): hide CMS lifecycle events from Recent Activity

### DIFF
--- a/cms/ui.py
+++ b/cms/ui.py
@@ -806,6 +806,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     dev_q = await db.execute(
         select(DeviceEvent)
         .where(DeviceEvent.created_at >= cutoff_24h)
+        .where(DeviceEvent.event_type.notin_(["cms_started", "cms_stopped"]))
         .order_by(DeviceEvent.created_at.desc())
         .limit(20)
     )

--- a/tests/test_schedule_log.py
+++ b/tests/test_schedule_log.py
@@ -259,6 +259,37 @@ class TestHistoryUI:
         assert resp.status_code == 200
         assert "Dashboard Schedule" in resp.text
 
+    async def test_dashboard_recent_activity_excludes_cms_lifecycle(self, client, db_session):
+        """CMS started/stopped lifecycle events should NOT appear in the
+        dashboard's Recent Activity panel — they are noise for end users.
+        They remain visible in the full event log page."""
+        from cms.models.device_event import DeviceEvent
+
+        db_session.add(DeviceEvent(
+            device_id=None,
+            device_name="",
+            event_type="cms_started",
+        ))
+        db_session.add(DeviceEvent(
+            device_id=None,
+            device_name="",
+            event_type="cms_stopped",
+        ))
+        # A non-lifecycle event should still render so we can confirm
+        # the panel itself is being populated.
+        db_session.add(DeviceEvent(
+            device_id=None,
+            device_name="Sentinel Device",
+            event_type="online",
+        ))
+        await db_session.commit()
+
+        resp = await client.get("/")
+        assert resp.status_code == 200
+        assert "Sentinel Device" in resp.text
+        assert "CMS Started" not in resp.text
+        assert "CMS Stopped" not in resp.text
+
     async def test_dashboard_json_activity_count(self, client, db_session):
         db_session.add(ScheduleLog(
             schedule_name="Count Test",


### PR DESCRIPTION
## Problem

The dashboard's **Recent Activity** panel was showing `cms_started` /
`cms_stopped` system events alongside real user-facing activity. These
are operator-level lifecycle markers and just clutter the dashboard.

## Fix

Filter `cms_started` and `cms_stopped` event types out of the recent
activity query in `cms/ui.py`. They remain visible on the full
`/event-log` page (and its `Event Type` filter dropdown) so operators
can still find them when needed.

## Tests

Added `test_dashboard_recent_activity_excludes_cms_lifecycle` which
seeds two lifecycle events plus a sentinel `online` event, hits `/`,
and asserts the lifecycle markers are filtered out while the sentinel
still renders.