### PR TITLE
Imager: derive wss URL from AGORA_CMS_BASE_URL (SSoT) + WPS guard

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -17,8 +17,11 @@ class Settings(SharedSettings):
     # MCP Server
     mcp_server_url: str = "http://mcp:8000"  # Docker default; override for Azure
 
-    # Asset downloads
-    asset_base_url: str | None = None  # override base URL for device asset downloads
+    # Optional override for asset download URLs (e.g., a CDN edge in front
+    # of this CMS).  When unset, asset URLs use ``base_url`` (the canonical
+    # public CMS URL) — see :pyattr:`base_url` and
+    # :pyattr:`effective_asset_base_url` below.
+    asset_base_url: str | None = None
 
     # Device defaults
     default_device_storage_mb: int = 500  # assumed device flash budget for assets
@@ -46,8 +49,29 @@ class Settings(SharedSettings):
     # If unset, the receiver echoes back whatever Azure sent (dev-friendly).
     wps_webhook_allowed_origin: str | None = None
 
-    # SMTP is configured via the web UI settings page (stored in DB)
-    base_url: str | None = None  # public URL for login links in emails
+    # Canonical public URL of this CMS (env: ``AGORA_CMS_BASE_URL``).
+    # Single source of truth for every place we need an absolute URL
+    # pointing at this deployment:
+    #   * Login / password-reset / invite links emailed to operators.
+    #   * Default base for device asset download URLs (overridable via
+    #     :pyattr:`asset_base_url` for CDN edge cases).
+    #   * Embedded into provisioned Pi images by the imager build —
+    #     transformed to ``wss://<host>/ws/device`` before being baked
+    #     into ``agora-fleet.env`` as ``AGORA_CMS_URL``.
+    # Format: scheme + host (no path, no trailing slash), e.g.
+    # ``https://agora.example.com``.  Required for image builds.
+    base_url: str | None = None
+
+    @property
+    def effective_asset_base_url(self) -> str | None:
+        """Return the override URL if set, else the canonical base URL.
+
+        Used by the WS / WPS asset-URL resolvers and any other code
+        that wants the public download base without caring whether
+        this deployment fronts a CDN.  Returns ``None`` only when
+        neither knob is configured.
+        """
+        return self.asset_base_url or self.base_url
 
     # Log-request drainer (issue #345 Stage 3d).  Self-healing loop for
     # the ``log_requests`` outbox: retries stuck ``pending`` rows with

--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -40,6 +40,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -223,6 +224,41 @@ def _resolve_catalog_entry(
             detail=f"catalog entry for {variant!r} missing url or sha256",
         )
     return entry
+
+
+def _derive_device_ws_url(base_url: str) -> str:
+    """Derive the device WebSocket URL the firmware connects to.
+
+    Maps ``https://host[:port]`` → ``wss://host[:port]/ws/device``
+    (and ``http://`` → ``ws://`` for local dev).  This is the value
+    baked into ``agora-fleet.env`` as ``AGORA_CMS_URL``; the firmware
+    passes it directly to ``websockets.connect()`` and derives the
+    HTTPS API base by swapping the scheme back.
+
+    The input must be a clean origin URL (scheme + host[:port], no
+    path/query/fragment) — anything else is rejected so we never
+    silently bake a half-correct URL into a Pi image.
+
+    Raises :class:`ValueError` on empty input, missing host, an
+    unsupported scheme, or any path/query/fragment.
+    """
+    if not base_url:
+        raise ValueError("base_url is empty")
+    parsed = urlparse(base_url.rstrip("/"))
+    if parsed.scheme not in ("http", "https", "ws", "wss"):
+        raise ValueError(
+            f"base_url {base_url!r} has unsupported scheme {parsed.scheme!r}; "
+            "expected http(s) or ws(s)"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"base_url {base_url!r} has no host component")
+    if parsed.path or parsed.params or parsed.query or parsed.fragment:
+        raise ValueError(
+            f"base_url {base_url!r} must be origin only "
+            "(scheme + host[:port], no path/query/fragment)"
+        )
+    ws_scheme = "wss" if parsed.scheme in ("https", "wss") else "ws"
+    return urlunparse((ws_scheme, parsed.netloc, "/ws/device", "", "", ""))
 
 
 def _fleet_env_payload(cms_url: str, fleet_id: str, fleet_secret: str) -> bytes:
