### PR TITLE
feat(dashboard): consolidate fleet status into 4 Device Health tiles

### DIFF
--- a/cms/services/device_alerts.py
+++ b/cms/services/device_alerts.py
@@ -49,6 +49,23 @@ NEEDS_ATTENTION_TAGS: frozenset[str] = frozenset({
 })
 
 
+# Severity buckets surfaced on the dashboard's Device Health tile grid.
+# These are a coarser view of NEEDS_ATTENTION_TAGS — Critical is the
+# "device is broken" subset (errors, offline, out of disk) and Warning
+# is the "needs eyes but still working" remainder. Maintenance and
+# Healthy are tracked separately.
+CRITICAL_TAGS: frozenset[str] = frozenset({
+    "error",
+    "offline",
+    "storage-critical",
+})
+
+WARNING_TAGS: frozenset[str] = frozenset({
+    "display-off",
+    "orphaned",
+})
+
+
 def _is_display_off(d) -> bool:
     """Mirror the macro logic for "no display detected".
 
@@ -134,6 +151,21 @@ def is_needs_attention(tags: Iterable[str]) -> bool:
     return any(t in NEEDS_ATTENTION_TAGS for t in tags)
 
 
+def is_critical(tags: Iterable[str]) -> bool:
+    """True if any tag in *tags* is in the Critical bucket."""
+    return any(t in CRITICAL_TAGS for t in tags)
+
+
+def is_warning(tags: Iterable[str]) -> bool:
+    """True if any tag in *tags* is in the Warning bucket and none in Critical.
+
+    A device with both critical and warning tags is counted Critical
+    only — buckets are mutually exclusive on the dashboard.
+    """
+    t = set(tags)
+    return not (t & CRITICAL_TAGS) and bool(t & WARNING_TAGS)
+
+
 def fleet_counts(devices, user_perms: Iterable[str] | None = None) -> dict[str, int]:
     """Compute triage-bar counts across a list of decorated devices.
 
