### PR TITLE
fix(worker): default imager scratch dir to asset_storage_path subdir

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,6 +23,7 @@ RUN LANG=C.UTF-8 LC_ALL=C.UTF-8 pip install --no-cache-dir --progress-bar off \
     -r worker/requirements.txt
 
 COPY shared/ shared/
+COPY cms/ cms/
 COPY worker/ worker/
 
 CMD ["python", "-m", "worker"]

--- a/cms/database.py
+++ b/cms/database.py
@@ -19,8 +19,6 @@ import asyncio
 import logging
 from pathlib import Path
 
-from alembic import command as alembic_command
-from alembic.config import Config as AlembicConfig
 from sqlalchemy import inspect as sa_inspect
 
 from shared.database import Base, init_db, get_db, dispose_db, create_tables  # noqa: F401
@@ -36,13 +34,20 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _ALEMBIC_INI = _REPO_ROOT / "alembic.ini"
 
 
-def _alembic_config() -> AlembicConfig:
+def _alembic_config():
     """Build an Alembic Config pointed at this repo's alembic.ini.
 
     We don't override ``sqlalchemy.url`` here — ``alembic/env.py`` resolves
     the URL from ``SharedSettings`` (the same source the running app uses),
     which keeps the CLI and the startup path on exactly one code path.
+
+    ``alembic`` is imported lazily here so non-CMS images (e.g. the worker
+    image, which imports CMS ORM models via ``cms.models`` to share
+    ``Base.metadata`` but never runs migrations) don't have to pip-install
+    alembic just to keep this module importable.
     """
+    from alembic.config import Config as AlembicConfig  # local import
+
     return AlembicConfig(str(_ALEMBIC_INI))
 
 
@@ -80,6 +85,8 @@ async def run_migrations() -> None:
     # internally call ``asyncio.run()``.  We can't call asyncio.run from
     # inside a running event loop, so we hand off to a worker thread,
     # which gets its own loop.
+    from alembic import command as alembic_command  # lazy: see _alembic_config
+
     cfg = _alembic_config()
 
     if not has_alembic and has_legacy_assets:

--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -111,6 +111,41 @@ def test_terminal_imager_error_is_exception() -> None:
     assert issubclass(TerminalImagerError, Exception)
 
 
+def test_scratch_dir_falls_back_to_asset_storage_when_unset(tmp_path: Path) -> None:
+    """Default ``imager_scratch_path=None`` must not crash.
+
+    In prod the worker's container app does NOT set IMAGER_SCRATCH_PATH;
+    ``shared.config.Settings.imager_scratch_path`` defaults to ``None``.
+    The docstring promises a fallback to a subdirectory under
+    ``asset_storage_path``; this test pins that contract so we don't
+    regress to ``Path(None)`` which TypeErrors the worker.
+    """
+    settings = SimpleNamespace(
+        imager_scratch_path=None,
+        asset_storage_path=tmp_path / "assets",
+    )
+    target = uuid.uuid4()
+    scratch = imager_handlers._scratch_dir(settings, "import", target)
+
+    assert scratch.is_relative_to(tmp_path / "assets")
+    assert "imager-scratch" in scratch.parts
+    assert f"import-{target}-" in scratch.name
+
+
+def test_scratch_dir_honors_explicit_imager_scratch_path(tmp_path: Path) -> None:
+    """When operators set IMAGER_SCRATCH_PATH, fallback is skipped."""
+    explicit = tmp_path / "dedicated-scratch"
+    settings = SimpleNamespace(
+        imager_scratch_path=explicit,
+        asset_storage_path=tmp_path / "assets",
+    )
+    target = uuid.uuid4()
+    scratch = imager_handlers._scratch_dir(settings, "build", target)
+
+    assert scratch.is_relative_to(explicit)
+    assert "imager-scratch" not in scratch.parts
+
+
 # ── Import handler ─────────────────────────────────────────────────
 
 

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -200,44 +200,55 @@ def test_worker_imports_do_not_pull_in_alembic() -> None:
     transitively imported it via ``cms.models.api_key`` →
     ``cms.database`` (because ``cms/models/__init__.py`` aggregates
     every model when *any* ``cms.models.*`` is imported).
