### PR TITLE
feat(imager): admin-configurable catalog URL + fix modal crash

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -56,6 +56,12 @@ from cms.models.user import User
 from cms.permissions import IMAGER_BUILD, IMAGER_MANAGE, IMAGER_READ
 from cms.services.audit_service import audit_log
 from cms.services.imager import is_valid_output_name
+from cms.services.imager_settings import (
+    CatalogUrlValidationError,
+    get_catalog_url,
+    set_catalog_url,
+    validate_catalog_url,
+)
 from shared.models.imager import (
     BaseImage,
     BaseImageStatus,
@@ -127,6 +133,21 @@ class BuildBody(BaseModel):
     output_name: str = Field(..., min_length=1, max_length=255)
 
 
+class ImagerSettingsOut(BaseModel):
+    """Imager runtime settings exposed over the API.
+
+    ``catalog_url`` is ``None`` when no catalog URL has been
+    configured -- the UI uses this to disable the "Import from
+    catalog" button and show an admin-targeted prompt to configure it.
+    """
+
+    catalog_url: str | None = None
+
+
+class ImagerSettingsUpdateBody(BaseModel):
+    catalog_url: str = Field(..., min_length=1, max_length=2048)
+
+
 class JobStatusOut(BaseModel):
     job_id: uuid.UUID
     type: str
@@ -144,12 +165,23 @@ class JobStatusOut(BaseModel):
 # ── Helpers ──────────────────────────────────────────────────────
 
 
-def _ensure_catalog_url(settings: Settings) -> str:
-    url = (settings.base_image_catalog_url or "").strip()
+async def _resolve_catalog_url_or_503(db: AsyncSession) -> str:
+    """Return the DB-configured catalog URL or raise 503.
+
+    PR 7 moved the catalog URL from a deploy-time env var to a runtime
+    setting an admin can edit at ``PUT /api/imager/settings``.  All
+    callers that previously read ``settings.base_image_catalog_url``
+    use this helper so a missing setting renders a helpful 503 instead
+    of failing later inside the catalog fetch.
+    """
+    url = await get_catalog_url(db)
     if not url:
         raise HTTPException(
             status_code=503,
-            detail="BASE_IMAGE_CATALOG_URL is not configured",
+            detail=(
+                "imager catalog URL is not configured; "
+                "set it via PUT /api/imager/settings"
+            ),
         )
     return url
 
@@ -224,9 +256,57 @@ async def list_fleets(
     return [FleetOut(fleet_id=f) for f in fleets]
 
 
+@router.get("/settings", response_model=ImagerSettingsOut)
+async def get_imager_settings(
+    user: User = Depends(require_permission(IMAGER_READ)),
+    db: AsyncSession = Depends(get_db),
+) -> ImagerSettingsOut:
+    """Return the current imager runtime settings.
+
+    Always 200; ``catalog_url`` may be ``None`` when unset, which the
+    UI uses to disable the "Import from catalog" button.
+    """
+    url = await get_catalog_url(db)
+    return ImagerSettingsOut(catalog_url=url)
+
+
+@router.put("/settings", response_model=ImagerSettingsOut)
+async def update_imager_settings(
+    body: ImagerSettingsUpdateBody,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_MANAGE)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> ImagerSettingsOut:
+    """Set the imager catalog URL.
+
+    Validates that the URL is https and the host is in
+    ``BASE_IMAGE_ALLOWED_HOSTS``.  Audited.
+    """
+    try:
+        cleaned = validate_catalog_url(
+            body.catalog_url, settings.base_image_allowed_hosts
+        )
+    except CatalogUrlValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    stored = await set_catalog_url(db, cleaned)
+    await audit_log(
+        db,
+        user=user,
+        action="imager.settings.update",
+        resource_type="imager_settings",
+        resource_id="catalog_url",
+        details={"catalog_url": stored},
+        request=request,
+    )
+    await db.commit()
+    return ImagerSettingsOut(catalog_url=stored)
+
+
 @router.get("/catalog", response_model=CatalogOut)
 async def get_catalog(
     user: User = Depends(require_permission(IMAGER_MANAGE)),
+    db: AsyncSession = Depends(get_db),
     settings: Settings = Depends(get_settings),
 ) -> CatalogOut:
     """Live-fetch and parse the upstream catalog manifest.
@@ -234,7 +314,7 @@ async def get_catalog(
     Side-effect-free; intended for the UI to populate the
     "import a new base image" picker without writing anything to DB.
     """
-    catalog_url = _ensure_catalog_url(settings)
+    catalog_url = await _resolve_catalog_url_or_503(db)
     allowlist = _allowlist(settings)
     if not allowlist:
         raise HTTPException(
@@ -305,7 +385,7 @@ async def import_base_image(
     # at enqueue time.  This eliminates the TOCTOU window between admin
     # click and worker pickup (worker uses the stamped values, not the
     # mutable catalog).
-    catalog_url = _ensure_catalog_url(settings)
+    catalog_url = await _resolve_catalog_url_or_503(db)
     allowlist = _allowlist(settings)
     try:
         async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:

--- a/cms/services/imager_settings.py
+++ b/cms/services/imager_settings.py
@@ -1,0 +1,99 @@
+"""Imager settings persisted in the ``cms_settings`` key/value table.
+
+Currently only ``imager.catalog_url`` lives here, but the module is
+written generically so future imager-related runtime settings can be
+added without proliferating tables.
+
+Storing the catalog URL in the DB (instead of an env var) lets a
+tenant admin point their CMS at a different upstream catalog from the
+UI without a redeploy.  The deploy-time env var was removed in PR 7.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.setting import CMSSetting
+from shared.services.imager_catalog import parse_allowed_hosts
+
+
+CATALOG_URL_KEY = "imager.catalog_url"
+
+
+class CatalogUrlValidationError(ValueError):
+    """Raised when a candidate catalog URL fails validation.
+
+    Carries a single ``message`` attribute suitable for surfacing
+    directly to the admin via an HTTP 422 response.
+    """
+
+
+def validate_catalog_url(url: str, allowed_hosts_raw: str) -> str:
+    """Return ``url`` (stripped) iff scheme is https and host allowlisted.
+
+    The URL must be ``https://`` and its hostname must appear in the
+    deploy-time ``base_image_allowed_hosts`` list.  We deliberately
+    keep the allowlist as a deployment guard rail (not user-tunable)
+    even though the URL itself is now user-tunable -- it limits the
+    blast radius if an admin account is compromised.
+    """
+    candidate = (url or "").strip()
+    if not candidate:
+        raise CatalogUrlValidationError("catalog URL must not be empty")
+    parsed = urlparse(candidate)
+    if parsed.scheme != "https":
+        raise CatalogUrlValidationError(
+            f"catalog URL must use https (got scheme={parsed.scheme!r})"
+        )
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise CatalogUrlValidationError("catalog URL has no hostname")
+    allowlist = parse_allowed_hosts(allowed_hosts_raw)
+    if not allowlist:
+        raise CatalogUrlValidationError(
+            "BASE_IMAGE_ALLOWED_HOSTS is empty; refusing to accept any URL"
+        )
+    if host not in allowlist:
+        raise CatalogUrlValidationError(
+            f"host {host!r} is not in BASE_IMAGE_ALLOWED_HOSTS ({sorted(allowlist)})"
+        )
+    return candidate
+
+
+async def get_catalog_url(db: AsyncSession) -> str | None:
+    """Return the configured catalog URL, or ``None`` if unset."""
+    result = await db.execute(
+        select(CMSSetting.value).where(CMSSetting.key == CATALOG_URL_KEY)
+    )
+    value = result.scalar_one_or_none()
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+async def set_catalog_url(db: AsyncSession, url: str) -> str:
+    """Upsert the catalog URL.  Returns the stored (stripped) value.
+
+    Caller is responsible for validation (call :func:`validate_catalog_url`
+    first) and for committing the session.  Empty / whitespace-only
+    values clear the setting.
+    """
+    cleaned = (url or "").strip()
+    result = await db.execute(
+        select(CMSSetting).where(CMSSetting.key == CATALOG_URL_KEY)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        db.add(CMSSetting(key=CATALOG_URL_KEY, value=cleaned))
+    else:
+        row.value = cleaned
+    return cleaned
+
+
+async def clear_catalog_url(db: AsyncSession) -> None:
+    """Clear the catalog URL setting (sets value to empty string)."""
+    await set_catalog_url(db, "")

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -75,9 +75,28 @@
 <div class="card" data-imager-manage>
     <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
         <h3 style="margin:0;">Base Images</h3>
+        {% if imager_catalog_url %}
         <button id="imagerCatalogBtn" type="button" class="btn btn-secondary">Import from catalog…</button>
+        {% else %}
+        <button id="imagerCatalogBtn" type="button" class="btn btn-secondary" disabled
+                title="Configure the catalog URL below before importing.">Import from catalog…</button>
+        {% endif %}
     </div>
-    <p class="text-muted" style="margin-top:0.25rem;">
+
+    {# Catalog URL configuration row.  PR 7 made this a runtime DB
+       setting so an admin can flip it from the UI. #}
+    <div id="imagerCatalogUrlRow"
+         style="margin-top:0.75rem; padding:0.5rem 0.75rem; border:1px solid #e5e7eb; border-radius:4px; background:#f9fafb; display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <span class="text-muted" style="font-weight:600;">Catalog URL:</span>
+        {% if imager_catalog_url %}
+        <code id="imagerCatalogUrlText" style="flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ imager_catalog_url }}</code>
+        {% else %}
+        <span id="imagerCatalogUrlText" class="text-muted" style="flex:1; font-style:italic;">not configured</span>
+        {% endif %}
+        <button id="imagerCatalogUrlEditBtn" type="button" class="btn btn-sm btn-secondary">Edit…</button>
+    </div>
+
+    <p class="text-muted" style="margin-top:0.5rem;">
         Cached upstream Raspberry Pi base images. Each version is downloaded once
         per CMS instance and reused for every build.
     </p>
@@ -101,6 +120,27 @@
                 <tr><td colspan="7" class="empty-state text-muted">Loading…</td></tr>
             </tbody>
         </table>
+    </div>
+</div>
+
+{# ── Catalog URL edit modal ─────────────────────────────────────── #}
+<div id="imagerCatalogUrlModal" class="modal-overlay" style="display:none;">
+    <div class="modal-box" style="max-width:560px;">
+        <h3 style="margin-top:0;">Catalog URL</h3>
+        <p class="text-muted" style="margin-top:0;">
+            URL of the upstream <code>catalog.json</code> manifest. Must be
+            <code>https://</code> on an allow-listed host.
+        </p>
+        <form id="imagerCatalogUrlForm" onsubmit="return false;">
+            <input type="url" id="imagerCatalogUrlInput" class="form-control"
+                   placeholder="https://github.com/&hellip;/catalog.json"
+                   style="width:100%;" required>
+            <p id="imagerCatalogUrlError" class="text-danger" style="display:none; margin:0.5rem 0 0;"></p>
+            <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" onclick="imagerCloseCatalogUrl()">Cancel</button>
+                <button type="submit" id="imagerCatalogUrlSave" class="btn btn-primary">Save</button>
+            </div>
+        </form>
     </div>
 </div>
 
@@ -458,9 +498,9 @@
 
     // ── Catalog modal ─────────────────────────────────────────
     function openCatalog() {
-        if (!manageSection) return;
-        var modal = $('#imagerCatalogModal', manageSection);
-        var body = $('#imagerCatalogBody', manageSection);
+        var modal = $('#imagerCatalogModal');
+        var body = $('#imagerCatalogBody');
+        if (!modal || !body) return;
         body.innerHTML = '<p class="empty-state text-muted">Loading catalog…</p>';
         modal.style.display = '';
         jsonFetch('/api/imager/catalog').then(function(cat) {
@@ -508,9 +548,56 @@
     }
 
     window.imagerCloseCatalog = function() {
-        if (!manageSection) return;
-        $('#imagerCatalogModal', manageSection).style.display = 'none';
+        var modal = $('#imagerCatalogModal');
+        if (modal) modal.style.display = 'none';
     };
+
+    // ── Catalog URL settings modal ────────────────────────────
+    function openCatalogUrl() {
+        var modal = $('#imagerCatalogUrlModal');
+        var input = $('#imagerCatalogUrlInput');
+        var err = $('#imagerCatalogUrlError');
+        if (!modal || !input) return;
+        err.style.display = 'none';
+        input.value = '';
+        // Pre-populate with the current value if any.
+        jsonFetch('/api/imager/settings').then(function(data) {
+            if (data && data.catalog_url) input.value = data.catalog_url;
+        }).catch(function() { /* leave blank on error */ });
+        modal.style.display = '';
+        setTimeout(function() { input.focus(); }, 0);
+    }
+
+    window.imagerCloseCatalogUrl = function() {
+        var modal = $('#imagerCatalogUrlModal');
+        if (modal) modal.style.display = 'none';
+    };
+
+    async function submitCatalogUrl(ev) {
+        ev.preventDefault();
+        var input = $('#imagerCatalogUrlInput');
+        var saveBtn = $('#imagerCatalogUrlSave');
+        var err = $('#imagerCatalogUrlError');
+        if (!input) return;
+        var url = (input.value || '').trim();
+        err.style.display = 'none';
+        saveBtn.disabled = true;
+        try {
+            var data = await jsonFetch('/api/imager/settings', {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ catalog_url: url }),
+            });
+            toast('Catalog URL saved', 'success');
+            // Reload the page so the disabled-state of the import button
+            // and the visible URL row update from server-rendered state.
+            window.location.reload();
+        } catch (e) {
+            err.textContent = e.message || String(e);
+            err.style.display = '';
+            saveBtn.disabled = false;
+        }
+    }
 
     async function importBase(variant, version, btn) {
         btn.disabled = true;
@@ -550,7 +637,12 @@
     }
 
     if (manageSection) {
-        $('#imagerCatalogBtn', manageSection).addEventListener('click', openCatalog);
+        var catBtn = $('#imagerCatalogBtn', manageSection);
+        if (catBtn) catBtn.addEventListener('click', openCatalog);
+        var urlEditBtn = $('#imagerCatalogUrlEditBtn', manageSection);
+        if (urlEditBtn) urlEditBtn.addEventListener('click', openCatalogUrl);
+        var urlForm = $('#imagerCatalogUrlForm');
+        if (urlForm) urlForm.addEventListener('submit', submitCatalogUrl);
         loadBaseImages();
     }
 

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -2537,6 +2537,7 @@ async def imager_page(
     request: Request,
     _user: User = Depends(require_permission(IMAGER_READ)),
     settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
 ):
     """Browser-driven Pi image provisioning page.
 
@@ -2549,10 +2550,14 @@ async def imager_page(
     access see explanatory empty state.  All data is loaded client-side
     via the ``/api/imager/*`` endpoints.
     """
+    from cms.services.imager_settings import get_catalog_url
+
     perms = _user.role.permissions if _user.role else []
+    catalog_url = await get_catalog_url(db)
     return templates.TemplateResponse(request, "imager.html", {
         "active_tab": "imager",
         "imager_can_build": has_permission(perms, IMAGER_BUILD),
         "imager_can_manage": has_permission(perms, IMAGER_MANAGE),
+        "imager_catalog_url": catalog_url,
         "provisioned_retention_hours": settings.provisioned_retention_hours,
     })

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -89,9 +89,6 @@ param adminPrincipalId string
 @description('Email recipient for telemetry alerts (CMS 5xx, latency, dependency failures, exceptions). Empty disables the alerts module entirely (e.g. for dev environments where pages are noise).')
 param alertEmail string = ''
 
-@description('Upstream URL of the base-image catalog manifest (catalog.json) used by the Imager feature. Empty disables catalog import (POST /api/imager/base-images and GET /api/imager/catalog return 503). Default points at the rolling stable from sslivins/agora.')
-param baseImageCatalogUrl string = 'https://github.com/sslivins/agora/releases/latest/download/catalog.json'
-
 var tags = {
   project: 'agora-cms'
   managedBy: 'bicep'
@@ -229,9 +226,6 @@ module containerApps 'modules/containerApps.bicep' = {
 
     // Bootstrap v2 fleet secrets (JSON map)
     fleetRegisterSecrets: fleetRegisterSecrets
-
-    // Imager — upstream catalog manifest URL
-    baseImageCatalogUrl: baseImageCatalogUrl
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -9,10 +9,6 @@ param containerAppsSubnetId string
 param containerAppsSubnetCidr string
 param tags object = {}
 
-// ── Imager (browser-driven Pi image provisioning) ──
-@description('Upstream URL of the base-image catalog manifest. Empty disables catalog import.')
-param baseImageCatalogUrl string = ''
-
 // ── CMS App config ──
 param cmsAppName string
 param cmsImage string
@@ -295,14 +291,6 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'OTEL_RESOURCE_ATTRIBUTES'
               value: 'service.name=agora-cms,service.namespace=agora,deployment.environment=${environmentName}'
             }
-            {
-              // Imager: upstream catalog manifest. Empty → /api/imager/catalog
-              // and POST /api/imager/base-images return 503. The CMS only
-              // needs this for the UI list + import-time SHA pinning; the
-              // actual base-image download happens in the worker.
-              name: 'AGORA_CMS_BASE_IMAGE_CATALOG_URL'
-              value: baseImageCatalogUrl
-            }
           ]
           volumeMounts: [
             {
@@ -485,13 +473,6 @@ resource workerJob 'Microsoft.App/jobs@2024-03-01' = {
             {
               name: 'AZURE_STORAGE_CONNECTION_STRING'
               secretRef: 'storage-connection-string'
-            }
-            {
-              // Imager: catalog URL is read by the worker fallback path
-              // (worker/imager_handlers.py) when a BaseImage row lacks a
-              // stamped source_url — defensive, normally unused.
-              name: 'AGORA_CMS_BASE_IMAGE_CATALOG_URL'
-              value: baseImageCatalogUrl
             }
           ]
           volumeMounts: [

--- a/shared/config.py
+++ b/shared/config.py
@@ -22,10 +22,11 @@ class SharedSettings(BaseSettings):
     azure_sas_expiry_hours: int = 1
 
     # ── Imager (browser-driven Pi image provisioning, Option E) ────
-    # Optional.  Only required when an admin actually triggers a
-    # catalog import or a provisioning build.  Empty default keeps
-    # existing deployments boot-clean until the imager UI ships.
-    base_image_catalog_url: str = ""
+    # NOTE (PR 7): the catalog URL was previously a deploy-time env var
+    # (``base_image_catalog_url``) but is now stored as a runtime setting
+    # in the ``cms_settings`` table (key ``imager.catalog_url``) and
+    # edited via ``PUT /api/imager/settings``.  See
+    # :mod:`cms.services.imager_settings`.
     # Hostname allowlist for upstream catalog + image fetches.  The
     # worker refuses fetches whose URL host is not in this list.
     # Default covers GitHub Releases (the only host upstream uses).

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -45,10 +45,13 @@ def imager_settings(app):
 
     Mutates the singleton settings instance the app fixture installed
     via ``dependency_overrides``.  Restores defaults on teardown.
+
+    NOTE: PR 7 moved the catalog URL out of ``Settings`` and into the
+    ``cms_settings`` table.  Tests that need a URL configured should
+    use the :func:`imager_catalog_url` fixture as well.
     """
     settings = app.dependency_overrides[get_settings]()
     saved = {
-        "base_image_catalog_url": settings.base_image_catalog_url,
         "base_image_allowed_hosts": settings.base_image_allowed_hosts,
         "base_image_cache_container": settings.base_image_cache_container,
         "provisioned_container": settings.provisioned_container,
@@ -56,9 +59,6 @@ def imager_settings(app):
         "fleet_register_secrets": dict(settings.fleet_register_secrets or {}),
         "base_url": settings.base_url,
     }
-    settings.base_image_catalog_url = (
-        "https://github.com/sslivins/agora/releases/download/v1.11.28/catalog.json"
-    )
     settings.base_image_allowed_hosts = "github.com,objects.githubusercontent.com"
     settings.base_image_cache_container = "base-images"
     settings.provisioned_container = "provisioned"
@@ -68,6 +68,24 @@ def imager_settings(app):
     yield settings
     for k, v in saved.items():
         setattr(settings, k, v)
+
+
+@pytest_asyncio.fixture
+async def imager_catalog_url(db_session):
+    """Seed the imager catalog URL setting in the DB.
+
+    PR 7 moved the URL out of ``Settings``.  Tests that exercise the
+    catalog or base-image-import endpoints need this fixture; tests
+    that exercise the unset/503 path should NOT request it.
+    """
+    from cms.services.imager_settings import set_catalog_url
+
+    url = (
+        "https://github.com/sslivins/agora/releases/download/v1.11.28/catalog.json"
+    )
+    await set_catalog_url(db_session, url)
+    await db_session.commit()
+    return url
 
 
 def _catalog_doc(ref: str = "v1.11.28") -> dict[str, Any]:
@@ -91,7 +109,7 @@ def _catalog_doc(ref: str = "v1.11.28") -> dict[str, Any]:
 
 
 @pytest.fixture
-def patch_catalog_ok(monkeypatch, imager_settings):
+def patch_catalog_ok(monkeypatch, imager_settings, imager_catalog_url):
     """Make every httpx call from the imager router return the canned catalog."""
     body = json.dumps(_catalog_doc()).encode("utf-8")
 
@@ -109,7 +127,7 @@ def patch_catalog_ok(monkeypatch, imager_settings):
 
 
 @pytest.fixture
-def patch_catalog_error(monkeypatch, imager_settings):
+def patch_catalog_error(monkeypatch, imager_settings, imager_catalog_url):
     """Make catalog fetches fail with a network error."""
     def _handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("test simulated network error")
@@ -200,7 +218,7 @@ async def test_list_fleets_returns_configured_ids_no_secrets(client, imager_sett
 
 @pytest.mark.asyncio
 async def test_catalog_503_when_url_unconfigured(client, imager_settings):
-    imager_settings.base_image_catalog_url = ""
+    # Default DB state: no imager.catalog_url row set.
     resp = await client.get("/api/imager/catalog")
     assert resp.status_code == 503
 
@@ -326,7 +344,7 @@ async def test_import_404_on_unknown_variant(client, patch_catalog_ok):
 
 @pytest.mark.asyncio
 async def test_import_503_when_catalog_url_unconfigured(client, imager_settings):
-    imager_settings.base_image_catalog_url = ""
+    # Default DB state: no imager.catalog_url row set.
     resp = await client.post(
         "/api/imager/base-images",
         json={"variant": "pi5", "version": "v1.11.28"},

--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -63,10 +63,9 @@ def _make_settings(tmp_path: Path, **overrides: Any) -> SimpleNamespace:
         imager_scratch_path=str(tmp_path / "scratch"),
         imager_min_free_bytes=1,  # tests run in tmpdirs with plenty of room
         base_image_allowed_hosts="github.com,objects.githubusercontent.com",
-        base_image_catalog_url=(
-            "https://github.com/sslivins/agora/releases/download/"
-            "stable/catalog.json"
-        ),
+        # PR 7: catalog URL is no longer on Settings.  Tests that
+        # exercise the worker fallback path seed a row in
+        # ``cms_settings`` via ``set_catalog_url`` instead.
         base_image_cache_container="base-images",
         provisioned_container="provisioned",
         provisioned_retention_hours=24,
@@ -310,6 +309,8 @@ async def test_import_catalog_fallback(
     db_session, session_factory, storage_backend, tmp_path, monkeypatch
 ):
     """No stamped URL -> resolve via catalog.json, then download."""
+    from cms.services.imager_settings import set_catalog_url
+
     settings = _make_settings(tmp_path)
     payload = b"image-bytes-via-catalog-fallback" * 16
     expected_sha = hashlib.sha256(payload).hexdigest()
@@ -326,6 +327,12 @@ async def test_import_catalog_fallback(
         },
     }
 
+    # PR 7: catalog URL lives in cms_settings now.
+    await set_catalog_url(
+        db_session,
+        "https://github.com/sslivins/agora/releases/download/"
+        "stable/catalog.json",
+    )
     bi = BaseImage(variant="pi5", version="v1.11.28")  # no source_url
     db_session.add(bi)
     await db_session.commit()

--- a/tests/test_imager_schema.py
+++ b/tests/test_imager_schema.py
@@ -256,7 +256,9 @@ def test_shared_settings_imager_defaults() -> None:
     try:
         from shared.config import SharedSettings
         s = SharedSettings()
-        assert s.base_image_catalog_url == ""  # no upstream set
+        # PR 7 removed base_image_catalog_url from Settings; it's now a
+        # runtime DB-backed setting.
+        assert not hasattr(s, "base_image_catalog_url")
         assert s.base_image_cache_container == "base-images"
         assert s.provisioned_container == "provisioned"
         assert s.provisioned_retention_hours == 24

--- a/tests/test_imager_settings.py
+++ b/tests/test_imager_settings.py
@@ -1,0 +1,224 @@
+"""API tests for the imager settings endpoints (PR 7).
+
+Covers ``GET /api/imager/settings`` (IMAGER_READ) and
+``PUT /api/imager/settings`` (IMAGER_MANAGE) -- the new admin-
+configurable catalog URL surface that replaced the
+``BASE_IMAGE_CATALOG_URL`` env var.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.auth import get_settings
+from cms.models.audit_log import AuditLog
+from cms.services.imager_settings import get_catalog_url, set_catalog_url
+
+from tests.test_rbac import _create_user, _login_as
+
+
+@pytest.fixture
+def imager_settings(app):
+    """Configure the singleton settings for imager tests.
+
+    Mirrors :func:`tests.test_imager_api.imager_settings` so this file
+    is self-contained.  Restores defaults on teardown.
+    """
+    settings = app.dependency_overrides[get_settings]()
+    saved = {
+        "base_image_allowed_hosts": settings.base_image_allowed_hosts,
+        "base_url": settings.base_url,
+    }
+    settings.base_image_allowed_hosts = "github.com,objects.githubusercontent.com"
+    settings.base_url = "https://cms.example.com"
+    yield settings
+    for k, v in saved.items():
+        setattr(settings, k, v)
+
+
+@pytest_asyncio.fixture
+async def seeded_url(db_session):
+    """Pre-seed a valid catalog URL in the DB."""
+    url = (
+        "https://github.com/sslivins/agora/releases/download/v1.11.28/catalog.json"
+    )
+    await set_catalog_url(db_session, url)
+    await db_session.commit()
+    return url
+
+
+# -- GET /settings -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_settings_unset_returns_null_url(client, imager_settings):
+    """Default state: setting unset → ``catalog_url`` is null."""
+    resp = await client.get("/api/imager/settings")
+    assert resp.status_code == 200
+    assert resp.json() == {"catalog_url": None}
+
+
+@pytest.mark.asyncio
+async def test_get_settings_returns_configured_url(
+    client, imager_settings, seeded_url
+):
+    resp = await client.get("/api/imager/settings")
+    assert resp.status_code == 200
+    assert resp.json() == {"catalog_url": seeded_url}
+
+
+@pytest.mark.asyncio
+async def test_get_settings_allowed_for_operator(
+    app, db_session, imager_settings, seeded_url
+):
+    """IMAGER_READ is enough to fetch settings (operator role)."""
+    await _create_user(
+        db_session, email="op-settings@test.com", role_name="Operator"
+    )
+    ac = await _login_as(app, "op-settings@test.com")
+    try:
+        resp = await ac.get("/api/imager/settings")
+        assert resp.status_code == 200
+        assert resp.json() == {"catalog_url": seeded_url}
+    finally:
+        await ac.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_settings_denied_for_viewer(
+    app, db_session, imager_settings
+):
+    await _create_user(
+        db_session, email="viewer-settings@test.com", role_name="Viewer"
+    )
+    ac = await _login_as(app, "viewer-settings@test.com")
+    try:
+        resp = await ac.get("/api/imager/settings")
+        assert resp.status_code == 403
+    finally:
+        await ac.aclose()
+
+
+# -- PUT /settings -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_settings_admin_succeeds_and_persists(
+    client, db_session, imager_settings
+):
+    new_url = (
+        "https://github.com/sslivins/agora/releases/download/v1.12.0/catalog.json"
+    )
+    resp = await client.put(
+        "/api/imager/settings", json={"catalog_url": new_url}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"catalog_url": new_url}
+    # Round-trip: GET sees the new value.
+    resp = await client.get("/api/imager/settings")
+    assert resp.json() == {"catalog_url": new_url}
+    # And it really is in the DB.
+    await db_session.commit()  # make sure we see the latest committed view
+    assert await get_catalog_url(db_session) == new_url
+
+
+@pytest.mark.asyncio
+async def test_put_settings_denied_for_operator(
+    app, db_session, imager_settings
+):
+    await _create_user(
+        db_session, email="op-put@test.com", role_name="Operator"
+    )
+    ac = await _login_as(app, "op-put@test.com")
+    try:
+        resp = await ac.put(
+            "/api/imager/settings",
+            json={
+                "catalog_url": (
+                    "https://github.com/sslivins/agora/releases/"
+                    "download/v1.11.28/catalog.json"
+                )
+            },
+        )
+        assert resp.status_code == 403
+    finally:
+        await ac.aclose()
+
+
+@pytest.mark.asyncio
+async def test_put_settings_denied_for_viewer(
+    app, db_session, imager_settings
+):
+    await _create_user(
+        db_session, email="viewer-put@test.com", role_name="Viewer"
+    )
+    ac = await _login_as(app, "viewer-put@test.com")
+    try:
+        resp = await ac.put(
+            "/api/imager/settings",
+            json={
+                "catalog_url": (
+                    "https://github.com/sslivins/agora/releases/"
+                    "download/v1.11.28/catalog.json"
+                )
+            },
+        )
+        assert resp.status_code == 403
+    finally:
+        await ac.aclose()
+
+
+@pytest.mark.asyncio
+async def test_put_settings_rejects_http(client, imager_settings):
+    resp = await client.put(
+        "/api/imager/settings",
+        json={
+            "catalog_url": (
+                "http://github.com/sslivins/agora/releases/"
+                "download/v1.11.28/catalog.json"
+            )
+        },
+    )
+    assert resp.status_code == 422
+    assert "https" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_put_settings_rejects_disallowed_host(client, imager_settings):
+    resp = await client.put(
+        "/api/imager/settings",
+        json={"catalog_url": "https://evil.example.com/catalog.json"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_settings_rejects_blank(client, imager_settings):
+    """Pydantic min_length=1 + service-side strip rejects empty/whitespace."""
+    resp = await client.put(
+        "/api/imager/settings", json={"catalog_url": ""}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_settings_audit_logged(client, db_session, imager_settings):
+    new_url = (
+        "https://github.com/sslivins/agora/releases/download/v1.12.0/catalog.json"
+    )
+    resp = await client.put(
+        "/api/imager/settings", json={"catalog_url": new_url}
+    )
+    assert resp.status_code == 200, resp.text
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "imager.settings.update")
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.resource_type == "imager_settings"
+    assert row.resource_id == "catalog_url"
+    assert row.details == {"catalog_url": new_url}

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -57,6 +57,7 @@ import httpx
 from sqlalchemy import select
 
 from cms.services.imager import ImagerError, build_provisioned
+from cms.services.imager_settings import get_catalog_url
 from shared.models.imager import (
     BaseImage,
     BaseImageStatus,
@@ -318,6 +319,9 @@ async def import_base_image_by_id(
             version = row.version
             source_url = row.source_url
             expected_sha256 = row.expected_sha256
+            # PR 7: catalog URL moved from env var to DB setting.
+            # Read it in the same session so the fallback below has it.
+            catalog_url = await get_catalog_url(db)
 
         # Per-attempt scratch directory.
         scratch = _scratch_dir(settings, "import", base_image_id)
@@ -337,10 +341,9 @@ async def import_base_image_by_id(
             # expected_sha256 at enqueue time.  PR 4 will populate both
             # at insert time, eliminating this fallback.
             if not source_url or not expected_sha256:
-                catalog_url = settings.base_image_catalog_url
                 if not catalog_url:
                     raise TerminalImagerError(
-                        "BASE_IMAGE_CATALOG_URL not configured and row has "
+                        "imager catalog URL is not configured and row has "
                         "no stamped source_url/expected_sha256"
                     )
                 catalog = await _fetch_catalog(catalog_url, allowlist, client)


### PR DESCRIPTION
## Summary

Two related fixes for the `/imager` page based on first prod-run feedback:

1. **Bug**: "Import from catalog…" button crashed with
   `TypeError: Cannot set properties of null (setting 'innerHTML')`
   in the browser console. The modal lookup was scoped to
   `[data-imager-manage]` but the modal is a sibling of that
   section, so the body ref was null.
2. **UX**: The catalog URL was a deploy-time env var
   (`AGORA_CMS_BASE_IMAGE_CATALOG_URL`, wired up by PR #509). For a
   multi-tenant SaaS, admins need to flip it from the UI without
   touching infra. Replaced the env var entirely with a DB-backed
   setting + admin UI.

## Changes

### Backend
- New `cms/services/imager_settings.py` — `get_catalog_url`,
  `set_catalog_url`, `validate_catalog_url`. Stored in the existing
  generic `cms_settings` key/value table (key
  `imager.catalog_url`). Validates `https://` + allowed-hosts.
- New endpoints:
  - `GET /api/imager/settings` (IMAGER_READ) — returns
    `{"catalog_url": "..."|null}`.
  - `PUT /api/imager/settings` (IMAGER_MANAGE, audited).
- Both `GET /api/imager/catalog` and `POST /api/imager/base-images`
  now resolve the URL from DB; 503 with a clear "Configure the
  catalog URL via PUT /api/imager/settings" message when unset.
- Worker `handle_image_import` fallback path reads the URL from DB.
- Removed `Settings.base_image_catalog_url` and reverted PR #509's
  bicep wiring (param + CMS env + worker env entries).

### Frontend
- New "Catalog URL" header row on the Base Images card showing the
  current URL or "_not configured_", with an Edit button visible to
  admins only.
- Inline modal to edit the URL with validation error display.
- "Import from catalog…" button rendered as disabled with tooltip
  ("Configure the catalog URL first") when URL is unset.
- **Fixed** `openCatalog` / `imagerCloseCatalog` to use unscoped
  `$()` lookups (IDs are unique). Added null-guards on event
  binding so future template tweaks don't reproduce the crash.

### Tests
- New `tests/test_imager_settings.py` (11 tests):
  - GET unset → null URL.
  - GET configured → URL.
  - GET allowed for operator (IMAGER_READ).
  - GET denied for viewer.
  - PUT happy path + persistence round-trip.
  - PUT denied for operator and viewer.
  - PUT rejects `http://`.
  - PUT rejects disallowed host.
  - PUT rejects blank.
  - PUT writes audit log row.
- Existing `test_imager_api.py` / `test_imager_handlers.py` /
  `test_imager_schema.py` updated for the new fixture pattern.
- 77 imager tests pass locally (60 existing + 11 new + 6 UI).

## Permissions

- Reading the setting: `IMAGER_READ` (Admin + Operator).
- Updating the setting: `IMAGER_MANAGE` (Admin only).

## Operational notes

- After deploy, an admin must visit `/imager` and click "Edit"
  next to "Catalog URL" to seed the value (it does not migrate
  from the now-deleted env var). The default the env var was set
  to was
  `https://github.com/sslivins/agora/releases/latest/download/catalog.json`.
- This obsoletes PR #509 (the bicep param it added is gone).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
