### PR TITLE
fix(imager-ui): handle 204 in jsonFetch + use showConfirm modal for delete

### DIFF
--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -177,6 +177,14 @@
     }
     async function jsonFetch(url, opts) {
         var resp = await fetch(url, Object.assign({ credentials: 'same-origin' }, opts || {}));
+        if (resp.status === 204) {
+            if (!resp.ok) {
+                var err204 = new Error('HTTP 204');
+                err204.status = resp.status;
+                throw err204;
+            }
+            return null;
+        }
         var ct = resp.headers.get('content-type') || '';
         var body = ct.indexOf('application/json') >= 0 ? await resp.json() : await resp.text();
         if (!resp.ok) {
@@ -467,7 +475,7 @@
     }
 
     async function deleteBase(id) {
-        if (!confirm('Delete this cached base image? Provisioning jobs that already used it will keep their audit record.')) return;
+        if (!await showConfirm('Delete this cached base image? Provisioning jobs that already used it will keep their audit record.')) return;
         try {
             await jsonFetch('/api/imager/base-images/' + encodeURIComponent(id), { method: 'DELETE' });
             toast('Base image deleted', 'success');


### PR DESCRIPTION
Two small UI fixes on the imager page that surfaced while clearing stuck base-image rows after #518.

## 1. 204 No Content crash
jsonFetch checked content-type for application/json and called .json() if present. FastAPI sets that header on 204 responses by default, so DELETE /api/imager/base-images/{id} blew up with```nFailed to execute 'json' on 'Response': Unexpected end of JSON input```even though the server-side delete had succeeded. Short-circuit on 204 -> return null before parsing.

## 2. confirm() -> showConfirm() modal
Delete confirmation was using the native window.confirm dialog. Switched to the in-app showConfirm helper (cms/static/app.js, used by users/schedules/dashboard) for visual consistency.

Manual: navigated, deleted a base-image row, modal appeared, no JSON error, row disappeared on refresh.