### PR TITLE
fix(dashboard): make Recent Activity playback-only

### DIFF
--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -216,7 +216,6 @@
             {% set log = entry.log %}
             <tr>
                 <td data-utc="{{ entry.timestamp.isoformat() }}">{{ entry.timestamp.astimezone(tz).strftime('%I:%M:%S %p').lstrip('0') }}</td>
-                {% if entry.kind == 'schedule' %}
                 <td>
                     {% if log.event.value == 'STARTED' %}
                     <span class="badge badge-started">Started</span>
@@ -232,38 +231,6 @@
                 <td>{{ log.device_name }}</td>
                 <td>{{ log.asset_filename }}</td>
                 <td class="text-muted">{{ log.details or '' }}</td>
-                {% else %}
-                <td>
-                    {% set et = log.event_type %}
-                    {% if et == 'online' %}
-                    <span class="badge badge-started">Online</span>
-                    {% elif et == 'offline' %}
-                    <span class="badge badge-missed">Offline</span>
-                    {% elif et == 'display_connected' %}
-                    <span class="badge badge-started">Display On</span>
-                    {% elif et == 'display_disconnected' %}
-                    <span class="badge badge-missed">Display Off</span>
-                    {% elif et == 'temp_high' %}
-                    <span class="badge badge-missed">Temp High</span>
-                    {% elif et == 'temp_cleared' %}
-                    <span class="badge badge-started">Temp Cleared</span>
-                    {% elif et == 'error' %}
-                    <span class="badge badge-missed">Error</span>
-                    {% elif et == 'error_cleared' %}
-                    <span class="badge badge-started">Error Cleared</span>
-                    {% elif et == 'cms_started' %}
-                    <span class="badge badge-started">CMS Started</span>
-                    {% elif et == 'cms_stopped' %}
-                    <span class="badge badge-skipped">CMS Stopped</span>
-                    {% else %}
-                    <span class="badge">{{ et }}</span>
-                    {% endif %}
-                </td>
-                <td class="text-muted">—</td>
-                <td>{{ log.device_name or '—' }}</td>
-                <td class="text-muted">—</td>
-                <td class="text-muted">{{ log.details or '' }}</td>
-                {% endif %}
             </tr>
             {% endfor %}
         </tbody>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -791,34 +791,24 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     upcoming_today = [u for u in upcoming if u["day_label"] == "today"]
     upcoming_tomorrow = [u for u in upcoming if u["day_label"] == "tomorrow"]
 
-    # Recent activity (last 24h) — merges schedule history with device events
-    # (online/offline, display connect/disconnect, temp, error transitions).
+    # Recent activity (last 24h) — playback events only (started / ended /
+    # skipped / missed). Device state changes (online/offline, display,
+    # temp, errors, CMS lifecycle) are surfaced live via the dashboard
+    # tiles and have a dedicated home in the full event log.
     from datetime import timedelta
-    from cms.models.device_event import DeviceEvent
     cutoff_24h = now - timedelta(hours=24)
     recent_q = await db.execute(
         select(ScheduleLog)
         .where(ScheduleLog.timestamp >= cutoff_24h)
         .order_by(ScheduleLog.timestamp.desc())
-        .limit(20)
+        .limit(10)
     )
     sched_entries = recent_q.scalars().all()
-    dev_q = await db.execute(
-        select(DeviceEvent)
-        .where(DeviceEvent.created_at >= cutoff_24h)
-        .where(DeviceEvent.event_type.notin_(["cms_started", "cms_stopped"]))
-        .order_by(DeviceEvent.created_at.desc())
-        .limit(20)
-    )
-    dev_entries = dev_q.scalars().all()
 
-    def _merged_ts(obj):
-        return getattr(obj, "timestamp", None) or getattr(obj, "created_at", None)
-
-    recent_activity = [{"kind": "schedule", "log": s, "timestamp": _merged_ts(s)} for s in sched_entries]
-    recent_activity += [{"kind": "device", "log": d, "timestamp": _merged_ts(d)} for d in dev_entries]
-    recent_activity.sort(key=lambda e: e["timestamp"], reverse=True)
-    recent_activity = recent_activity[:10]
+    recent_activity = [
+        {"kind": "schedule", "log": s, "timestamp": s.timestamp}
+        for s in sched_entries
+    ]
 
     # Groups for the adoption modal dropdown
     # Admins see all groups; scoped users see only their assigned groups.

