### PR TITLE
fix(worker): unblock worker image — copy cms/ + lazy-load alembic in cms.database

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,6 +23,7 @@ RUN LANG=C.UTF-8 LC_ALL=C.UTF-8 pip install --no-cache-dir --progress-bar off \
     -r worker/requirements.txt
 
 COPY shared/ shared/
+COPY cms/ cms/
 COPY worker/ worker/
 
 CMD ["python", "-m", "worker"]

--- a/cms/database.py
+++ b/cms/database.py
@@ -19,8 +19,6 @@ import asyncio
 import logging
 from pathlib import Path
 
-from alembic import command as alembic_command
-from alembic.config import Config as AlembicConfig
 from sqlalchemy import inspect as sa_inspect
 
 from shared.database import Base, init_db, get_db, dispose_db, create_tables  # noqa: F401
@@ -36,13 +34,20 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _ALEMBIC_INI = _REPO_ROOT / "alembic.ini"
 
 
-def _alembic_config() -> AlembicConfig:
+def _alembic_config():
     """Build an Alembic Config pointed at this repo's alembic.ini.
 
     We don't override ``sqlalchemy.url`` here — ``alembic/env.py`` resolves
     the URL from ``SharedSettings`` (the same source the running app uses),
     which keeps the CLI and the startup path on exactly one code path.
+
+    ``alembic`` is imported lazily here so non-CMS images (e.g. the worker
+    image, which imports CMS ORM models via ``cms.models`` to share
+    ``Base.metadata`` but never runs migrations) don't have to pip-install
+    alembic just to keep this module importable.
     """
+    from alembic.config import Config as AlembicConfig  # local import
+
     return AlembicConfig(str(_ALEMBIC_INI))
 
 
@@ -80,6 +85,8 @@ async def run_migrations() -> None:
     # internally call ``asyncio.run()``.  We can't call asyncio.run from
     # inside a running event loop, so we hand off to a worker thread,
     # which gets its own loop.
+    from alembic import command as alembic_command  # lazy: see _alembic_config
+
     cfg = _alembic_config()
 
     if not has_alembic and has_legacy_assets:

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -200,44 +200,55 @@ def test_worker_imports_do_not_pull_in_alembic() -> None:
     transitively imported it via ``cms.models.api_key`` →
     ``cms.database`` (because ``cms/models/__init__.py`` aggregates
     every model when *any* ``cms.models.*`` is imported).
