### PR TITLE
Bake AGORA_CMS_BASE_URL into bicep + settings.base_url for user setup links

### DIFF
--- a/cms/routers/users.py
+++ b/cms/routers/users.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from cms.auth import get_current_user, hash_password, require_permission, verify_password
+from cms.auth import get_current_user, get_settings, hash_password, require_permission, verify_password
 from cms.database import get_db
 from cms.models.user import Role, User, UserGroup
 from cms.permissions import USERS_READ, USERS_WRITE
@@ -186,7 +186,7 @@ async def create_user(
 
     # Send welcome email in background — failures create a notification
     from cms.services.email_service import send_welcome_email_background
-    base = request.base_url._url.rstrip("/")
+    base = (get_settings().base_url or request.base_url._url).rstrip("/")
     setup_url = f"{base}/setup-account?token={setup_token}"
     background_tasks.add_task(
         send_welcome_email_background,
@@ -329,7 +329,7 @@ async def resend_invite(
     user.setup_token = new_token
     await db.commit()
 
-    base = request.base_url._url.rstrip("/")
+    base = (get_settings().base_url or request.base_url._url).rstrip("/")
     setup_url = f"{base}/setup-account?token={new_token}"
     background_tasks.add_task(
         send_welcome_email_background,

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -278,6 +278,16 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               secretRef: 'github-issues-token'
             }
             {
+              // Public URL of the CMS — derived from the container app name +
+              // the managed environment's default domain so we have a single
+              // source of truth. The imager router and fleet env payload read
+              // this to build wss://host/ws/device for provisioned Pis. If you
+              // ever front the app with a custom domain (e.g. agora.example.com)
+              // this is the one place to override it.
+              name: 'AGORA_CMS_BASE_URL'
+              value: 'https://${cmsAppName}.${containerAppsEnv.properties.defaultDomain}'
+            }
+            {
               // Picked up by azure-monitor-opentelemetry's
               // configure_azure_monitor() at process start (see
               // cms/observability.py).  When unset (e.g. local dev,


### PR DESCRIPTION
## Summary

Closes the SSoT loop opened by #523 (code) and #524 (Pi env). After this lands, the imager build path works end-to-end with **zero** manual env-var management on the container app.

## What was broken

After #524 deploy, image build still failed with:

> `Build failed to start: AGORA_CMS_BASE_URL is not configured. Set it to the public URL of this CMS...`

`AGORA_CMS_BASE_URL` was never wired into the bicep, so a fresh deploy left `settings.base_url == None` and the `imager.py::_derive_device_ws_url` guard tripped.

## Changes

### `infra/modules/containerApps.bicep`

Adds `AGORA_CMS_BASE_URL` to the `cmsApp` container env, derived from the existing bicep-known values:

```bicep
{
  name: 'AGORA_CMS_BASE_URL'
  value: 'https://${cmsAppName}.${containerAppsEnv.properties.defaultDomain}'
}
```

This is the same FQDN the bicep already exposes via the `cmsUrl` output. No new parameters, no new secrets, no infra redeploy choreography. A tenant deploying from scratch gets a working imager pipeline on first apply.

### `cms/routers/users.py`

Two call sites that were still using `request.base_url._url` for password-setup / resend-invite email links now prefer `settings.base_url` first, matching the SSoT pattern already used by `routers/ws.py`, `routers/wps_webhook.py`, and `routers/imager.py`. Falls back to `request.base_url` when `AGORA_CMS_BASE_URL` is unset (existing behavior).

## SSoT chain (full picture)

```
AGORA_CMS_BASE_URL (env, set by bicep on first deploy)
        │
        ▼
settings.base_url
        ├─► routers/imager.py::_derive_device_ws_url    → wss://<host>/ws/device  (Pi fleet env)
        ├─► routers/ws.py::get_asset_base_url            → asset URLs to device
        ├─► routers/wps_webhook.py::_get_asset_base_url  → asset URLs over WPS
        ├─► config.effective_asset_base_url              → asset_base_url || base_url (CDN override)
        └─► routers/users.py                             → password-setup / invite links
```

## Verification

- Bicep compiles clean (`az bicep build`).
- Compiled ARM JSON contains the env var with the resolved expression.
- Existing test coverage for `imager.py`, `ws.py`, `wps_webhook.py` already verifies the consumers.
- After this deploys to prod, image build via `/imager` should succeed end-to-end and produced Pi images will boot with `AGORA_CMS_TRANSPORT=wps` + `AGORA_CMS_URL=wss://<cms-fqdn>/ws/device`.
