### PR TITLE
fix(worker): install parted/mtools/xz-utils in Dockerfile.worker

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -146,6 +146,21 @@ jobs:
                 from worker.imager_handlers import import_base_image_by_id, provision_image_by_id; \
                 print('worker image imports OK')"
 
+      # Verify OS-level tools required by ``cms.services.imager`` are
+      # present in the final worker image.  The Python import smoke
+      # above will not catch a missing ``parted``/``mcopy``/``xz`` --
+      # those are discovered at runtime via ``shutil.which`` the first
+      # time an imager job runs.  Without this gate we ship workers
+      # that import cleanly but blow up on every IMAGE_IMPORT /
+      # IMAGE_PROVISION job (see hotfix/worker-imager-scratch-path).
+      - name: Smoke-test worker image runtime tools
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python \
+            ${{ env.ACR_REGISTRY }}/agora-worker:${{ steps.version.outputs.version }} \
+            -c "from cms.services.imager import _Tools; t = _Tools.discover(); \
+                print(f'worker image imager tools OK: parted={t.parted} mcopy={t.mcopy} xz={t.xz}')"
+
       - name: Record image digests
         run: |
           echo "CMS digest:    ${{ steps.acr_cms.outputs.digest }}"

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -7,14 +7,27 @@ WORKDIR /app
 # FFmpeg 8.1 static build + libheif for HEIC image conversion
 ARG TARGETARCH
 
+#
+# Runtime tools required by ``cms.services.imager``:
+#   - ``parted``      partition table inspection (parted, libparted)
+#   - ``mtools``      ``mcopy``/``mdir`` for FAT writes without root/loopback
+#   - ``xz-utils``    base ``.img.xz`` decompress/recompress; also used here
+#                     to unpack the ffmpeg tarball below
+#
+# These packages MUST be kept in the final image -- the deploy-time
+# smoke test (.github/workflows/publish-image.yml) verifies their
+# presence by running ``cms.services.imager._Tools.discover()`` against
+# the built image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libheif-examples \
     curl \
     xz-utils \
+    mtools \
+    parted \
     && ARCH=$(case "$TARGETARCH" in arm64) echo linuxarm64;; *) echo linux64;; esac) \
     && curl -fsSL "https://github.com/sslivins/agora-cms/releases/download/ffmpeg-8.1/ffmpeg-${ARCH}.tar.xz" \
        | tar -xJ --strip-components=1 -C /usr/local \
-    && apt-get purge -y curl xz-utils && apt-get autoremove -y \
+    && apt-get purge -y curl && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-shared.txt ./

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -23,6 +23,7 @@ the worker image needs ``foo`` too.
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -185,6 +186,78 @@ def test_dockerfile_worker_copies_every_top_level_package_imported_by_worker() -
         f"ModuleNotFoundError on boot.  Either add ``COPY {{pkg}}/ "
         f"{{pkg}}/`` to Dockerfile.worker, or move the imported "
         f"symbol into ``shared/``."
