### PR TITLE
test(nightly): make log-request poll more resilient and diagnostic

### DIFF
--- a/tests/nightly/test_12b_logs_success_paths.py
+++ b/tests/nightly/test_12b_logs_success_paths.py
@@ -32,7 +32,9 @@ from playwright.sync_api import Page
 from tests.nightly.helpers.simulator import SimulatorClient
 
 
-LOGS_POLL_TIMEOUT_S = 60.0
+# Generous to absorb scheduling pauses under full nightly E2E load (one sim
+# stack handles ~88 tests). Small-payload completion is normally sub-second.
+LOGS_POLL_TIMEOUT_S = 120.0
 COUNTER_POLL_TIMEOUT_S = 30.0
 
 # Stay comfortably under the firmware ``LOGS_JSON_MAX_BYTES`` (900_000) on the
@@ -68,7 +70,14 @@ def _wait_for_online(page: Page, device_id: str, timeout: float):
     raise AssertionError(f"device {device_id} did not come online in {timeout}s")
 
 
-def _poll_log_request_ready(page: Page, request_id: str, *, timeout: float) -> dict:
+def _poll_log_request_ready(
+    page: Page,
+    request_id: str,
+    *,
+    timeout: float,
+    sim: SimulatorClient | None = None,
+    serial: str | None = None,
+) -> dict:
     deadline = time.monotonic() + timeout
     last: dict = {}
     while time.monotonic() < deadline:
@@ -84,8 +93,17 @@ def _poll_log_request_ready(page: Page, request_id: str, *, timeout: float) -> d
                 f"log request {request_id} failed: {last!r}"
             )
         time.sleep(1.0)
+    # Timeout — pull sim-side counters so the failure message tells us whether
+    # the device actually received the WS request or if the hop was lost.
+    extra = ""
+    if sim is not None and serial is not None:
+        try:
+            rec = sim.get_recording(serial)
+            extra = f"; sim recording on {serial}: {rec!r}"
+        except Exception as e:  # noqa: BLE001 — diagnostic best-effort
+            extra = f"; sim get_recording({serial}) raised: {e!r}"
     raise AssertionError(
-        f"log request {request_id} did not reach ready in {timeout}s: {last!r}"
+        f"log request {request_id} did not reach ready in {timeout}s: {last!r}{extra}"
     )
 
 
@@ -177,7 +195,10 @@ def test_request_logs_small_payload_takes_ws_json_branch(
     )
     request_id = resp.json()["request_id"]
 
-    final = _poll_log_request_ready(page, request_id, timeout=LOGS_POLL_TIMEOUT_S)
+    final = _poll_log_request_ready(
+        page, request_id, timeout=LOGS_POLL_TIMEOUT_S,
+        sim=simulator, serial=device_id,
+    )
     assert final.get("status") == "ready"
 
     # Branch proof: the firmware took the JSON-over-WS path.
@@ -226,7 +247,10 @@ def test_request_logs_large_payload_takes_http_upload_branch(
     )
     request_id = resp.json()["request_id"]
 
-    final = _poll_log_request_ready(page, request_id, timeout=LOGS_POLL_TIMEOUT_S)
+    final = _poll_log_request_ready(
+        page, request_id, timeout=LOGS_POLL_TIMEOUT_S,
+        sim=simulator, serial=device_id,
+    )
     assert final.get("status") == "ready"
 
     # Branch proof: the firmware took the HTTP-upload path.


### PR DESCRIPTION
Follow-up after PR #507's smoke run hit a flake on `test_request_logs_small_payload_takes_ws_json_branch`.```Failure was: log request reached `sent` in 2 ms but never reached `ready` in 60 s (`attempts=1`, `last_error=None` — WS send succeeded but the device's `logs_response` reply never came back). Under full nightly E2E load (one sim stack handling ~88 tests in series) this can happen if scheduling pauses stretch the round-trip beyond 60 s.```## Changes`- Bump `LOGS_POLL_TIMEOUT_S` from 60.0 → 120.0. Small-payload completion is normally sub-second; doubling absorbs sim scheduling jitter without hiding real bugs (`status=='failed'` still raises immediately).`- Thread the simulator client + serial into `_poll_log_request_ready` so the timeout assertion message includes the sim recorder dump. Future failures reveal whether the device received and started processing the WS request, or whether the hop was lost — instead of just the CMS-side row state.```UI / runtime behaviour unchanged.`