### PR TITLE
telemetry(D-tiles): add CMS internals panels to workbook

### DIFF
--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -355,6 +355,132 @@ var workbookContent = {
       }
       name: 'exceptions'
     }
+    // ── CMS internals (Pillar B counters) ─────────────────────────
+    // Surfaces the OpenTelemetry counters emitted from
+    // ``cms/metrics.py``: WPS send health (B1), scheduler tick health
+    // (B2), and leader-lease state changes (B-presence).  All
+    // counters land in the App Insights resource-scoped
+    // ``customMetrics`` table; ``sum(value)`` aggregates the
+    // exported delta points back into per-bin totals.
+    {
+      type: 1
+      content: {
+        json: '## CMS internals — Pillar B counters\nWPS send health, scheduler tick health, and leader-lease state changes emitted from ``cms.metrics``. Empty series labelled ``unknown`` indicate an instrumentation regression (counter incremented without the expected attribute).'
+      }
+      name: 'b-counters-header'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name in ("agora.wps.send.attempt","agora.wps.send.success","agora.wps.send.failure")\n| extend outcome = case(\n    name == "agora.wps.send.attempt", "attempt",\n    name == "agora.wps.send.success", "success",\n    name == "agora.wps.send.failure", "failure",\n    name)\n| summarize Count = sum(value) by bin(timestamp, 5m), outcome\n| order by timestamp asc'
+        size: 0
+        title: 'WPS send rate by outcome (attempt / success / failure)'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'wps-rate'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name in ("agora.wps.send.success","agora.wps.send.failure")\n| summarize\n    Success = sumif(value, name == "agora.wps.send.success"),\n    Failure = sumif(value, name == "agora.wps.send.failure")\n  by bin(timestamp, 5m)\n| extend Total = Success + Failure\n| extend FailurePct = iff(Total > 0, 100.0 * Failure / Total, real(null))\n| project timestamp, FailurePct\n| order by timestamp asc'
+        size: 0
+        title: 'WPS failure % (failure / (success + failure))'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'wps-failure-pct'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name == "agora.wps.send.failure"\n| extend reason = tostring(customDimensions.reason)\n| extend reason = iff(isempty(reason), "unknown", reason)\n| summarize Count = sum(value) by bin(timestamp, 5m), reason\n| order by timestamp asc'
+        size: 0
+        title: 'WPS failures by reason (404 / 429 / http_error / unexpected)'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'wps-failures-by-reason'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name == "agora.scheduler.tick"\n| extend outcome = tostring(customDimensions.outcome)\n| extend outcome = iff(isempty(outcome), "unknown", outcome)\n| summarize Count = sum(value) by bin(timestamp, 5m), outcome\n| order by timestamp asc'
+        size: 0
+        title: 'Scheduler tick by outcome (evaluated / skipped_not_leader / error)'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'scheduler-tick'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name == "agora.scheduler.missed_emitted"\n| summarize Count = sum(value) by bin(timestamp, 5m)\n| order by timestamp asc'
+        size: 0
+        title: 'Scheduler MISSED schedules emitted'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'scheduler-missed'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name in ("agora.presence.claim","agora.presence.claim_lost")\n| extend loop = tostring(customDimensions.loop_name)\n| extend loop = iff(isempty(loop), "unknown", loop)\n| extend event = case(\n    name == "agora.presence.claim", "claim",\n    name == "agora.presence.claim_lost", "claim_lost",\n    name)\n| summarize Count = sum(value) by bin(timestamp, 5m), event, loop\n| order by timestamp asc'
+        size: 0
+        title: 'Leader lease state changes (claim / claim_lost) by loop'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'presence-lease'
+    }
+    {
+      type: 3
+      content: {
+        version: 'KqlItem/1.0'
+        query: 'customMetrics\n| where name == "agora.presence.heartbeat_late"\n| extend loop = tostring(customDimensions.loop_name)\n| extend loop = iff(isempty(loop), "unknown", loop)\n| summarize Count = sum(value) by bin(timestamp, 5m), loop\n| order by timestamp asc'
+        size: 0
+        title: 'Leader lease heartbeat_late by loop (renewal exceptions)'
+        timeContext: {
+          durationMs: 86400000
+        }
+        queryType: 0
+        resourceType: 'microsoft.insights/components'
+        visualization: 'timechart'
+      }
+      name: 'presence-heartbeat-late'
+    }
   ]
   styleSettings: {}
   '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
