### PR TITLE
fix(worker): add httpx to shared deps + smoke-test worker image imports

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -129,6 +129,23 @@ jobs:
             ${{ env.ACR_REGISTRY }}/agora-worker:latest
             ${{ env.ACR_REGISTRY }}/agora-worker:${{ steps.version.outputs.version }}
 
+      # Deploy-gate the worker image by exercising every top-level
+      # import the queue dispatcher pulls in.  worker/__main__.py
+      # imports worker.imager_handlers lazily inside _queue_mode so a
+      # plain "python -m worker --help" wouldn't catch a missing dep
+      # in shared/ or worker/ -- production has already paid the cost
+      # of finding such gaps the hard way (see hotfix/worker-httpx-
+      # missing).  Force the imports here.
+      - name: Smoke-test worker image imports
+        run: |
+          set -euo pipefail
+          docker pull ${{ env.ACR_REGISTRY }}/agora-worker:${{ steps.version.outputs.version }}
+          docker run --rm --entrypoint python \
+            ${{ env.ACR_REGISTRY }}/agora-worker:${{ steps.version.outputs.version }} \
+            -c "import worker.__main__, worker.imager_handlers, worker.transcoder; \
+                from worker.imager_handlers import import_base_image_by_id, provision_image_by_id; \
+                print('worker image imports OK')"
+
       - name: Record image digests
         run: |
           echo "CMS digest:    ${{ steps.acr_cms.outputs.digest }}"

--- a/requirements-shared.txt
+++ b/requirements-shared.txt
@@ -4,6 +4,12 @@ pydantic-settings>=2.7,<3.0
 sqlalchemy[asyncio]>=2.0,<3.0
 asyncpg>=0.30,<1.0
 
+# httpx — used by shared/services/imager_catalog.py to fetch the
+# upstream catalog.json + verify hop-by-hop redirect targets.  Both
+# the CMS (catalog list / PUT /import) and the worker (import handler)
+# import this module, so httpx must be present in both images.
+httpx>=0.27,<1.0
+
 # Azure Blob Storage (only needed when AGORA_CMS_STORAGE_BACKEND=azure)
 azure-storage-blob>=12.20,<13.0
 aiohttp>=3.9,<4.0

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -1,0 +1,147 @@
+"""Regression test: worker image must declare every third-party
+import that ``worker/`` and ``shared/`` modules pull in at module
+import time.
+
+Background: PR #513-era the worker shipped without ``httpx`` in its
+image even though ``shared/services/imager_catalog.py`` (and therefore
+``worker/imager_handlers.py``) imported it at module top.  The CMS
+image worked because ``cms/requirements.txt`` happened to list httpx,
+but the worker (which only installs ``worker/requirements.txt`` →
+``-r ../requirements-shared.txt``) crashed with ``ModuleNotFoundError``
+the first time a queued ``imager.import`` job tried to dispatch.
+
+This test enforces the invariant: any third-party module name used in
+top-level ``import``/``from … import`` statements anywhere under
+``shared/`` must be declared in ``requirements-shared.txt`` (or be a
+stdlib module).  ``worker/`` is allowed to additionally rely on
+``worker/requirements.txt``.
+
+This keeps the bug from reappearing the next time someone adds a
+top-level ``import foo`` to a shared module without remembering that
+the worker image needs ``foo`` too.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Map of import-name → distribution-name where they differ.  Most
+# packages match (httpx → httpx); the long tail does not.
+IMPORT_TO_DIST = {
+    "azure": "azure-storage-blob",  # also azure-storage-queue; presence of either is fine
+    "sqlalchemy": "sqlalchemy",
+    "asyncpg": "asyncpg",
+    "pydantic": "pydantic",
+    "pydantic_settings": "pydantic-settings",
+    "aiohttp": "aiohttp",
+    "httpx": "httpx",
+}
+
+
+def _stdlib_top_levels() -> set[str]:
+    """Best-effort enumeration of stdlib top-level names for the
+    interpreter running the tests.  Python 3.10+ ships
+    ``sys.stdlib_module_names`` which is exactly what we want."""
+    return set(getattr(sys, "stdlib_module_names", ()))
+
+
+def _first_party_top_levels() -> set[str]:
+    """Top-level names that map to repo packages (not deps)."""
+    return {"shared", "worker", "cms", "tests", "alembic"}
+
+
+def _read_requirement_names(path: Path) -> set[str]:
+    """Parse a pip requirements file into the set of distribution
+    names it pins (lower-cased, stripped of version specifiers)."""
+    names: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-r "):
+            continue
+        # split on first version operator or whitespace
+        for sep in ("[", ">=", "<=", "==", ">", "<", "~=", "!=", " "):
+            idx = line.find(sep)
+            if idx > 0:
+                line = line[:idx]
+                break
+        names.add(line.lower())
+    return names
+
+
+def _walk_imports(directory: Path) -> set[str]:
+    """Collect the top-level module name from every top-level
+    ``import``/``from … import`` in every .py under ``directory``.
+    Conditional / function-local imports are intentionally ignored
+    -- those are the ones it's safe to gate behind extras."""
+    seen: set[str] = set()
+    for py in directory.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in tree.body:  # only module-level imports
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    seen.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.level == 0 and node.module:
+                    seen.add(node.module.split(".")[0])
+    return seen
+
+
+def test_shared_top_level_imports_are_in_requirements_shared() -> None:
+    """Every third-party top-level import in ``shared/`` must be
+    installable from ``requirements-shared.txt``.  This is the file
+    the worker image installs from -- gaps here crash the worker at
+    boot."""
+    shared_dir = REPO_ROOT / "shared"
+    assert shared_dir.is_dir(), shared_dir
+
+    imports = _walk_imports(shared_dir)
+    third_party = imports - _stdlib_top_levels() - _first_party_top_levels()
+
+    declared = _read_requirement_names(
+        REPO_ROOT / "requirements-shared.txt"
+    )
+    # Translate import names → distribution names where they differ.
+    needed = {IMPORT_TO_DIST.get(name, name).lower() for name in third_party}
+
+    # ``azure`` import name maps to multiple azure-* dists; treat any
+    # azure-* declaration as satisfying it.
+    azure_satisfied = any(name.startswith("azure-") for name in declared)
+
+    missing: set[str] = set()
+    for dist in needed:
+        if dist == "azure-storage-blob" and azure_satisfied:
+            continue
+        if dist not in declared:
+            missing.add(dist)
+
+    assert not missing, (
+        f"shared/ imports {sorted(missing)} at top-level but they are "
+        f"not declared in requirements-shared.txt.  The worker image "
+        f"installs only requirements-shared.txt (+ worker/requirements.txt) "
+        f"and will ModuleNotFoundError on boot.  Add the missing "
+        f"package(s) to requirements-shared.txt."
+    )
+
+
+def test_worker_can_import_imager_handlers() -> None:
+    """Smoke check: the worker's imager handler module must import
+    cleanly under the test environment.  This catches the specific
+    httpx-missing regression that bricked production -- the test
+    runner uses cms/requirements.txt which superset shared, so a
+    fresh ``import worker.imager_handlers`` proves only that the
+    test env works.  The strong guard is the requirements check
+    above; this test just doubles up.
+    """
+    import importlib
+
+    mod = importlib.import_module("worker.imager_handlers")
+    # Sanity: handler entrypoints exposed.
+    assert hasattr(mod, "import_base_image_by_id")


