### PR TITLE
feat(imager): case-insensitive status checks + cleanup nits + tests

### DIFF
--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -195,8 +195,9 @@
         }
         return body;
     }
+    function statusUp(s) { return String(s || '').toUpperCase(); }
     function statusBadgeClass(status) {
-        var s = String(status || '').toUpperCase();
+        var s = statusUp(status);
         if (s === 'DONE' || s === 'READY') return 'badge badge-success';
         if (s === 'FAILED') return 'badge badge-failed';
         if (s === 'CANCELLED') return 'badge badge-cancelled';
@@ -223,7 +224,7 @@
                 jsonFetch('/api/imager/base-images'),
             ]);
             fleetsCache = fleets || [];
-            basesCache = (bases || []).filter(function(b) { return b.status === 'READY'; });
+            basesCache = (bases || []).filter(function(b) { return statusUp(b.status) === 'READY'; });
 
             fleetSel.innerHTML = '';
             if (fleetsCache.length === 0) {
@@ -237,7 +238,7 @@
 
             baseSel.innerHTML = '';
             if (basesCache.length === 0) {
-                baseSel.innerHTML = '<option value="">No ready base images</option>';
+                baseSel.innerHTML = '<option value="">No base images ready</option>';
             } else {
                 baseSel.innerHTML = '<option value="">Select base image…</option>' +
                     basesCache.map(function(b) {
@@ -308,23 +309,25 @@
         if (job.output_name) metaParts.push(escHtml(job.output_name));
         if (job.created_at) metaParts.push('started ' + fmtDate(job.created_at));
         meta.innerHTML = metaParts.join(' · ');
-        if (job.status === 'DONE') {
+        if (statusUp(job.status) === 'DONE') {
             dl.style.display = '';
             dl.href = '/api/imager/download/' + encodeURIComponent(job.job_id);
             errBox.style.display = 'none';
         } else {
             dl.style.display = 'none';
         }
-        if (job.status === 'FAILED' || job.status === 'CANCELLED') {
+        var js = statusUp(job.status);
+        if (js === 'FAILED' || js === 'CANCELLED') {
             errBox.style.display = '';
             errBox.textContent = job.error_message || 'Build did not complete.';
-        } else if (job.status !== 'DONE') {
+        } else if (js !== 'DONE') {
             errBox.style.display = 'none';
         }
     }
 
     function isTerminal(status) {
-        return status === 'DONE' || status === 'FAILED' || status === 'CANCELLED';
+        var s = statusUp(status);
+        return s === 'DONE' || s === 'FAILED' || s === 'CANCELLED';
     }
 
     async function pollOnce(jobId) {
@@ -333,7 +336,7 @@
             renderJobCard(job);
             if (isTerminal(job.status)) {
                 stopPolling();
-                if (job.status === 'DONE') {
+                if (statusUp(job.status) === 'DONE') {
                     toast('Image build complete', 'success');
                 }
             }
@@ -427,7 +430,7 @@
                     renderImportProgress();
                     loadBaseImages();
                     if (buildSection) loadFleetsAndBases();
-                    if (job.status === 'DONE') {
+                    if (statusUp(job.status) === 'DONE') {
                         toast('Imported ' + info.variant + ' / ' + info.version, 'success');
                     } else {
                         toast('Import failed: ' + (job.error_message || job.status), 'error');
@@ -464,17 +467,18 @@
     function notifyBaseTransitions(bases) {
         bases.forEach(function(b) {
             var prev = basesLastStatus[b.id];
-            if (prev === 'IMPORTING' && b.status !== 'IMPORTING') {
-                if (b.status === 'READY') {
+            var cur = statusUp(b.status);
+            if (prev === 'IMPORTING' && cur !== 'IMPORTING') {
+                if (cur === 'READY') {
                     toast('Import complete: ' + b.variant + ' / ' + b.version, 'success');
-                } else if (b.status === 'FAILED') {
+                } else if (cur === 'FAILED') {
                     var msg = b.error_message ? (': ' + b.error_message) : '';
                     toast('Import failed: ' + b.variant + ' / ' + b.version + msg, 'error');
                 }
             }
         });
         var next = {};
-        bases.forEach(function(b) { next[b.id] = b.status; });
+        bases.forEach(function(b) { next[b.id] = statusUp(b.status); });
         basesLastStatus = next;
     }
 
@@ -492,7 +496,8 @@
             notifyBaseTransitions(bases);
             tbody.innerHTML = bases.map(function(b) {
                 var sha = b.sha256 ? b.sha256.slice(0, 12) + '…' : '—';
-                var del = b.status === 'IMPORTING' ? '' :
+                var shaTitle = b.sha256 ? ' title="' + escHtml(b.sha256) + '"' : '';
+                var del = statusUp(b.status) === 'IMPORTING' ? '' :
                     '<button type="button" class="btn btn-sm btn-danger-subtle" data-delete-base="' + escHtml(b.id) + '">Delete</button>';
                 return '<tr>' +
                     '<td>' + escHtml(b.variant) + '</td>' +
@@ -500,14 +505,14 @@
                     '<td><span class="' + statusBadgeClass(b.status) + '">' + escHtml(b.status) + '</span></td>' +
                     '<td>' + fmtBytes(b.size_bytes) + '</td>' +
                     '<td title="' + escHtml(b.imported_at || '') + '">' + fmtDate(b.imported_at) + '</td>' +
-                    '<td><code style="font-size:0.75rem;">' + escHtml(sha) + '</code></td>' +
+                    '<td><code style="font-size:0.75rem;"' + shaTitle + '>' + escHtml(sha) + '</code></td>' +
                     '<td style="text-align:right;">' + del + '</td>' +
                     '</tr>';
             }).join('');
             tbody.querySelectorAll('[data-delete-base]').forEach(function(btn) {
                 btn.addEventListener('click', function() { deleteBase(btn.getAttribute('data-delete-base')); });
             });
-            var anyImporting = bases.some(function(b) { return b.status === 'IMPORTING'; });
+            var anyImporting = bases.some(function(b) { return statusUp(b.status) === 'IMPORTING'; });
             if (anyImporting) scheduleBasesPoll();
         } catch (e) {
             tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">Failed to load: ' + escHtml(e.message || e) + '</td></tr>';

--- a/shared/config.py
+++ b/shared/config.py
@@ -48,8 +48,22 @@ class SharedSettings(BaseSettings):
     # Defaults to a subdirectory under ``asset_storage_path`` so the
     # worker doesn't need extra mounts in the simple case; production
     # deployments should override with a path on a dedicated volume.
+    # Use ``resolved_imager_scratch_path`` to read with the fallback
+    # applied — never branch on ``imager_scratch_path`` directly.
     imager_scratch_path: Path | None = None
     # Minimum free bytes the worker requires on the scratch volume
     # before starting an imager job.  ~10 GiB headroom over the
     # ~6 GiB worst-case peak (decompress + recompress in parallel).
     imager_min_free_bytes: int = 10 * 1024 * 1024 * 1024
+
+    @property
+    def resolved_imager_scratch_path(self) -> Path:
+        """Return the effective imager scratch directory.
+
+        Centralises the ``imager_scratch_path`` ⇒ ``asset_storage_path /
+        'imager-scratch'`` fallback so every consumer (worker handler,
+        diagnostic tools, future tests) agrees on the resolved location.
+        """
+        if self.imager_scratch_path is not None:
+            return Path(self.imager_scratch_path)
+        return Path(self.asset_storage_path) / "imager-scratch"

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -365,6 +365,11 @@ async def test_list_base_images(client, db_session, imager_settings):
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 2
+    # API contract: status field is lowercase on the wire. The frontend
+    # normalizes via statusUp(); breaking this contract silently breaks
+    # auto-refresh, transition toasts, dropdown filters, etc.
+    statuses = sorted(b["status"] for b in data)
+    assert statuses == ["importing", "ready"]
 
 
 # ── Base-image delete ──────────────────────────────────────────────
@@ -536,6 +541,8 @@ async def test_get_job_returns_status(client, db_session, imager_settings):
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == JobStatus.PENDING.value
+    # API contract: lowercase on the wire. Frontend depends on this.
+    assert body["status"] == "pending"
     assert body["type"] == JobType.IMAGE_IMPORT.value
     assert body["download_url"] is None
 

--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -60,10 +60,15 @@ from worker.imager_handlers import (
 # Default settings sufficient for handler tests; per-test overrides
 # happen via ``dataclasses.replace``-style ``SimpleNamespace`` updates.
 def _make_settings(tmp_path: Path, **overrides: Any) -> SimpleNamespace:
+    scratch_path = tmp_path / "scratch"
     base = dict(
-        imager_scratch_path=str(tmp_path / "scratch"),
+        imager_scratch_path=str(scratch_path),
+        resolved_imager_scratch_path=scratch_path,
         imager_min_free_bytes=1,  # tests run in tmpdirs with plenty of room
-        base_image_allowed_hosts="github.com,objects.githubusercontent.com",
+        base_image_allowed_hosts=(
+            "github.com,objects.githubusercontent.com,"
+            "release-assets.githubusercontent.com"
+        ),
         # PR 7: catalog URL is no longer on Settings.  Tests that
         # exercise the worker fallback path seed a row in
         # ``cms_settings`` via ``set_catalog_url`` instead.
@@ -124,6 +129,7 @@ def test_scratch_dir_falls_back_to_asset_storage_when_unset(tmp_path: Path) -> N
     settings = SimpleNamespace(
         imager_scratch_path=None,
         asset_storage_path=tmp_path / "assets",
+        resolved_imager_scratch_path=tmp_path / "assets" / "imager-scratch",
     )
     target = uuid.uuid4()
     scratch = imager_handlers._scratch_dir(settings, "import", target)
@@ -139,6 +145,7 @@ def test_scratch_dir_honors_explicit_imager_scratch_path(tmp_path: Path) -> None
     settings = SimpleNamespace(
         imager_scratch_path=explicit,
         asset_storage_path=tmp_path / "assets",
+        resolved_imager_scratch_path=explicit,
     )
     target = uuid.uuid4()
     scratch = imager_handlers._scratch_dir(settings, "build", target)
@@ -283,6 +290,47 @@ async def test_import_redirect_to_disallowed_host_terminal(
 
     with pytest.raises(TerminalImagerError, match="not in base_image_allowed_hosts"):
         await import_base_image_by_id(session_factory, settings, bi.id)
+
+
+@pytest.mark.asyncio
+async def test_import_redirect_to_release_assets_cdn_succeeds(
+    db_session, session_factory, storage_backend, tmp_path, monkeypatch
+):
+    """github.com -> release-assets.githubusercontent.com is the real-world
+    redirect path; the allowlist must permit it end-to-end."""
+    payload = b"release-assets-cdn-payload" * 64
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    settings = _make_settings(tmp_path)
+    bi = BaseImage(
+        variant="pi5", version="v1.11.28",
+        source_url=("https://github.com/sslivins/agora/releases/"
+                    "download/v1.11.28/agora-pi5.img.xz"),
+        expected_sha256=expected_sha,
+    )
+    db_session.add(bi)
+    await db_session.commit()
+    await db_session.refresh(bi)
+
+    cdn_url = ("https://release-assets.githubusercontent.com/"
+               "github-production-release-asset/abc/agora-pi5.img.xz")
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "github.com":
+            return httpx.Response(302, headers={"location": cdn_url})
+        if request.url.host == "release-assets.githubusercontent.com":
+            return httpx.Response(200, content=payload)
+        return httpx.Response(404)
+    _patch_httpx(monkeypatch, handle)
+
+    ok = await import_base_image_by_id(session_factory, settings, bi.id)
+    assert ok is True
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(BaseImage).where(BaseImage.id == bi.id)
+        )).scalar_one()
+    assert fresh.status == BaseImageStatus.READY.value
+    assert fresh.sha256 == expected_sha
 
 
 @pytest.mark.asyncio

--- a/tests/test_imager_ui.py
+++ b/tests/test_imager_ui.py
@@ -87,3 +87,34 @@ async def test_nav_link_absent_for_viewer(app, db_session):
         assert 'href="/imager"' not in resp.text
     finally:
         await ac.aclose()
+
+
+# ── Status casing regression guard ─────────────────────────────────
+
+
+def test_imager_html_no_raw_uppercase_status_compare():
+    """Guard against the case-bug class that silently broke PR C.
+
+    The API emits status enums lowercase ("ready", "done", "importing", ...).
+    The frontend must normalize via ``statusUp(...)`` before comparing to
+    uppercase literals; comparing the raw API field directly to an
+    uppercase string never matches and silently breaks auto-refresh,
+    transition toasts, dropdown filters, and terminal-state detection.
+
+    This guard catches the bad pattern (``foo.status === 'UPPERCASE'``)
+    while allowing the good one (``statusUp(foo.status) === 'UPPERCASE'``).
+    """
+    import re
+    from pathlib import Path
+
+    template = Path(__file__).resolve().parents[1] / "cms" / "templates" / "imager.html"
+    text = template.read_text(encoding="utf-8")
+    # Match `<word>.status === 'UPPERCASE'` (or !==). Won't match
+    # `statusUp(foo.status) === 'UP'` because `)` sits between
+    # `.status` and the operator.
+    bad = re.findall(r"\b\w+\.status\s*[!=]==\s*['\"][A-Z_]+['\"]", text)
+    assert not bad, (
+        "Raw uppercase status comparison(s) found in imager.html — "
+        "API emits lowercase, must normalize via statusUp(). "
+        f"Offending sites: {bad}"
+    )

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -146,14 +146,12 @@ def _scratch_dir(settings: Any, prefix: str, target_id: uuid.UUID) -> Path:
     cannot rmtree another worker's in-flight files.
 
     When ``settings.imager_scratch_path`` is unset (the default in
-    deployments without a dedicated scratch volume), fall back to
-    a subdirectory under ``asset_storage_path`` per the config
-    docstring contract.
+    deployments without a dedicated scratch volume), the path falls
+    back to a subdirectory under ``asset_storage_path``.  The fallback
+    lives on :attr:`SharedSettings.resolved_imager_scratch_path` so
+    every consumer agrees on the resolved location.
     """
-    scratch_root = settings.imager_scratch_path
-    if scratch_root is None:
-        scratch_root = Path(settings.asset_storage_path) / "imager-scratch"
-    root = Path(scratch_root)
+    root = settings.resolved_imager_scratch_path
     return root / f"{prefix}-{target_id}-{uuid.uuid4().hex[:8]}"
 
 


### PR DESCRIPTION
# Imager polish: case-insensitive status + cleanup nits + tests

## Critical bug fix (rolled in)

`imager.html` was comparing API status fields to UPPERCASE literals
everywhere, but `BaseImageStatus` and `JobStatus` enum values are
**lowercase** on the wire (`"ready"`, `"done"`, `"importing"`,
`"failed"`, `"cancelled"`). Three prior PRs shipped with this
silently broken; the only thing that worked was `statusBadgeClass`
because it `.toUpperCase()`'d first — masking the bug visually.

Symptoms in prod:
- PR C's row-level **auto-refresh** never triggered (`anyImporting`
  always false).
- PR C's **transition toasts** never fired.
- Build tab dropdown filter rejected every row → user-reported
  *"No base images ready"* even with two ready bases.
- Build-job poller never recognized terminal state.
- Delete button rendered on IMPORTING rows.

Fix: added a one-liner `statusUp(s)` helper and routed 9 comparison
sites through it. `statusBadgeClass` now reuses the helper too.

## Regression guards

- **API contract pinned** — `test_list_base_images` and
  `test_get_job_returns_status` now assert lowercase status literals
  on the wire.
- **Static guard** — new `test_imager_html_no_raw_uppercase_status_compare`
  regex-fails any future `foo.status === 'UPPERCASE'` while
  allowing the normalized `statusUp(foo.status) === 'UPPERCASE'`.

## Cleanup nits

- `shared/config.py`: new `resolved_imager_scratch_path` property
  centralizes the asset-storage fallback.
- `worker/imager_handlers.py`: `_scratch_dir` reads the property —
  one source of truth.
- Copy: `"No ready base images"` → `"No base images ready"`.
- SHA tooltip on the digest column.
- New `test_import_redirect_to_release_assets_cdn_succeeds` covering
  github.com → release-assets.githubusercontent.com 302, with the
  host added to the fixture allowlist.

## Verification

`pytest tests/test_imager_ui.py tests/test_imager_handlers.py tests/test_imager_api.py`
→ **66 passed**.

Rubber-duck pass before commit. Sibling-bug sweep covered
assets/devices/settings — clean.