--- a/tests/test_schedule_log.py
+++ b/tests/test_schedule_log.py
@@ -259,36 +259,49 @@ class TestHistoryUI:
         assert resp.status_code == 200
         assert "Dashboard Schedule" in resp.text
 
-    async def test_dashboard_recent_activity_excludes_cms_lifecycle(self, client, db_session):
-        """CMS started/stopped lifecycle events should NOT appear in the
-        dashboard's Recent Activity panel — they are noise for end users.
-        They remain visible in the full event log page."""
+    async def test_dashboard_recent_activity_excludes_device_events(self, client, db_session):
+        """Recent Activity is now playback-only. Device state changes
+        (online/offline, display, temp, error, CMS lifecycle) belong in
+        the dedicated /event-log page and the live dashboard tiles —
+        not in the activity stream."""
         from cms.models.device_event import DeviceEvent
 
-        db_session.add(DeviceEvent(
-            device_id=None,
-            device_name="",
-            event_type="cms_started",
-        ))
-        db_session.add(DeviceEvent(
-            device_id=None,
-            device_name="",
-            event_type="cms_stopped",
-        ))
-        # A non-lifecycle event should still render so we can confirm
-        # the panel itself is being populated.
-        db_session.add(DeviceEvent(
-            device_id=None,
-            device_name="Sentinel Device",
-            event_type="online",
+        # Seed a representative range of device events that previously
+        # would have rendered in Recent Activity.
+        for et in (
+            "cms_started",
+            "cms_stopped",
+            "online",
+            "offline",
+            "display_connected",
+            "display_disconnected",
+            "temp_high",
+            "error",
+        ):
+            db_session.add(DeviceEvent(
+                device_id=None,
+                device_name="DeviceEventSentinel",
+                event_type=et,
+            ))
+        # And a real playback row so we can confirm the panel itself is
+        # populated.
+        db_session.add(ScheduleLog(
+            schedule_name="PlaybackSentinel",
+            device_name="Dev",
+            asset_filename="play.mp4",
+            event=ScheduleLogEvent.STARTED,
         ))
         await db_session.commit()
 
         resp = await client.get("/")
         assert resp.status_code == 200
-        assert "Sentinel Device" in resp.text
-        assert "CMS Started" not in resp.text
-        assert "CMS Stopped" not in resp.text
+        assert "PlaybackSentinel" in resp.text
+        assert "DeviceEventSentinel" not in resp.text
+        for label in ("Online", "Offline", "Display On", "Display Off",
+                      "Temp High", "CMS Started", "CMS Stopped"):
+            # Badge labels from the old device-event template branch
+            # should no longer render.
+            assert f">{label}<" not in resp.text
 
     async def test_dashboard_json_activity_count(self, client, db_session):
         db_session.add(ScheduleLog(


### PR DESCRIPTION
## Problem

The dashboard's **Recent Activity** panel was a mix of two very different things:

- **Playback events** (schedule started / ended / skipped / missed) — operationally meaningful: `what is my signage actually showing right now?`
- **Device state events** (online/offline, display connect/disconnect, temp, error/cleared, CMS lifecycle) — infrastructure noise that already has dedicated homes on the dashboard.

Device state is already surfaced *live* via the dashboard tiles:
- `Needs Attention`, `Errors`, `Offline`, `Display Off`, `Storage Critical`  (all click-through to filtered device list)
- `Now Playing` rows already badge `Device Offline` / `Not Playing` inline

…and historically via the full `/event-log` page (with a per-event-type filter).

A flapping device or a CMS restart could easily push real playback events out of view.

## Fix

Recent Activity is now **playback-only** — just `ScheduleLog` rows. The DeviceEvent merge, sort, and slice were removed from `cms/ui.py`, and the corresponding device-event branch was stripped from `dashboard.html`. Net: -75 / +45 lines.

## Tests

Replaced the previous `excludes_cms_lifecycle` test (added in #498) with a broader `excludes_device_events` test that seeds eight representative device events (cms_started/stopped, online/offline, display_connected/disconnected, temp_high, error) plus a sentinel ScheduleLog row, then asserts only the playback row renders.