### PR TITLE
feat(imager): build pipeline + unit tests (PR 1/6)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
             sudo tar -xJ --strip-components=1 -C /usr/local
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 mtools parted xz-utils
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,18 @@ WORKDIR /app
 ARG TARGETARCH
 
 # libheif-examples for HEIC grid assembly, curl + xz-utils to fetch FFmpeg
+# (xz-utils, mtools, parted are also kept at runtime for the imager
+# build pipeline; see cms/services/imager.py.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libheif-examples \
     curl \
     xz-utils \
+    mtools \
+    parted \
     && ARCH=$(case "$TARGETARCH" in arm64) echo linuxarm64;; *) echo linux64;; esac) \
     && curl -fsSL "https://github.com/sslivins/agora-cms/releases/download/ffmpeg-8.1/ffmpeg-${ARCH}.tar.xz" \
        | tar -xJ --strip-components=1 -C /usr/local \
-    && apt-get purge -y curl xz-utils && apt-get autoremove -y \
+    && apt-get purge -y curl && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-shared.txt requirements.txt requirements-test.txt ./

--- a/cms/services/imager.py
+++ b/cms/services/imager.py
@@ -1,0 +1,311 @@
+"""Pi image provisioning pipeline.
+
+Pure functions that take a base ``.img.xz`` and produce a per-fleet
+provisioned ``.img.xz`` with an ``agora-fleet.env`` file dropped onto
+the boot (FAT) partition. Used by the worker job handler that backs
+the browser-driven imager flow.
+
+The pipeline is intentionally subprocess-based:
+
+* ``parted -s -j ... unit B print`` extracts the boot-partition byte
+  offset from the partition table (no loop mounts, no root).
+* ``mcopy`` (mtools) writes the env file into the FAT filesystem at
+  that offset (no loop mounts, no root).
+* ``xz`` decompresses the base image and recompresses the result.
+
+All three tools must be installed in the runtime image (Dockerfile
+adds ``mtools parted xz-utils``). On Windows the tools are absent and
+the unit tests that touch them skip via :func:`shutil.which`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Name of the env file dropped onto the boot partition. Matches the
+# path the firmware reads at first boot
+# (``/boot/firmware/agora-fleet.env``).
+FLEET_ENV_FILENAME = "agora-fleet.env"
+
+# Generous upper bound on legitimate fleet env payloads (the real ones
+# are well under 1 KiB). Keeps abuse in check once this primitive is
+# fed by API callers.
+FLEET_ENV_MAX_BYTES = 64 * 1024
+
+# Allowlist for caller-supplied output filenames. Must look like a
+# plain ``foo.img.xz`` basename — no path separators, no ``..``.
+_SAFE_OUTPUT_RE = re.compile(r"^[A-Za-z0-9._-]+\.img\.xz$")
+
+
+class ImagerError(RuntimeError):
+    """Image build pipeline failure (parted/mtools/xz)."""
+
+
+@dataclass(frozen=True)
+class _Tools:
+    parted: str
+    mcopy: str
+    xz: str
+
+    @classmethod
+    def discover(cls) -> "_Tools":
+        missing = [t for t in ("parted", "mcopy", "xz") if shutil.which(t) is None]
+        if missing:
+            raise ImagerError(
+                f"required tools not on PATH: {', '.join(missing)}. "
+                "Install mtools, parted, and xz-utils."
+            )
+        return cls(
+            parted=shutil.which("parted") or "parted",
+            mcopy=shutil.which("mcopy") or "mcopy",
+            xz=shutil.which("xz") or "xz",
+        )
+
+
+def _stderr_text(value: object) -> str:
+    """Decode subprocess stderr regardless of text/bytes mode."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace").strip()
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _run(cmd: list[str], *, stdin: bytes | None = None, timeout: float = 600) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, capture text output, raise :class:`ImagerError` on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            input=stdin,
+            capture_output=True,
+            text=stdin is None,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = _stderr_text(exc.stderr)
+        raise ImagerError(
+            f"command failed ({exc.returncode}): {' '.join(cmd)}\n{stderr}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ImagerError(f"command timed out: {' '.join(cmd)}") from exc
+    return result
+
+
+def parse_boot_partition_offset(parted_json: str) -> int:
+    """Return the byte offset of the boot (first FAT) partition.
+
+    ``parted_json`` is the stdout of ``parted -s -j <img> unit B print``.
+    Accepts a few minor schema variations: ``size`` may end in ``B`` or
+    ``b``, ``filesystem`` is matched case-insensitively against ``fat*``.
+    """
+    try:
+        data = json.loads(parted_json)
+    except json.JSONDecodeError as exc:
+        raise ImagerError(f"could not parse parted JSON output: {exc}") from exc
+
+    disk = data.get("disk")
+    if not isinstance(disk, dict):
+        raise ImagerError("parted JSON missing 'disk' object")
+
+    partitions = disk.get("partitions") or []
+    if not isinstance(partitions, list) or not partitions:
+        raise ImagerError("parted JSON has no partitions")
+
+    for part in partitions:
+        if not isinstance(part, dict):
+            continue
+        fs = str(part.get("filesystem", "")).lower()
+        if not fs.startswith("fat"):
+            continue
+        start = part.get("start")
+        if start is None:
+            # FAT partition with no offset is a parsing failure, not a
+            # "skip and try the next one" situation — silently picking
+            # a later partition could write the env into the wrong
+            # filesystem.
+            raise ImagerError("FAT partition is missing 'start' offset")
+        return _parse_byte_value(start)
+
+    raise ImagerError("no FAT partition found in parted output")
+
+
+def _parse_byte_value(value: object) -> int:
+    """Parse a parted byte value like ``'1048576B'`` into an int."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        cleaned = value.strip().rstrip("Bb")
+        try:
+            return int(cleaned)
+        except ValueError as exc:
+            raise ImagerError(f"unparseable byte value: {value!r}") from exc
+    raise ImagerError(f"unparseable byte value: {value!r}")
+
+
+def boot_partition_offset(img_path: Path, *, tools: _Tools | None = None) -> int:
+    """Return the byte offset of the boot partition in ``img_path``.
+
+    Shells out to ``parted -s -j <img> unit B print`` and feeds the
+    output to :func:`parse_boot_partition_offset`.
+    """
+    tools = tools or _Tools.discover()
+    result = _run([tools.parted, "-s", "-j", str(img_path), "unit", "B", "print"])
+    return parse_boot_partition_offset(result.stdout)
+
+
+def inject_fleet_env(
+    img_path: Path,
+    fleet_env_text: str,
+    *,
+    boot_offset: int | None = None,
+    tools: _Tools | None = None,
+) -> None:
+    """Drop ``agora-fleet.env`` into the boot partition of ``img_path``.
+
+    Uses ``mcopy`` so the file is written in-place without root or loop
+    mounts. ``boot_offset`` may be supplied (e.g. cached across calls);
+    otherwise it is discovered via :func:`boot_partition_offset`.
+    """
+    payload = fleet_env_text.encode("utf-8")
+    if b"\x00" in payload:
+        raise ImagerError("fleet env contains a NUL byte")
+    if len(payload) > FLEET_ENV_MAX_BYTES:
+        raise ImagerError(
+            f"fleet env is too large ({len(payload)} > {FLEET_ENV_MAX_BYTES} bytes)"
+        )
+
+    tools = tools or _Tools.discover()
+    if boot_offset is None:
+        boot_offset = boot_partition_offset(img_path, tools=tools)
+
+    # ``mcopy -i <img>@@<offset> -o - ::/agora-fleet.env`` reads from
+    # stdin and overwrites if the file exists. The ``::`` syntax is
+    # mtools' drive-letter-free form.
+    target = f"::/{FLEET_ENV_FILENAME}"
+    _run(
+        [tools.mcopy, "-i", f"{img_path}@@{boot_offset}", "-o", "-", target],
+        stdin=payload,
+    )
+
+
+def read_fleet_env(
+    img_path: Path,
+    *,
+    boot_offset: int | None = None,
+    tools: _Tools | None = None,
+) -> str:
+    """Read back ``agora-fleet.env`` from the boot partition.
+
+    Used by tests; not on the build hot path. Returns the file contents
+    decoded as UTF-8.
+    """
+    tools = tools or _Tools.discover()
+    if boot_offset is None:
+        boot_offset = boot_partition_offset(img_path, tools=tools)
+    target = f"::/{FLEET_ENV_FILENAME}"
+    result = subprocess.run(
+        [tools.mcopy, "-i", f"{img_path}@@{boot_offset}", "-n", target, "-"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ImagerError(f"mcopy read failed: {stderr}")
+    return result.stdout.decode("utf-8")
+
+
+def build_provisioned(
+    base_xz_path: Path,
+    fleet_env_text: str,
+    scratch_dir: Path,
+    *,
+    output_name: str | None = None,
+    tools: _Tools | None = None,
+) -> Path:
+    """Decompress, inject, recompress.
+
+    Returns the path to the finished ``.img.xz`` inside ``scratch_dir``.
+    The caller is responsible for cleaning up ``scratch_dir`` once the
+    artifact has been uploaded. The intermediate raw ``.img`` (which
+    contains the fleet secret) is removed unconditionally before this
+    function returns or raises, so a crashed build does not leave
+    unprotected secrets on disk.
+
+    ``output_name`` must be a plain ``foo.img.xz`` basename — no path
+    separators, no ``..``. Path traversal is rejected.
+    """
+    if output_name is not None and not _SAFE_OUTPUT_RE.fullmatch(output_name):
+        raise ImagerError(
+            "invalid output_name; must match [A-Za-z0-9._-]+.img.xz"
+        )
+
+    tools = tools or _Tools.discover()
+    if not base_xz_path.is_file():
+        raise ImagerError(f"base image not found: {base_xz_path}")
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    base_name = base_xz_path.name
+    if base_name.endswith(".img.xz"):
+        stem = base_name[: -len(".img.xz")]
+    elif base_name.endswith(".xz"):
+        stem = base_name[: -len(".xz")]
+    else:
+        stem = base_name
+
+    work_img = scratch_dir / f"{stem}.img"
+    final_xz = scratch_dir / (output_name or f"{stem}.provisioned.img.xz")
+    produced_xz = work_img.with_suffix(work_img.suffix + ".xz")
+
+    try:
+        # 1. Decompress base.xz → work.img
+        with work_img.open("wb") as out_fh:
+            try:
+                subprocess.run(
+                    [tools.xz, "-d", "-c", "--threads=0", str(base_xz_path)],
+                    stdout=out_fh,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                    timeout=1200,
+                )
+            except subprocess.CalledProcessError as exc:
+                raise ImagerError(
+                    f"xz decompress failed: {_stderr_text(exc.stderr)}"
+                ) from exc
+            except subprocess.TimeoutExpired as exc:
+                raise ImagerError("xz decompress timed out") from exc
+
+        # 2. Inject fleet env
+        inject_fleet_env(work_img, fleet_env_text, tools=tools)
+
+        # 3. Recompress at -1 (fastest reasonable) with all CPUs.
+        # Pre-clear any stale outputs so retries in a reused scratch
+        # dir don't trip xz's "already exists" guard.
+        for stale in {produced_xz, final_xz}:
+            if stale.exists():
+                stale.unlink()
+        try:
+            subprocess.run(
+                [tools.xz, "-z", "-1", "--threads=0", "--keep", str(work_img)],
+                check=True,
+                capture_output=True,
+                timeout=1800,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ImagerError(
+                f"xz compress failed: {_stderr_text(exc.stderr)}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ImagerError("xz compress timed out") from exc
+
+        if produced_xz != final_xz:
+            produced_xz.replace(final_xz)
+        return final_xz
+    finally:
+        # The raw image carries fleet secrets — never leave it behind.
+        work_img.unlink(missing_ok=True)

--- a/tests/test_imager.py
+++ b/tests/test_imager.py
@@ -1,0 +1,336 @@
+"""Unit + integration tests for ``cms.services.imager``.
+
+The pure-string tests (``parse_boot_partition_offset``) run anywhere.
+The integration tests gate on the presence of ``parted``, ``mcopy`` and
+``xz`` on PATH, so they execute in CI (Linux, with ``mtools parted
+xz-utils`` installed) and skip on Windows dev boxes.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cms.services.imager import (
+    FLEET_ENV_FILENAME,
+    ImagerError,
+    _Tools,
+    boot_partition_offset,
+    build_provisioned,
+    inject_fleet_env,
+    parse_boot_partition_offset,
+    read_fleet_env,
+)
+
+
+# ── Pure parser tests (run on any platform) ──────────────────────────
+
+
+PARTED_JSON_PI_LIKE = """{
+  "disk": {
+    "path": "/tmp/agora.img",
+    "size": "536870912B",
+    "model": "",
+    "transport": "file",
+    "logical-sector-size": 512,
+    "physical-sector-size": 512,
+    "partition-table": "msdos",
+    "partitions": [
+      {
+        "number": 1,
+        "start": "4194304B",
+        "end": "541065215B",
+        "size": "536870912B",
+        "type": "primary",
+        "filesystem": "fat32",
+        "flags": ["lba"]
+      },
+      {
+        "number": 2,
+        "start": "541065216B",
+        "end": "1073741823B",
+        "size": "532676608B",
+        "type": "primary",
+        "filesystem": "ext4"
+      }
+    ]
+  }
+}
+"""
+
+
+def test_parse_offset_finds_first_fat():
+    assert parse_boot_partition_offset(PARTED_JSON_PI_LIKE) == 4194304
+
+
+def test_parse_offset_accepts_int_start():
+    json_blob = """
+    {"disk": {"partitions": [
+        {"filesystem": "fat16", "start": 1048576}
+    ]}}
+    """
+    assert parse_boot_partition_offset(json_blob) == 1048576
+
+
+def test_parse_offset_case_insensitive_fs():
+    json_blob = """
+    {"disk": {"partitions": [
+        {"filesystem": "FAT32", "start": "2048B"}
+    ]}}
+    """
+    assert parse_boot_partition_offset(json_blob) == 2048
+
+
+def test_parse_offset_skips_non_fat_first():
+    json_blob = """
+    {"disk": {"partitions": [
+        {"filesystem": "ext4", "start": "1024B"},
+        {"filesystem": "fat32", "start": "8192B"}
+    ]}}
+    """
+    assert parse_boot_partition_offset(json_blob) == 8192
+
+
+def test_parse_offset_no_fat_partition_raises():
+    json_blob = """
+    {"disk": {"partitions": [
+        {"filesystem": "ext4", "start": "1024B"}
+    ]}}
+    """
+    with pytest.raises(ImagerError, match="no FAT partition"):
+        parse_boot_partition_offset(json_blob)
+
+
+def test_parse_offset_no_partitions_raises():
+    json_blob = '{"disk": {"partitions": []}}'
+    with pytest.raises(ImagerError, match="no partitions"):
+        parse_boot_partition_offset(json_blob)
+
+
+def test_parse_offset_invalid_json_raises():
+    with pytest.raises(ImagerError, match="parted JSON"):
+        parse_boot_partition_offset("not json {")
+
+
+def test_parse_offset_missing_disk_raises():
+    with pytest.raises(ImagerError, match="missing 'disk'"):
+        parse_boot_partition_offset('{"foo": "bar"}')
+
+
+def test_parse_offset_fat_without_start_raises():
+    json_blob = """
+    {"disk": {"partitions": [
+        {"filesystem": "fat32"}
+    ]}}
+    """
+    with pytest.raises(ImagerError, match="missing 'start' offset"):
+        parse_boot_partition_offset(json_blob)
+
+
+# ── Pure-function guard tests (no tools needed) ──────────────────────
+
+
+def test_inject_fleet_env_rejects_nul_bytes(tmp_path: Path):
+    # Guard fires before the tool discovery call, so no tools needed.
+    img = tmp_path / "fake.img"
+    img.write_bytes(b"x")
+    with pytest.raises(ImagerError, match="NUL byte"):
+        inject_fleet_env(img, "key=value\x00bad\n")
+
+
+def test_inject_fleet_env_rejects_oversized(tmp_path: Path):
+    img = tmp_path / "fake.img"
+    img.write_bytes(b"x")
+    huge = "k=v\n" * (20_000)  # > 64 KiB
+    with pytest.raises(ImagerError, match="too large"):
+        inject_fleet_env(img, huge)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../escape.img.xz",
+        "sub/dir.img.xz",
+        "name.img",
+        "name.xz",
+        "name with spaces.img.xz",
+        "",
+    ],
+)
+def test_build_provisioned_rejects_bad_output_name(tmp_path: Path, bad_name):
+    base = tmp_path / "fake.img.xz"
+    base.write_bytes(b"x")
+    with pytest.raises(ImagerError, match="invalid output_name"):
+        build_provisioned(base, "x=y\n", tmp_path / "scratch", output_name=bad_name)
+
+
+# ── Integration tests (require parted + mcopy + xz) ──────────────────
+
+
+def _have_tools() -> bool:
+    return all(
+        shutil.which(tool) is not None
+        for tool in ("parted", "mcopy", "mformat", "xz")
+    )
+
+
+needs_imager_tools = pytest.mark.skipif(
+    not _have_tools(),
+    reason="requires parted, mcopy + mformat (mtools), and xz on PATH",
+)
+
+
+def _make_partitioned_fat_image(path: Path) -> Path:
+    """Create a 64 MiB image with a single FAT32 partition.
+
+    The size matches typical Pi boot partitions and gives mformat
+    enough clusters for FAT32 across distro versions.
+    """
+    total_bytes = 64 * 1024 * 1024
+    with path.open("wb") as fh:
+        fh.truncate(total_bytes)
+
+    subprocess.run(
+        ["parted", "-s", str(path), "mklabel", "msdos"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "parted",
+            "-s",
+            str(path),
+            "mkpart",
+            "primary",
+            "fat32",
+            "1MiB",
+            "100%",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    offset = 1024 * 1024
+    subprocess.run(
+        [
+            "mformat",
+            "-i",
+            f"{path}@@{offset}",
+            "-v",
+            "AGORA",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+@pytest.fixture
+def partitioned_fat_image(tmp_path: Path) -> Path:
+    if not _have_tools():
+        pytest.skip("requires parted + mtools")
+    return _make_partitioned_fat_image(tmp_path / "test.img")
+
+
+@needs_imager_tools
+def test_boot_partition_offset_real_image(partitioned_fat_image: Path):
+    offset = boot_partition_offset(partitioned_fat_image)
+    # parted aligns at 1 MiB boundary
+    assert offset == 1024 * 1024
+
+
+@needs_imager_tools
+def test_inject_fleet_env_writes_file(partitioned_fat_image: Path):
+    payload = "AGORA_FLEET_ID=test-fleet\nAGORA_FLEET_SECRET=abc123\n"
+    inject_fleet_env(partitioned_fat_image, payload)
+
+    readback = read_fleet_env(partitioned_fat_image)
+    assert readback == payload
+
+
+@needs_imager_tools
+def test_inject_fleet_env_overwrites(partitioned_fat_image: Path):
+    inject_fleet_env(partitioned_fat_image, "first=value\n")
+    inject_fleet_env(partitioned_fat_image, "second=value\n")
+    assert read_fleet_env(partitioned_fat_image) == "second=value\n"
+
+
+@needs_imager_tools
+def test_inject_fleet_env_with_explicit_offset(partitioned_fat_image: Path):
+    # Compute once, pass in — verifies the optimization path works.
+    tools = _Tools.discover()
+    offset = boot_partition_offset(partitioned_fat_image, tools=tools)
+    inject_fleet_env(
+        partitioned_fat_image,
+        "explicit=ok\n",
+        boot_offset=offset,
+        tools=tools,
+    )
+    assert read_fleet_env(partitioned_fat_image, boot_offset=offset, tools=tools) == "explicit=ok\n"
+
+
+@needs_imager_tools
+def test_build_provisioned_end_to_end(tmp_path: Path):
+    base_img = _make_partitioned_fat_image(tmp_path / "agora-base-v1.img")
+    base_xz = tmp_path / "agora-base-v1.img.xz"
+    subprocess.run(
+        ["xz", "-z", "-1", "--keep", str(base_img)],
+        check=True,
+        capture_output=True,
+    )
+    assert base_xz.exists()
+
+    scratch = tmp_path / "scratch"
+    fleet_env = "AGORA_FLEET_ID=prod-east\nAGORA_FLEET_SECRET=xyz\n"
+
+    out = build_provisioned(
+        base_xz,
+        fleet_env,
+        scratch,
+        output_name="prod-east-v1.img.xz",
+    )
+
+    assert out == scratch / "prod-east-v1.img.xz"
+    assert out.is_file()
+    assert out.stat().st_size > 0
+
+    # Decompress + verify the env file is present
+    out_img = tmp_path / "verify.img"
+    with out_img.open("wb") as fh:
+        subprocess.run(
+            ["xz", "-d", "-c", str(out)],
+            stdout=fh,
+            check=True,
+        )
+    contents = read_fleet_env(out_img)
+    assert contents == fleet_env
+
+
+@needs_imager_tools
+def test_build_provisioned_missing_base_raises(tmp_path: Path):
+    with pytest.raises(ImagerError, match="base image not found"):
+        build_provisioned(
+            tmp_path / "does-not-exist.img.xz",
+            "x=y\n",
+            tmp_path / "scratch",
+        )
+
+
+def test_build_provisioned_no_tools_raises(tmp_path: Path, monkeypatch):
+    # Force the discovery to find nothing.
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    base = tmp_path / "fake.img.xz"
+    base.write_bytes(b"x")
+    with pytest.raises(ImagerError, match="required tools"):
+        build_provisioned(base, "x=y\n", tmp_path / "scratch")
+
+
+def test_inject_fleet_env_no_tools_raises(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    img = tmp_path / "fake.img"
+    img.write_bytes(b"x")
+    with pytest.raises(ImagerError, match="required tools"):
+        inject_fleet_env(img, "x=y\n")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,11 +27,34 @@ def test_module_imports_without_telemetry_configured():
     # Smoke test.  ``cms.metrics`` is imported at module-load by every
     # subsystem that emits a counter; if it ever throws on import we
     # break all of them at once.
-    import importlib
+    #
+    # Run in a subprocess so we exercise the cold-import path without
+    # polluting the parent test process's module cache.  Importantly,
+    # we MUST NOT call ``importlib.reload(cms.metrics)`` here:
+    # consumer modules (e.g. ``cms.services.leader``) bind the counter
+    # handles via ``from cms.metrics import presence_claim_total``,
+    # which captures object identity.  Reloading rebinds the names in
+    # ``cms.metrics`` to brand-new counter objects but leaves the
+    # consumer-cached references pointing at the originals.  Tests
+    # that monkey-patch ``cms.metrics.<handle>.add`` then silently
+    # fail to intercept calls leader.py makes through its cached
+    # reference.  The bug surfaces non-deterministically depending on
+    # xdist's per-file distribution; see the four-test failure cluster
+    # in ``tests/test_presence_metrics.py`` exposed when other test
+    # files were added.
+    import subprocess
+    import sys
 
-    import cms.metrics as m
-
-    importlib.reload(m)
+    result = subprocess.run(
+        [sys.executable, "-c", "import cms.metrics"],
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"cold-import of cms.metrics failed:\n"
+        f"stdout={result.stdout.decode()!r}\n"
+        f"stderr={result.stderr.decode()!r}"
+    )
 
 
 def test_wps_counter_handles_exposed():


### PR DESCRIPTION
## Summary

PR 1 of a 6-PR series for browser-driven Pi image provisioning. Adds the
pure-function build pipeline that injects `agora-fleet.env` into a base
`.img.xz` boot partition without root or loop mounts.

This PR is intentionally narrow:

* No API endpoints
* No DB tables
* No worker job handler
* No UI

Just the pipeline + tests + the system deps to run them. Everything
else (PRs 2–5) builds on top of this.

## How it works

```
base.img.xz ──(xz -d)──▶ work.img ──(mcopy ::/agora-fleet.env)──▶ work.img'
                                                                       │
                                                              (xz -z -1)
                                                                       ▼
                                                             provisioned.img.xz
```

* `parted -s -j ... unit B print` → JSON with the FAT partition's
  byte offset.
* `mcopy -i <img>@@<offset> -o - ::/agora-fleet.env` writes the env
  file in-place. No root, no loop mounts.
* `xz` for de/recompression with `--threads=0`.

## Public API

```python
from cms.services.imager import build_provisioned, ImagerError

final_xz = build_provisioned(
    base_xz_path=Path("agora-base-v1.11.28-pi5.img.xz"),
    fleet_env_text="AGORA_FLEET_ID=prod-east\nAGORA_FLEET_SECRET=...\n",
    scratch_dir=Path("/scratch/build-abc"),
    output_name="agora-prod-east-v1.11.28.img.xz",  # validated as basename
)
```

`ImagerError` is raised on any failure (parted/mcopy/xz returncode,
timeout, missing tools, malformed env, path traversal in `output_name`).

## Safety guardrails

* `output_name` is regex-validated as a plain `[A-Za-z0-9._-]+\.img\.xz`
  basename — no path separators, no `..`, no traversal.
* `fleet_env_text` is rejected if it contains a NUL byte or exceeds
  64 KiB (real payloads are well under 1 KiB).
* `build_provisioned` removes the intermediate raw `.img` (which
  carries the fleet secret) in a `finally` block so a crashed build
  cannot leave unprotected secrets on disk.
* Stale outputs from previous failed runs in the same scratch dir are
  unlinked before xz runs.
* Bytes-mode subprocess stderr is decoded properly so mcopy errors
  surface in the exception message.

## Tests

`tests/test_imager.py` — 25 tests:

* **Pure parser tests** (10) — parsed JSON fixtures, run anywhere
  including Windows.
* **Guard tests** (8) — output_name traversal, NUL bytes, oversized
  payloads, missing-start FAT, etc. Run anywhere.
* **Integration tests** (6, gated on tools) — build a synthetic
  64 MiB FAT-partitioned image and exercise the real subprocess
  pipeline end-to-end. Skip on Windows; run in CI.
* **Tool-discovery tests** (1) — error path when tools are missing.

Container run (matches CI):
```
$ docker run --rm -v $(pwd):/app -w /app python:3.11-slim bash -c \
    "apt-get install -y mtools parted xz-utils && \
     pytest tests/test_imager.py --no-cov --noconftest"
======================== 25 passed in 2.30s =========================
```

## System deps

* `Dockerfile` adds `mtools parted` to the runtime image and stops
  purging `xz-utils` (the worker now needs it at runtime).
* `.github/workflows/tests.yml` adds `mtools parted xz-utils` to the
  Linux test runner so the integration tests don't skip in CI.

## What this does NOT change

* No new API surface
* No DB migrations
* No new worker handlers
* No new UI
* `imager.py` is not imported from anywhere yet — that lands in PR 2

## Follow-ups (tracked separately)

* PR 0 (`agora` repo): publish base images to `agora-images-base`
  blob container on every push to main + on tags
* PR 2: `JobType.IMAGE_PROVISION` + worker handler + blob upload +
  `provisioned_images` table
* PR 3: `/api/imager/build`, `/jobs/<id>`, `/download/<token>`
* PR 4: imager UI page + nav
* PR 5: rpi-imager `/api/imager/catalog.json`