@@ -554,11 +590,35 @@ async def build_provisioned_image(
             detail=f"fleet_id {body.fleet_id!r} is not configured on this CMS",
         )
 
-    cms_url = (settings.base_url or "").rstrip("/")
-    if not cms_url:
+    if settings.device_transport != "local":
         raise HTTPException(
             status_code=503,
-            detail="AGORA_BASE_URL is not configured; the image needs an absolute CMS URL",
+            detail=(
+                f"Image builds require AGORA_CMS_DEVICE_TRANSPORT='local'; "
+                f"this CMS is configured for {settings.device_transport!r} "
+                "and does not expose /ws/device. Provisioned images embed "
+                "a wss:// URL pointing at /ws/device, which would not work "
+                "in this transport mode."
+            ),
+        )
+
+    cms_base = (settings.base_url or "").rstrip("/")
+    if not cms_base:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "AGORA_CMS_BASE_URL is not configured. Set it to the public URL "
+                "of this CMS (e.g. https://agora.example.com) — image builds "
+                "embed it in the Pi's fleet env so the device can reach "
+                "/ws/device and /api/devices/register."
+            ),
+        )
+    try:
+        cms_url = _derive_device_ws_url(cms_base)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"AGORA_CMS_BASE_URL is invalid ({exc}); expected an absolute URL like https://agora.example.com",
         )
 
     bi = await db.get(BaseImage, body.base_image_id)

--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -68,8 +68,12 @@ def _extract_access_keys(connection_string: str | None) -> list[str]:
 
 def _get_asset_base_url(request: Request, settings: Settings) -> str:
     """Base URL for asset download links — mirrors ws.get_asset_base_url."""
-    if settings.asset_base_url:
-        return settings.asset_base_url.rstrip("/")
+    asset_base_url = getattr(settings, "asset_base_url", None)
+    if asset_base_url:
+        return asset_base_url.rstrip("/")
+    base_url = getattr(settings, "base_url", None)
+    if base_url:
+        return base_url.rstrip("/")
     host = request.headers.get("host")
     if host:
         scheme = "https" if request.url.scheme in ("https", "wss") else "http"

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -51,13 +51,18 @@ def get_asset_base_url(request=None) -> str:
     """Return the base URL for asset download links.
 
     Priority:
-    1. AGORA_CMS_ASSET_BASE_URL config override
-    2. Request Host header (what the client actually connected to)
-    3. Request base_url (server-side view — last resort)
+    1. ``asset_base_url`` (explicit override — typically a CDN edge
+       fronting this CMS).
+    2. ``base_url`` (canonical public CMS URL — single source of
+       truth set per deployment).
+    3. Request Host header (what the client actually connected to).
+    4. Request base_url (server-side view — last resort).
     """
     settings = get_settings()
     if settings.asset_base_url:
         return settings.asset_base_url.rstrip("/")
+    if settings.base_url:
+        return settings.base_url.rstrip("/")
     if request is not None:
         host = request.headers.get("host")
         if host:

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -461,6 +461,34 @@ async def test_build_503_when_base_url_missing(client, db_session, imager_settin
         },
     )
     assert resp.status_code == 503
+    detail = resp.json()["detail"]
+    assert "AGORA_CMS_BASE_URL" in detail
+    assert "/ws/device" in detail or "register" in detail
+
+
+@pytest.mark.asyncio
+async def test_build_503_when_device_transport_wps(client, db_session, imager_settings):
+    """WPS-mode CMS does not mount /ws/device, so image builds must refuse."""
+    saved_transport = imager_settings.device_transport
+    try:
+        imager_settings.device_transport = "wps"
+        bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+        db_session.add(bi)
+        await db_session.commit()
+        resp = await client.post(
+            "/api/imager/build",
+            json={
+                "base_image_id": str(bi.id),
+                "fleet_id": "fleet-test",
+                "output_name": "x.img.xz",
+            },
+        )
+        assert resp.status_code == 503
+        detail = resp.json()["detail"]
+        assert "transport" in detail.lower()
+        assert "wps" in detail.lower()
+    finally:
+        imager_settings.device_transport = saved_transport
 
 
 @pytest.mark.asyncio