+
+    Runs in a subprocess so the import-tracking shim and module-cache
+    wipes can't pollute other tests sharing the xdist worker (e.g.
+    ``test_logs_response_shim`` relies on ``shared.database`` module
+    state that this check would otherwise reset).
     """
-    import importlib
+    import subprocess
     import sys
+    import textwrap
 
-    # If alembic is already loaded in this interpreter, drop it so the
-    # check is meaningful.  Test runs that hit cms startup paths will
-    # have loaded it; here we want to observe what worker imports
-    # alone require.
-    for mod in [m for m in list(sys.modules) if m == "alembic" or m.startswith("alembic.")]:
-        del sys.modules[mod]
-    # Wipe cached worker / cms / shared modules too so the import
-    # actually runs and the trace is honest.
-    for prefix in ("worker", "cms", "shared"):
-        for mod in [m for m in list(sys.modules) if m == prefix or m.startswith(prefix + ".")]:
-            del sys.modules[mod]
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+        import sys
 
-    triggered: list[str] = []
-    real_import = importlib.__import__
+        triggered = []
+        real_import = builtins.__import__
 
-    def tracking_import(name: str, *args, **kwargs):
-        top = name.split(".")[0]
-        if top == "alembic":
-            triggered.append(name)
-        return real_import(name, *args, **kwargs)
+        def tracking_import(name, *args, **kwargs):
+            if name == "alembic" or name.startswith("alembic."):
+                triggered.append(name)
+            return real_import(name, *args, **kwargs)
 
-    import builtins
-    saved = builtins.__import__
-    builtins.__import__ = tracking_import
-    try:
-        importlib.import_module("worker.imager_handlers")
-        importlib.import_module("worker.transcoder")
-        importlib.import_module("worker.__main__")
-    finally:
-        builtins.__import__ = saved
+        builtins.__import__ = tracking_import
+        try:
+            importlib.import_module("worker.imager_handlers")
+            importlib.import_module("worker.transcoder")
+            importlib.import_module("worker.__main__")
+        finally:
+            builtins.__import__ = real_import
 
-    assert not triggered, (
-        f"Worker top-level imports pulled in alembic ({triggered[:3]}); "
-        f"the worker image does not install alembic and will crash on "
-        f"boot.  Move alembic imports inside the migration functions "
-        f"(see ``cms/database.py``) or otherwise break the chain."
+        if triggered:
+            print("ALEMBIC_IMPORTED:" + ",".join(triggered[:5]))
+            sys.exit(2)
+        sys.exit(0)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"Worker top-level imports pulled in alembic; the worker image "
+        f"does not install alembic and will crash on boot.  Move alembic "
+        f"imports inside migration functions (see ``cms/database.py``) "
+        f"or otherwise break the chain.\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
     )

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -145,3 +145,99 @@ def test_worker_can_import_imager_handlers() -> None:
     mod = importlib.import_module("worker.imager_handlers")
     # Sanity: handler entrypoints exposed.
     assert hasattr(mod, "import_base_image_by_id")
+
+
+def test_dockerfile_worker_copies_every_top_level_package_imported_by_worker() -> None:
+    """Every first-party top-level package that ``worker/`` imports at
+    module-level must be COPY'd into Dockerfile.worker.
+
+    Background: PR #515-era ``worker/imager_handlers.py`` grew
+    ``from cms.services.imager import ...`` at module top, but
+    Dockerfile.worker only copied ``shared/`` and ``worker/``.  The
+    worker image therefore raised ``ModuleNotFoundError: No module
+    named 'cms'`` the first time its handlers were imported.  The
+    deploy-time docker import smoke caught it; this test catches it
+    at PR time.
+    """
+    worker_dir = REPO_ROOT / "worker"
+    dockerfile = REPO_ROOT / "Dockerfile.worker"
+    assert worker_dir.is_dir(), worker_dir
+    assert dockerfile.is_file(), dockerfile
+
+    imports = _walk_imports(worker_dir)
+    first_party_imported = imports & _first_party_top_levels()
+
+    dockerfile_text = dockerfile.read_text(encoding="utf-8")
+    missing: set[str] = set()
+    for pkg in first_party_imported:
+        # Test packages and alembic are repo-only paths workers never need.
+        if pkg in {"tests", "alembic"}:
+            continue
+        # Look for a COPY line that brings the package directory into the image.
+        # Match either "COPY pkg/ pkg/" or "COPY pkg/ <dest>/".
+        if f"COPY {pkg}/" not in dockerfile_text:
+            missing.add(pkg)
+
+    assert not missing, (
+        f"worker/ imports first-party packages {sorted(missing)} at "
+        f"module top-level but Dockerfile.worker does not COPY them "
+        f"into the image.  The worker container will raise "
+        f"ModuleNotFoundError on boot.  Either add ``COPY {{pkg}}/ "
+        f"{{pkg}}/`` to Dockerfile.worker, or move the imported "
+        f"symbol into ``shared/``."
+    )
+
+
+def test_worker_imports_do_not_pull_in_alembic() -> None:
+    """The worker image installs only ``requirements-shared.txt`` and
+    ``worker/requirements.txt`` — neither lists ``alembic``.  If any
+    module reachable from worker top-level imports does
+    ``from alembic import ...`` (or ``import alembic``) at module top,
+    the worker container will ``ModuleNotFoundError`` on first use.
+
+    This caught a regression where ``cms/database.py`` used
+    ``from alembic import command`` at module top, and the worker
+    transitively imported it via ``cms.models.api_key`` →
+    ``cms.database`` (because ``cms/models/__init__.py`` aggregates
+    every model when *any* ``cms.models.*`` is imported).
+    """
+    import importlib
+    import sys
+
+    # If alembic is already loaded in this interpreter, drop it so the
+    # check is meaningful.  Test runs that hit cms startup paths will
+    # have loaded it; here we want to observe what worker imports
+    # alone require.
+    for mod in [m for m in list(sys.modules) if m == "alembic" or m.startswith("alembic.")]:
+        del sys.modules[mod]
+    # Wipe cached worker / cms / shared modules too so the import
+    # actually runs and the trace is honest.
+    for prefix in ("worker", "cms", "shared"):
+        for mod in [m for m in list(sys.modules) if m == prefix or m.startswith(prefix + ".")]:
+            del sys.modules[mod]
+
+    triggered: list[str] = []
+    real_import = importlib.__import__
+
+    def tracking_import(name: str, *args, **kwargs):
+        top = name.split(".")[0]
+        if top == "alembic":
+            triggered.append(name)
+        return real_import(name, *args, **kwargs)
+
+    import builtins
+    saved = builtins.__import__
+    builtins.__import__ = tracking_import
+    try:
+        importlib.import_module("worker.imager_handlers")
+        importlib.import_module("worker.transcoder")
+        importlib.import_module("worker.__main__")
+    finally:
+        builtins.__import__ = saved
+
+    assert not triggered, (
+        f"Worker top-level imports pulled in alembic ({triggered[:3]}); "
+        f"the worker image does not install alembic and will crash on "
+        f"boot.  Move alembic imports inside the migration functions "
+        f"(see ``cms/database.py``) or otherwise break the chain."
+    )


### PR DESCRIPTION
## What

Hotfix the worker image — the `agoracms-worker` container was failing to start after PR #515 (and likely earlier) because:

```
File "/app/worker/imager_handlers.py", line 59, in <module>
    from cms.services.imager import ImagerError, build_provisioned
ModuleNotFoundError: No module named 'cms'
```

This was caught at the deploy-time docker-import smoke step added in PR #514 (`Smoke-test worker image imports`), so prod did **not** roll over to a broken image.

## Root cause

`Dockerfile.worker` only `COPY shared/` and `COPY worker/`. But `worker/imager_handlers.py` imports `cms.services.imager` and `cms.services.imager_settings` at module top, so the worker image was missing modules its handlers need.

Even after adding `COPY cms/ cms/`, there's a second trap: every `cms.models.*` module imports `from cms.database import Base`, and `cms/database.py` did `from alembic import command` at module top. Since `cms/models/__init__.py` aggregates every model when *any* model is touched, just importing `cms.services.imager_settings` (→ `cms.models.setting` → triggers `cms/models/__init__.py` → imports `cms.models.api_key` → `cms.database` → alembic) pulled alembic into the worker. Worker requirements don't include alembic, so the image would still crash on `ModuleNotFoundError: alembic`.

## Fix (three parts)

1. **`Dockerfile.worker`** — `COPY cms/ cms/` so the modules are present.
2. **`cms/database.py`** — move alembic imports inside the functions that use them (`_alembic_config`, `run_migrations`). No behavior change for CMS startup; just defers loading. Verified 70 existing alembic/migration/database tests still pass.
3. **`tests/test_worker_dependencies.py`** — two new PR-time guards so this can't recur silently:
   - `test_dockerfile_worker_copies_every_top_level_package_imported_by_worker` — parses `worker/*.py` for top-level first-party imports and asserts each is `COPY`d in `Dockerfile.worker`.
   - `test_worker_imports_do_not_pull_in_alembic` — runs `import worker.imager_handlers` etc. with a tracking `__import__` hook and asserts alembic was never touched.

Both new tests fail against the broken state (verified locally — the dockerfile test fails with `missing={'cms'}`) and pass after the fix.

## Why didn't existing tests catch this?

The pre-existing `test_shared_top_level_imports_are_in_requirements_shared` only checks `shared/` against `requirements-shared.txt`. The pre-existing `test_worker_can_import_imager_handlers` runs in the test environment, which is the CMS env (has alembic, has cms/ on path) — so it passes even when the worker image is broken. The two new tests are image-aware in a way the old ones aren't.

## Out of scope

This does not refactor `worker/imager_handlers.py` to depend only on `shared/`. That's the architecturally cleaner end-state (worker shouldn't import from cms at all), but it requires moving `cms/services/imager.py`, `cms/services/imager_settings.py`, and possibly `cms/models/setting.py` out of `cms/` — bigger blast radius than appropriate for a hotfix unblocking the deploy pipeline.
