### PR TITLE
feat(imager): API endpoints for browser-driven Pi image provisioning (PR 4)

### DIFF
--- a/alembic/versions/0019_imager_provisioned_fleet_id.py
+++ b/alembic/versions/0019_imager_provisioned_fleet_id.py
@@ -1,0 +1,37 @@
+"""imager: add fleet_id audit column to provisioned_images
+
+The PR 4 build API records the ``fleet_id`` the operator selected on
+each ``provisioned_images`` row so the audit trail survives after the
+worker clears ``fleet_env_payload`` on terminal success.
+
+Nullable for backward-compatibility with existing rows (the table is
+empty in practice but PR 3 worker tests insert rows without fleet_id).
+PR 4's API populates it on insert.
+
+Revision ID: 0019
+Revises: 0018
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "provisioned_images",
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "downgrade not implemented; restore from backup if rollback required"
+    )

--- a/cms/main.py
+++ b/cms/main.py
@@ -826,6 +826,7 @@ from cms.routers.stream_probe import router as stream_probe_router  # noqa: E402
 from cms.routers.users import router as users_router  # noqa: E402
 from cms.routers.bootstrap import router as bootstrap_router  # noqa: E402
 from cms.routers.issue_report import router as issue_report_router  # noqa: E402
+from cms.routers.imager import router as imager_router  # noqa: E402
 from cms.ui import router as ui_router  # noqa: E402
 
 app.include_router(bootstrap_router)
@@ -849,6 +850,7 @@ app.include_router(users_router)
 app.include_router(roles_router)
 app.include_router(stream_probe_router)
 app.include_router(issue_report_router)
+app.include_router(imager_router)
 # /ws/device is only mounted in local transport mode. In WPS mode, devices
 # reach the CMS via Azure Web PubSub, and exposing a direct websocket is a
 # security/confusion risk (devices that connect there appear "online" but

--- a/cms/permissions.py
+++ b/cms/permissions.py
@@ -66,6 +66,11 @@ GROUPS_VIEW_ALL = "groups:view_all"
 # ── System health permissions ──
 SYSTEM_HEALTH = "system:health"
 
+# ── Imager (browser-driven Pi image provisioning, Option E) ──
+IMAGER_READ = "imager:read"      # List fleets, base images, view jobs
+IMAGER_BUILD = "imager:build"    # Build provisioned images, download
+IMAGER_MANAGE = "imager:manage"  # Catalog refresh, base-image import/delete
+
 
 ALL_PERMISSIONS: list[str] = [
     DEVICES_READ, DEVICES_WRITE, DEVICES_MANAGE,
@@ -84,6 +89,7 @@ ALL_PERMISSIONS: list[str] = [
     NOTIFICATIONS_SYSTEM,
     GROUPS_VIEW_ALL,
     SYSTEM_HEALTH,
+    IMAGER_READ, IMAGER_BUILD, IMAGER_MANAGE,
 ]
 
 PERMISSION_DESCRIPTIONS: dict[str, str] = {
@@ -115,6 +121,9 @@ PERMISSION_DESCRIPTIONS: dict[str, str] = {
     NOTIFICATIONS_SYSTEM: "View system-level notifications (SMTP failures, errors)",
     GROUPS_VIEW_ALL: "View all groups and their resources regardless of group assignment",
     SYSTEM_HEALTH: "View system health indicators",
+    IMAGER_READ: "View configured fleets, cached base images, and imager jobs",
+    IMAGER_BUILD: "Build provisioned Pi images and download outputs",
+    IMAGER_MANAGE: "Refresh the upstream catalog and import or delete cached base images",
 }
 
 # ── Predefined role templates ──
@@ -129,6 +138,7 @@ OPERATOR_PERMISSIONS: list[str] = [
     PROFILES_READ,
     LOGS_READ,
     MCP_KEYS_SELF,
+    IMAGER_READ, IMAGER_BUILD,
 ]
 
 VIEWER_PERMISSIONS: list[str] = [

--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -1,0 +1,639 @@
+"""Browser-driven Pi image provisioning API (Option E, Model B).
+
+This router exposes the operator-facing surface for the imager
+pipeline shipped in PRs 1–3:
+
+* :http:get:`/api/imager/fleets` — list the fleet IDs this CMS is
+  configured to register devices for (no secrets returned).
+* :http:get:`/api/imager/catalog` — live-fetch the upstream
+  ``catalog.json`` and return its parsed entries.  Side-effect-free.
+* :http:get:`/api/imager/base-images` — list cached
+  :class:`shared.models.imager.BaseImage` rows.
+* :http:post:`/api/imager/base-images` — enqueue an ``IMAGE_IMPORT``
+  job for ``(variant, version)``.  Idempotent against the unique
+  constraint: if the row already exists we either return it (READY /
+  IMPORTING) or restart it (FAILED).
+* :http:delete:`/api/imager/base-images/{id}` — delete a cached
+  base image and its blob.  Refused with 409 if any
+  ``ProvisionedImage`` references it (FK is RESTRICT).
+* :http:post:`/api/imager/build` — enqueue an ``IMAGE_PROVISION``
+  job that produces a generic enrollment image carrying
+  ``(AGORA_CMS_URL, AGORA_FLEET_ID, AGORA_FLEET_SECRET)``.  No
+  per-device API key minting.
+* :http:get:`/api/imager/jobs/{job_id}` — poll job status.  Filtered
+  to imager job types so non-imager jobs cannot be peeked through
+  this endpoint.  Includes the SAS download URL once a successful
+  ``IMAGE_PROVISION`` lands.
+* :http:get:`/api/imager/download/{job_id}` — 302 to a fresh SAS
+  URL for the provisioned image.  Audited.
+
+Identity model is **Model B only**: the image carries fleet
+credentials, not per-device credentials.  Each Pi flashed with the
+output pairs as a brand-new device via the existing
+``/api/devices/register`` HMAC flow on first boot.  Device-targeted
+re-flashes (Model A) are tracked as a future feature.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_settings, require_permission
+from cms.config import Settings
+from cms.database import get_db
+from cms.models.user import User
+from cms.permissions import IMAGER_BUILD, IMAGER_MANAGE, IMAGER_READ
+from cms.services.audit_service import audit_log
+from cms.services.imager import is_valid_output_name
+from shared.models.imager import (
+    BaseImage,
+    BaseImageStatus,
+    ProvisionedImage,
+    ProvisionedImageStatus,
+)
+from shared.models.job import Job, JobStatus, JobType
+from shared.services.imager_catalog import (
+    CatalogError,
+    HTTP_TIMEOUT,
+    fetch_catalog,
+    parse_allowed_hosts,
+)
+from shared.services.jobs import enqueue_job
+from shared.services.storage import get_storage
+
+
+router = APIRouter(prefix="/api/imager")
+
+
+_VARIANT_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_FLEET_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+# ── Schemas ──────────────────────────────────────────────────────
+
+
+class FleetOut(BaseModel):
+    fleet_id: str
+
+
+class CatalogEntryOut(BaseModel):
+    variant: str
+    url: str
+    sha256: str
+    size_bytes: int | None = None
+
+
+class CatalogOut(BaseModel):
+    ref: str | None = None
+    entries: list[CatalogEntryOut]
+
+
+class BaseImageOut(BaseModel):
+    id: uuid.UUID
+    variant: str
+    version: str
+    sha256: str | None
+    blob_path: str | None
+    size_bytes: int | None
+    status: str
+    error_message: str
+    is_default: bool
+    imported_at: datetime | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BaseImageImportBody(BaseModel):
+    variant: str = Field(..., min_length=1, max_length=64)
+    version: str = Field(..., min_length=1, max_length=64)
+
+
+class BuildBody(BaseModel):
+    base_image_id: uuid.UUID
+    fleet_id: str = Field(..., min_length=1, max_length=64)
+    output_name: str = Field(..., min_length=1, max_length=255)
+
+
+class JobStatusOut(BaseModel):
+    job_id: uuid.UUID
+    type: str
+    status: str
+    target_id: uuid.UUID
+    error_message: str
+    created_at: datetime
+    completed_at: datetime | None
+    # Populated only for terminal-success IMAGE_PROVISION jobs.
+    download_url: str | None = None
+    output_name: str | None = None
+    expires_at: datetime | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _ensure_catalog_url(settings: Settings) -> str:
+    url = (settings.base_image_catalog_url or "").strip()
+    if not url:
+        raise HTTPException(
+            status_code=503,
+            detail="BASE_IMAGE_CATALOG_URL is not configured",
+        )
+    return url
+
+
+def _allowlist(settings: Settings) -> set[str]:
+    return parse_allowed_hosts(settings.base_image_allowed_hosts)
+
+
+def _base_image_to_out(bi: BaseImage) -> BaseImageOut:
+    return BaseImageOut.model_validate(bi)
+
+
+def _resolve_catalog_entry(
+    catalog: dict[str, Any], variant: str, version: str
+) -> dict[str, Any]:
+    """Return the catalog entry for ``variant`` validated against ``version``.
+
+    Raises :class:`HTTPException` 404 if no entry, 422 if ``ref``
+    mismatches, 422 if entry is missing url/sha256.
+    """
+    ref = catalog.get("ref")
+    if ref and ref != version:
+        raise HTTPException(
+            status_code=422,
+            detail=f"catalog ref {ref!r} does not match requested version {version!r}",
+        )
+    variants = catalog.get("variants") or {}
+    entry = variants.get(variant)
+    if not isinstance(entry, dict):
+        raise HTTPException(
+            status_code=404,
+            detail=f"catalog has no entry for variant {variant!r}",
+        )
+    url = entry.get("url")
+    sha256 = entry.get("sha256")
+    if not url or not sha256:
+        raise HTTPException(
+            status_code=422,
+            detail=f"catalog entry for {variant!r} missing url or sha256",
+        )
+    return entry
+
+
+def _fleet_env_payload(cms_url: str, fleet_id: str, fleet_secret: str) -> bytes:
+    """Render the ``agora-fleet.env`` body the worker will inject.
+
+    Plaintext on purpose -- see model docstring for rationale.  Order
+    matters only for human readability; the firmware reads via
+    standard ``KEY=VALUE`` env parsing.
+    """
+    return (
+        f"AGORA_CMS_URL={cms_url}\n"
+        f"AGORA_FLEET_ID={fleet_id}\n"
+        f"AGORA_FLEET_SECRET={fleet_secret}\n"
+    ).encode("utf-8")
+
+
+# ── Endpoints ────────────────────────────────────────────────────
+
+
+@router.get("/fleets", response_model=list[FleetOut])
+async def list_fleets(
+    user: User = Depends(require_permission(IMAGER_READ)),
+    settings: Settings = Depends(get_settings),
+) -> list[FleetOut]:
+    """Return the fleet IDs this CMS can register devices for.
+
+    Source of truth is :attr:`Settings.fleet_register_secrets`
+    (env-configured).  Secrets themselves are never returned.
+    """
+    fleets = sorted((settings.fleet_register_secrets or {}).keys())
+    return [FleetOut(fleet_id=f) for f in fleets]
+
+
+@router.get("/catalog", response_model=CatalogOut)
+async def get_catalog(
+    user: User = Depends(require_permission(IMAGER_MANAGE)),
+    settings: Settings = Depends(get_settings),
+) -> CatalogOut:
+    """Live-fetch and parse the upstream catalog manifest.
+
+    Side-effect-free; intended for the UI to populate the
+    "import a new base image" picker without writing anything to DB.
+    """
+    catalog_url = _ensure_catalog_url(settings)
+    allowlist = _allowlist(settings)
+    if not allowlist:
+        raise HTTPException(
+            status_code=503,
+            detail="BASE_IMAGE_ALLOWED_HOSTS is empty; refusing catalog fetch",
+        )
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            doc = await fetch_catalog(catalog_url, allowlist, client)
+    except CatalogError as e:
+        raise HTTPException(status_code=502, detail=f"catalog: {e}") from e
+    except httpx.HTTPError as e:
+        raise HTTPException(status_code=502, detail=f"catalog fetch failed: {e}") from e
+
+    entries: list[CatalogEntryOut] = []
+    for variant, payload in (doc.get("variants") or {}).items():
+        if not isinstance(payload, dict):
+            continue
+        url = payload.get("url")
+        sha256 = payload.get("sha256")
+        if not url or not sha256:
+            continue
+        entries.append(CatalogEntryOut(
+            variant=variant,
+            url=url,
+            sha256=sha256,
+            size_bytes=payload.get("size_bytes"),
+        ))
+    return CatalogOut(ref=doc.get("ref"), entries=entries)
+
+
+@router.get("/base-images", response_model=list[BaseImageOut])
+async def list_base_images(
+    user: User = Depends(require_permission(IMAGER_READ)),
+    db: AsyncSession = Depends(get_db),
+) -> list[BaseImageOut]:
+    """List cached base images, newest first."""
+    result = await db.execute(
+        select(BaseImage).order_by(BaseImage.created_at.desc())
+    )
+    return [_base_image_to_out(bi) for bi in result.scalars().all()]
+
+
+@router.post("/base-images", response_model=BaseImageOut)
+async def import_base_image(
+    body: BaseImageImportBody,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_MANAGE)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> BaseImageOut:
+    """Resolve ``(variant, version)`` against the catalog and enqueue an import.
+
+    Behaviour matrix on the unique ``(variant, version)`` constraint:
+
+    * No existing row → create + enqueue.
+    * Existing READY → return existing row, do nothing.
+    * Existing IMPORTING → return existing row, do nothing.
+    * Existing FAILED → reset to IMPORTING, restamp catalog
+      coordinates, re-enqueue.
+    """
+    if not _VARIANT_RE.match(body.variant):
+        raise HTTPException(status_code=422, detail="invalid variant")
+    if not _VERSION_RE.match(body.version):
+        raise HTTPException(status_code=422, detail="invalid version")
+
+    # Live-resolve the catalog entry so we stamp source_url + expected_sha256
+    # at enqueue time.  This eliminates the TOCTOU window between admin
+    # click and worker pickup (worker uses the stamped values, not the
+    # mutable catalog).
+    catalog_url = _ensure_catalog_url(settings)
+    allowlist = _allowlist(settings)
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            doc = await fetch_catalog(catalog_url, allowlist, client)
+    except CatalogError as e:
+        raise HTTPException(status_code=502, detail=f"catalog: {e}") from e
+    except httpx.HTTPError as e:
+        raise HTTPException(status_code=502, detail=f"catalog fetch failed: {e}") from e
+    entry = _resolve_catalog_entry(doc, body.variant, body.version)
+
+    existing = await db.execute(
+        select(BaseImage).where(
+            BaseImage.variant == body.variant,
+            BaseImage.version == body.version,
+        )
+    )
+    bi = existing.scalar_one_or_none()
+    if bi is not None and bi.status != BaseImageStatus.FAILED.value:
+        # READY or IMPORTING: idempotent no-op.
+        return _base_image_to_out(bi)
+
+    if bi is None:
+        bi = BaseImage(
+            variant=body.variant,
+            version=body.version,
+            source_url=entry["url"],
+            expected_sha256=entry["sha256"],
+            size_bytes=entry.get("size_bytes"),
+            imported_by=user.id,
+            status=BaseImageStatus.IMPORTING.value,
+        )
+        db.add(bi)
+        try:
+            await db.flush()
+        except IntegrityError:
+            # Lost the race against a concurrent insert; reload winner.
+            await db.rollback()
+            again = await db.execute(
+                select(BaseImage).where(
+                    BaseImage.variant == body.variant,
+                    BaseImage.version == body.version,
+                )
+            )
+            bi = again.scalar_one()
+            return _base_image_to_out(bi)
+    else:
+        # FAILED: restart.
+        bi.source_url = entry["url"]
+        bi.expected_sha256 = entry["sha256"]
+        bi.size_bytes = entry.get("size_bytes")
+        bi.status = BaseImageStatus.IMPORTING.value
+        bi.error_message = ""
+        bi.sha256 = None
+        bi.blob_path = None
+        bi.imported_at = None
+        bi.imported_by = user.id
+        await db.flush()
+
+    await audit_log(
+        db, user=user, action="imager.base_image.import",
+        resource_type="base_image", resource_id=str(bi.id),
+        details={
+            "variant": bi.variant,
+            "version": bi.version,
+            "source_url": bi.source_url,
+            "expected_sha256": bi.expected_sha256,
+        },
+        request=request,
+    )
+
+    # ``enqueue_job`` commits the surrounding transaction, persisting
+    # both the BaseImage row and the audit entry.
+    await enqueue_job(db, JobType.IMAGE_IMPORT, bi.id)
+    await db.refresh(bi)
+    return _base_image_to_out(bi)
+
+
+@router.delete("/base-images/{base_image_id}", status_code=204)
+async def delete_base_image(
+    base_image_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_MANAGE)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> None:
+    """Delete a cached base image (DB row + tenant blob).
+
+    Refuses with 409 if any ``ProvisionedImage`` row references this
+    base image.  The DB FK is ``RESTRICT`` so a relaxed implementation
+    would still surface that error -- we check eagerly for a clearer
+    message.
+    """
+    bi = await db.get(BaseImage, base_image_id)
+    if bi is None:
+        raise HTTPException(status_code=404, detail="base image not found")
+
+    ref_count = await db.scalar(
+        select(func.count()).select_from(ProvisionedImage).where(
+            ProvisionedImage.base_image_id == base_image_id
+        )
+    )
+    if ref_count and int(ref_count) > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"cannot delete: {int(ref_count)} provisioned image(s) "
+                "reference this base image"
+            ),
+        )
+
+    blob_path = bi.blob_path
+    container = settings.base_image_cache_container
+
+    await db.delete(bi)
+    await audit_log(
+        db, user=user, action="imager.base_image.delete",
+        resource_type="base_image", resource_id=str(base_image_id),
+        details={"variant": bi.variant, "version": bi.version, "blob_path": blob_path},
+        request=request,
+    )
+    await db.commit()
+
+    # Best-effort blob cleanup.  We've already committed the delete
+    # so a blob-cleanup failure should not roll back the row removal;
+    # an admin-initiated retry will succeed once Azure recovers.
+    if blob_path:
+        try:
+            storage = get_storage()
+            if hasattr(storage, "delete_blob"):
+                await storage.delete_blob(container, blob_path)  # type: ignore[attr-defined]
+        except Exception:
+            # Logged via audit_log already; we don't fail the API.
+            pass
+
+
+@router.post("/build", response_model=JobStatusOut)
+async def build_provisioned_image(
+    body: BuildBody,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_BUILD)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> JobStatusOut:
+    """Enqueue an ``IMAGE_PROVISION`` job and return the job handle.
+
+    Validates that:
+
+    * ``output_name`` is a safe ``.img.xz`` basename;
+    * ``fleet_id`` is configured on this CMS (resolves to a secret);
+    * ``base_image_id`` exists and is READY;
+    * a CMS public base URL is configured (the firmware needs an
+      absolute URL to call ``/api/devices/register``).
+    """
+    if not is_valid_output_name(body.output_name):
+        raise HTTPException(
+            status_code=422,
+            detail="output_name must be a basename like 'foo.img.xz'",
+        )
+    if not _FLEET_ID_RE.match(body.fleet_id):
+        raise HTTPException(status_code=422, detail="invalid fleet_id")
+
+    secret = (settings.fleet_register_secrets or {}).get(body.fleet_id)
+    if not secret:
+        raise HTTPException(
+            status_code=404,
+            detail=f"fleet_id {body.fleet_id!r} is not configured on this CMS",
+        )
+
+    cms_url = (settings.base_url or "").rstrip("/")
+    if not cms_url:
+        raise HTTPException(
+            status_code=503,
+            detail="AGORA_BASE_URL is not configured; the image needs an absolute CMS URL",
+        )
+
+    bi = await db.get(BaseImage, body.base_image_id)
+    if bi is None:
+        raise HTTPException(status_code=404, detail="base image not found")
+    if bi.status != BaseImageStatus.READY.value:
+        raise HTTPException(
+            status_code=409,
+            detail=f"base image is not ready (status={bi.status})",
+        )
+
+    payload = _fleet_env_payload(cms_url, body.fleet_id, secret)
+
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name=body.output_name,
+        fleet_env_payload=payload,
+        fleet_id=body.fleet_id,
+        built_by=user.id,
+        status=ProvisionedImageStatus.PROVISIONING.value,
+    )
+    db.add(pi)
+    await db.flush()
+
+    await audit_log(
+        db, user=user, action="imager.build",
+        resource_type="provisioned_image", resource_id=str(pi.id),
+        # NEVER include the secret here.
+        details={
+            "base_image_id": str(bi.id),
+            "variant": bi.variant,
+            "version": bi.version,
+            "fleet_id": body.fleet_id,
+            "output_name": body.output_name,
+        },
+        request=request,
+    )
+
+    job_id = await enqueue_job(db, JobType.IMAGE_PROVISION, pi.id)
+    await db.refresh(pi)
+
+    job = await db.get(Job, job_id)
+    assert job is not None
+    return JobStatusOut(
+        job_id=job.id,
+        type=job.type.value if hasattr(job.type, "value") else str(job.type),
+        status=job.status.value if hasattr(job.status, "value") else str(job.status),
+        target_id=job.target_id,
+        error_message=job.error_message,
+        created_at=job.created_at,
+        completed_at=job.completed_at,
+        output_name=pi.output_name,
+    )
+
+
+_IMAGER_JOB_TYPES = (JobType.IMAGE_IMPORT, JobType.IMAGE_PROVISION)
+
+
+@router.get("/jobs/{job_id}", response_model=JobStatusOut)
+async def get_job_status(
+    job_id: uuid.UUID,
+    user: User = Depends(require_permission(IMAGER_READ)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> JobStatusOut:
+    """Return the status of an imager job.
+
+    Filtered to imager job types so this endpoint cannot be used to
+    peek at unrelated CMS jobs (transcode, capture, etc.).
+    """
+    job = await db.get(Job, job_id)
+    if job is None or job.type not in _IMAGER_JOB_TYPES:
+        raise HTTPException(status_code=404, detail="imager job not found")
+
+    out = JobStatusOut(
+        job_id=job.id,
+        type=job.type.value if hasattr(job.type, "value") else str(job.type),
+        status=job.status.value if hasattr(job.status, "value") else str(job.status),
+        target_id=job.target_id,
+        error_message=job.error_message,
+        created_at=job.created_at,
+        completed_at=job.completed_at,
+    )
+
+    if job.type == JobType.IMAGE_PROVISION and job.status == JobStatus.DONE:
+        pi = await db.get(ProvisionedImage, job.target_id)
+        if pi is not None:
+            out.output_name = pi.output_name
+            out.expires_at = pi.expires_at
+            if (
+                pi.status == ProvisionedImageStatus.READY.value
+                and pi.blob_path
+            ):
+                storage = get_storage()
+                out.download_url = storage.generate_blob_sas_url(
+                    settings.provisioned_container,
+                    pi.blob_path,
+                    settings.imager_sas_ttl_hours,
+                )
+
+    return out
+
+
+@router.get("/download/{job_id}")
+async def download_provisioned(
+    job_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_BUILD)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> RedirectResponse:
+    """Return a 302 to a fresh SAS URL for the provisioned image.
+
+    Audited.  404s when the job is unknown, not an ``IMAGE_PROVISION``,
+    not yet succeeded, or whose row is no longer ``READY`` (e.g. the
+    24 h Azure lifecycle policy has expired the blob and the row is
+    now ``EXPIRED``).
+    """
+    job = await db.get(Job, job_id)
+    if job is None or job.type != JobType.IMAGE_PROVISION:
+        raise HTTPException(status_code=404, detail="imager job not found")
+    if job.status != JobStatus.DONE:
+        raise HTTPException(
+            status_code=409,
+            detail=f"job is not ready (status={job.status.value if hasattr(job.status, 'value') else job.status})",
+        )
+
+    pi = await db.get(ProvisionedImage, job.target_id)
+    if pi is None or pi.status != ProvisionedImageStatus.READY.value or not pi.blob_path:
+        raise HTTPException(status_code=404, detail="provisioned image not available")
+
+    # Verify the blob actually exists before handing back a SAS so an
+    # expired-and-cleaned-up artifact 404s here cleanly rather than
+    # the operator's browser landing on a generic Azure 404.
+    storage = get_storage()
+    if not await storage.blob_exists(settings.provisioned_container, pi.blob_path):
+        raise HTTPException(status_code=404, detail="provisioned image blob is gone")
+
+    url = storage.generate_blob_sas_url(
+        settings.provisioned_container,
+        pi.blob_path,
+        settings.imager_sas_ttl_hours,
+    )
+
+    await audit_log(
+        db, user=user, action="imager.download",
+        resource_type="provisioned_image", resource_id=str(pi.id),
+        details={
+            "job_id": str(job.id),
+            "base_image_id": str(pi.base_image_id),
+            "fleet_id": pi.fleet_id,
+            "output_name": pi.output_name,
+        },
+        request=request,
+    )
+    await db.commit()
+
+    return RedirectResponse(url=url, status_code=302)

--- a/cms/services/imager.py
+++ b/cms/services/imager.py
@@ -42,6 +42,11 @@ FLEET_ENV_MAX_BYTES = 64 * 1024
 _SAFE_OUTPUT_RE = re.compile(r"^[A-Za-z0-9._-]+\.img\.xz$")
 
 
+def is_valid_output_name(name: str) -> bool:
+    """Return ``True`` iff ``name`` is a safe ``.img.xz`` basename."""
+    return bool(_SAFE_OUTPUT_RE.match(name or ""))
+
+
 class ImagerError(RuntimeError):
     """Image build pipeline failure (parted/mtools/xz)."""
 

--- a/shared/models/imager.py
+++ b/shared/models/imager.py
@@ -190,14 +190,24 @@ class ProvisionedImage(Base):
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
-    # Encrypted at the application layer (PR 4 picks the cipher and
-    # key source).  Opaque ciphertext at this level — never log this
-    # column, never serialize it through the API.
+    # Audit-only: the fleet_id the operator selected at build time.
+    # Populated by PR 4's API on insert; left null on legacy rows.
+    # Useful after terminal success when ``fleet_env_payload`` is cleared.
+    fleet_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Plaintext ``agora-fleet.env`` body — UTF-8 bytes of
+    # ``AGORA_CMS_URL=...\nAGORA_FLEET_ID=...\nAGORA_FLEET_SECRET=...\n``.
+    # Plaintext is intentional: the same secret already lives in clear
+    # in the operator's CMS env config (``fleet_register_secrets``) and
+    # ends up plaintext on the SD card itself, so encrypting the brief
+    # DB copy adds minimal defense-in-depth without a separate key
+    # store.  Worker clears this column to NULL on terminal success so
+    # the secret does not linger longer than necessary.  Never log
+    # this column, never serialize it through the API.
     fleet_env_payload: Mapped[bytes | None] = mapped_column(
         LargeBinary, nullable=True,
     )
     # Caller-supplied output filename.  Validated against
-    # ``imager.is_valid_output_name`` before use.
+    # ``imager._SAFE_OUTPUT_RE`` before use.
     output_name: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(
         Text, nullable=False,

--- a/shared/services/imager_catalog.py
+++ b/shared/services/imager_catalog.py
@@ -1,0 +1,106 @@
+"""Shared imager catalog helpers.
+
+The CMS API (PR 4) and the worker handlers (PR 3) both need to:
+
+* enforce a hostname allowlist on every URL we hit — *including*
+  every redirect Location — so a malicious catalog cannot point us at
+  an internal address;
+* parse the upstream catalog.json on demand.
+
+Originally these helpers lived inside ``worker/imager_handlers.py``.
+They were moved here so the API layer can resolve a catalog entry at
+enqueue time (stamping ``source_url`` + ``expected_sha256`` onto the
+``BaseImage`` row) without importing worker internals or reaching for
+the upstream catalog twice.
+
+This module is deliberately narrow: pure-async URL/IO helpers, no DB
+state, no sleep loops, no logging side effects beyond what httpx
+emits internally.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+# Hard ceiling on how many redirect hops we will walk while validating
+# every Location against the allowlist.  GitHub-Releases->blob normally
+# resolves in <=2 hops.
+MAX_REDIRECTS = 5
+
+# Default per-call total HTTP timeout (catalog + download both).
+HTTP_TIMEOUT = httpx.Timeout(connect=15.0, read=120.0, write=120.0, pool=15.0)
+
+
+class CatalogError(Exception):
+    """Deterministic catalog-fetch failure -- do not retry.
+
+    Raised for allowlist violations, non-https URLs, malformed JSON,
+    or oversized redirect chains.  Callers translate this into either
+    a 400/422 (API layer) or a TerminalImagerError (worker layer).
+    """
+
+
+def parse_allowed_hosts(raw: str | None) -> set[str]:
+    """Split a comma-separated host list into a normalized set."""
+    raw = (raw or "").strip()
+    if not raw:
+        return set()
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def validate_url(url: str, allowlist: set[str]) -> str:
+    """Return ``url`` iff its scheme is https and host is allowlisted.
+
+    Raises :class:`CatalogError` otherwise.  Centralised so the same
+    rule applies to the catalog URL **and** every redirect target
+    while streaming an image.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise CatalogError(
+            f"refusing non-https url for imager fetch: scheme={parsed.scheme!r}"
+        )
+    host = (parsed.hostname or "").lower()
+    if host not in allowlist:
+        raise CatalogError(
+            f"host {host!r} not in base_image_allowed_hosts ({sorted(allowlist)})"
+        )
+    return url
+
+
+async def fetch_catalog(
+    catalog_url: str,
+    allowlist: set[str],
+    client: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Resolve + parse the upstream ``catalog.json``.
+
+    Returns the parsed JSON dict.  Raises :class:`CatalogError` on
+    allowlist violation, non-JSON body, or excessive redirects.
+    Re-raises generic :mod:`httpx` exceptions on transient network
+    errors so callers can decide whether to retry.
+    """
+    validate_url(catalog_url, allowlist)
+    resp = await client.get(catalog_url, follow_redirects=False)
+    hops = 0
+    while resp.is_redirect and hops < MAX_REDIRECTS:
+        loc = resp.headers.get("location")
+        if not loc:
+            raise httpx.RemoteProtocolError("redirect without Location")
+        validate_url(loc, allowlist)
+        resp = await client.get(loc, follow_redirects=False)
+        hops += 1
+    if resp.is_redirect:
+        raise CatalogError(
+            f"too many redirects ({MAX_REDIRECTS}) fetching catalog"
+        )
+    resp.raise_for_status()
+    try:
+        return resp.json()
+    except json.JSONDecodeError as e:
+        raise CatalogError(f"catalog is not valid json: {e}") from e

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -1,0 +1,666 @@
+"""API tests for the browser-driven Pi image provisioning router (PR 4).
+
+Covers RBAC, schema validation, catalog wiring, idempotent imports,
+delete-with-references guard, build payload + audit, job polling,
+and download SAS handing.
+
+Catalog HTTP fetches are mocked via ``httpx.MockTransport`` so tests
+do not hit the real upstream.  Worker job execution is *not* exercised
+here -- ``test_imager_handlers.py`` covers that.  These tests verify
+that the API layer correctly enqueues, validates, and reads back job
+state.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.auth import get_settings
+from cms.routers import imager as imager_router
+from shared.models.imager import (
+    BaseImage,
+    BaseImageStatus,
+    ProvisionedImage,
+    ProvisionedImageStatus,
+)
+from shared.models.job import Job, JobStatus, JobType
+
+from tests.test_rbac import _create_user, _login_as
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def imager_settings(app):
+    """Configure the test settings with imager fields populated.
+
+    Mutates the singleton settings instance the app fixture installed
+    via ``dependency_overrides``.  Restores defaults on teardown.
+    """
+    settings = app.dependency_overrides[get_settings]()
+    saved = {
+        "base_image_catalog_url": settings.base_image_catalog_url,
+        "base_image_allowed_hosts": settings.base_image_allowed_hosts,
+        "base_image_cache_container": settings.base_image_cache_container,
+        "provisioned_container": settings.provisioned_container,
+        "imager_sas_ttl_hours": settings.imager_sas_ttl_hours,
+        "fleet_register_secrets": dict(settings.fleet_register_secrets or {}),
+        "base_url": settings.base_url,
+    }
+    settings.base_image_catalog_url = (
+        "https://github.com/sslivins/agora/releases/download/v1.11.28/catalog.json"
+    )
+    settings.base_image_allowed_hosts = "github.com,objects.githubusercontent.com"
+    settings.base_image_cache_container = "base-images"
+    settings.provisioned_container = "provisioned"
+    settings.imager_sas_ttl_hours = 2
+    settings.fleet_register_secrets = {"fleet-test": "c2VjcmV0LWJhc2U2NA=="}
+    settings.base_url = "https://cms.example.com"
+    yield settings
+    for k, v in saved.items():
+        setattr(settings, k, v)
+
+
+def _catalog_doc(ref: str = "v1.11.28") -> dict[str, Any]:
+    return {
+        "ref": ref,
+        "variants": {
+            "pi5": {
+                "url": "https://github.com/sslivins/agora/releases/download/"
+                       f"{ref}/agora-pi5.img.xz",
+                "sha256": "a" * 64,
+                "size_bytes": 600 * 1024 * 1024,
+            },
+            "pi4": {
+                "url": "https://github.com/sslivins/agora/releases/download/"
+                       f"{ref}/agora-pi4.img.xz",
+                "sha256": "b" * 64,
+                "size_bytes": 600 * 1024 * 1024,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def patch_catalog_ok(monkeypatch, imager_settings):
+    """Make every httpx call from the imager router return the canned catalog."""
+    body = json.dumps(_catalog_doc()).encode("utf-8")
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr(imager_router.httpx, "AsyncClient", _factory)
+
+
+@pytest.fixture
+def patch_catalog_error(monkeypatch, imager_settings):
+    """Make catalog fetches fail with a network error."""
+    def _handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("test simulated network error")
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr(imager_router.httpx, "AsyncClient", _factory)
+
+
+# ── Auth / RBAC ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_endpoints_require_auth(unauthed_client):
+    """Every imager endpoint must reject unauthenticated requests."""
+    paths = [
+        ("GET", "/api/imager/fleets"),
+        ("GET", "/api/imager/catalog"),
+        ("GET", "/api/imager/base-images"),
+        ("POST", "/api/imager/base-images"),
+        ("DELETE", f"/api/imager/base-images/{uuid.uuid4()}"),
+        ("POST", "/api/imager/build"),
+        ("GET", f"/api/imager/jobs/{uuid.uuid4()}"),
+        ("GET", f"/api/imager/download/{uuid.uuid4()}"),
+    ]
+    for method, path in paths:
+        kwargs = {"json": {}} if method == "POST" else {}
+        resp = await unauthed_client.request(method, path, **kwargs)
+        assert resp.status_code == 401, f"{method} {path} got {resp.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_viewer_denied_imager_read(app, db_session):
+    """Viewer role has no IMAGER_READ — every endpoint returns 403."""
+    await _create_user(db_session, email="viewer-img@test.com", role_name="Viewer")
+    ac = await _login_as(app, "viewer-img@test.com")
+    try:
+        for method, path in [
+            ("GET", "/api/imager/fleets"),
+            ("GET", "/api/imager/base-images"),
+        ]:
+            resp = await ac.request(method, path)
+            assert resp.status_code == 403, f"{method} {path}: {resp.status_code}"
+    finally:
+        await ac.aclose()
+
+
+@pytest.mark.asyncio
+async def test_operator_denied_imager_manage(app, db_session, imager_settings):
+    """Operator has IMAGER_READ + IMAGER_BUILD but not IMAGER_MANAGE."""
+    await _create_user(db_session, email="op-img@test.com", role_name="Operator")
+    ac = await _login_as(app, "op-img@test.com")
+    try:
+        # MANAGE-gated:
+        resp = await ac.get("/api/imager/catalog")
+        assert resp.status_code == 403
+        resp = await ac.post("/api/imager/base-images", json={"variant": "pi5", "version": "v1"})
+        assert resp.status_code == 403
+        # READ-gated should pass:
+        resp = await ac.get("/api/imager/fleets")
+        assert resp.status_code == 200
+        resp = await ac.get("/api/imager/base-images")
+        assert resp.status_code == 200
+    finally:
+        await ac.aclose()
+
+
+# ── Fleets ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_fleets_returns_configured_ids_no_secrets(client, imager_settings):
+    resp = await client.get("/api/imager/fleets")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == [{"fleet_id": "fleet-test"}]
+    # Sanity: secret is never serialized.
+    assert "secret" not in resp.text.lower()
+
+
+# ── Catalog ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_catalog_503_when_url_unconfigured(client, imager_settings):
+    imager_settings.base_image_catalog_url = ""
+    resp = await client.get("/api/imager/catalog")
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_catalog_502_on_network_error(client, patch_catalog_error):
+    resp = await client.get("/api/imager/catalog")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_catalog_happy_path(client, patch_catalog_ok):
+    resp = await client.get("/api/imager/catalog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ref"] == "v1.11.28"
+    variants = {e["variant"] for e in body["entries"]}
+    assert variants == {"pi5", "pi4"}
+
+
+# ── Base-image import ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_creates_row_and_stamps_catalog(client, db_session, patch_catalog_ok):
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["variant"] == "pi5"
+    assert body["version"] == "v1.11.28"
+    assert body["status"] == BaseImageStatus.IMPORTING.value
+    # DB row stamped with catalog coords.
+    row = (await db_session.execute(
+        select(BaseImage).where(BaseImage.id == uuid.UUID(body["id"]))
+    )).scalar_one()
+    assert row.source_url and "agora-pi5.img.xz" in row.source_url
+    assert row.expected_sha256 == "a" * 64
+    # Job row enqueued.
+    job = (await db_session.execute(
+        select(Job).where(Job.target_id == row.id, Job.type == JobType.IMAGE_IMPORT)
+    )).scalar_one()
+    assert job.status == JobStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_import_idempotent_when_row_already_ready(
+    client, db_session, patch_catalog_ok
+):
+    bi = BaseImage(
+        variant="pi5",
+        version="v1.11.28",
+        sha256="a" * 64,
+        blob_path="base-images/pi5/v1.11.28/base.img.xz",
+        size_bytes=1234,
+        status=BaseImageStatus.READY.value,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(bi.id)
+    assert body["status"] == BaseImageStatus.READY.value
+    # No job should have been enqueued for an already-READY row.
+    jobs = (await db_session.execute(
+        select(Job).where(Job.target_id == bi.id, Job.type == JobType.IMAGE_IMPORT)
+    )).scalars().all()
+    assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_import_restarts_failed_row(client, db_session, patch_catalog_ok):
+    bi = BaseImage(
+        variant="pi5",
+        version="v1.11.28",
+        status=BaseImageStatus.FAILED.value,
+        error_message="prior failure",
+        source_url="https://old/example.img.xz",
+        expected_sha256="z" * 64,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(bi.id)
+    assert body["status"] == BaseImageStatus.IMPORTING.value
+    assert (body["error_message"] or "") == ""
+    # Source URL re-stamped from catalog.
+    await db_session.refresh(bi)
+    assert "agora-pi5.img.xz" in bi.source_url
+    assert bi.expected_sha256 == "a" * 64
+
+
+@pytest.mark.asyncio
+async def test_import_422_on_ref_mismatch(client, patch_catalog_ok):
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v9.99.99"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_import_404_on_unknown_variant(client, patch_catalog_ok):
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "nope", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_import_503_when_catalog_url_unconfigured(client, imager_settings):
+    imager_settings.base_image_catalog_url = ""
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 503
+
+
+# ── Base-image list ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_base_images(client, db_session, imager_settings):
+    db_session.add(BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value))
+    db_session.add(BaseImage(variant="pi4", version="v1", status=BaseImageStatus.IMPORTING.value))
+    await db_session.commit()
+
+    resp = await client.get("/api/imager/base-images")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+
+# ── Base-image delete ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_404_when_missing(client, imager_settings):
+    resp = await client.delete(f"/api/imager/base-images/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_409_when_referenced(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"AGORA_CMS_URL=https://x\nAGORA_FLEET_ID=f\nAGORA_FLEET_SECRET=s\n",
+        status=ProvisionedImageStatus.READY.value,
+    )
+    db_session.add(pi)
+    await db_session.commit()
+
+    resp = await client.delete(f"/api/imager/base-images/{bi.id}")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_delete_succeeds_when_unreferenced(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.delete(f"/api/imager/base-images/{bi.id}")
+    assert resp.status_code == 204
+    # Row gone.
+    assert (await db_session.execute(select(BaseImage).where(BaseImage.id == bi.id))).scalar_one_or_none() is None
+
+
+# ── Build ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_422_on_invalid_output_name(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "../etc/passwd",
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_build_404_when_fleet_unknown(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "no-such-fleet",
+            "output_name": "x.img.xz",
+        },
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_build_503_when_base_url_missing(client, db_session, imager_settings):
+    imager_settings.base_url = None
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "x.img.xz",
+        },
+    )
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_build_409_when_base_not_ready(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.IMPORTING.value)
+    db_session.add(bi)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "x.img.xz",
+        },
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_build_creates_provisioned_row_with_payload(
+    client, db_session, imager_settings
+):
+    bi = BaseImage(variant="pi5", version="v1.11.28", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "kitchen.img.xz",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == JobStatus.PENDING.value
+    assert body["type"] == JobType.IMAGE_PROVISION.value
+    assert body["output_name"] == "kitchen.img.xz"
+
+    # Provisioned row has the plaintext payload + fleet_id.
+    pi = (await db_session.execute(
+        select(ProvisionedImage).where(ProvisionedImage.base_image_id == bi.id)
+    )).scalar_one()
+    assert pi.fleet_id == "fleet-test"
+    assert pi.output_name == "kitchen.img.xz"
+    payload = pi.fleet_env_payload.decode("utf-8")
+    assert "AGORA_CMS_URL=https://cms.example.com" in payload
+    assert "AGORA_FLEET_ID=fleet-test" in payload
+    assert "AGORA_FLEET_SECRET=c2VjcmV0LWJhc2U2NA==" in payload  # gitleaks:allow
+
+    # And a Job row was enqueued.
+    job = (await db_session.execute(
+        select(Job).where(Job.target_id == pi.id, Job.type == JobType.IMAGE_PROVISION)
+    )).scalar_one()
+    assert job.status == JobStatus.PENDING
+
+
+# ── Jobs / download ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_job_404_for_non_imager_job(client, imager_settings):
+    resp = await client.get(f"/api/imager/jobs/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_job_returns_status(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.IMPORTING.value)
+    db_session.add(bi)
+    await db_session.flush()
+    job = Job(type=JobType.IMAGE_IMPORT, target_id=bi.id, status=JobStatus.PENDING)
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/jobs/{job.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == JobStatus.PENDING.value
+    assert body["type"] == JobType.IMAGE_IMPORT.value
+    assert body["download_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_job_includes_download_url_when_ready(
+    client, db_session, imager_settings
+):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"AGORA_CMS_URL=https://x\n",
+        status=ProvisionedImageStatus.READY.value,
+        blob_path="provisioned/abc/x.img.xz",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+    )
+    db_session.add(pi)
+    await db_session.flush()
+    job = Job(
+        type=JobType.IMAGE_PROVISION, target_id=pi.id,
+        status=JobStatus.DONE,
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/jobs/{job.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["download_url"]
+    assert body["output_name"] == "x.img.xz"
+
+
+@pytest.mark.asyncio
+async def test_download_404_when_not_ready(client, db_session, imager_settings):
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"x\n",
+        status=ProvisionedImageStatus.PROVISIONING.value,
+    )
+    db_session.add(pi)
+    await db_session.flush()
+    job = Job(type=JobType.IMAGE_PROVISION, target_id=pi.id, status=JobStatus.PENDING)
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/download/{job.id}", follow_redirects=False)
+    # Job not SUCCEEDED → 409 ('not ready').
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_download_redirects_when_ready(
+    client, db_session, imager_settings, monkeypatch, tmp_path,
+):
+    """Download endpoint hands back a 302 once everything is in place."""
+    # Stub blob_exists+SAS so the test does not depend on the local-backend
+    # ``file://`` URL (httpx rejects Windows paths in Location headers).
+    from shared.services import storage as storage_mod
+
+    async def _blob_exists(self, container: str, blob_name: str) -> bool:
+        return True
+
+    def _sas(self, container: str, blob_name: str, ttl_hours: int) -> str:
+        return f"https://example.com/sas/{container}/{blob_name}"
+
+    monkeypatch.setattr(
+        storage_mod.LocalStorageBackend, "blob_exists", _blob_exists,
+    )
+    monkeypatch.setattr(
+        storage_mod.LocalStorageBackend, "generate_blob_sas_url", _sas,
+    )
+
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"x\n",
+        status=ProvisionedImageStatus.READY.value,
+        blob_path="abc/x.img.xz",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+    )
+    db_session.add(pi)
+    await db_session.flush()
+    job = Job(
+        type=JobType.IMAGE_PROVISION, target_id=pi.id,
+        status=JobStatus.DONE,
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/download/{job.id}", follow_redirects=False)
+    assert resp.status_code == 302, resp.text
+    assert resp.headers.get("location", "").startswith("https://example.com/sas/")
+
+
+# ── Audit ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_writes_audit_row(client, db_session, imager_settings):
+    from cms.models.audit_log import AuditLog
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "x.img.xz",
+        },
+    )
+    assert resp.status_code == 200
+
+    rows = (await db_session.execute(
+        select(AuditLog).where(AuditLog.action == "imager.build")
+    )).scalars().all()
+    assert len(rows) == 1
+    details = rows[0].details or {}
+    # Ensure the secret is NOT in the audit details.
+    assert "c2VjcmV0LWJhc2U2NA==" not in str(details)
+    assert details.get("fleet_id") == "fleet-test"
+
+
+@pytest.mark.asyncio
+async def test_import_writes_audit_row(client, db_session, patch_catalog_ok):
+    from cms.models.audit_log import AuditLog
+    resp = await client.post(
+        "/api/imager/base-images",
+        json={"variant": "pi5", "version": "v1.11.28"},
+    )
+    assert resp.status_code == 200
+    rows = (await db_session.execute(
+        select(AuditLog).where(AuditLog.action == "imager.base_image.import")
+    )).scalars().all()
+    assert len(rows) == 1

--- a/tests/test_rbac_matrix.py
+++ b/tests/test_rbac_matrix.py
@@ -130,6 +130,18 @@ ENDPOINTS: list[EP] = [
     # ── Logs ──
     EP("GET", "/api/cms/logs", (ADMIN, OPERATOR, VIEWER)),
 
+    # ── Imager (browser-driven Pi image provisioning) ──
+    EP("GET", "/api/imager/fleets", (ADMIN, OPERATOR)),
+    EP("GET", "/api/imager/base-images", (ADMIN, OPERATOR)),
+    EP("GET", "/api/imager/catalog", (ADMIN,)),
+    EP("POST", "/api/imager/base-images", (ADMIN,),
+       json_body={"variant": "pi5", "version": "v1.0"}),
+    EP("DELETE", f"/api/imager/base-images/{_FAKE_ID}", (ADMIN,)),
+    EP("POST", "/api/imager/build", (ADMIN, OPERATOR),
+       json_body={"base_image_id": _FAKE_ID, "fleet_id": "x", "output_name": "x.img.xz"}),
+    EP("GET", f"/api/imager/jobs/{_FAKE_ID}", (ADMIN, OPERATOR)),
+    EP("GET", f"/api/imager/download/{_FAKE_ID}", (ADMIN, OPERATOR)),
+
     # ── Admin-managed API keys ──
     EP("GET", "/api/keys", (ADMIN,)),
     EP("POST", "/api/keys", (ADMIN,), json_body={}),

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 import logging
 import re
 import shutil
@@ -53,7 +52,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import httpx
 from sqlalchemy import select
@@ -64,6 +62,14 @@ from shared.models.imager import (
     BaseImageStatus,
     ProvisionedImage,
     ProvisionedImageStatus,
+)
+from shared.services.imager_catalog import (
+    HTTP_TIMEOUT as _HTTP_TIMEOUT,
+    MAX_REDIRECTS as _MAX_REDIRECTS,
+    CatalogError,
+    fetch_catalog as _fetch_catalog_shared,
+    parse_allowed_hosts,
+    validate_url as _validate_url_shared,
 )
 from shared.services.storage import get_storage
 
@@ -106,40 +112,21 @@ _BASE_BLOB_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/base\.img\.xz
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 # Bound the chunked download buffer.
 _DOWNLOAD_CHUNK_BYTES = 1 << 20  # 1 MiB
-# Hard ceiling on how many redirect hops we will walk while validating
-# every Location against the allowlist.  GitHub-Releases->blob normally
-# resolves in <=2 hops.
-_MAX_REDIRECTS = 5
-# Default per-handler total HTTP timeout (catalog + download both).
-_HTTP_TIMEOUT = httpx.Timeout(connect=15.0, read=120.0, write=120.0, pool=15.0)
 
 
 # ── Internal helpers ──────────────────────────────────────────────
 
 
 def _allowed_hosts(settings: Any) -> set[str]:
-    raw = getattr(settings, "base_image_allowed_hosts", "") or ""
-    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+    return parse_allowed_hosts(getattr(settings, "base_image_allowed_hosts", ""))
 
 
 def _validate_url(url: str, allowlist: set[str]) -> str:
-    """Return ``url`` iff its scheme is https and host is allowlisted.
-
-    Raises ``TerminalImagerError`` otherwise.  Centralised so the
-    same rule applies to the catalog URL **and** every redirect
-    target while streaming the image.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme != "https":
-        raise TerminalImagerError(
-            f"refusing non-https url for imager fetch: scheme={parsed.scheme!r}"
-        )
-    host = (parsed.hostname or "").lower()
-    if host not in allowlist:
-        raise TerminalImagerError(
-            f"host {host!r} not in base_image_allowed_hosts ({sorted(allowlist)})"
-        )
-    return url
+    """Wrap the shared validator and surface failures as terminal."""
+    try:
+        return _validate_url_shared(url, allowlist)
+    except CatalogError as e:
+        raise TerminalImagerError(str(e)) from e
 
 
 async def _free_bytes(path: Path) -> int:
@@ -201,32 +188,11 @@ async def _set_provisioned_terminal(
 async def _fetch_catalog(
     catalog_url: str, allowlist: set[str], client: httpx.AsyncClient
 ) -> dict[str, Any]:
-    """Resolve + parse the upstream catalog.json.
-
-    Returns the parsed JSON.  Raises ``TerminalImagerError`` on
-    allowlist violation or non-JSON; raises generic exceptions
-    (caught + retried by the dispatcher) on transient network errors.
-    """
-    _validate_url(catalog_url, allowlist)
-    resp = await client.get(catalog_url, follow_redirects=False)
-    # Walk redirect chain manually so every Location is allowlisted.
-    hops = 0
-    while resp.is_redirect and hops < _MAX_REDIRECTS:
-        loc = resp.headers.get("location")
-        if not loc:
-            raise httpx.RemoteProtocolError("redirect without Location")
-        _validate_url(loc, allowlist)
-        resp = await client.get(loc, follow_redirects=False)
-        hops += 1
-    if resp.is_redirect:
-        raise TerminalImagerError(
-            f"too many redirects ({_MAX_REDIRECTS}) fetching catalog"
-        )
-    resp.raise_for_status()
+    """Wrap the shared catalog fetcher; surface CatalogError as terminal."""
     try:
-        return resp.json()
-    except json.JSONDecodeError as e:
-        raise TerminalImagerError(f"catalog is not valid json: {e}") from e
+        return await _fetch_catalog_shared(catalog_url, allowlist, client)
+    except CatalogError as e:
+        raise TerminalImagerError(str(e)) from e
 
 
 async def _download_with_sha(


### PR DESCRIPTION
# PR 4 — Imager API endpoints

## Summary

Adds the FastAPI HTTP layer that drives the worker handlers shipped in
PR 3 ([#504](https://github.com/sslivins/agora-cms/pull/504)). Together
with the upcoming PR 5 (UI page) this completes the browser-driven Pi
image provisioning flow.

## Endpoints

All under `/api/imager`:

| Method | Path | Permission | Purpose |
|---|---|---|---|
| GET | `/fleets` | `IMAGER_READ` | list configured fleet IDs (no secrets) |
| GET | `/catalog` | `IMAGER_MANAGE` | live-fetch upstream catalog manifest |
| GET | `/base-images` | `IMAGER_READ` | list cached `BaseImage` rows |
| POST | `/base-images` | `IMAGER_MANAGE` | enqueue `IMAGE_IMPORT` (idempotent) |
| DELETE | `/base-images/{id}` | `IMAGER_MANAGE` | delete row + blob (409 if referenced) |
| POST | `/build` | `IMAGER_BUILD` | enqueue `IMAGE_PROVISION` |
| GET | `/jobs/{id}` | `IMAGER_READ` | status; download URL when DONE |
| GET | `/download/{id}` | `IMAGER_BUILD` | 302 to fresh SAS (audited) |

## Image identity model — Model B only

The image carries `(AGORA_CMS_URL, AGORA_FLEET_ID, AGORA_FLEET_SECRET)`
so a fresh Pi flashed with the image can call `POST /api/devices/register`
with a valid fleet HMAC and pair as a brand-new device via the existing
`bootstrap.py` flow. **No per-device API key is minted at build time.**
Device-targeted re-flashes (Model A) are tracked separately in
[#505](https://github.com/sslivins/agora-cms/issues/505).

The `fleet_env_payload` is stored **plaintext** in DB. The real-world
surface (image blob, SD card, CMS env config) is already plaintext;
encrypting only the brief DB copy adds little defense-in-depth without
a separate key-store.

## Permissions

Three new constants plumbed through all existing role lists:

- `IMAGER_READ` — Admin + Operator
- `IMAGER_BUILD` — Admin + Operator
- `IMAGER_MANAGE` — Admin only

## Schema

Migration `0019_imager_provisioned_fleet_id` adds a nullable
`fleet_id TEXT` column to `provisioned_images` so audit can reconstruct
which fleet a build was provisioned for, without storing the secret.

## Shared helpers

The URL allowlist + httpx catalog fetch logic that PR 3 added to the
worker has been extracted to `shared/services/imager_catalog.py` so
the API and worker share a single implementation. Worker retains thin
wrappers that translate `CatalogError` into `TerminalImagerError` to
preserve dispatcher retry semantics.

## Audit envelope

Build, import, delete, and download record audit rows. Catalog reads
and job-status polls are intentionally not audited (high-volume,
low-value). Audit details for `build` include `fleet_id` but never
the fleet secret.

## Tests

- `tests/test_imager_api.py` — 29 tests: RBAC, schema validation,
  catalog wiring, idempotent imports, 409 on delete-with-references,
  build payload + audit, download SAS handling.
- `tests/test_rbac_matrix.py` — 8 new endpoint rows for systematic
  auth-gate coverage.

Full local run: `479 passed, 6 skipped` across imager + RBAC suites.

## Out of scope

- UI (PR 5)
- rpi-imager `catalog.json` (PR 6)
- Device-targeted re-flashes (#505)
