### PR TITLE
Imager: support WPS transport mode in image builds

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -261,15 +261,27 @@ def _derive_device_ws_url(base_url: str) -> str:
     return urlunparse((ws_scheme, parsed.netloc, "/ws/device", "", "", ""))
 
 
-def _fleet_env_payload(cms_url: str, fleet_id: str, fleet_secret: str) -> bytes:
+def _fleet_env_payload(
+    cms_url: str, fleet_id: str, fleet_secret: str, device_transport: str
+) -> bytes:
     """Render the ``agora-fleet.env`` body the worker will inject.
 
     Plaintext on purpose -- see model docstring for rationale.  Order
     matters only for human readability; the firmware reads via
     standard ``KEY=VALUE`` env parsing.
+
+    ``device_transport`` is the CMS-side mode (``local`` or ``wps``).
+    It is mapped to the firmware-side value (``direct`` or ``wps``)
+    and emitted as ``AGORA_CMS_TRANSPORT`` so the Pi opens the right
+    transport at boot.  In ``wps`` mode the firmware reuses the same
+    ``cms_url`` (only its scheme+netloc) to derive the API base for
+    ``/api/devices/.../connect-token``; the ``/ws/device`` path is
+    ignored, so the same URL form works for both modes.
     """
+    fw_transport = "direct" if device_transport == "local" else device_transport
     return (
         f"AGORA_CMS_URL={cms_url}\n"
+        f"AGORA_CMS_TRANSPORT={fw_transport}\n"
         f"AGORA_FLEET_ID={fleet_id}\n"
         f"AGORA_FLEET_SECRET={fleet_secret}\n"
     ).encode("utf-8")
@@ -590,15 +602,13 @@ async def build_provisioned_image(
             detail=f"fleet_id {body.fleet_id!r} is not configured on this CMS",
         )
 
-    if settings.device_transport != "local":
+    if settings.device_transport not in ("local", "wps"):
         raise HTTPException(
             status_code=503,
             detail=(
-                f"Image builds require AGORA_CMS_DEVICE_TRANSPORT='local'; "
-                f"this CMS is configured for {settings.device_transport!r} "
-                "and does not expose /ws/device. Provisioned images embed "
-                "a wss:// URL pointing at /ws/device, which would not work "
-                "in this transport mode."
+                f"Image builds require AGORA_CMS_DEVICE_TRANSPORT to be "
+                f"'local' or 'wps'; this CMS is configured for "
+                f"{settings.device_transport!r}."
             ),
         )
 
@@ -630,7 +640,9 @@ async def build_provisioned_image(
             detail=f"base image is not ready (status={bi.status})",
         )
 
-    payload = _fleet_env_payload(cms_url, body.fleet_id, secret)
+    payload = _fleet_env_payload(
+        cms_url, body.fleet_id, secret, settings.device_transport
+    )
 
     pi = ProvisionedImage(
         base_image_id=bi.id,

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -467,8 +467,10 @@ async def test_build_503_when_base_url_missing(client, db_session, imager_settin
 
 
 @pytest.mark.asyncio
-async def test_build_503_when_device_transport_wps(client, db_session, imager_settings):
-    """WPS-mode CMS does not mount /ws/device, so image builds must refuse."""
+async def test_build_succeeds_in_wps_mode_with_transport_baked(
+    client, db_session, imager_settings
+):
+    """WPS-mode CMS bakes AGORA_CMS_TRANSPORT=wps into the fleet env."""
     saved_transport = imager_settings.device_transport
     try:
         imager_settings.device_transport = "wps"
@@ -483,10 +485,38 @@ async def test_build_503_when_device_transport_wps(client, db_session, imager_se
                 "output_name": "x.img.xz",
             },
         )
+        assert resp.status_code == 200, resp.text
+        pi = (await db_session.execute(
+            select(ProvisionedImage).where(ProvisionedImage.base_image_id == bi.id)
+        )).scalar_one()
+        payload = pi.fleet_env_payload.decode("utf-8")
+        assert "AGORA_CMS_URL=wss://cms.example.com/ws/device" in payload
+        assert "AGORA_CMS_TRANSPORT=wps" in payload
+    finally:
+        imager_settings.device_transport = saved_transport
+
+
+@pytest.mark.asyncio
+async def test_build_503_when_device_transport_invalid(
+    client, db_session, imager_settings
+):
+    """Anything other than local/wps should refuse cleanly."""
+    saved_transport = imager_settings.device_transport
+    try:
+        imager_settings.device_transport = "carrier-pigeon"
+        bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+        db_session.add(bi)
+        await db_session.commit()
+        resp = await client.post(
+            "/api/imager/build",
+            json={
+                "base_image_id": str(bi.id),
+                "fleet_id": "fleet-test",
+                "output_name": "x.img.xz",
+            },
+        )
         assert resp.status_code == 503
-        detail = resp.json()["detail"]
-        assert "transport" in detail.lower()
-        assert "wps" in detail.lower()
+        assert "carrier-pigeon" in resp.json()["detail"]
     finally:
         imager_settings.device_transport = saved_transport
 
@@ -540,6 +570,7 @@ async def test_build_creates_provisioned_row_with_payload(
     # The firmware passes this directly to websockets.connect() and derives
     # the HTTPS API base by swapping the scheme back.
     assert "AGORA_CMS_URL=wss://cms.example.com/ws/device" in payload
+    assert "AGORA_CMS_TRANSPORT=direct" in payload
     assert "AGORA_FLEET_ID=fleet-test" in payload
     assert "AGORA_FLEET_SECRET=c2VjcmV0LWJhc2U2NA==" in payload  # gitleaks:allow
 


### PR DESCRIPTION
## Why

PR #523 added a WPS-mode guard to the imager build endpoint, on the assumption that the wss URL we bake into Pi images would not work in WPS mode. Investigating the firmware side (`agora.cms_client.transport.open_wps`) showed the assumption was wrong: in WPS mode the firmware uses **only the scheme+netloc** of the baked URL — it derives `https://host` for the `POST /api/devices/{id}/connect-token` call and ignores the `/ws/device` path entirely. The signed connect-token flow used by fleet-bootstrapped devices (`bootstrap_boot.ensure_wps_credentials`) handles WPS just as well as direct.

The user hit the guard immediately on the prod CMS (which runs in WPS mode) and got a 503 they couldn't get past without flipping the entire transport.

## What

- Drop the `device_transport != 'local'` 503.
- Bake `AGORA_CMS_TRANSPORT=<direct|wps>` into the Pi's fleet env so the firmware opens the matching transport at boot. Mapping: CMS `local` → fw `direct`; CMS `wps` → fw `wps`.
- Replaced with a stricter 503 only for genuinely unrecognised `device_transport` values (typos, unset, etc.).

## Tests

- New: `test_build_succeeds_in_wps_mode_with_transport_baked` — WPS mode returns 200, payload contains `AGORA_CMS_TRANSPORT=wps`.
- New: `test_build_503_when_device_transport_invalid` — unknown values still refuse cleanly.
- Updated: `test_build_creates_provisioned_row_with_payload` asserts `AGORA_CMS_TRANSPORT=direct` in default mode.
- 98 tests pass locally (`test_imager_api.py + test_wps_webhook.py + test_imager_handlers.py`).

## Risk

Low. The fleet env now carries one extra line; existing Pis (already adopted) read their settings from `bootstrap_state.json`, not the fleet env. Only newly-flashed Pis pick up the new variable, and they need it.
