### PR TITLE
feat(imager): auto-refresh base-image rows during import

### DIFF
--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -443,15 +443,53 @@
         }, 3000);
     }
 
+    // Auto-refresh state for in-flight imports.
+    var basesPollTimer = null;
+    var basesLastStatus = {};
+    var BASES_POLL_MS = 4000;
+
+    function clearBasesPollTimer() {
+        if (basesPollTimer) { clearTimeout(basesPollTimer); basesPollTimer = null; }
+    }
+
+    function scheduleBasesPoll() {
+        clearBasesPollTimer();
+        if (document.hidden) return;
+        basesPollTimer = setTimeout(function() {
+            basesPollTimer = null;
+            loadBaseImages();
+        }, BASES_POLL_MS);
+    }
+
+    function notifyBaseTransitions(bases) {
+        bases.forEach(function(b) {
+            var prev = basesLastStatus[b.id];
+            if (prev === 'IMPORTING' && b.status !== 'IMPORTING') {
+                if (b.status === 'READY') {
+                    toast('Import complete: ' + b.variant + ' / ' + b.version, 'success');
+                } else if (b.status === 'FAILED') {
+                    var msg = b.error_message ? (': ' + b.error_message) : '';
+                    toast('Import failed: ' + b.variant + ' / ' + b.version + msg, 'error');
+                }
+            }
+        });
+        var next = {};
+        bases.forEach(function(b) { next[b.id] = b.status; });
+        basesLastStatus = next;
+    }
+
     async function loadBaseImages() {
         if (!manageSection) return;
+        clearBasesPollTimer();
         var tbody = $('#imagerBaseTbody', manageSection);
         try {
             var bases = await jsonFetch('/api/imager/base-images');
             if (!bases || bases.length === 0) {
+                basesLastStatus = {};
                 tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No base images cached. Click "Import from catalog…" to add one.</td></tr>';
                 return;
             }
+            notifyBaseTransitions(bases);
             tbody.innerHTML = bases.map(function(b) {
                 var sha = b.sha256 ? b.sha256.slice(0, 12) + '…' : '—';
                 var del = b.status === 'IMPORTING' ? '' :
@@ -469,8 +507,12 @@
             tbody.querySelectorAll('[data-delete-base]').forEach(function(btn) {
                 btn.addEventListener('click', function() { deleteBase(btn.getAttribute('data-delete-base')); });
             });
+            var anyImporting = bases.some(function(b) { return b.status === 'IMPORTING'; });
+            if (anyImporting) scheduleBasesPoll();
         } catch (e) {
             tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">Failed to load: ' + escHtml(e.message || e) + '</td></tr>';
+            // Retry on transient failures so the UI recovers without a manual refresh.
+            scheduleBasesPoll();
         }
     }
 
@@ -691,9 +733,19 @@
 
     // Re-poll immediately when the tab becomes visible.
     document.addEventListener('visibilitychange', function() {
-        if (document.hidden) return;
+        if (document.hidden) {
+            clearBasesPollTimer();
+            return;
+        }
         var jid = loadActiveJob();
         if (jid && pollTimer) pollOnce(jid);
+        // Resume base-images polling if there are in-flight imports.
+        if (manageSection) {
+            var hasImporting = Object.keys(basesLastStatus).some(function(k) {
+                return basesLastStatus[k] === 'IMPORTING';
+            });
+            if (hasImporting) loadBaseImages();
+        }
     });
 })();
 </script>


### PR DESCRIPTION
## Summary

Auto-refresh imager base-image rows while imports are in flight, so admins don't need to manually reload the page to see status transitions.

## What was wrong

The import-submit handler in `cms/templates/imager.html` called `loadBaseImages()` exactly once after POST and then stopped. The row would land in `IMPORTING` state and sit there until the user hit refresh.

The dead `pollImportJob()` function defined earlier in the file had a self-aware comment admitting it didn't have a `job_id` to poll with — the API returns the BaseImage row, not the spawned job. So no polling ran at all.

## What this changes

- **Self-rescheduling poll** (4 s interval) over `loadBaseImages()` while any row is `IMPORTING`. Stops as soon as no row is `IMPORTING`.
- **Toasts on transitions** (`IMPORTING → READY` ⇒ success, `IMPORTING → FAILED` ⇒ error, including the row's `error_message` so the PR B poison-kill message actually reaches the user).
- **Visibility-aware**: pauses polling when the tab is hidden, resumes on `visibilitychange` if there are still in-flight rows.
- **Resilient to transient failures**: list-fetch errors also schedule a retry, so the table recovers without manual refresh.

No API change. No new dependencies. ~50 lines of pure JS in one template.

## Out of scope

- Per-job progress percentage (no `total_bytes` plumbing yet).
- Cancel button.
- Same treatment for build/provision flow — the build flow already polls correctly via `pollTimer` + `loadActiveJob`.

## Testing

`tests/test_imager_ui.py` — 6/6 passing.
