### PR TITLE
Fix worker image_provision crash + lower imager disk threshold to 6 GiB

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -52,9 +52,10 @@ class SharedSettings(BaseSettings):
     # applied — never branch on ``imager_scratch_path`` directly.
     imager_scratch_path: Path | None = None
     # Minimum free bytes the worker requires on the scratch volume
-    # before starting an imager job.  ~10 GiB headroom over the
-    # ~6 GiB worst-case peak (decompress + recompress in parallel).
-    imager_min_free_bytes: int = 10 * 1024 * 1024 * 1024
+    # before starting an imager job.  ~6 GiB matches the worst-case
+    # peak (decompress + recompress in parallel); operators wanting
+    # more headroom can override via AGORA_CMS_IMAGER_MIN_FREE_BYTES.
+    imager_min_free_bytes: int = 6 * 1024 * 1024 * 1024
 
     @property
     def resolved_imager_scratch_path(self) -> Path:

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -664,7 +664,7 @@ async def provision_image_by_id(
                 staged_base,
                 fleet_env_text,
                 scratch,
-                output_name,
+                output_name=output_name,
             )
         except ImagerError as e:
             # ImagerError covers (a) input validation (output_name,


### PR DESCRIPTION
## What

Two-line worker imager fix bundle:

1. **Pass `output_name` as kwarg** in `worker/imager_handlers.py` provision path.
   `cms.services.imager.build_provisioned` declares `output_name` as keyword-only
   (after `*,`), but the worker call site passed it positionally, so every
   `image_provision` job crashes immediately with:

   ```
   TypeError: build_provisioned() takes 3 positional arguments but 4 were given
   ```

   Fix: pass `output_name=output_name`. `asyncio.to_thread` forwards kwargs.

2. **Drop `imager_min_free_bytes` default from 10 GiB → 6 GiB.**
   The 10 GiB threshold was conservative headroom; in production the
   worker job's ephemeral disk only has ~9.3 GiB free at job start, so
   the pre-flight gate fires before any real work happens and the job
   exhausts retries. Worst-case peak (decompress + recompress in
   parallel) is ~6 GiB, which matches the new default. Operators wanting
   more headroom can still override via `AGORA_CMS_IMAGER_MIN_FREE_BYTES`.

## Why

Discovered both while debugging an image build that retried 3x (disk
gate) and then, with a runtime env-var override applied to the worker
job, immediately hit the kwarg TypeError. The `*,` was added in a prior
imager refactor without updating the worker call site.

## Risk

Low.
- Threshold change keeps the schema floor at 5 GiB (existing test) and
  matches the documented worst-case peak. Worker memory tier (8Gi)
  unchanged.
- kwarg fix is a single argument-passing tweak; no behavior change.

## Test plan

- Local syntax check passes.
- Will validate end-to-end on prod by retrying the previously-failing
  image build after deploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