### PR DESCRIPTION
## Summary

Worker container has been crash-looping in production since this
afternoon's first `imager.import` queue message:

```
ModuleNotFoundError: No module named 'httpx'
  File "/app/worker/imager_handlers.py", line 56, in <module>
    import httpx
```

`httpx` is imported at module top in `shared/services/imager_catalog.py`
and `worker/imager_handlers.py`, but it lived only in
`requirements.txt` (CMS image deps) — not in `requirements-shared.txt`
(which is the only thing the worker image installs).  Asset transcoding
and base-image imports are both broken in prod until this lands.

## Root cause

The worker image (`Dockerfile.worker`) installs only:

```
COPY requirements-shared.txt ./
COPY worker/requirements.txt worker/requirements.txt
RUN pip install -r worker/requirements.txt   # which -r ../requirements-shared.txt
```

`worker/__main__.py` defers `from worker.imager_handlers import …` to
inside `_queue_mode()`, so plain `python -m worker --help` (or any
import-only smoke) wouldn't trip the missing dep — the crash only
fires the first time a queue message dispatches an imager job.  CI
ran every test under the CMS image (which happens to ship httpx via
its own `requirements.txt`) so the gap was invisible until it hit
production.

## Fix

1. Move `httpx>=0.27,<1.0` to `requirements-shared.txt` so both
   the CMS image and the worker image get it.  The CMS image already
   pulls a compatible httpx via `requirements.txt`, so no change in
   behaviour for CMS — this just plugs the worker hole.

2. **Test guard** (`tests/test_worker_dependencies.py`):
   `test_shared_top_level_imports_are_in_requirements_shared` walks
   every `.py` under `shared/`, parses the AST, and asserts that
   every third-party top-level import has a matching distribution in
   `requirements-shared.txt`.  Verified by removing httpx and
   confirming the test fails with a useful message.

3. **CI deploy gate** (`.github/workflows/publish-image.yml`):
   after pushing the worker image to ACR, pull it back and run
   `docker run --rm --entrypoint python <worker> -c "import
   worker.__main__, worker.imager_handlers, worker.transcoder;
   from worker.imager_handlers import import_base_image_by_id,
   provision_image_by_id"`.  This forces the lazy-imported handler
   chain through the same byte sequence the queue dispatcher will,
   so a missing dep in any shared/ or worker/ module fails the
   workflow before deploy ever runs.

The combination of (2) + (3) is belt-and-suspenders: (2) catches it
at PR review time, (3) catches it at deploy time even if (2) is
removed or bypassed.

## Verification

- `pytest tests/test_worker_dependencies.py -p no:timeout -v` → 2 passed.
- Manually confirmed the dep-check test fails with httpx removed from
  `requirements-shared.txt`.
- After deploy: worker job executions should start succeeding again
  (the queued `imager.import` message that's been retrying since
  ~13:35 UTC will dispatch on next KEDA trigger).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