+
+    Runs in a subprocess so the import-tracking shim and module-cache
+    wipes can't pollute other tests sharing the xdist worker (e.g.
+    ``test_logs_response_shim`` relies on ``shared.database`` module
+    state that this check would otherwise reset).
     """
-    import importlib
+    import subprocess
     import sys
+    import textwrap
 
-    # If alembic is already loaded in this interpreter, drop it so the
-    # check is meaningful.  Test runs that hit cms startup paths will
-    # have loaded it; here we want to observe what worker imports
-    # alone require.
-    for mod in [m for m in list(sys.modules) if m == "alembic" or m.startswith("alembic.")]:
-        del sys.modules[mod]
-    # Wipe cached worker / cms / shared modules too so the import
-    # actually runs and the trace is honest.
-    for prefix in ("worker", "cms", "shared"):
-        for mod in [m for m in list(sys.modules) if m == prefix or m.startswith(prefix + ".")]:
-            del sys.modules[mod]
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+        import sys
 
-    triggered: list[str] = []
-    real_import = importlib.__import__
+        triggered = []
+        real_import = builtins.__import__
 
-    def tracking_import(name: str, *args, **kwargs):
-        top = name.split(".")[0]
-        if top == "alembic":
-            triggered.append(name)
-        return real_import(name, *args, **kwargs)
+        def tracking_import(name, *args, **kwargs):
+            if name == "alembic" or name.startswith("alembic."):
+                triggered.append(name)
+            return real_import(name, *args, **kwargs)
 
-    import builtins
-    saved = builtins.__import__
-    builtins.__import__ = tracking_import
-    try:
-        importlib.import_module("worker.imager_handlers")
-        importlib.import_module("worker.transcoder")
-        importlib.import_module("worker.__main__")
-    finally:
-        builtins.__import__ = saved
+        builtins.__import__ = tracking_import
+        try:
+            importlib.import_module("worker.imager_handlers")
+            importlib.import_module("worker.transcoder")
+            importlib.import_module("worker.__main__")
+        finally:
+            builtins.__import__ = real_import
 
-    assert not triggered, (
-        f"Worker top-level imports pulled in alembic ({triggered[:3]}); "
-        f"the worker image does not install alembic and will crash on "
-        f"boot.  Move alembic imports inside the migration functions "
-        f"(see ``cms/database.py``) or otherwise break the chain."
+        if triggered:
+            print("ALEMBIC_IMPORTED:" + ",".join(triggered[:5]))
+            sys.exit(2)
+        sys.exit(0)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"Worker top-level imports pulled in alembic; the worker image "
+        f"does not install alembic and will crash on boot.  Move alembic "
+        f"imports inside migration functions (see ``cms/database.py``) "
+        f"or otherwise break the chain.\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
     )

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -145,3 +145,99 @@ def test_worker_can_import_imager_handlers() -> None:
     mod = importlib.import_module("worker.imager_handlers")
     # Sanity: handler entrypoints exposed.
     assert hasattr(mod, "import_base_image_by_id")
+
+
+def test_dockerfile_worker_copies_every_top_level_package_imported_by_worker() -> None:
+    """Every first-party top-level package that ``worker/`` imports at
+    module-level must be COPY'd into Dockerfile.worker.
+
+    Background: PR #515-era ``worker/imager_handlers.py`` grew
+    ``from cms.services.imager import ...`` at module top, but
+    Dockerfile.worker only copied ``shared/`` and ``worker/``.  The
+    worker image therefore raised ``ModuleNotFoundError: No module
+    named 'cms'`` the first time its handlers were imported.  The
+    deploy-time docker import smoke caught it; this test catches it
+    at PR time.
+    """
+    worker_dir = REPO_ROOT / "worker"
+    dockerfile = REPO_ROOT / "Dockerfile.worker"
+    assert worker_dir.is_dir(), worker_dir
+    assert dockerfile.is_file(), dockerfile
+
+    imports = _walk_imports(worker_dir)
+    first_party_imported = imports & _first_party_top_levels()
+
+    dockerfile_text = dockerfile.read_text(encoding="utf-8")
+    missing: set[str] = set()
+    for pkg in first_party_imported:
+        # Test packages and alembic are repo-only paths workers never need.
+        if pkg in {"tests", "alembic"}:
+            continue
+        # Look for a COPY line that brings the package directory into the image.
+        # Match either "COPY pkg/ pkg/" or "COPY pkg/ <dest>/".
+        if f"COPY {pkg}/" not in dockerfile_text:
+            missing.add(pkg)
+
+    assert not missing, (
+        f"worker/ imports first-party packages {sorted(missing)} at "
+        f"module top-level but Dockerfile.worker does not COPY them "
+        f"into the image.  The worker container will raise "
+        f"ModuleNotFoundError on boot.  Either add ``COPY {{pkg}}/ "
+        f"{{pkg}}/`` to Dockerfile.worker, or move the imported "
+        f"symbol into ``shared/``."
+    )
+
+
+def test_worker_imports_do_not_pull_in_alembic() -> None:
+    """The worker image installs only ``requirements-shared.txt`` and
+    ``worker/requirements.txt`` — neither lists ``alembic``.  If any
+    module reachable from worker top-level imports does
+    ``from alembic import ...`` (or ``import alembic``) at module top,
+    the worker container will ``ModuleNotFoundError`` on first use.
+
+    This caught a regression where ``cms/database.py`` used
+    ``from alembic import command`` at module top, and the worker
+    transitively imported it via ``cms.models.api_key`` →
+    ``cms.database`` (because ``cms/models/__init__.py`` aggregates
+    every model when *any* ``cms.models.*`` is imported).
+    """
+    import importlib
+    import sys
+
+    # If alembic is already loaded in this interpreter, drop it so the
+    # check is meaningful.  Test runs that hit cms startup paths will
+    # have loaded it; here we want to observe what worker imports
+    # alone require.
+    for mod in [m for m in list(sys.modules) if m == "alembic" or m.startswith("alembic.")]:
+        del sys.modules[mod]
+    # Wipe cached worker / cms / shared modules too so the import
+    # actually runs and the trace is honest.
+    for prefix in ("worker", "cms", "shared"):
+        for mod in [m for m in list(sys.modules) if m == prefix or m.startswith(prefix + ".")]:
+            del sys.modules[mod]
+
+    triggered: list[str] = []
+    real_import = importlib.__import__
+
+    def tracking_import(name: str, *args, **kwargs):
+        top = name.split(".")[0]
+        if top == "alembic":
+            triggered.append(name)
+        return real_import(name, *args, **kwargs)
+
+    import builtins
+    saved = builtins.__import__
+    builtins.__import__ = tracking_import
+    try:
+        importlib.import_module("worker.imager_handlers")
+        importlib.import_module("worker.transcoder")
+        importlib.import_module("worker.__main__")
+    finally:
+        builtins.__import__ = saved
+
+    assert not triggered, (
+        f"Worker top-level imports pulled in alembic ({triggered[:3]}); "
+        f"the worker image does not install alembic and will crash on "
+        f"boot.  Move alembic imports inside the migration functions "
+        f"(see ``cms/database.py``) or otherwise break the chain."
+    )

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -143,8 +143,16 @@ def _scratch_dir(settings: Any, prefix: str, target_id: uuid.UUID) -> Path:
     Includes a fresh ``uuid4`` suffix so a duplicate pickup of the
     same queue message (lease loss) lands in its own directory and
     cannot rmtree another worker's in-flight files.
+
+    When ``settings.imager_scratch_path`` is unset (the default in
+    deployments without a dedicated scratch volume), fall back to
+    a subdirectory under ``asset_storage_path`` per the config
+    docstring contract.
     """