+    )
+
+
+def test_dockerfile_worker_keeps_imager_runtime_tools() -> None:
+    """``cms.services.imager`` shells out to ``parted``, ``mcopy``, and
+    ``xz`` at runtime via ``_Tools.discover()`` (which uses
+    ``shutil.which``).  The packages providing them must be installed
+    in ``Dockerfile.worker`` AND must NOT be removed by a subsequent
+    ``apt-get purge``/``apt-get remove``.
+
+    Background: the original ``Dockerfile.worker`` installed
+    ``xz-utils`` only to unpack the ffmpeg tarball, then purged it in
+    the same RUN step.  ``mtools`` and ``parted`` were never installed
+    at all.  The Python import smoke at deploy time passes (no Python
+    import requires those binaries), but the first time an
+    ``IMAGE_IMPORT`` or ``IMAGE_PROVISION`` job actually runs the
+    handler, ``_Tools.discover()`` raises::
+
+        ImagerError: required tools not on PATH: parted, mcopy, xz
+
+    There is also a deploy-time gate
+    (``.github/workflows/publish-image.yml`` "Smoke-test worker image
+    runtime tools") that runs ``_Tools.discover()`` against the built
+    image.  This static test catches the same regression at PR time
+    so a broken Dockerfile cannot reach the publish stage.
+    """
+    dockerfile = REPO_ROOT / "Dockerfile.worker"
+    assert dockerfile.is_file(), dockerfile
+    text = dockerfile.read_text(encoding="utf-8")
+
+    # Required apt packages → import-name they provide
+    required_pkgs = {
+        "parted": "parted",
+        "mtools": "mcopy",
+        "xz-utils": "xz",
+    }
+
+    # Find every ``apt-get install ...`` and ``apt-get purge|remove ...``
+    # line.  Continuation lines end with ``\``; collapse them so we
+    # don't miss a package on a wrapped line.
+    collapsed = re.sub(r"\\\s*\n\s*", " ", text)
+
+    install_pkgs: set[str] = set()
+    purged_pkgs: set[str] = set()
+    for m in re.finditer(
+        r"apt-get\s+install[^\n&|;]*", collapsed
+    ):
+        for tok in m.group(0).split():
+            install_pkgs.add(tok)
+    for m in re.finditer(
+        r"apt-get\s+(?:purge|remove)[^\n&|;]*", collapsed
+    ):
+        for tok in m.group(0).split():
+            purged_pkgs.add(tok)
+
+    missing_install = sorted(p for p in required_pkgs if p not in install_pkgs)
+    purged_after = sorted(p for p in required_pkgs if p in purged_pkgs)
+
+    assert not missing_install, (
+        f"Dockerfile.worker is missing apt package(s) {missing_install} "
+        f"in its ``apt-get install`` line.  ``cms.services.imager`` "
+        f"requires {sorted(required_pkgs.values())} on PATH at runtime; "
+        f"without them every IMAGE_IMPORT / IMAGE_PROVISION job will "
+        f"fail with ``required tools not on PATH``.  Add the missing "
+        f"package(s) to the install line."
+    )
+    assert not purged_after, (
+        f"Dockerfile.worker installs but then purges/removes "
+        f"{purged_after}.  These packages must remain in the final "
+        f"image so ``cms.services.imager._Tools.discover()`` can find "
+        f"the binaries at runtime.  Remove the package(s) from the "
+        f"``apt-get purge`` line."
     )
 
 


### PR DESCRIPTION
# Install parted / mtools / xz-utils in `Dockerfile.worker`

## Why

`cms.services.imager` (used by both `IMAGE_IMPORT` and `IMAGE_PROVISION` worker handlers) shells out to three OS binaries at runtime via `_Tools.discover()`:

- `parted` — partition table inspection
- `mcopy` (from `mtools`) — write the fleet env file into the FAT boot partition
- `xz` — decompress / recompress base `.img.xz`

The original `Dockerfile.worker` only installed `xz-utils` to unpack the ffmpeg tarball and **purged it in the same RUN step**. `mtools` and `parted` were never installed.

The Python-import smoke at deploy time passed because no Python import requires those binaries — they're discovered at runtime via `shutil.which`. So the bug was invisible until a job actually ran. The first imager handler invocation against the worker image would have raised:

```
ImagerError: required tools not on PATH: parted, mcopy, xz
```

We didn't trip this in production yet because the prior two hotfixes (#516 cms COPY, #517 imager_scratch_path default) prevented imager handlers from completing successfully end-to-end. **This was the next shoe.**

## What this PR does

1. **`Dockerfile.worker`**: adds `mtools` and `parted` to the apt install line; removes `xz-utils` from the subsequent purge so it remains in the final image. Adds an inline comment documenting the runtime contract.

2. **`.github/workflows/publish-image.yml`** ("Smoke-test worker image runtime tools"): extends the per-publish smoke test to actually invoke `cms.services.imager._Tools.discover()` against the just-built worker image. Future regressions caught at publish time instead of post-deploy.

3. **`tests/test_worker_dependencies.py`** (`test_dockerfile_worker_keeps_imager_runtime_tools`): a static Dockerfile parser that asserts the runtime packages are installed and never purged. Caught at PR review time so a broken Dockerfile cannot reach publish.

## Why this is part of a stack

Found by an audit pass after the imager feature suffered three consecutive surprise regressions (#514 httpx, #516 cms COPY, #517 imager_scratch_path). This is **PR A** in a sequenced cleanup:

- **PR A (this one)**: worker image runtime tools.
- **PR B**: poison-job handling — flip `BaseImage`/`ProvisionedImage` rows to FAILED on retry exhaustion + allow re-import on stale `IMPORTING`.
- **PR C**: UI feedback loop — return `job_id` from POST, wire up `pollImportJob`, render `error_message` on FAILED rows.
- **PR D**: SHA tooltip, copy nit, `Settings.resolved_imager_scratch_path` property, allowlist test pin.

## Verification

Local `pytest tests/test_worker_dependencies.py -v -p no:timeout`: 5 passed including the new one.