@@ -508,7 +536,10 @@ async def test_build_creates_provisioned_row_with_payload(
     assert pi.fleet_id == "fleet-test"
     assert pi.output_name == "kitchen.img.xz"
     payload = pi.fleet_env_payload.decode("utf-8")
-    assert "AGORA_CMS_URL=https://cms.example.com" in payload
+    # AGORA_CMS_BASE_URL=https://cms.example.com → wss://cms.example.com/ws/device
+    # The firmware passes this directly to websockets.connect() and derives
+    # the HTTPS API base by swapping the scheme back.
+    assert "AGORA_CMS_URL=wss://cms.example.com/ws/device" in payload
     assert "AGORA_FLEET_ID=fleet-test" in payload
     assert "AGORA_FLEET_SECRET=c2VjcmV0LWJhc2U2NA==" in payload  # gitleaks:allow
 
@@ -689,3 +720,68 @@ async def test_import_writes_audit_row(client, db_session, patch_catalog_ok):
         select(AuditLog).where(AuditLog.action == "imager.base_image.import")
     )).scalars().all()
     assert len(rows) == 1
+
+
+# ── _derive_device_ws_url unit tests ──────────────────────────────
+
+
+def test_derive_device_ws_url_https_to_wss():
+    from cms.routers.imager import _derive_device_ws_url
+
+    assert _derive_device_ws_url("https://agora.example.com") == "wss://agora.example.com/ws/device"
+
+
+def test_derive_device_ws_url_http_to_ws():
+    from cms.routers.imager import _derive_device_ws_url
+
+    assert _derive_device_ws_url("http://192.168.1.10:8080") == "ws://192.168.1.10:8080/ws/device"
+
+
+def test_derive_device_ws_url_strips_trailing_slash():
+    from cms.routers.imager import _derive_device_ws_url
+
+    assert _derive_device_ws_url("https://agora.example.com/") == "wss://agora.example.com/ws/device"
+
+
+def test_derive_device_ws_url_preserves_port():
+    from cms.routers.imager import _derive_device_ws_url
+
+    assert (
+        _derive_device_ws_url("https://cms.example.com:8443")
+        == "wss://cms.example.com:8443/ws/device"
+    )
+
+
+def test_derive_device_ws_url_rejects_empty():
+    from cms.routers.imager import _derive_device_ws_url
+
+    with pytest.raises(ValueError):
+        _derive_device_ws_url("")
+
+
+def test_derive_device_ws_url_rejects_no_host():
+    from cms.routers.imager import _derive_device_ws_url
+
+    with pytest.raises(ValueError):
+        _derive_device_ws_url("not-a-url")
+
+
+def test_derive_device_ws_url_rejects_path():
+    from cms.routers.imager import _derive_device_ws_url
+
+    with pytest.raises(ValueError):
+        _derive_device_ws_url("https://agora.example.com/some/path")
+
+
+def test_derive_device_ws_url_rejects_query():
+    from cms.routers.imager import _derive_device_ws_url
+
+    with pytest.raises(ValueError):
+        _derive_device_ws_url("https://agora.example.com?x=1")
+
+
+def test_derive_device_ws_url_rejects_unsupported_scheme():
+    from cms.routers.imager import _derive_device_ws_url
+
+    with pytest.raises(ValueError):
+        _derive_device_ws_url("ftp://agora.example.com")

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -378,3 +378,70 @@ class TestWebSocket:
                     ws.close()
         finally:
             settings.asset_base_url = original_value
