### PR TITLE
feat(imager): wire BASE_IMAGE_CATALOG_URL into CMS + worker env

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -89,6 +89,9 @@ param adminPrincipalId string
 @description('Email recipient for telemetry alerts (CMS 5xx, latency, dependency failures, exceptions). Empty disables the alerts module entirely (e.g. for dev environments where pages are noise).')
 param alertEmail string = ''
 
+@description('Upstream URL of the base-image catalog manifest (catalog.json) used by the Imager feature. Empty disables catalog import (POST /api/imager/base-images and GET /api/imager/catalog return 503). Default points at the rolling stable from sslivins/agora.')
+param baseImageCatalogUrl string = 'https://github.com/sslivins/agora/releases/latest/download/catalog.json'
+
 var tags = {
   project: 'agora-cms'
   managedBy: 'bicep'
@@ -226,6 +229,9 @@ module containerApps 'modules/containerApps.bicep' = {
 
     // Bootstrap v2 fleet secrets (JSON map)
     fleetRegisterSecrets: fleetRegisterSecrets
+
+    // Imager — upstream catalog manifest URL
+    baseImageCatalogUrl: baseImageCatalogUrl
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -9,6 +9,10 @@ param containerAppsSubnetId string
 param containerAppsSubnetCidr string
 param tags object = {}
 
+// ── Imager (browser-driven Pi image provisioning) ──
+@description('Upstream URL of the base-image catalog manifest. Empty disables catalog import.')
+param baseImageCatalogUrl string = ''
+
 // ── CMS App config ──
 param cmsAppName string
 param cmsImage string
@@ -291,6 +295,14 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'OTEL_RESOURCE_ATTRIBUTES'
               value: 'service.name=agora-cms,service.namespace=agora,deployment.environment=${environmentName}'
             }
+            {
+              // Imager: upstream catalog manifest. Empty → /api/imager/catalog
+              // and POST /api/imager/base-images return 503. The CMS only
+              // needs this for the UI list + import-time SHA pinning; the
+              // actual base-image download happens in the worker.
+              name: 'AGORA_CMS_BASE_IMAGE_CATALOG_URL'
+              value: baseImageCatalogUrl
+            }
           ]
           volumeMounts: [
             {
@@ -473,6 +485,13 @@ resource workerJob 'Microsoft.App/jobs@2024-03-01' = {
             {
               name: 'AZURE_STORAGE_CONNECTION_STRING'
               secretRef: 'storage-connection-string'
+            }
+            {
+              // Imager: catalog URL is read by the worker fallback path
+              // (worker/imager_handlers.py) when a BaseImage row lacks a
+              // stamped source_url — defensive, normally unused.
+              name: 'AGORA_CMS_BASE_IMAGE_CATALOG_URL'
+              value: baseImageCatalogUrl
             }
           ]
           volumeMounts: [


### PR DESCRIPTION
## What

Adds the `AGORA_CMS_BASE_IMAGE_CATALOG_URL` env var to the CMS and worker containers via a new Bicep param `baseImageCatalogUrl`, defaulted to the rolling-stable manifest from `sslivins/agora`:

```nhttps://github.com/sslivins/agora/releases/latest/download/catalog.json
```

## Why

The Imager feature (PR #502, #503, #506, #507) is fully implemented end-to-end, but `GET /api/imager/catalog` and `POST /api/imager/base-images` return **503 'imager catalog url is not configured'** because the env var was never wired up. The user-facing symptom is that pressing **'Import from catalog…'** on `/imager` opens the modal showing `Failed to load catalog: …`.

## Changed files

- `infra/main.bicep` — new param `baseImageCatalogUrl` (default = upstream rolling-stable URL); passed to `containerApps` module.
- `infra/modules/containerApps.bicep` — accepts the param, injects it into both the CMS container env block and the worker job env block.

## Notes

- The allowed-hosts list (`AGORA_CMS_BASE_IMAGE_ALLOWED_HOSTS`) already defaults correctly in `shared/config.py` to `github.com,objects.githubusercontent.com` — no env var needed.
- Tenants who want a different catalog (e.g. a fork) can override `baseImageCatalogUrl` in their bicepparam file. Empty string disables catalog import (returns 503), which is the existing behavior.
- Catalog feature won't actually work until `sslivins/agora` publishes a `catalog.json` to a release — that's tracked by a separate test PR opening shortly to trigger the post-#157 chain end-to-end.

## Verification

`az bicep build` passes (warnings are pre-existing, unrelated to this PR).