@@ -368,7 +494,7 @@ resource workbook 'Microsoft.Insights/workbooks@2023-06-01' = {
   properties: {
     displayName: 'Agora CMS — Telemetry triage'
     serializedData: string(workbookContent)
-    version: '1.0'
+    version: '1.1'
     sourceId: appInsightsId
     category: 'workbook'
   }


### PR DESCRIPTION
## Summary

Surfaces the eight already-shipping Pillar B counters on the existing
"Telemetry triage" Application Insights workbook (defined in
`infra/modules/alerts.bicep`) so operators can see WPS, scheduler, and
leader-lease activity without writing ad-hoc KQL.

This is **Pillar D — workbook only** from the telemetry plan. Alerts
and the broader Fleet-health / Rollout views are separate follow-ups.

## What's added

1 markdown header + 7 timechart panels appended to `workbookContent.items`:

| Panel | Counter(s) | Pillar |
| --- | --- | --- |
| WPS send rate by outcome | `agora.wps.send.{attempt,success,failure}` | B1 |
| WPS failure % | `agora.wps.send.{success,failure}` | B1 |
| WPS failures by reason | `agora.wps.send.failure{reason=…}` | B1 |
| Scheduler tick by outcome | `agora.scheduler.tick{outcome=…}` | B2 |
| MISSED schedules emitted | `agora.scheduler.missed_emitted` | B2 |
| Leader lease changes | `agora.presence.{claim,claim_lost}{loop_name=…}` | B-presence |
| Heartbeat late by loop | `agora.presence.heartbeat_late{loop_name=…}` | B-presence |

## Why append, not split into a new workbook

The existing workbook is already named "Telemetry triage" and lives at
`alerts.bicep`. Splitting CMS internals into a separate workbook would
fragment the on-call experience for no real gain — the additional
panels share the same App Insights resource and time context. A future
*Fleet health* workbook (Pi-side telemetry) is a different blast radius
and will get its own resource.

## KQL design notes

- All queries use `sum(value)` on the resource-scoped `customMetrics`
  table. This is the correct aggregation for OpenTelemetry counter
  deltas as exported by `azure-monitor-opentelemetry` — `itemCount` and
  `valueSum` are the wrong axes here.
- Empty/missing dimension values are wrapped as `iff(isempty(x), "unknown", x)`
  so a regression that drops a counter attribute is loudly visible
  rather than silently absorbed.
- Series labels are normalized via `case(name == ..., ...)` so the
  legend reads `attempt / success / failure` instead of the full
  `agora.wps.send.*` counter name.
- WPS failure-% is computed in 5-minute bins via `sumif` and emits
  `real(null)` when `Total == 0`, which renders as a gap in the chart
  rather than a dishonest 0%.

## Bumped workbook version

`workbook.properties.version` bumped from `1.0` -> `1.1`. Without this,
the existing workbook resource sees no change to *its* declared
properties (only the `serializedData` payload, which is opaque to ARM
diff) and may not refresh on some deploy paths.

## Verification

- `az bicep build --file infra/main.bicep` → clean (only pre-existing
  unrelated `outputs-should-not-contain-secrets` warnings on
  `acr.bicep` and `storage.bicep`).
- Manual eyeball of the seven KQL bodies against `cms/metrics.py` —
  every counter name and attribute is sourced from the actual
  instantiation sites, not invented.

## Out of scope (follow-ups)

- Pillar D Alerts (8 alert rules in the plan, lines 549-563).
- Fleet-health workbook (Pi-side telemetry — once Pillar C lands).
- Rollout-view workbook (build/deploy correlation overlay).
- Adding alert_sweep / webhook / log_drainer / DB pool gauge counters
  (B-counters phase 2). These will get their own workbook section once
  shipped so the panels exist for the data on day 1.