+
+
+# ── get_asset_base_url priority unit tests ────────────────────────────
+
+
+from cms.auth import get_settings as _get_settings_for_unit_tests
+
+
+class _StubReq:
+    def __init__(self, host: str | None = "localhost:8000", scheme: str = "http"):
+        self.headers = {"host": host} if host else {}
+
+        class _U:
+            pass
+
+        u = _U()
+        u.scheme = scheme
+        self.url = u
+        self.base_url = f"{scheme}://{host or 'unknown'}/"
+
+
+def test_get_asset_base_url_override_wins_over_base_url():
+    from cms.routers.ws import get_asset_base_url
+
+    settings = _get_settings_for_unit_tests()
+    saved_override = settings.asset_base_url
+    saved_base = settings.base_url
+    try:
+        settings.asset_base_url = "https://cdn.example.com"
+        settings.base_url = "https://agora.example.com"
+        assert get_asset_base_url(_StubReq()) == "https://cdn.example.com"
+    finally:
+        settings.asset_base_url = saved_override
+        settings.base_url = saved_base
+
+
+def test_get_asset_base_url_falls_back_to_base_url():
+    from cms.routers.ws import get_asset_base_url
+
+    settings = _get_settings_for_unit_tests()
+    saved_override = settings.asset_base_url
+    saved_base = settings.base_url
+    try:
+        settings.asset_base_url = None
+        settings.base_url = "https://agora.example.com"
+        assert get_asset_base_url(_StubReq(host="upstream:8000")) == "https://agora.example.com"
+    finally:
+        settings.asset_base_url = saved_override
+        settings.base_url = saved_base
+
+
+def test_get_asset_base_url_falls_back_to_host_header():
+    from cms.routers.ws import get_asset_base_url
+
+    settings = _get_settings_for_unit_tests()
+    saved_override = settings.asset_base_url
+    saved_base = settings.base_url
+    try:
+        settings.asset_base_url = None
+        settings.base_url = None
+        assert (
+            get_asset_base_url(_StubReq(host="cms.local:8000", scheme="http"))
+            == "http://cms.local:8000"
+        )
+    finally:
+        settings.asset_base_url = saved_override
+        settings.base_url = saved_base


### PR DESCRIPTION
## Why

Image builds were 503'ing in prod with "AGORA_BASE_URL is not configured." The actual env var Pydantic reads from is `AGORA_CMS_BASE_URL` (env_prefix `AGORA_CMS_`), and beyond the typo the imager was set up to bake a bare `https://host` URL into `agora-fleet.env` — but firmware's `cms_client.transport.connect()` calls `websockets.connect(cms_url)` directly, so the string MUST be `wss://host/ws/device`. No Pi image ever shipped on this path because `base_url` was unset and the missing-config check tripped first.

## What

- `base_url` (env: `AGORA_CMS_BASE_URL`) is now the **single source of truth** for the public CMS URL. Email links, asset downloads, imager builds all derive from it.
- Imager build endpoint:
  - Sharper 503 when `base_url` unset (names the env var, shows an example).
  - New 503 when `device_transport != "local"` — WPS-mode CMS does not mount `/ws/device`, so a baked wss URL would not work and we refuse rather than ship broken Pis.
  - Calls a new `_derive_device_ws_url(base)` → `wss://host[:port]/ws/device`. It validates input is an *origin* URL: rejects non-empty path / query / fragment / unsupported schemes so we never silently bake a half-correct URL into an SD card.
- Asset URL resolvers (`cms.routers.ws.get_asset_base_url` and the mirrored WPS webhook helper) fall back to `base_url` between an explicit `asset_base_url` override and the request `Host` header. CDN override behaviour is preserved.
- New `Settings.effective_asset_base_url` for callers that just want the public download base.

## Tests

- `test_imager_api.py` — existing missing-config test asserts new env var name; new `test_build_503_when_device_transport_wps`; existing happy path asserts WSS form. **39 pass locally.**
- 9 `_derive_device_ws_url` unit tests (scheme conversion, port preservation, trailing slash, all reject paths).
- `test_websocket.py` — 3 new `get_asset_base_url` priority tests (override / base_url / Host fallback). My new tests pass in isolation; full file hangs locally on Windows for unrelated reasons but runs in CI.
- `test_wps_webhook.py + test_imager_handlers.py`: 58 pass.

## Deploy follow-up

After this merges and ACA rolls, set on the prod Container App:

```
AGORA_CMS_BASE_URL=https://agora.mennlabs.com
```

…then retry the failed image build. (The wrong/old name `AGORA_BASE_URL` will be silently ignored by Pydantic.)

## Risk

Low. Three behaviour changes are guarded by tests, all existing callers continue to work without `base_url` set (only the imager build path goes from 503-with-wrong-message to 503-with-right-message). WPS-transport guard is new but the WPS path was never working for image builds anyway.
