### PR TITLE
feat(imager): worker handlers for image import/provision (PR 3)

### DIFF
--- a/alembic/versions/0018_imager_source_url.py
+++ b/alembic/versions/0018_imager_source_url.py
@@ -41,5 +41,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("base_images", "expected_sha256")
-    op.drop_column("base_images", "source_url")
+    raise NotImplementedError(
+        "downgrade not implemented; restore from backup if rollback required"
+    )

--- a/alembic/versions/0018_imager_source_url.py
+++ b/alembic/versions/0018_imager_source_url.py
@@ -1,0 +1,45 @@
+"""imager: per-row catalog source URL + expected sha256
+
+Adds two immutable fields to ``base_images`` populated at API enqueue
+time so the worker (PR 3) does not have to re-fetch the upstream
+catalog -- which is mutable -- to learn what bytes the admin actually
+clicked on.  Without these columns, an upstream catalog rewrite
+between API enqueue and worker pickup could silently swap the bytes
+imported under the same ``(variant, version)`` key (TOCTOU).
+
+Both columns are nullable for backward-compatibility with rows that
+existed before this migration; PR 4's API endpoint will populate them
+on insert.  The worker treats a NULL ``source_url`` / ``expected_sha256``
+as a fall-back-to-catalog signal so PR 3 tests can run before PR 4
+ships.
+
+Revision ID: 0018
+Revises: 0017
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "base_images",
+        sa.Column("source_url", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "base_images",
+        sa.Column("expected_sha256", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("base_images", "expected_sha256")
+    op.drop_column("base_images", "source_url")

--- a/shared/models/imager.py
+++ b/shared/models/imager.py
@@ -92,8 +92,20 @@ class BaseImage(Base):
     # of the on-disk ``.img.xz`` payload, copied from the catalog
     # after verification.
     sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
-    # ``base-images/<variant>/<version>/base.img.xz`` in the
-    # ``base-images`` container.  Null until import success.
+    # Upstream catalog URL the API resolved at enqueue time.  Immutable
+    # for the lifetime of the row -- the worker downloads from this URL
+    # rather than re-resolving the (mutable) catalog, eliminating the
+    # TOCTOU window between admin click and worker pickup.  Nullable so
+    # PR 3 tests can run before PR 4's API populates it.
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Expected SHA256 stamped at enqueue time from the catalog entry.
+    # The worker compares against this; on mismatch the import is a
+    # terminal failure (tampering signal).  Nullable for the same
+    # backfill reason as ``source_url``.
+    expected_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Container-relative blob name within
+    # ``settings.base_image_cache_container``: ``<variant>/<version>/base.img.xz``.
+    # Null until import success.
     blob_path: Mapped[str | None] = mapped_column(Text, nullable=True)
     size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     imported_at: Mapped[datetime | None] = mapped_column(

--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -1,0 +1,646 @@
+"""Worker handler tests for browser-driven Pi image provisioning (PR 3).
+
+Covers:
+
+* Import handler happy path with stamped (source_url, expected_sha256).
+* Import idempotency (already-READY row returns True without I/O).
+* Import terminal failures: disallowed host, redirect to disallowed
+  host, SHA256 mismatch, size overflow, malformed catalog entry.
+* Import retryable failures: low disk space, missing row.
+* Import catalog-fallback path when the row does not have stamped
+  URL/SHA (PR 4 will populate at enqueue; PR 3 needs the fallback
+  for tests + safety).
+* Provision happy path (with mocked ``build_provisioned``).
+* Provision idempotency.
+* Provision base-not-READY: IMPORTING is retryable, FAILED is terminal.
+* Provision tenant blob drift (SHA256 mismatch on cached base).
+* Provision invalid UTF-8 payload.
+* Provision clears ``fleet_env_payload`` on terminal failure + on
+  success, leaves it on retryable failure.
+* Provision low disk retryable.
+
+The real ``build_provisioned`` pipeline is tested in PR 1's
+``tests/test_imager_pipeline.py``.  We mock it here because (a)
+parted/mtools/xz are not portable to Windows test runs and (b) the
+handler's job is wiring + status transitions, not subprocess
+behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from shared.models.imager import (
+    BaseImage,
+    BaseImageStatus,
+    ProvisionedImage,
+    ProvisionedImageStatus,
+)
+from shared.services.storage import LocalStorageBackend, init_storage
+from worker import imager_handlers
+from worker.imager_handlers import (
+    TerminalImagerError,
+    import_base_image_by_id,
+    provision_image_by_id,
+)
+
+
+# Default settings sufficient for handler tests; per-test overrides
+# happen via ``dataclasses.replace``-style ``SimpleNamespace`` updates.
+def _make_settings(tmp_path: Path, **overrides: Any) -> SimpleNamespace:
+    base = dict(
+        imager_scratch_path=str(tmp_path / "scratch"),
+        imager_min_free_bytes=1,  # tests run in tmpdirs with plenty of room
+        base_image_allowed_hosts="github.com,objects.githubusercontent.com",
+        base_image_catalog_url=(
+            "https://github.com/sslivins/agora/releases/download/"
+            "stable/catalog.json"
+        ),
+        base_image_cache_container="base-images",
+        provisioned_container="provisioned",
+        provisioned_retention_hours=24,
+        imager_sas_ttl_hours=2,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest_asyncio.fixture
+async def session_factory(db_engine):
+    """async_sessionmaker matching the worker's signature."""
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def storage_backend(tmp_path):
+    """LocalStorageBackend rooted at ``tmp_path/blobs`` and registered
+    as the global ``shared.services.storage`` backend."""
+    backend = LocalStorageBackend(base_path=tmp_path / "blobs")
+    init_storage(backend)
+    return backend
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    """Swap ``httpx.AsyncClient`` (as imported by ``imager_handlers``)
+    for one backed by a ``MockTransport`` running ``handler``."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(imager_handlers.httpx, "AsyncClient", _factory)
+
+
+# ── Sanity ─────────────────────────────────────────────────────────
+
+
+def test_terminal_imager_error_is_exception() -> None:
+    """Dispatcher catches it explicitly via ``except TerminalImagerError``."""
+    assert issubclass(TerminalImagerError, Exception)
+
+
+# ── Import handler ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_happy_path_with_stamped_url(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """Stamped (source_url, expected_sha256) -> direct download, upload,
+    row -> READY with sha/size/blob_path populated."""
+    payload = b"pretend-this-is-a-real-image-xz-blob" * 32
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    settings = _make_settings(tmp_path)
+
+    bi = BaseImage(
+        variant="pi5", version="v1.11.28",
+        source_url=("https://objects.githubusercontent.com/foo/"
+                    "agora-pi5.img.xz"),
+        expected_sha256=expected_sha,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "objects.githubusercontent.com"
+        return httpx.Response(200, content=payload)
+
+    _patch_httpx(monkeypatch, handle)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is True
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.READY.value
+    assert fresh.sha256 == expected_sha
+    assert fresh.size_bytes == len(payload)
+    assert fresh.blob_path == "pi5/v1.11.28/base.img.xz"
+    assert fresh.imported_at is not None
+
+    # Blob is in tenant container.
+    assert await storage_backend.blob_exists(
+        "base-images", "pi5/v1.11.28/base.img.xz"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_idempotent_when_already_ready(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """READY row -> True, no HTTP, no blob writes."""
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        status=BaseImageStatus.READY.value,
+        sha256="a" * 64, blob_path="pi5/v1/base.img.xz", size_bytes=100,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def fail(request):
+        raise AssertionError("must not call httpx for idempotent skip")
+    _patch_httpx(monkeypatch, fail)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_import_missing_row_returns_false(
+    session_factory, storage_backend, tmp_path
+):
+    """Phantom target_id -> False, no error."""
+    settings = _make_settings(tmp_path)
+    ok = await import_base_image_by_id(
+        session_factory, settings, uuid.uuid4()
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_import_disallowed_host_terminal(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://evil.example.com/agora-pi5.img.xz",
+        expected_sha256="a" * 64,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def fail(request):
+        raise AssertionError("must not reach network for disallowed host")
+    _patch_httpx(monkeypatch, fail)
+
+    with pytest.raises(TerminalImagerError, match="not in base_image_allowed_hosts"):
+        await import_base_image_by_id(session_factory, settings, bi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.FAILED.value
+    assert "evil.example.com" in fresh.error_message
+
+
+@pytest.mark.asyncio
+async def test_import_redirect_to_disallowed_host_terminal(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """Allowed catalog url -> 302 to a disallowed host -> terminal."""
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/redir/agora-pi5.img.xz",
+        expected_sha256="a" * 64,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        # Pretend GitHub redirects to an attacker-controlled mirror.
+        return httpx.Response(
+            302, headers={"location": "https://evil.example.com/x.img.xz"}
+        )
+    _patch_httpx(monkeypatch, handle)
+
+    with pytest.raises(TerminalImagerError, match="not in base_image_allowed_hosts"):
+        await import_base_image_by_id(session_factory, settings, bi.id)
+
+
+@pytest.mark.asyncio
+async def test_import_sha_mismatch_terminal(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/foo/x.img.xz",
+        expected_sha256="0" * 64,  # bytes won't hash to all-zero
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    _patch_httpx(monkeypatch, lambda r: httpx.Response(200, content=b"hello"))
+
+    with pytest.raises(TerminalImagerError, match="sha256 mismatch"):
+        await import_base_image_by_id(session_factory, settings, bi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_import_low_disk_retryable(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """Below ``imager_min_free_bytes`` -> False (retryable), row stays IMPORTING."""
+    settings = _make_settings(tmp_path, imager_min_free_bytes=10**18)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/x.img.xz",
+        expected_sha256="0" * 64,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def fail(request):
+        raise AssertionError("must not reach network when low on disk")
+    _patch_httpx(monkeypatch, fail)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is False
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.IMPORTING.value
+
+
+@pytest.mark.asyncio
+async def test_import_catalog_fallback(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """No stamped URL -> resolve via catalog.json, then download."""
+    settings = _make_settings(tmp_path)
+    payload = b"image-bytes-via-catalog-fallback" * 16
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    image_url = ("https://objects.githubusercontent.com/foo/"
+                 "agora-pi5.img.xz")
+    catalog = {
+        "ref": "v1.11.28",
+        "variants": {
+            "pi5": {
+                "url": image_url,
+                "sha256": expected_sha,
+                "size_bytes": len(payload),
+            },
+        },
+    }
+
+    bi = BaseImage(variant="pi5", version="v1.11.28")  # no source_url
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith("catalog.json"):
+            return httpx.Response(200, content=json.dumps(catalog))
+        if request.url.host == "objects.githubusercontent.com":
+            return httpx.Response(200, content=payload)
+        raise AssertionError(f"unexpected url {request.url}")
+    _patch_httpx(monkeypatch, handle)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is True
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.READY.value
+    assert fresh.sha256 == expected_sha
+
+
+# ── Provision handler ──────────────────────────────────────────────
+
+
+async def _make_ready_base(db_session, *, sha: str, blob_path: str = "pi5/v1/base.img.xz"):
+    """Insert a READY BaseImage row + write a fake blob to the storage
+    backend.  Returns the row.  Caller has committed the session.
+    """
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        status=BaseImageStatus.READY.value,
+        sha256=sha, blob_path=blob_path, size_bytes=100,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+    return bi
+
+
+def _stage_blob(backend: LocalStorageBackend, container: str, blob_name: str, data: bytes) -> None:
+    """Lay down a blob under the LocalStorageBackend root."""
+    target = Path(backend._base_path) / container / blob_name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+
+
+@pytest.mark.asyncio
+async def test_provision_happy_path(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """End-to-end: base READY, payload valid UTF-8, build_provisioned mocked."""
+    settings = _make_settings(tmp_path)
+    base_bytes = b"base-image-bytes" * 8
+    base_sha = hashlib.sha256(base_bytes).hexdigest()
+    bi = await _make_ready_base(db_session, sha=base_sha)
+    _stage_blob(storage_backend, "base-images", "pi5/v1/base.img.xz", base_bytes)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="agora-pi5-fleet42.img.xz",
+        fleet_env_payload=b"AGORA_CMS_URL=https://cms.example\nAGORA_DEVICE_API_KEY=abc\n",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    def fake_build_provisioned(base_xz_path, fleet_env_text, scratch_dir, output_name):
+        # Verify handler passed the right things
+        assert Path(base_xz_path).read_bytes() == base_bytes
+        assert "AGORA_DEVICE_API_KEY" in fleet_env_text
+        assert output_name == "agora-pi5-fleet42.img.xz"
+        out = Path(scratch_dir) / output_name
+        out.write_bytes(b"final-image-payload")
+        return out
+    monkeypatch.setattr(imager_handlers, "build_provisioned", fake_build_provisioned)
+
+    ok = await provision_image_by_id(session_factory, settings, pi.id)
+    assert ok is True
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.READY.value
+    assert fresh.output_size == len(b"final-image-payload")
+    assert fresh.output_sha256 == hashlib.sha256(b"final-image-payload").hexdigest()
+    assert fresh.blob_path == f"{pi.id}/agora-pi5-fleet42.img.xz"
+    assert fresh.built_at is not None
+    assert fresh.expires_at is not None
+    # Secret hygiene: payload cleared on success.
+    assert fresh.fleet_env_payload is None
+
+    assert await storage_backend.blob_exists(
+        "provisioned", f"{pi.id}/agora-pi5-fleet42.img.xz"
+    )
+
+
+@pytest.mark.asyncio
+async def test_provision_idempotent_when_already_ready(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    settings = _make_settings(tmp_path)
+    bi = await _make_ready_base(db_session, sha="a" * 64)
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+        status=ProvisionedImageStatus.READY.value,
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    def fail(*args, **kwargs):
+        raise AssertionError("build_provisioned must not run on idempotent skip")
+    monkeypatch.setattr(imager_handlers, "build_provisioned", fail)
+
+    ok = await provision_image_by_id(session_factory, settings, pi.id)
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_provision_base_importing_retryable(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    """If base import is still in-flight, retry rather than fail."""
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(variant="pi5", version="v1")  # status=IMPORTING by default
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    ok = await provision_image_by_id(session_factory, settings, pi.id)
+    assert ok is False
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    # Retryable -> still PROVISIONING, payload retained for next try.
+    assert fresh.status == ProvisionedImageStatus.PROVISIONING.value
+    assert fresh.fleet_env_payload == b"k=v"
+
+
+@pytest.mark.asyncio
+async def test_provision_base_failed_terminal(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        status=BaseImageStatus.FAILED.value,
+        error_message="upstream catalog returned 404",
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    with pytest.raises(TerminalImagerError, match="cannot provision"):
+        await provision_image_by_id(session_factory, settings, pi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.FAILED.value
+    # Terminal -> payload cleared.
+    assert fresh.fleet_env_payload is None
+
+
+@pytest.mark.asyncio
+async def test_provision_base_sha_drift_terminal(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    """Cached blob bytes don't match BaseImage.sha256 -> tampering -> terminal."""
+    settings = _make_settings(tmp_path)
+    bi = await _make_ready_base(db_session, sha="b" * 64)
+    _stage_blob(storage_backend, "base-images", "pi5/v1/base.img.xz", b"actual")
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    with pytest.raises(TerminalImagerError, match="drifted"):
+        await provision_image_by_id(session_factory, settings, pi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.FAILED.value
+    assert fresh.fleet_env_payload is None
+
+
+@pytest.mark.asyncio
+async def test_provision_invalid_utf8_terminal(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    settings = _make_settings(tmp_path)
+    base_bytes = b"x"
+    base_sha = hashlib.sha256(base_bytes).hexdigest()
+    bi = await _make_ready_base(db_session, sha=base_sha)
+    _stage_blob(storage_backend, "base-images", "pi5/v1/base.img.xz", base_bytes)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"\xff\xfe-not-utf8",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    with pytest.raises(TerminalImagerError, match="not valid utf-8"):
+        await provision_image_by_id(session_factory, settings, pi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.FAILED.value
+    assert fresh.fleet_env_payload is None
+
+
+@pytest.mark.asyncio
+async def test_provision_low_disk_retryable(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    """Below threshold -> False (retryable), row + payload preserved."""
+    settings = _make_settings(tmp_path, imager_min_free_bytes=10**18)
+    bi = await _make_ready_base(db_session, sha="a" * 64)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    ok = await provision_image_by_id(session_factory, settings, pi.id)
+    assert ok is False
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.PROVISIONING.value
+    assert fresh.fleet_env_payload == b"k=v"
+
+
+@pytest.mark.asyncio
+async def test_provision_imager_error_terminal(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """build_provisioned raises ImagerError -> TerminalImagerError, FAILED, payload cleared."""
+    from cms.services.imager import ImagerError
+
+    settings = _make_settings(tmp_path)
+    base_bytes = b"base"
+    base_sha = hashlib.sha256(base_bytes).hexdigest()
+    bi = await _make_ready_base(db_session, sha=base_sha)
+    _stage_blob(storage_backend, "base-images", "pi5/v1/base.img.xz", base_bytes)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"AGORA_CMS_URL=foo\n",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    def boom(*args, **kwargs):
+        raise ImagerError("xz decompression failed")
+    monkeypatch.setattr(imager_handlers, "build_provisioned", boom)
+
+    with pytest.raises(TerminalImagerError, match="imager pipeline failed"):
+        await provision_image_by_id(session_factory, settings, pi.id)
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.FAILED.value
+    assert fresh.fleet_env_payload is None
+
+
+@pytest.mark.asyncio
+async def test_provision_missing_row_returns_false(
+    session_factory, storage_backend, tmp_path
+):
+    settings = _make_settings(tmp_path)
+    ok = await provision_image_by_id(
+        session_factory, settings, uuid.uuid4()
+    )
+    assert ok is False

--- a/tests/test_imager_schema.py
+++ b/tests/test_imager_schema.py
@@ -159,11 +159,12 @@ async def test_provisioned_image_round_trip(db_session) -> None:
 
 
 def test_worker_dispatcher_routes_imager_types() -> None:
-    """The PR 2 stub must raise NotImplementedError for IMAGE_*.
+    """Dispatcher routes IMAGE_IMPORT/IMAGE_PROVISION to PR 3 handlers.
 
-    PR 3 replaces this branch with real handler calls.  The branch's
-    presence is what guarantees an unhandled enum value can't sneak
-    through to ``Unknown job type`` and look like a typo.
+    Source-inspects ``worker/__main__.py`` to assert both enum
+    branches exist and call into the imager handler module.  Cheap,
+    deterministic, and pinned to the import path so a refactor of
+    handler internals doesn't make this test stale.
     """
     import inspect as _inspect
     import worker.__main__ as worker_main
@@ -171,7 +172,11 @@ def test_worker_dispatcher_routes_imager_types() -> None:
     src = _inspect.getsource(worker_main)
     assert "JobType.IMAGE_IMPORT" in src
     assert "JobType.IMAGE_PROVISION" in src
-    assert "PR 3" in src  # tombstone for the followup
+    assert "import_base_image_by_id" in src
+    assert "provision_image_by_id" in src
+    assert "TerminalImagerError" in src
+    # The PR 2 tombstone is gone now that real handlers ship.
+    assert "Imager handlers ship in PR 3" not in src
 
 
 # ── LocalStorageBackend imager primitives ───────────────────────

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -267,6 +267,11 @@ async def _queue_mode(settings: WorkerSettings) -> None:
         recover_interrupted,
         transcode_variant_by_id,
     )
+    from worker.imager_handlers import (
+        TerminalImagerError,
+        import_base_image_by_id,
+        provision_image_by_id,
+    )
     from sqlalchemy import select
 
     session_factory = get_session_factory()
@@ -507,6 +512,7 @@ async def _queue_mode(settings: WorkerSettings) -> None:
 
     success = False
     error_message: str | None = None
+    terminal_failure = False
     try:
         logger.info(
             "Processing job %s type=%s target=%s (attempt %d)",
@@ -516,20 +522,24 @@ async def _queue_mode(settings: WorkerSettings) -> None:
             success = await transcode_variant_by_id(session_factory, asset_dir, job.target_id)
         elif job.type == JobType.STREAM_CAPTURE:
             success = await capture_stream_by_id(session_factory, asset_dir, job.target_id)
-        elif job.type in (JobType.IMAGE_IMPORT, JobType.IMAGE_PROVISION):
-            # Imager schema lands in PR 2; handlers land in PR 3.  Until
-            # the handlers ship we surface a clear error so tests + ops
-            # see exactly what is missing instead of falling through to
-            # the "Unknown job type" branch (which would falsely imply
-            # an unrecognised enum value).
-            raise NotImplementedError(
-                f"Imager handlers ship in PR 3 (got {job.type.value})"
-            )
+        elif job.type == JobType.IMAGE_IMPORT:
+            success = await import_base_image_by_id(session_factory, settings, job.target_id)
+        elif job.type == JobType.IMAGE_PROVISION:
+            success = await provision_image_by_id(session_factory, settings, job.target_id)
         else:
             error_message = f"Unknown job type: {job.type}"
             logger.error(error_message)
     except asyncio.CancelledError:
         raise
+    except TerminalImagerError as e:
+        # Deterministic failure -- the imager handler has already
+        # marked the BaseImage / ProvisionedImage row FAILED.  Mark
+        # the Job FAILED + delete the queue message so we don't burn
+        # MAX_JOB_RETRIES on something that will always fail.
+        error_message = f"{type(e).__name__}: {e}"
+        logger.error("Job %s terminal imager failure: %s", job_id, e)
+        terminal_failure = True
+        success = False
     except Exception as e:
         error_message = f"{type(e).__name__}: {e}"
         logger.exception("Job %s raised an exception", job_id)
@@ -616,6 +626,21 @@ async def _queue_mode(settings: WorkerSettings) -> None:
         except Exception:
             logger.warning("Job %s cancelled but queue delete failed", job_id, exc_info=True)
         logger.info("Job %s cancelled mid-transcode", job_id)
+    elif terminal_failure:
+        # Imager-handler raised TerminalImagerError -- the row has
+        # already been flipped to FAILED by the handler.  Mark the
+        # Job FAILED + delete the queue message so the dispatcher
+        # does not burn MAX_JOB_RETRIES on a deterministic failure.
+        async with session_factory() as db:
+            await mark_failed(db, job_id, (error_message or "terminal")[:2000])
+        try:
+            queue.delete_message(msg, pop_receipt=current_popreceipt)
+        except Exception:
+            logger.warning(
+                "Job %s terminal-failed but queue delete failed",
+                job_id, exc_info=True,
+            )
+        logger.info("Job %s terminal failure: %s", job_id, error_message)
     elif success:
         async with session_factory() as db:
             await mark_done(db, job_id)

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -1,0 +1,636 @@
+"""Worker handlers for browser-driven Pi image provisioning (PR 3).
+
+Two job types from ``JobType``:
+
+* ``IMAGE_IMPORT``  -- fetch upstream ``.img.xz`` + ``catalog.json``
+  entry, verify SHA256, upload to tenant blob.  One per
+  ``(variant, version)`` per tenant; idempotent.
+* ``IMAGE_PROVISION`` -- decompress base, drop ``agora-fleet.env``
+  onto FAT boot partition (``cms.services.imager.build_provisioned``),
+  recompress, upload to ``provisioned/<id>/<output_name>``.  One per
+  per-fleet build; on demand.
+
+Both follow the existing dispatcher contract used by transcode +
+capture handlers:
+
+* ``async def handler(session_factory, settings, target_id) -> bool``
+* Return ``True`` for success (dispatcher marks Job DONE, deletes msg).
+* Return ``False`` for transient failure (dispatcher flips Job back
+  to ``PENDING``, leaves queue msg visible -> retry after
+  ``VISIBILITY_TIMEOUT``).
+* Raise ``TerminalImagerError`` for deterministic failures that
+  retrying cannot fix (SHA mismatch, allowlist violation, malformed
+  blob path).  The dispatcher catches this and marks Job FAILED +
+  deletes the queue msg so retries don't burn cycles.
+* Raise any other exception for unexpected errors -- dispatcher
+  treats these as transient (retry).
+
+Subprocess work in ``cms.services.imager.build_provisioned`` is
+synchronous and slow (~minutes).  We dispatch it via
+``asyncio.to_thread`` so the dispatcher's heartbeat coroutine keeps
+renewing the queue lease while the imager runs.
+
+Secret hygiene
+--------------
+``ProvisionedImage.fleet_env_payload`` is the device API key bundle.
+PR 4 wraps this in real encryption; in PR 3 we treat the bytes as
+plaintext UTF-8 (the API endpoint in PR 4 will be the only writer
+once it lands).  After terminal success **or** terminal failure we
+clear the payload to ``None`` so the secret does not linger in the
+DB longer than necessary.  For retryable failures we leave the
+payload in place because the next attempt needs it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+import shutil
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy import select
+
+from cms.services.imager import ImagerError, build_provisioned
+from shared.models.imager import (
+    BaseImage,
+    BaseImageStatus,
+    ProvisionedImage,
+    ProvisionedImageStatus,
+)
+from shared.services.storage import get_storage
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public exceptions ─────────────────────────────────────────────
+
+
+class TerminalImagerError(Exception):
+    """Deterministic imager failure -- do not retry.
+
+    Raised by the handlers for conditions that no number of retries
+    will fix:
+
+    * Catalog or download URL host not in the allowlist.
+    * SHA256 of downloaded base image does not match the catalog.
+    * Tenant-blob base image SHA256 has drifted from the row's
+      ``sha256`` (storage tampering).
+    * ``BaseImage`` row in ``FAILED`` state when a provision job
+      tries to consume it.
+    * Malformed ``blob_path`` / ``output_name`` (regex deny).
+    * Decoded ``fleet_env_payload`` not valid UTF-8.
+
+    The dispatcher in ``worker/__main__.py`` catches this exception
+    explicitly, marks the ``Job`` row ``FAILED``, and deletes the
+    queue message so it does not redeliver.
+    """
+
+
+# ── Constants ─────────────────────────────────────────────────────
+
+
+# Container-relative blob_path produced by the import handler.  The
+# read side (provision handler) re-validates against the same regex
+# to guard against a corrupted/tampered DB.  Two path segments
+# (variant / version) followed by the literal ``base.img.xz``.
+_BASE_BLOB_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/base\.img\.xz$")
+# 64 hex chars -- defensive guard before any download.
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+# Bound the chunked download buffer.
+_DOWNLOAD_CHUNK_BYTES = 1 << 20  # 1 MiB
+# Hard ceiling on how many redirect hops we will walk while validating
+# every Location against the allowlist.  GitHub-Releases->blob normally
+# resolves in <=2 hops.
+_MAX_REDIRECTS = 5
+# Default per-handler total HTTP timeout (catalog + download both).
+_HTTP_TIMEOUT = httpx.Timeout(connect=15.0, read=120.0, write=120.0, pool=15.0)
+
+
+# ── Internal helpers ──────────────────────────────────────────────
+
+
+def _allowed_hosts(settings: Any) -> set[str]:
+    raw = getattr(settings, "base_image_allowed_hosts", "") or ""
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def _validate_url(url: str, allowlist: set[str]) -> str:
+    """Return ``url`` iff its scheme is https and host is allowlisted.
+
+    Raises ``TerminalImagerError`` otherwise.  Centralised so the
+    same rule applies to the catalog URL **and** every redirect
+    target while streaming the image.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise TerminalImagerError(
+            f"refusing non-https url for imager fetch: scheme={parsed.scheme!r}"
+        )
+    host = (parsed.hostname or "").lower()
+    if host not in allowlist:
+        raise TerminalImagerError(
+            f"host {host!r} not in base_image_allowed_hosts ({sorted(allowlist)})"
+        )
+    return url
+
+
+async def _free_bytes(path: Path) -> int:
+    """Disk-usage probe; offloaded to a thread because ``statvfs``
+    can block on networked filesystems (Azure Files mount in prod).
+    """
+    return await asyncio.to_thread(lambda: shutil.disk_usage(path).free)
+
+
+def _scratch_dir(settings: Any, prefix: str, target_id: uuid.UUID) -> Path:
+    """Per-attempt scratch directory.
+
+    Includes a fresh ``uuid4`` suffix so a duplicate pickup of the
+    same queue message (lease loss) lands in its own directory and
+    cannot rmtree another worker's in-flight files.
+    """
+    root = Path(settings.imager_scratch_path)
+    return root / f"{prefix}-{target_id}-{uuid.uuid4().hex[:8]}"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _set_base_image_terminal(
+    session_factory: Any, base_image_id: uuid.UUID, message: str
+) -> None:
+    """Mark a ``BaseImage`` row FAILED with ``message`` (truncated)."""
+    async with session_factory() as db:
+        row = (await db.execute(
+            select(BaseImage).where(BaseImage.id == base_image_id)
+        )).scalar_one_or_none()
+        if row is None:
+            return
+        row.status = BaseImageStatus.FAILED.value
+        row.error_message = message[:2000]
+        await db.commit()
+
+
+async def _set_provisioned_terminal(
+    session_factory: Any, provisioned_id: uuid.UUID, message: str
+) -> None:
+    """Mark a ``ProvisionedImage`` row FAILED with ``message`` and
+    clear the encrypted payload (the secret is no longer needed)."""
+    async with session_factory() as db:
+        row = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == provisioned_id)
+        )).scalar_one_or_none()
+        if row is None:
+            return
+        row.status = ProvisionedImageStatus.FAILED.value
+        row.error_message = message[:2000]
+        # Secret hygiene: terminal failures clear the payload.  Retryable
+        # failures leave it in place because the next attempt needs it.
+        row.fleet_env_payload = None
+        await db.commit()
+
+
+async def _fetch_catalog(
+    catalog_url: str, allowlist: set[str], client: httpx.AsyncClient
+) -> dict[str, Any]:
+    """Resolve + parse the upstream catalog.json.
+
+    Returns the parsed JSON.  Raises ``TerminalImagerError`` on
+    allowlist violation or non-JSON; raises generic exceptions
+    (caught + retried by the dispatcher) on transient network errors.
+    """
+    _validate_url(catalog_url, allowlist)
+    resp = await client.get(catalog_url, follow_redirects=False)
+    # Walk redirect chain manually so every Location is allowlisted.
+    hops = 0
+    while resp.is_redirect and hops < _MAX_REDIRECTS:
+        loc = resp.headers.get("location")
+        if not loc:
+            raise httpx.RemoteProtocolError("redirect without Location")
+        _validate_url(loc, allowlist)
+        resp = await client.get(loc, follow_redirects=False)
+        hops += 1
+    if resp.is_redirect:
+        raise TerminalImagerError(
+            f"too many redirects ({_MAX_REDIRECTS}) fetching catalog"
+        )
+    resp.raise_for_status()
+    try:
+        return resp.json()
+    except json.JSONDecodeError as e:
+        raise TerminalImagerError(f"catalog is not valid json: {e}") from e
+
+
+async def _download_with_sha(
+    url: str,
+    dest: Path,
+    expected_sha256: str,
+    expected_size_bytes: int | None,
+    allowlist: set[str],
+    client: httpx.AsyncClient,
+) -> tuple[str, int]:
+    """Stream ``url`` to ``dest`` while hashing.
+
+    Validates each redirect Location against ``allowlist``; aborts
+    early if the running byte count exceeds ``expected_size_bytes``
+    (avoids filling the disk on a malicious catalog).  Returns
+    ``(actual_sha256_hex, actual_bytes)``.
+
+    Raises ``TerminalImagerError`` on hash mismatch / size mismatch /
+    allowlist redirect violation.  Raises generic httpx errors on
+    transient network problems (caught upstream + retried).
+    """
+    if not _SHA256_RE.match(expected_sha256):
+        raise TerminalImagerError(
+            f"expected_sha256 is not a 64-char hex string: {expected_sha256!r}"
+        )
+
+    # Manual redirect walk -- httpx's built-in follower won't let us
+    # validate every hop's host against our allowlist.
+    target_url = _validate_url(url, allowlist)
+    hops = 0
+    while True:
+        async with client.stream("GET", target_url) as resp:
+            if resp.is_redirect and hops < _MAX_REDIRECTS:
+                loc = resp.headers.get("location")
+                if not loc:
+                    raise httpx.RemoteProtocolError("redirect without Location")
+                target_url = _validate_url(loc, allowlist)
+                hops += 1
+                continue
+            if resp.is_redirect:
+                raise TerminalImagerError(
+                    f"too many redirects ({_MAX_REDIRECTS}) downloading image"
+                )
+            resp.raise_for_status()
+
+            hasher = hashlib.sha256()
+            written = 0
+            with dest.open("wb") as fh:
+                async for chunk in resp.aiter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                    if not chunk:
+                        continue
+                    written += len(chunk)
+                    if (
+                        expected_size_bytes is not None
+                        and written > expected_size_bytes
+                    ):
+                        raise TerminalImagerError(
+                            f"download exceeded expected size "
+                            f"({written} > {expected_size_bytes})"
+                        )
+                    hasher.update(chunk)
+                    fh.write(chunk)
+            actual_sha = hasher.hexdigest()
+            if actual_sha.lower() != expected_sha256.lower():
+                raise TerminalImagerError(
+                    f"sha256 mismatch: expected {expected_sha256.lower()}, "
+                    f"got {actual_sha.lower()}"
+                )
+            if (
+                expected_size_bytes is not None
+                and written != expected_size_bytes
+            ):
+                raise TerminalImagerError(
+                    f"size mismatch: expected {expected_size_bytes}, got {written}"
+                )
+            return actual_sha, written
+
+
+async def _hash_file(path: Path) -> str:
+    """SHA256 a local file off the event loop."""
+    def _do() -> str:
+        h = hashlib.sha256()
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(_DOWNLOAD_CHUNK_BYTES), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    return await asyncio.to_thread(_do)
+
+
+# ── Public handlers ───────────────────────────────────────────────
+
+
+async def import_base_image_by_id(
+    session_factory: Any, settings: Any, base_image_id: uuid.UUID
+) -> bool:
+    """Import one upstream base image into tenant blob.
+
+    Returns True on success (or idempotent no-op when the row is
+    already READY).  Returns False for retryable failures (caller
+    will redeliver the queue message).  Raises ``TerminalImagerError``
+    for deterministic failures.
+    """
+    storage = get_storage()
+    allowlist = _allowed_hosts(settings)
+    scratch: Path | None = None
+
+    try:
+        async with session_factory() as db:
+            row = (await db.execute(
+                select(BaseImage).where(BaseImage.id == base_image_id)
+            )).scalar_one_or_none()
+            if row is None:
+                logger.info(
+                    "BaseImage %s no longer exists -- skipping", base_image_id
+                )
+                return False
+            if row.status == BaseImageStatus.READY.value:
+                logger.info(
+                    "BaseImage %s already READY -- idempotent skip", base_image_id
+                )
+                return True
+            variant = row.variant
+            version = row.version
+            source_url = row.source_url
+            expected_sha256 = row.expected_sha256
+
+        # Per-attempt scratch directory.
+        scratch = _scratch_dir(settings, "import", base_image_id)
+        scratch.mkdir(parents=True, exist_ok=True)
+
+        # Free-space pre-flight (retryable -- another job may free disk soon).
+        free = await _free_bytes(scratch)
+        if free < settings.imager_min_free_bytes:
+            logger.warning(
+                "BaseImage %s import: free space %d below threshold %d -- retry",
+                base_image_id, free, settings.imager_min_free_bytes,
+            )
+            return False
+
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            # Resolve the catalog if the API didn't stamp source_url +
+            # expected_sha256 at enqueue time.  PR 4 will populate both
+            # at insert time, eliminating this fallback.
+            if not source_url or not expected_sha256:
+                catalog_url = settings.base_image_catalog_url
+                if not catalog_url:
+                    raise TerminalImagerError(
+                        "BASE_IMAGE_CATALOG_URL not configured and row has "
+                        "no stamped source_url/expected_sha256"
+                    )
+                catalog = await _fetch_catalog(catalog_url, allowlist, client)
+                variants = catalog.get("variants") or {}
+                entry = variants.get(variant)
+                if not isinstance(entry, dict):
+                    raise TerminalImagerError(
+                        f"catalog has no entry for variant {variant!r}"
+                    )
+                if catalog.get("ref") and catalog["ref"] != version:
+                    raise TerminalImagerError(
+                        f"catalog ref {catalog.get('ref')!r} != row version {version!r}"
+                    )
+                source_url = entry.get("url")
+                expected_sha256 = entry.get("sha256")
+                expected_size = entry.get("size_bytes")
+                if not source_url or not expected_sha256:
+                    raise TerminalImagerError(
+                        f"catalog entry for {variant!r} missing url/sha256"
+                    )
+            else:
+                expected_size = None  # PR 4 may add expected_size_bytes col
+
+            staged = scratch / "base.img.xz"
+            actual_sha, actual_size = await _download_with_sha(
+                source_url, staged, expected_sha256, expected_size,
+                allowlist, client,
+            )
+
+        blob_path = f"{variant}/{version}/base.img.xz"
+        if not _BASE_BLOB_PATH_RE.match(blob_path):
+            # variant/version are admin-controlled in PR 4 but
+            # Postgres-stored as Text -- defence in depth.
+            raise TerminalImagerError(
+                f"refusing malformed blob_path {blob_path!r} (variant/version "
+                f"contain disallowed characters)"
+            )
+
+        await storage.upload_local_file(
+            settings.base_image_cache_container,
+            blob_path,
+            staged,
+            overwrite=True,
+        )
+
+        async with session_factory() as db:
+            row = (await db.execute(
+                select(BaseImage).where(BaseImage.id == base_image_id)
+            )).scalar_one_or_none()
+            if row is None:
+                # Row vanished between start and end -- we still
+                # uploaded a blob, but there's nothing to flip ready.
+                logger.warning(
+                    "BaseImage %s row vanished post-upload -- not flipping READY",
+                    base_image_id,
+                )
+                return False
+            row.sha256 = actual_sha.lower()
+            row.size_bytes = actual_size
+            row.blob_path = blob_path
+            row.imported_at = _utcnow()
+            row.status = BaseImageStatus.READY.value
+            row.error_message = ""
+            await db.commit()
+
+        logger.info(
+            "BaseImage %s imported: %s (%d bytes)",
+            base_image_id, blob_path, actual_size,
+        )
+        return True
+    except TerminalImagerError as e:
+        logger.error("BaseImage %s import terminal failure: %s", base_image_id, e)
+        await _set_base_image_terminal(session_factory, base_image_id, str(e))
+        raise
+    finally:
+        if scratch is not None and scratch.exists():
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+async def provision_image_by_id(
+    session_factory: Any, settings: Any, provisioned_id: uuid.UUID
+) -> bool:
+    """Build one per-fleet provisioned ``.img.xz``.
+
+    See module docstring for the contract.  Returns True on success
+    or idempotent no-op; False for retryable; raises
+    ``TerminalImagerError`` for deterministic failures.
+    """
+    storage = get_storage()
+    scratch: Path | None = None
+
+    try:
+        async with session_factory() as db:
+            row = (await db.execute(
+                select(ProvisionedImage).where(
+                    ProvisionedImage.id == provisioned_id
+                )
+            )).scalar_one_or_none()
+            if row is None:
+                logger.info(
+                    "ProvisionedImage %s no longer exists -- skipping",
+                    provisioned_id,
+                )
+                return False
+            if row.status == ProvisionedImageStatus.READY.value:
+                logger.info(
+                    "ProvisionedImage %s already READY -- idempotent skip",
+                    provisioned_id,
+                )
+                return True
+            base_image_id = row.base_image_id
+            output_name = row.output_name
+            payload = row.fleet_env_payload
+
+            base = (await db.execute(
+                select(BaseImage).where(BaseImage.id == base_image_id)
+            )).scalar_one_or_none()
+            if base is None:
+                raise TerminalImagerError(
+                    f"base image {base_image_id} not found for provision"
+                )
+            base_status = base.status
+            base_blob_path = base.blob_path
+            base_sha256 = base.sha256
+
+        # Base must be READY before we can provision off it.  If it's
+        # IMPORTING the base import is in flight -- be patient and let
+        # the queue redeliver.  FAILED is terminal.
+        if base_status == BaseImageStatus.IMPORTING.value:
+            logger.info(
+                "ProvisionedImage %s: base %s still IMPORTING -- retry",
+                provisioned_id, base_image_id,
+            )
+            return False
+        if base_status != BaseImageStatus.READY.value:
+            raise TerminalImagerError(
+                f"base image {base_image_id} status={base_status} -- "
+                f"cannot provision"
+            )
+        if not base_blob_path or not _BASE_BLOB_PATH_RE.match(base_blob_path):
+            raise TerminalImagerError(
+                f"base image {base_image_id} blob_path {base_blob_path!r} "
+                f"is malformed"
+            )
+        if not base_sha256 or not _SHA256_RE.match(base_sha256):
+            raise TerminalImagerError(
+                f"base image {base_image_id} sha256 {base_sha256!r} invalid"
+            )
+        if payload is None:
+            raise TerminalImagerError(
+                "fleet_env_payload is null -- API enqueue must populate it"
+            )
+        try:
+            fleet_env_text = bytes(payload).decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise TerminalImagerError(
+                f"fleet_env_payload is not valid utf-8: {e}"
+            ) from e
+
+        scratch = _scratch_dir(settings, "build", provisioned_id)
+        scratch.mkdir(parents=True, exist_ok=True)
+
+        # Provisioning needs ~10 GiB headroom (xz + raw + output).
+        free = await _free_bytes(scratch)
+        if free < settings.imager_min_free_bytes:
+            logger.warning(
+                "ProvisionedImage %s: free space %d below threshold %d -- retry",
+                provisioned_id, free, settings.imager_min_free_bytes,
+            )
+            return False
+
+        # Stage the base image locally.
+        staged_base = scratch / "base.img.xz"
+        await storage.download_to_file(
+            settings.base_image_cache_container,
+            base_blob_path,
+            staged_base,
+        )
+
+        # Defence in depth: blob bytes' SHA256 must still match the row.
+        actual_base_sha = await _hash_file(staged_base)
+        if actual_base_sha.lower() != base_sha256.lower():
+            raise TerminalImagerError(
+                f"tenant base blob sha256 drifted: row={base_sha256.lower()}, "
+                f"blob={actual_base_sha.lower()}"
+            )
+
+        # Run the (synchronous, multi-minute) imager pipeline off the
+        # event loop so the dispatcher heartbeat keeps renewing the
+        # queue lease.  build_provisioned validates output_name itself
+        # and raises ImagerError on bad input or subprocess failure.
+        try:
+            output_path: Path = await asyncio.to_thread(
+                build_provisioned,
+                staged_base,
+                fleet_env_text,
+                scratch,
+                output_name,
+            )
+        except ImagerError as e:
+            # ImagerError covers (a) input validation (output_name,
+            # fleet_env contents) which is terminal, and (b)
+            # subprocess failures which are usually transient.  We
+            # treat all ImagerError as terminal because retrying with
+            # the same inputs will hit the same failure -- if a
+            # subprocess flake is seen we'd rather surface it to the
+            # operator than burn 5 retries.
+            raise TerminalImagerError(f"imager pipeline failed: {e}") from e
+
+        actual_sha = await _hash_file(output_path)
+        actual_size = output_path.stat().st_size
+
+        blob_path = f"{provisioned_id}/{output_name}"
+        await storage.upload_local_file(
+            settings.provisioned_container,
+            blob_path,
+            output_path,
+            overwrite=True,
+        )
+
+        now = _utcnow()
+        expires_at = now + timedelta(hours=settings.provisioned_retention_hours)
+        async with session_factory() as db:
+            row = (await db.execute(
+                select(ProvisionedImage).where(
+                    ProvisionedImage.id == provisioned_id
+                )
+            )).scalar_one_or_none()
+            if row is None:
+                logger.warning(
+                    "ProvisionedImage %s row vanished post-upload",
+                    provisioned_id,
+                )
+                return False
+            row.output_sha256 = actual_sha.lower()
+            row.output_size = actual_size
+            row.blob_path = blob_path
+            row.built_at = now
+            row.expires_at = expires_at
+            row.status = ProvisionedImageStatus.READY.value
+            row.error_message = ""
+            # Secret hygiene: success path also clears the payload.
+            row.fleet_env_payload = None
+            await db.commit()
+
+        logger.info(
+            "ProvisionedImage %s built: %s (%d bytes)",
+            provisioned_id, blob_path, actual_size,
+        )
+        return True
+    except TerminalImagerError as e:
+        logger.error(
+            "ProvisionedImage %s terminal failure: %s", provisioned_id, e,
+        )
+        await _set_provisioned_terminal(session_factory, provisioned_id, str(e))
+        raise
+    finally:
+        if scratch is not None and scratch.exists():
+            shutil.rmtree(scratch, ignore_errors=True)


### PR DESCRIPTION
## Summary

PR 3 of 6 (Option E) — wires the worker dispatcher to two new
async handlers that drive the browser-driven Pi image
provisioning flow:

- **`import_base_image_by_id`** — pulls an upstream `.img.xz` from
  the GitHub-Releases catalog into the tenant's Azure Blob cache,
  pinned by SHA256.
- **`provision_image_by_id`** — pulls a cached base, runs
  `cms.services.imager.build_provisioned()` (PR 1, no-mount FAT-edit
  via `mcopy`), uploads the per-device output to
  `provisioned/<job-id>/`, mints SAS metadata for download.

PR 0 (catalog publish) and PR 1 (pure pipeline) and PR 2
(schema + storage plumbing) have all merged. PR 4 (HTTP API) builds
on this.

## What's in this PR

| Area | Change |
|---|---|
| `worker/imager_handlers.py` (new) | Both handlers + `TerminalImagerError` + helpers (URL allowlist, redirect-aware download, scratch dir lifecycle, hash-while-streaming with size cap) |
| `worker/__main__.py` | Dispatcher routes `IMAGE_IMPORT`/`IMAGE_PROVISION` to the new handlers; new `terminal_failure` finalize branch (FAILED + queue delete, no retries on deterministic failures) |
| `alembic/versions/0018_imager_source_url.py` (new) | Adds `source_url` + `expected_sha256` columns to `base_images` (TOCTOU mitigation — PR 4 stamps both at enqueue time) |
| `shared/models/imager.py` | `BaseImage.source_url` + `BaseImage.expected_sha256` |
| `tests/test_imager_handlers.py` (new, 18 tests) | Happy path, idempotency, terminal vs retryable contract, allowlist enforcement, SHA mismatch / size overflow / drift / utf-8 / low-disk |
| `tests/test_imager_schema.py` | Updated dispatcher-routing assertion now that the PR 2 tombstone is gone |

## Design highlights

**Terminal vs retryable contract** — Handlers raise
`TerminalImagerError` for deterministic failures (SHA mismatch,
disallowed host, blob drift, malformed payload, base in `FAILED`).
The dispatcher catches it explicitly and marks the Job `FAILED` +
deletes the queue message — no `MAX_JOB_RETRIES` waste. Returning
`False` (or any other exception) keeps the existing retry path.

**Async/blocking boundary** — `build_provisioned` is sync (parted /
mcopy / xz-1, runs for minutes). Wrapped in `asyncio.to_thread`
so the dispatcher's heartbeat keeps renewing the queue lease.
`shutil.disk_usage` and large-file SHA hashing are also offloaded.

**Redirect-aware allowlist** — GitHub Releases redirect
`github.com → objects.githubusercontent.com`. `_validate_url`
enforces `https://` + exact case-insensitive hostname match against
`settings.base_image_allowed_hosts` (CSV). `_fetch_catalog` and
`_download_with_sha` walk redirects manually with
`follow_redirects=False`, validating every `Location:` (max 5
hops). This is the SSRF mitigation.

**Per-attempt scratch dirs** —
`imager_scratch_path / "{prefix}-{target_id}-{uuid8}"`. Unique per
attempt prevents lease-loss duplicate-pickup workers from rmtree'ing
each other's in-flight files. Cleaned in `finally`.

**Idempotency** — Status check at start: `READY` → return `True`
(no I/O). Uploads use `overwrite=True` so retry after a
crash-after-upload-before-DB-commit works cleanly. Both Local and
Azure backends honor `overwrite`.

**TOCTOU mitigation** — `source_url` + `expected_sha256` on
`BaseImage` are populated by PR 4 at enqueue time, so the catalog
isn't re-fetched at handler time (eliminates the mutability
window). PR 3 falls back to re-fetching the catalog if those
fields are NULL — safety net for transitional rows + PR-3-only
test cases.

**`fleet_env_payload` contract** — Bytes treated as plaintext
UTF-8 *for now*; PR 4 will wrap with real encryption. Both
terminal-success and terminal-failure paths clear the column;
retryable failures leave it intact (next attempt needs it).

**Streaming size cap** — Aborts download mid-stream if running
byte count exceeds `expected_size_bytes`. Prevents disk fill from
a malicious catalog claiming 100 MiB and serving 50 GiB.

**Blob-path validation regex** —
`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/base\.img\.xz$` enforced at write
(import) and read (provision). Defence-in-depth against DB
corruption / variant-with-slashes.

## Followups (deferred)

- SIGTERM kill of in-flight imager subprocesses (would require
  refactoring PR 1's pure pipeline; the current behavior is the
  worker's existing graceful-shutdown timeout).
- User-cancellation honored mid-pipeline.
- Stale-scratch janitor on worker startup (cleans up dirs left
  behind by crashed workers).

## Test results

```
tests/test_imager_handlers.py  18 passed (new)
tests/test_imager_schema.py    13 passed (1 updated)
tests/test_worker.py           ... passed
tests/test_imager.py           25 passed (PR 1)
```

## Plan

PR 0 ✅ • PR 1 ✅ • PR 2 ✅ • **PR 3 (this)** • PR 4 (API) • PR 5 (UI) • PR 6 (rpi-imager catalog)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