@@ -150,11 +182,23 @@ def fleet_counts(devices, user_perms: Iterable[str] | None = None) -> dict[str, 
     - ``all`` — total adopted/orphaned devices
     - ``needs_attention`` — devices with at least one tag in
       :data:`NEEDS_ATTENTION_TAGS`
+    - ``critical`` — devices with at least one tag in
+      :data:`CRITICAL_TAGS` (dashboard bucket)
+    - ``warning`` — devices in the Warning bucket: at least one tag in
+      :data:`WARNING_TAGS` and no tags in :data:`CRITICAL_TAGS`. Buckets
+      are mutually exclusive on the dashboard so a device with both an
+      error and a display-off only counts as Critical.
     - one key per tag in :data:`SEVERITY_TAGS` (with hyphens kept;
       the template references them as ``counts['display-off']`` etc.)
     - ``healthy`` — devices with zero tags
     """
-    counts: dict[str, int] = {"all": 0, "needs_attention": 0, "healthy": 0}
+    counts: dict[str, int] = {
+        "all": 0,
+        "needs_attention": 0,
+        "critical": 0,
+        "warning": 0,
+        "healthy": 0,
+    }
     for tag in SEVERITY_TAGS:
         counts[tag] = 0
 
@@ -169,6 +213,10 @@ def fleet_counts(devices, user_perms: Iterable[str] | None = None) -> dict[str, 
             continue
         if is_needs_attention(tags):
             counts["needs_attention"] += 1
+        if is_critical(tags):
+            counts["critical"] += 1
+        elif is_warning(tags):
+            counts["warning"] += 1
         for t in tags:
             counts[t] = counts.get(t, 0) + 1
 

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -4,30 +4,54 @@
 {% block content %}
 <h1>Dashboard</h1>
 
-{# ── Fleet status (stat tiles, link into filtered /devices) ─────────── #}
+{# ── Device Health (consolidated severity tiles) ─────────────────────── #}
 {% if fleet_counts is defined and fleet_counts.all is defined %}
 <style>
-.stat-tile-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.6rem;
+.device-health-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.1rem;
     margin: 0 0 1rem 0;
 }
+.device-health-card h2 {
+    margin: 0 0 0.15rem 0;
+    font-size: 1.05rem;
+}
+.device-health-subtitle {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    margin: 0 0 0.8rem 0;
+}
+.stat-tile-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.6rem;
+}
+@media (max-width: 720px) {
+    .stat-tile-grid { grid-template-columns: repeat(2, 1fr); }
+}
 .stat-tile {
-    display: block;
-    padding: 0.7rem 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: 0.75rem 0.9rem;
     background: var(--surface);
     border: 1px solid var(--border);
     border-left: 4px solid var(--border);
     border-radius: 8px;
     text-decoration: none;
     color: var(--text);
-    transition: transform 0.08s ease, box-shadow 0.08s ease, border-color 0.08s ease;
+    transition: transform 0.08s ease, box-shadow 0.08s ease;
 }
 .stat-tile:hover {
     transform: translateY(-1px);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    border-color: var(--border-strong, var(--border));
+}
+.stat-tile-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 4.5rem;
 }
 .stat-tile-label {
     display: block;
@@ -35,7 +59,7 @@
     color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    margin: 0 0 0.3rem 0;
+    margin: 0 0 0.25rem 0;
     white-space: nowrap;
 }
 .stat-tile-value {
@@ -44,42 +68,107 @@
     font-weight: 600;
     line-height: 1;
 }
+.stat-tile-detail {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 0.8rem;
+    border-left: 1px solid var(--border);
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+    flex: 1;
+    min-width: 0;
+}
+.stat-tile-detail li { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .stat-tile-zero .stat-tile-value { color: var(--text-muted); font-weight: 400; }
-.stat-tile.sev-attn      { border-left-color: #f59e0b; }
-.stat-tile.sev-error     { border-left-color: #dc2626; }
-.stat-tile.sev-offline   { border-left-color: #6b7280; }
-.stat-tile.sev-display   { border-left-color: #f97316; }
-.stat-tile.sev-storage   { border-left-color: #b91c1c; }
-.stat-tile.sev-orphan    { border-left-color: #92400e; }
-.stat-tile.sev-maint     { border-left-color: #1e40af; }
-.stat-tile.sev-healthy   { border-left-color: #15803d; }
+.stat-tile.sev-critical { border-left-color: #dc2626; background: #fef2f2; }
+.stat-tile.sev-warning  { border-left-color: #f59e0b; background: #fffbeb; }
+.stat-tile.sev-action   { border-left-color: #2563eb; background: #eff6ff; }
+.stat-tile.sev-good     { border-left-color: #15803d; background: #f0fdf4; }
+.stat-tile.sev-critical:hover { background: #fee2e2; }
+.stat-tile.sev-warning:hover  { background: #fef3c7; }
+.stat-tile.sev-action:hover   { background: #dbeafe; }
+.stat-tile.sev-good:hover     { background: #dcfce7; }
+.stat-tile.stat-tile-zero { background: var(--surface); }
 </style>
-<div class="stat-tile-grid" role="navigation" aria-label="Fleet status">
-    {# Tiles render only when count > 0, except 'healthy' which is always shown
-       so the dashboard has a baseline signal even when nothing's wrong. #}
-    {% set _tiles = [
-        ('needs_attention',  'Needs Attention',   'sev-attn',    false),
-        ('error',            'Errors',            'sev-error',   false),
-        ('offline',          'Offline',           'sev-offline', false),
-        ('display-off',      'Display Off',       'sev-display', false),
-        ('storage-critical', 'Storage Critical',  'sev-storage', false),
-        ('orphaned',         'Orphaned',          'sev-orphan',  false),
-    ] %}
-    {% if 'devices:manage' in user_perms %}
-    {% set _tiles = _tiles + [('maintenance', 'Maintenance', 'sev-maint', false)] %}
-    {% endif %}
-    {% set _tiles = _tiles + [('healthy', 'Healthy', 'sev-healthy', true)] %}
-    {% for key, label, css, always_show in _tiles %}
-    {% set count = fleet_counts.get(key, 0) %}
-    {% if always_show or count > 0 %}
-    {% set filter_key = 'needs-attention' if key == 'needs_attention' else key %}
-    {% set href = '/devices?alert=' + filter_key %}
-    <a class="stat-tile {{ css }}{{ ' stat-tile-zero' if count == 0 }}" href="{{ href }}">
-        <span class="stat-tile-label">{{ label }}</span>
-        <span class="stat-tile-value">{{ count }}</span>
-    </a>
-    {% endif %}
-    {% endfor %}
+<div class="device-health-card">
+    <h2>Device Health</h2>
+    <div class="device-health-subtitle">{{ fleet_counts.all }} device{{ '' if fleet_counts.all == 1 else 's' }} total</div>
+    <div class="stat-tile-grid" role="navigation" aria-label="Device health summary">
+        {% set _critical_count = fleet_counts.get('critical', 0) %}
+        {% set _warning_count = fleet_counts.get('warning', 0) %}
+        {% set _maint_count = fleet_counts.get('maintenance', 0) %}
+        {% set _healthy_count = fleet_counts.get('healthy', 0) %}
+
+        {# ── Critical ── #}
+        <a class="stat-tile sev-critical{{ ' stat-tile-zero' if _critical_count == 0 }}"
+           href="/devices?alert=critical">
+            <div class="stat-tile-main">
+                <span class="stat-tile-label">Critical</span>
+                <span class="stat-tile-value">{{ _critical_count }}</span>
+            </div>
+            <ul class="stat-tile-detail">
+                {% if _critical_count == 0 %}
+                <li>No critical issues</li>
+                {% else %}
+                {% if fleet_counts.get('error', 0) > 0 %}<li>{{ fleet_counts['error'] }} error{{ '' if fleet_counts['error'] == 1 else 's' }}</li>{% endif %}
+                {% if fleet_counts.get('offline', 0) > 0 %}<li>{{ fleet_counts['offline'] }} offline</li>{% endif %}
+                {% if fleet_counts.get('storage-critical', 0) > 0 %}<li>{{ fleet_counts['storage-critical'] }} storage critical</li>{% endif %}
+                {% endif %}
+            </ul>
+        </a>
+
+        {# ── Warning ── #}
+        <a class="stat-tile sev-warning{{ ' stat-tile-zero' if _warning_count == 0 }}"
+           href="/devices?alert=warning">
+            <div class="stat-tile-main">
+                <span class="stat-tile-label">Warning</span>
+                <span class="stat-tile-value">{{ _warning_count }}</span>
+            </div>
+            <ul class="stat-tile-detail">
+                {% if _warning_count == 0 %}
+                <li>No warnings</li>
+                {% else %}
+                {% if fleet_counts.get('display-off', 0) > 0 %}<li>{{ fleet_counts['display-off'] }} display off</li>{% endif %}
+                {% if fleet_counts.get('orphaned', 0) > 0 %}<li>{{ fleet_counts['orphaned'] }} orphaned</li>{% endif %}
+                {% endif %}
+            </ul>
+        </a>
+
+        {# ── Updates Available (admins only) ── #}
+        {% if 'devices:manage' in user_perms %}
+        <a class="stat-tile sev-action{{ ' stat-tile-zero' if _maint_count == 0 }}"
+           href="/devices?alert=maintenance">
+            <div class="stat-tile-main">
+                <span class="stat-tile-label">Updates Available</span>
+                <span class="stat-tile-value">{{ _maint_count }}</span>
+            </div>
+            <ul class="stat-tile-detail">
+                {% if _maint_count == 0 %}
+                <li>All devices up to date</li>
+                {% else %}
+                <li>{{ _maint_count }} device{{ '' if _maint_count == 1 else 's' }} ready to update</li>
+                {% endif %}
+            </ul>
+        </a>
+        {% endif %}
+
+        {# ── Healthy ── #}
+        <a class="stat-tile sev-good{{ ' stat-tile-zero' if _healthy_count == 0 }}"
+           href="/devices?alert=healthy">
+            <div class="stat-tile-main">
+                <span class="stat-tile-label">Healthy</span>
+                <span class="stat-tile-value">{{ _healthy_count }}</span>
+            </div>
+            <ul class="stat-tile-detail">
+                {% if _healthy_count == 0 %}
+                <li>No healthy devices</li>
+                {% else %}
+                <li>Running normally</li>
+                {% endif %}
+            </ul>
+        </a>
+    </div>
 </div>
 {% endif %}
 

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -81,15 +81,22 @@
 }
 .stat-tile-detail li { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .stat-tile-zero .stat-tile-value { color: var(--text-muted); font-weight: 400; }
-.stat-tile.sev-critical { border-left-color: #dc2626; background: #fef2f2; }
-.stat-tile.sev-warning  { border-left-color: #f59e0b; background: #fffbeb; }
-.stat-tile.sev-action   { border-left-color: #2563eb; background: #eff6ff; }
-.stat-tile.sev-good     { border-left-color: #15803d; background: #f0fdf4; }
-.stat-tile.sev-critical:hover { background: #fee2e2; }
-.stat-tile.sev-warning:hover  { background: #fef3c7; }
-.stat-tile.sev-action:hover   { background: #dbeafe; }
-.stat-tile.sev-good:hover     { background: #dcfce7; }
-.stat-tile.stat-tile-zero { background: var(--surface); }
+.stat-tile.sev-critical { border-left-color: #ef4444; background: color-mix(in srgb, #ef4444 16%, var(--surface)); }
+.stat-tile.sev-warning  { border-left-color: #f59e0b; background: color-mix(in srgb, #f59e0b 16%, var(--surface)); }
+.stat-tile.sev-action   { border-left-color: #3b82f6; background: color-mix(in srgb, #3b82f6 16%, var(--surface)); }
+/* Healthy is the "normal" / good state — no tint, just the surface. */
+.stat-tile.sev-good     { border-left-color: #22c55e; background: var(--surface); }
+.stat-tile.sev-critical:hover { background: color-mix(in srgb, #ef4444 26%, var(--surface)); }
+.stat-tile.sev-warning:hover  { background: color-mix(in srgb, #f59e0b 26%, var(--surface)); }
+.stat-tile.sev-action:hover   { background: color-mix(in srgb, #3b82f6 26%, var(--surface)); }
+.stat-tile.sev-good:hover     { background: var(--surface-alt); }
+/* Zero-state hover stays neutral — a tile showing "0 warnings" should NOT
+   pick up the severity tint just because the cursor is over it. */
+.stat-tile.stat-tile-zero:hover { background: var(--surface-alt); }
+/* Zero-state: drop the tint entirely — use surface-alt so a 0 count
+   visually recedes but is still distinguishable from the card body. */
+.stat-tile.stat-tile-zero { background-color: var(--surface-alt); border-left-color: var(--border); }
+.stat-tile.stat-tile-zero .stat-tile-detail { color: var(--text-muted); opacity: 0.6; }
 </style>
 <div class="device-health-card">
     <h2>Device Health</h2>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -93,18 +93,18 @@
    the row td backgrounds (table rows ignore `background` directly in
    most browsers when border-collapse: collapse is in effect). */
 @keyframes row-flash-critical {
-    0%   { background-color: #fee2e2; }
-    60%  { background-color: #fee2e2; }
+    0%   { background-color: #5a1d24; }
+    60%  { background-color: #5a1d24; }
     100% { background-color: transparent; }
 }
 @keyframes row-flash-warning {
-    0%   { background-color: #fef3c7; }
-    60%  { background-color: #fef3c7; }
+    0%   { background-color: #4d3d14; }
+    60%  { background-color: #4d3d14; }
     100% { background-color: transparent; }
 }
 @keyframes row-flash-maintenance {
-    0%   { background-color: #dbeafe; }
-    60%  { background-color: #dbeafe; }
+    0%   { background-color: #1e3a6e; }
+    60%  { background-color: #1e3a6e; }
     100% { background-color: transparent; }
 }
 tr.row-flash > td { animation-duration: 1.6s; animation-timing-function: ease-out; animation-fill-mode: forwards; }

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -87,6 +87,33 @@
     padding: 1rem;
     font-style: italic;
 }
+/* Row flash: when arriving from a Device Health tile on the dashboard,
+   matching rows pulse a tinted background for ~1.5s so the user can
+   see at a glance which rows triggered the count. The keyframe ramps
+   the row td backgrounds (table rows ignore `background` directly in
+   most browsers when border-collapse: collapse is in effect). */
+@keyframes row-flash-critical {
+    0%   { background-color: #fee2e2; }
+    60%  { background-color: #fee2e2; }
+    100% { background-color: transparent; }
+}
+@keyframes row-flash-warning {
+    0%   { background-color: #fef3c7; }
+    60%  { background-color: #fef3c7; }
+    100% { background-color: transparent; }
+}
+@keyframes row-flash-maintenance {
+    0%   { background-color: #dbeafe; }
+    60%  { background-color: #dbeafe; }
+    100% { background-color: transparent; }
+}
+tr.row-flash > td { animation-duration: 1.6s; animation-timing-function: ease-out; animation-fill-mode: forwards; }
+tr.row-flash.row-flash-critical    > td { animation-name: row-flash-critical; }
+tr.row-flash.row-flash-warning     > td { animation-name: row-flash-warning; }
+tr.row-flash.row-flash-maintenance > td { animation-name: row-flash-maintenance; }
+@media (prefers-reduced-motion: reduce) {
+    tr.row-flash > td { animation: none; }
+}
 /* Per-group rollup chips rendered next to the group name (Phase C). */
 .group-rollup {
     display: inline-flex;
@@ -187,6 +214,8 @@
 const TRIAGE_NEEDS_ATTENTION = new Set([
     'error', 'offline', 'display-off', 'storage-critical', 'orphaned'
 ]);
+const TRIAGE_CRITICAL = new Set(['error', 'offline', 'storage-critical']);
+const TRIAGE_WARNING = new Set(['display-off', 'orphaned']);
 
 function triageGetTags(tr) {
     const raw = (tr.getAttribute('data-severity-tags') || '').trim();
@@ -199,6 +228,15 @@ function triageRowMatches(tr, filter) {
     if (filter === 'healthy') return tags.length === 0;
     if (filter === 'needs-attention') {
         return tags.some(t => TRIAGE_NEEDS_ATTENTION.has(t));
+    }
+    if (filter === 'critical') {
+        return tags.some(t => TRIAGE_CRITICAL.has(t));
+    }
+    if (filter === 'warning') {
+        // Mutually exclusive with critical: a device with both shows
+        // only under Critical, matching the dashboard tile semantics.
+        if (tags.some(t => TRIAGE_CRITICAL.has(t))) return false;
+        return tags.some(t => TRIAGE_WARNING.has(t));
     }
     return tags.includes(filter);
 }
@@ -248,7 +286,7 @@ function triageBarApply(filter) {
 
 function triageBarRecomputeCounts() {
     const counts = {
-        'all': 0, 'needs-attention': 0, 'healthy': 0,
+        'all': 0, 'needs-attention': 0, 'critical': 0, 'warning': 0, 'healthy': 0,
         'error': 0, 'offline': 0, 'display-off': 0,
         'storage-critical': 0, 'orphaned': 0, 'maintenance': 0,
     };
@@ -266,11 +304,17 @@ function triageBarRecomputeCounts() {
             return;
         }
         let needsAttn = false;
+        let isCritical = false;
+        let isWarning = false;
         tags.forEach(t => {
             if (counts[t] !== undefined) counts[t] += 1;
             if (TRIAGE_NEEDS_ATTENTION.has(t)) needsAttn = true;
+            if (TRIAGE_CRITICAL.has(t)) isCritical = true;
+            if (TRIAGE_WARNING.has(t)) isWarning = true;
         });
         if (needsAttn) counts['needs-attention'] += 1;
+        if (isCritical) counts['critical'] += 1;
+        else if (isWarning) counts['warning'] += 1;
     });
     Object.keys(counts).forEach(key => {
         const el = document.querySelector(`[data-triage-count="${key}"]`);
@@ -293,7 +337,28 @@ document.addEventListener('DOMContentLoaded', () => {
     // Apply initial filter from server-rendered active state.
     const initial = document.querySelector('.triage-chip.is-active');
     if (initial) triageBarApply(initial.getAttribute('data-filter'));
+    // Flash matching rows when arriving from a dashboard tile so the
+    // user can see at a glance which rows triggered the count.
+    triageFlashFromUrl();
 });
+
+function triageFlashFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    const alert = (params.get('alert') || '').toLowerCase();
+    const flashable = new Set(['critical', 'warning', 'maintenance']);
+    if (!flashable.has(alert)) return;
+    const flashClass = `row-flash-${alert}`;
+    document.querySelectorAll('tr.device-row[data-severity-tags]').forEach(tr => {
+        if (!triageRowMatches(tr, alert)) return;
+        // Stagger via reflow + class add so the animation fires.
+        tr.classList.add('row-flash', flashClass);
+        // Auto-remove after the keyframe finishes so the row settles
+        // back to its normal background.
+        window.setTimeout(() => {
+            tr.classList.remove('row-flash', flashClass);
+        }, 1800);
+    });
+}
 
 function toggleGroup(header) {
     const panel = header.closest('.group-panel');

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1188,7 +1188,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         g.rollup = fleet_counts(g.devices, user_perms)
 
     raw_alert = (request.query_params.get("alert") or "").strip().lower()
-    valid_filters = {"all", "needs-attention", "healthy", *SEVERITY_TAGS}
+    valid_filters = {"all", "needs-attention", "critical", "warning", "healthy", *SEVERITY_TAGS}
     active_alert = raw_alert if raw_alert in valid_filters else "all"
 
     return templates.TemplateResponse(request, "devices.html", {

--- a/tests/test_devices_triage_bar.py
+++ b/tests/test_devices_triage_bar.py
@@ -9,11 +9,15 @@ from types import SimpleNamespace
 import pytest
 
 from cms.services.device_alerts import (
+    CRITICAL_TAGS,
     NEEDS_ATTENTION_TAGS,
     SEVERITY_TAGS,
+    WARNING_TAGS,
     device_severity_tags,
     fleet_counts,
+    is_critical,
     is_needs_attention,
+    is_warning,
 )
 
 
@@ -185,6 +189,15 @@ def test_fleet_counts_aggregate():
     # needs_attention = error + offline + display-off + storage-crit + orphaned,
     # de-duplicated per device. 2 error + 1 offline + 1 orphaned + 1 storage = 5.
     assert counts["needs_attention"] == 5
+    # Critical bucket = error + offline + storage-critical, de-duped per
+    # device. 2 error + 1 offline + 1 storage = 4. (The orphaned device,
+    # though is_online=False, only gets the 'orphaned' tag because
+    # orphaned subsumes other tags.)
+    assert counts["critical"] == 4
+    # Warning bucket = display-off + orphaned, mutually exclusive with
+    # critical. The single orphaned device has only that tag, so it
+    # lands in Warning.
+    assert counts["warning"] == 1
 
 
 def test_fleet_counts_keys_present():
@@ -192,6 +205,8 @@ def test_fleet_counts_keys_present():
     assert counts["all"] == 0
     assert counts["healthy"] == 0
     assert counts["needs_attention"] == 0
+    assert counts["critical"] == 0
+    assert counts["warning"] == 0
     for tag in SEVERITY_TAGS:
         assert tag in counts
 
@@ -199,3 +214,51 @@ def test_fleet_counts_keys_present():
 def test_needs_attention_set_is_a_subset_of_severity_tags():
     # Sanity guard against typos in the constants.
     assert NEEDS_ATTENTION_TAGS <= set(SEVERITY_TAGS)
+
+
+def test_critical_and_warning_are_disjoint_subsets_of_needs_attention():
+    # Buckets are surfaced on the dashboard as mutually exclusive
+    # severity tiles; their union must equal NEEDS_ATTENTION_TAGS.
+    assert CRITICAL_TAGS.isdisjoint(WARNING_TAGS)
+    assert CRITICAL_TAGS | WARNING_TAGS == NEEDS_ATTENTION_TAGS
+
+
+def test_is_critical_and_is_warning_predicates():
+    assert is_critical(["error"])
+    assert is_critical(["offline", "display-off"])
+    assert not is_critical(["display-off"])
+    assert not is_critical([])
+    # Warning is exclusive of critical: a row with both tags is NOT a
+    # warning (it's critical).
+    assert is_warning(["display-off"])
+    assert is_warning(["orphaned"])
+    assert not is_warning(["error", "display-off"])
+    assert not is_warning([])
+    assert not is_warning(["maintenance"])
+
+
+def test_fleet_counts_warning_only_device():
+    # Warning-only device (display-off, no critical tags) lands in
+    # the Warning bucket but not Critical.
+    fleet = [
+        _device(display_ports=[{"connected": False}, {"connected": False}]),
+    ]
+    counts = fleet_counts(fleet)
+    assert counts["all"] == 1
+    assert counts["display-off"] == 1
+    assert counts["critical"] == 0
+    assert counts["warning"] == 1
+
+
+def test_fleet_counts_critical_warning_mutually_exclusive():
+    # A device with both a critical tag (error) and a warning tag
+    # (display-off) counts as Critical only — Warning bucket stays 0.
+    fleet = [
+        _device(error="boom", display_ports=[{"connected": False}, {"connected": False}]),
+    ]
+    counts = fleet_counts(fleet)
+    assert counts["all"] == 1
+    assert counts["error"] == 1
+    assert counts["display-off"] == 1
+    assert counts["critical"] == 1
+    assert counts["warning"] == 0


### PR DESCRIPTION
## Summary

Consolidates the 8-tile fleet status grid on the dashboard into **4 Device Health tiles** with a simpler 3-color severity scheme + blue for action, plus per-tile breakdown sublists in the open horizontal space, and matching `/devices` filter/flash support.

| Tile | Severity tags | Filter URL |
|---|---|---|
| **Critical** | `error`, `offline`, `storage-critical` | `/devices?alert=critical` |
| **Warning** | `display-off`, `orphaned` (mutually exclusive with Critical) | `/devices?alert=warning` |
| **Updates Available** *(admin only)* | maintenance / pending firmware | `/devices?alert=maintenance` |
| **Healthy** | none | `/devices?alert=healthy` |

## What changed

**Severity taxonomy** (`cms/services/device_alerts.py`)
- Adds `CRITICAL_TAGS`, `WARNING_TAGS` frozensets and `is_critical()`, `is_warning()` predicates. Warning is mutually exclusive with Critical (a device with both `error` and `display-off` counts as Critical only).
- Extends `fleet_counts()` to emit `critical` / `warning` keys.

**Dashboard** (`cms/templates/dashboard.html`)
- Replaces the 8-tile grid with a single Device Health card containing 4 stretched stat tiles. Each tile has a label + count and a breakdown `<ul>` in the open space (e.g. "2 errors · 1 offline").
- Dark-theme-aware tints via `color-mix()` at 16% (26% on hover); Healthy is the normal surface; zero-state tiles drop the tint and stay neutral on hover so "0 warnings" doesn't turn amber.
- Updates Available is gated on `'devices:manage' in user_perms`; non-admins see 3 tiles.

**Devices page** (`cms/templates/devices.html`, `cms/ui.py`)
- `valid_filters` extended with `critical` and `warning`.
- JS filter logic mirrors the same mutual-exclusion rule.
- Adds row-flash animation when arriving via `?alert=...` from a tile (1.6s, respects `prefers-reduced-motion`).

**Tests** (`tests/test_devices_triage_bar.py`)
- New cases covering the predicates, mutual exclusivity, and the new bucket counts. Existing 79 related tests still pass.

## Why

The previous tile grid had 8 status chips (needs-attention / storage critical / errors / offline / display-off / orphaned / updates / healthy) with five different colors. It was visually noisy and forced viewers to translate "what does each mean?" Consolidating into 4 severity buckets with a simple Critical → Warning → Action → Good progression makes the dashboard scannable in one glance, and the per-tile breakdown gives admins the same diagnostic detail without the chip overload.

## Notes

- **Auto-merge is intentionally NOT enabled** on this PR — manual control requested.
- Branch was previewed locally in Docker before push.