-    root = Path(settings.imager_scratch_path)
+    scratch_root = settings.imager_scratch_path
+    if scratch_root is None:
+        scratch_root = Path(settings.asset_storage_path) / "imager-scratch"
+    root = Path(scratch_root)
     return root / f"{prefix}-{target_id}-{uuid.uuid4().hex[:8]}"
 
 


### PR DESCRIPTION
# Hotfix: worker imager scratch dir crashes prod imports

## Bug

After PR #516 unblocked the worker image (cms imports), prod still
fails every queued `imager.import` job with:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
  File "/app/worker/imager_handlers.py", line 147, in _scratch_dir
    root = Path(settings.imager_scratch_path)
```

`Settings.imager_scratch_path` defaults to `None`. The docstring
already promises a fallback to a subdirectory under
`asset_storage_path` ("worker doesn't need extra mounts in the simple
case"), but no code ever implemented it.

The handler unit tests never caught this because the test fixture
always sets `imager_scratch_path` explicitly to a tmpdir.

## Fix

`_scratch_dir` now honors the docstring: when `imager_scratch_path` is
`None`, fall back to `asset_storage_path / "imager-scratch"`.

## Tests

- `test_scratch_dir_falls_back_to_asset_storage_when_unset` — pins the
  prod-default path so we can't regress to `Path(None)`.
- `test_scratch_dir_honors_explicit_imager_scratch_path` — operators
  who set `IMAGER_SCRATCH_PATH` still get a dedicated volume.

## Post-deploy

Existing `IMAGE_IMPORT` job rows already FAILED (retry-exhausted) by
the broken code stay FAILED — the user re-triggers import from the
catalog UI to enqueue fresh jobs.
