### PR TITLE
fix(imager): tighten import disk threshold + mirror poison-killed jobs onto target rows

### DIFF
--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -47,6 +47,7 @@ from shared.models.imager import (
     ProvisionedImage,
     ProvisionedImageStatus,
 )
+from shared.models.job import Job, JobType
 from shared.services.storage import LocalStorageBackend, init_storage
 from worker import imager_handlers
 from worker.imager_handlers import (
@@ -686,3 +687,336 @@ async def test_provision_missing_row_returns_false(
         session_factory, settings, uuid.uuid4()
     )
     assert ok is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Import threshold (size-aware) tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_size_aware_threshold_passes_when_free_space_enough(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """expected_size known + free space ample -> threshold check passes
+    (test stops at SHA mismatch from a tiny canned response)."""
+    settings = _make_settings(tmp_path, imager_min_free_bytes=10 * 1024**3)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/x.img.xz",
+        expected_sha256="0" * 64,
+        size_bytes=1_500_000_000,  # 1.5 GB
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    # 4 GiB free is plenty for a 1.5 GB import (needs 2*1.5 + 256 MiB).
+    monkeypatch.setattr(
+        imager_handlers, "_free_bytes",
+        lambda *_: _async_return(4 * 1024**3),
+    )
+    _patch_httpx(monkeypatch, lambda r: httpx.Response(200, content=b"hi"))
+
+    # The handler will pass the threshold check, download "hi", and fail
+    # SHA verify (terminal).  We just want to confirm the threshold
+    # check did not bail out early as retryable False.
+    with pytest.raises(TerminalImagerError, match="sha256 mismatch"):
+        await import_base_image_by_id(session_factory, settings, bi.id)
+
+
+@pytest.mark.asyncio
+async def test_import_size_aware_threshold_fails_when_free_space_low(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """expected_size known + free space tight -> retryable False without
+    touching the network."""
+    # Set imager_min_free_bytes deliberately tiny: prove the import path
+    # is using the size-derived threshold, not the env knob.
+    settings = _make_settings(tmp_path, imager_min_free_bytes=1)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/x.img.xz",
+        expected_sha256="0" * 64,
+        size_bytes=1_500_000_000,  # 1.5 GB -> needs ~3.25 GiB
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    # 1 GiB free is below the size-derived threshold.
+    monkeypatch.setattr(
+        imager_handlers, "_free_bytes",
+        lambda *_: _async_return(1 * 1024**3),
+    )
+
+    def fail(request):
+        raise AssertionError("must not reach network when low on disk")
+    _patch_httpx(monkeypatch, fail)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is False
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.IMPORTING.value
+
+
+@pytest.mark.asyncio
+async def test_import_unknown_size_uses_conservative_fallback(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """When size_bytes is None, fall back to imager_min_free_bytes (10 GiB)
+    rather than a tiny default that could let downloads fill the disk."""
+    settings = _make_settings(tmp_path, imager_min_free_bytes=10 * 1024**3)
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://github.com/x.img.xz",
+        expected_sha256="0" * 64,
+        size_bytes=None,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    # 5 GiB free: above any size-derived guess (would have passed at 2 GiB),
+    # below the 10 GiB conservative fallback.
+    monkeypatch.setattr(
+        imager_handlers, "_free_bytes",
+        lambda *_: _async_return(5 * 1024**3),
+    )
+
+    def fail(request):
+        raise AssertionError("must not reach network with unknown size + low disk")
+    _patch_httpx(monkeypatch, fail)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# mark_target_failed_on_exhaustion tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_exhausted_job(target_id: uuid.UUID, job_type, *, retry_count=4,
+                        error_message="last attempt: connection reset"):
+    """Build a Job-shaped object with the fields the helper consumes.
+    We don't need the row to be in DB -- the helper takes the job by
+    value (it was just claimed, on its way to the dispatcher)."""
+    from shared.models.job import Job, JobStatus
+    j = Job(
+        type=job_type,
+        target_id=target_id,
+        status=JobStatus.FAILED,
+        retry_count=retry_count,
+        error_message=error_message,
+    )
+    j.id = uuid.uuid4()
+    return j
+
+
+async def _async_return(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_flips_importing_base_image(
+    db_session, session_factory, tmp_path
+):
+    """IMPORTING BaseImage + exhausted IMAGE_IMPORT job -> FAILED with
+    descriptive error_message."""
+    from shared.services.jobs import enqueue_job
+
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://x/y.img.xz",
+        expected_sha256="0" * 64,
+        status=BaseImageStatus.IMPORTING.value,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    # Persist a job with this target_id so the latest-job guard finds
+    # exactly one match.  enqueue_job uses target_id consistently.
+    from shared.models.job import JobStatus
+    job_id = await enqueue_job(db_session, JobType.IMAGE_IMPORT, bi.id)
+    async with session_factory() as db:
+        j = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+        j.retry_count = 4
+        j.error_message = "transient network failure"
+        j.status = JobStatus.FAILED
+        await db.commit()
+        job_row = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, job_row,
+    )
+    assert result == "updated"
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.FAILED.value
+    assert "exceeded retry limit" in (fresh.error_message or "")
+    assert "4 attempts" in (fresh.error_message or "")
+    assert "transient network failure" in (fresh.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_flips_provisioning_provisioned_image(
+    db_session, session_factory, tmp_path
+):
+    """PROVISIONING ProvisionedImage + exhausted IMAGE_PROVISION job ->
+    FAILED with descriptive error AND fleet_env_payload cleared."""
+    from shared.services.jobs import enqueue_job
+    from shared.models.job import Job, JobStatus
+
+    bi = await _make_ready_base(db_session, sha="a" * 64)
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"AGORA_FLEET_SECRET=topsecret\n",
+        status=ProvisionedImageStatus.PROVISIONING.value,
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    job_id = await enqueue_job(db_session, JobType.IMAGE_PROVISION, pi.id)
+    async with session_factory() as db:
+        j = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+        j.retry_count = 4
+        j.status = JobStatus.FAILED
+        j.error_message = "build_provisioned subprocess crashed"
+        await db.commit()
+        job_row = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, job_row,
+    )
+    assert result == "updated"
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.FAILED.value
+    assert fresh.fleet_env_payload is None
+    assert "exceeded retry limit" in (fresh.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_skips_non_imager_job(session_factory):
+    """VARIANT_TRANSCODE jobs are owned by the transcoder flow; the
+    helper must no-op safely."""
+    job = _make_exhausted_job(uuid.uuid4(), JobType.VARIANT_TRANSCODE)
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, job,
+    )
+    assert result == "not_imager"
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_skips_when_target_row_missing(
+    session_factory, tmp_path
+):
+    """Poison message arrives after the user deleted the BaseImage -> no-op."""
+    job = _make_exhausted_job(uuid.uuid4(), JobType.IMAGE_IMPORT)
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, job,
+    )
+    assert result == "missing"
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_does_not_clobber_ready_base_image(
+    db_session, session_factory, tmp_path
+):
+    """Re-import after a previous FAILED reuses the same row UUID; if
+    the new attempt has already succeeded (READY), a stale poison
+    message from an OLDER attempt must NOT flip it back to FAILED."""
+    from shared.services.jobs import enqueue_job
+    from shared.models.job import Job, JobStatus
+
+    bi = await _make_ready_base(db_session, sha="b" * 64)
+
+    # Old job for this same target -- this is the one that "exhausted".
+    old_id = await enqueue_job(db_session, JobType.IMAGE_IMPORT, bi.id)
+    async with session_factory() as db:
+        j = (await db.execute(select(Job).where(Job.id == old_id))).scalar_one()
+        j.retry_count = 4
+        j.status = JobStatus.FAILED
+        j.error_message = "stale failure"
+        await db.commit()
+
+    # Newer job for the same target (the user re-imported).  Latest-job
+    # guard should kick in.  Tiny sleep so created_at orders correctly
+    # on filesystems where the resolution is coarse.
+    import asyncio as _aio
+    await _aio.sleep(0.01)
+    new_id = await enqueue_job(db_session, JobType.IMAGE_IMPORT, bi.id)
+    assert new_id != old_id
+
+    async with session_factory() as db:
+        old_row = (await db.execute(
+            select(Job).where(Job.id == old_id)
+        )).scalar_one()
+
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, old_row,
+    )
+    # Either skipped_newer_job (stale-job guard) or skipped_status
+    # (status guard) -- both are correct outcomes.  We must not flip.
+    assert result in ("skipped_newer_job", "skipped_status")
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.READY.value
+
+
+@pytest.mark.asyncio
+async def test_poison_helper_skips_when_status_is_not_in_flight(
+    db_session, session_factory, tmp_path
+):
+    """If somehow the row has already moved past IMPORTING (e.g. another
+    job concurrently set it READY), the status guard prevents clobber."""
+    from shared.services.jobs import enqueue_job
+    from shared.models.job import Job, JobStatus
+
+    bi = BaseImage(
+        variant="pi5", version="v1",
+        source_url="https://x/y.img.xz",
+        expected_sha256="0" * 64,
+        # Already READY despite the job being the latest.
+        status=BaseImageStatus.READY.value,
+        sha256="c" * 64, blob_path="pi5/v1/base.img.xz", size_bytes=1,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    job_id = await enqueue_job(db_session, JobType.IMAGE_IMPORT, bi.id)
+    async with session_factory() as db:
+        j = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+        j.retry_count = 4
+        j.status = JobStatus.FAILED
+        await db.commit()
+        job_row = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one()
+
+    result = await imager_handlers.mark_target_failed_on_exhaustion(
+        session_factory, job_row,
+    )
+    assert result == "skipped_status"
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.READY.value
+

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -456,6 +456,22 @@ async def _queue_mode(settings: WorkerSettings) -> None:
     if job.status == JobStatus.FAILED:
         # claim_job flipped us to FAILED because retry_count exceeded MAX.
         logger.error("Job %s exhausted retries — deleting poison message", job_id)
+        # Mirror the terminal state onto the imager target row so the
+        # UI sees FAILED instead of a stuck IMPORTING/PROVISIONING zombie.
+        # If this raises (e.g. transient DB error), DO NOT delete the
+        # queue message: let it redeliver so we get another shot at
+        # mirroring the failure.  Better to send the user a duplicate
+        # "import failed" log line than leave a row stuck forever.
+        try:
+            from worker.imager_handlers import mark_target_failed_on_exhaustion
+            await mark_target_failed_on_exhaustion(session_factory, job)
+        except Exception:
+            logger.exception(
+                "Failed to mirror poison-job %s onto target row -- "
+                "leaving queue message for redelivery", job_id,
+            )
+            await _stop_heartbeat()
+            return
         await _stop_heartbeat()
         try:
             queue.delete_message(msg, pop_receipt=current_popreceipt)

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -64,6 +64,7 @@ from shared.models.imager import (
     ProvisionedImage,
     ProvisionedImageStatus,
 )
+from shared.models.job import Job, JobType
 from shared.services.imager_catalog import (
     HTTP_TIMEOUT as _HTTP_TIMEOUT,
     MAX_REDIRECTS as _MAX_REDIRECTS,
@@ -192,6 +193,108 @@ async def _set_provisioned_terminal(
         # failures leave it in place because the next attempt needs it.
         row.fleet_env_payload = None
         await db.commit()
+
+
+# Return values for ``mark_target_failed_on_exhaustion``.  The dispatcher
+# uses these to decide whether to delete the poison queue message.
+#
+# * ``"updated"``      — target row was flipped to FAILED.  Safe to delete.
+# * ``"missing"``      — target row no longer exists (deleted).  Safe to delete.
+# * ``"skipped_newer_job"`` — a newer job exists for the same target; the
+#   target is being handled by that newer job.  Safe to delete the poison
+#   message; do not stomp the target row.
+# * ``"skipped_status"``    — target row is in a non-IMPORTING / non-PROVISIONING
+#   state (READY, FAILED, EXPIRED, ...).  Safe to delete the poison message;
+#   the row is not stuck.
+# * ``"not_imager"``        — job type is not an imager job; nothing to do.
+#   Safe to delete (existing behavior preserved for other job types).
+#
+# If the helper raises an exception, the dispatcher MUST NOT delete the
+# queue message — leaving it to redeliver gives us another shot at
+# mirroring the failure onto the target row.
+async def mark_target_failed_on_exhaustion(
+    session_factory: Any, job: Job
+) -> str:
+    """Mirror a poison-killed job's terminal state onto its imager
+    target row so the UI sees FAILED instead of a stuck IMPORTING /
+    PROVISIONING zombie.
+
+    Called by ``worker/__main__.py`` after ``claim_job`` has already
+    flipped the job to FAILED due to retry exhaustion.
+
+    Guarded so we never clobber:
+
+    * a row that has already moved past the in-flight state (e.g. the
+      user re-imported and the row is now IMPORTING again under a new
+      job, or the row was successfully imported under a previous attempt
+      and is READY).
+    * a row whose newest job is not the one that exhausted -- that
+      newer job is responsible for the target row's state.
+
+    See module docstring for the wider lifecycle.
+    """
+    if job.type not in (JobType.IMAGE_IMPORT, JobType.IMAGE_PROVISION):
+        return "not_imager"
+
+    msg = (
+        f"job exceeded retry limit ({job.retry_count} attempts): "
+        f"{(job.error_message or 'unknown failure')[:200]}"
+    )
+
+    async with session_factory() as db:
+        # Stale-job guard: if a newer job exists for the same target,
+        # leave the target row alone -- the newer job owns it now.
+        latest_id = (await db.execute(
+            select(Job.id)
+            .where(Job.type == job.type, Job.target_id == job.target_id)
+            .order_by(Job.created_at.desc())
+            .limit(1)
+        )).scalar_one_or_none()
+        if latest_id is not None and latest_id != job.id:
+            logger.info(
+                "Poison job %s for target %s is stale -- newer job %s "
+                "owns the target row; not flipping",
+                job.id, job.target_id, latest_id,
+            )
+            return "skipped_newer_job"
+
+        if job.type == JobType.IMAGE_IMPORT:
+            row = (await db.execute(
+                select(BaseImage).where(BaseImage.id == job.target_id)
+            )).scalar_one_or_none()
+            if row is None:
+                return "missing"
+            if row.status != BaseImageStatus.IMPORTING.value:
+                logger.info(
+                    "BaseImage %s status is %s (not IMPORTING) -- not "
+                    "clobbering on poison kill of job %s",
+                    row.id, row.status, job.id,
+                )
+                return "skipped_status"
+            row.status = BaseImageStatus.FAILED.value
+            row.error_message = msg[:2000]
+            await db.commit()
+            return "updated"
+
+        # IMAGE_PROVISION
+        row = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == job.target_id)
+        )).scalar_one_or_none()
+        if row is None:
+            return "missing"
+        if row.status != ProvisionedImageStatus.PROVISIONING.value:
+            logger.info(
+                "ProvisionedImage %s status is %s (not PROVISIONING) -- "
+                "not clobbering on poison kill of job %s",
+                row.id, row.status, job.id,
+            )
+            return "skipped_status"
+        row.status = ProvisionedImageStatus.FAILED.value
+        row.error_message = msg[:2000]
+        # Secret hygiene: terminal failures clear the payload.
+        row.fleet_env_payload = None
+        await db.commit()
+        return "updated"
 
 
 async def _fetch_catalog(
@@ -327,6 +430,7 @@ async def import_base_image_by_id(
             version = row.version
             source_url = row.source_url
             expected_sha256 = row.expected_sha256
+            expected_size = row.size_bytes
             # PR 7: catalog URL moved from env var to DB setting.
             # Read it in the same session so the fallback below has it.
             catalog_url = await get_catalog_url(db)
@@ -336,11 +440,24 @@ async def import_base_image_by_id(
         scratch.mkdir(parents=True, exist_ok=True)
 
         # Free-space pre-flight (retryable -- another job may free disk soon).
+        # Import is download->upload only: we stage the .img.xz on scratch,
+        # SHA-stream-verify it (no extra copy), and stream-upload to blob.
+        # Peak scratch usage is essentially one file, so 2x source size +
+        # 256 MiB headroom is plenty.  Provision (decompress->mutate->
+        # recompress) uses the much larger ``imager_min_free_bytes``.
+        if expected_size and expected_size > 0:
+            needed = max(int(expected_size) * 2 + 256 * 1024 * 1024,
+                         512 * 1024 * 1024)
+        else:
+            # Unknown source size: fall back to the conservative provision-
+            # sized threshold rather than guess low and risk filling disk.
+            needed = settings.imager_min_free_bytes
         free = await _free_bytes(scratch)
-        if free < settings.imager_min_free_bytes:
+        if free < needed:
             logger.warning(
-                "BaseImage %s import: free space %d below threshold %d -- retry",
-                base_image_id, free, settings.imager_min_free_bytes,
+                "BaseImage %s import: free space %d below import threshold "
+                "%d (expected_size=%s) -- retry",
+                base_image_id, free, needed, expected_size,
             )
             return False
 


### PR DESCRIPTION
## Summary

Two related imager fixes shipped together. Both surfaced from the recent stuck pi5 import + the duck-review of the catalog feature gaps.

### 1. Import disk-space threshold was wrong knob

`worker/imager_handlers.py` was using `settings.imager_min_free_bytes` (10 GiB) to gate the IMAGE_IMPORT path. That number is sized for the provision pipeline (decompress → mutate → recompress, ~6 GiB peak). Imports only need ~1.5 GiB (download + upload). With a 10 GB ACA Files volume, every import was getting marked retryable-low-disk, retried 3×, then poison-killed.

**New behavior**: when `BaseImage.size_bytes` is known (the common path, captured by the catalog manifest in PR #506), require `max(2 * expected_size + 256 MiB, 512 MiB)` free. Falls back to `imager_min_free_bytes` when size is unknown so we still defend against malformed/legacy rows.

### 2. Poison-killed imager jobs left target rows stuck

When `claim_job` exhausts retries it flips the Job to FAILED, but nothing was mirroring that onto the `BaseImage` / `ProvisionedImage` row. UI showed a spinner forever; only recovery was delete + re-import.

**New helper** `mark_target_failed_on_exhaustion` flips the target row to FAILED with a descriptive `error_message` ("job exceeded retry limit (N attempts): ..."). For `ProvisionedImage` we also clear `fleet_env_payload`.

Two guards prevent clobbering a healthy row (BaseImage UUIDs are reused on re-import after FAILED — see `cms/routers/imager.py:434-444`):

- **Stale-job guard**: if a newer Job exists for the same `(type, target_id)`, that one owns the row. Returns `"skipped_newer_job"`.
- **Status guard**: if row has moved past in-flight (READY, FAILED, EXPIRED, ...), leave it alone. Returns `"skipped_status"`.

The dispatcher only deletes the poison queue message when the helper returns normally. If the helper raises (e.g. transient DB error), the queue message redelivers so we get another shot at mirroring.

## Test plan

6 new tests in `tests/test_imager_handlers.py`:

- threshold known-size passes (4 GiB free, 1.5 GB image)
- threshold known-size fails (1 GiB free, 1.5 GB image — and `imager_min_free_bytes=1` to prove we're not using the env knob)
- threshold unknown-size falls back to conservative `imager_min_free_bytes`
- poison helper updates `BaseImage` (IMPORTING → FAILED with error message)
- poison helper updates `ProvisionedImage` (PROVISIONING → FAILED, payload cleared)
- poison helper skips when newer job exists for same target (re-import after failure)
- poison helper skips when row already in terminal state (READY)
- poison helper returns `"missing"` when target row was deleted
- poison helper returns `"not_imager"` for non-imager job types

Local: 29 imager handler tests pass (was 23). 4 worker_lifecycle tests still pass.

## Why this matters

User reported pi5 import "stuck" — this is exactly that failure mode. After PR B deploys, the user can either click Import again (will auto-flip the existing stuck row on the next poison-kill cycle, ~3 attempts) or delete + re-import (faster, no waiting for retries).

PR B in the imager-feature-hardening sequence (PR A #518 worker tools, PR #519 delete UI fixes, **PR B = this**, PR C UI feedback loop, PR D cleanup).

## Risks

- Behavior change in the poison-message branch of the dispatcher: previously always deleted the message; now conditionally retains it on helper failure. This is a strictly safer policy — at worst we deliver a duplicate "import failed" log line, at best we recover from a transient DB blip. The non-imager job path (transcode etc.) is unchanged because the helper short-circuits with `"not_imager"`.
- New SQL `ORDER BY created_at DESC LIMIT 1` lookup runs on every poison kill. Fully covered by `(target_id, type)` index already used by the rest of the worker.

🤖 Drafted with rubber-duck review (3 blocking issues identified + addressed: row-reuse race, queue-message-delete sequencing, conservative unknown-size fallback).
