### PR TITLE
Catch deploy-shape misconfig in /healthz/system (PR-A)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -378,6 +378,25 @@ jobs:
             STATUS=$(python3 -c "import json; d=json.load(open('/tmp/sys.json')); print(d.get('status','?'))")
             if [ "$STATUS" != "ok" ]; then
               echo "::error::/healthz/system reported status=$STATUS"
+              # Surface which subsystem(s) failed so the operator
+              # doesn't need to dig through container logs to find
+              # out *what* is degraded.  Keeps blast-radius small
+              # for future degradation modes.
+              python3 - <<'PY' /tmp/sys.json
+import json, sys
+d = json.load(open(sys.argv[1]))
+db = d.get("db", {})
+mcp = d.get("mcp", {})
+smtp = d.get("smtp", {})
+cfg = d.get("config", {})
+if not db.get("ok", True):
+    print("::error::  db: not OK")
+if mcp.get("enabled") and not mcp.get("ok", True):
+    print("::error::  mcp: enabled but not reachable")
+if not cfg.get("ok", True):
+    for m in cfg.get("missing", []):
+        print(f"::error::  config: {m.get('env_var','?')} -- {m.get('message','?')}")
+PY
               fail=1
             fi
           fi

--- a/cms/deploy_config.py
+++ b/cms/deploy_config.py
@@ -1,0 +1,147 @@
+"""Deploy-shape configuration checks.
+
+Some settings are only consumed by specific request paths or subsystems
+(image build, custom domains, transport-specific webhooks).  When such a
+setting is missing the container boots fine and ``/healthz`` and the
+classic ``/healthz/system`` checks all pass — the misconfig only surfaces
+when a real user hits the affected code path.  That is exactly the
+failure mode that took prod offline in the AGORA_CMS_BASE_URL incident.
+
+This module centralises the list of "required-for-this-deployment-shape"
+settings so:
+
+* the lifespan startup logs a single loud ``ERROR`` line listing what's
+  missing (visible in ``az containerapp logs show`` immediately after
+  deploy);
+* ``/healthz/system`` reports a dedicated ``config`` subsystem and
+  degrades the overall ``status``, which causes the post-deploy smoke
+  probe in ``publish-image.yml`` to fail and (under the upcoming
+  blue/green workflow) blocks traffic from cutting over.
+
+To register a new check:
+
+1. Add a :class:`DeployConfigCheck` to :data:`_CHECKS` with a predicate
+   that decides whether the setting is required for the current
+   deployment shape, and a validator that verifies the value is sane.
+2. Add a unit test in ``tests/test_deploy_config.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class DeployConfigFinding:
+    """A single missing-or-invalid required-for-shape setting."""
+
+    setting: str   # pydantic field name, e.g. "base_url"
+    env_var: str   # corresponding env var, e.g. "AGORA_CMS_BASE_URL"
+    message: str   # operator-facing description of what's wrong
+
+
+@dataclass(frozen=True)
+class DeployConfigCheck:
+    """Declarative entry in the deploy-shape registry."""
+
+    setting: str
+    env_var: str
+    # Predicate run against ``settings`` to decide whether this setting is
+    # required for the current deployment shape.  Defaults to "always
+    # required".  Use this to scope checks to e.g. ``device_transport ==
+    # "wps"`` if the future setting only applies in some modes.
+    required_when: Callable[[object], bool]
+    # Validator run against the setting's current value.  Should return a
+    # human-readable error message if invalid, or ``None`` if OK.  When
+    # the setting is missing entirely, the registry produces a generic
+    # "is not configured" message and skips the validator.
+    validate: Callable[[str], str | None]
+    # Operator-facing summary (one line) used when the setting is unset.
+    missing_message: str
+
+
+def _validate_base_url(value: str) -> str | None:
+    """Return an error string if ``value`` is not a usable BASE_URL."""
+    parsed = urlparse(value.rstrip("/"))
+    if parsed.scheme not in ("http", "https"):
+        return (
+            f"AGORA_CMS_BASE_URL={value!r} has unsupported scheme "
+            f"{parsed.scheme!r}; expected http(s)"
+        )
+    if not parsed.netloc:
+        return f"AGORA_CMS_BASE_URL={value!r} has no host component"
+    if parsed.path or parsed.params or parsed.query or parsed.fragment:
+        return (
+            f"AGORA_CMS_BASE_URL={value!r} must be origin only "
+            "(scheme + host[:port], no path/query/fragment)"
+        )
+    return None
+
+
+_CHECKS: tuple[DeployConfigCheck, ...] = (
+    DeployConfigCheck(
+        setting="base_url",
+        env_var="AGORA_CMS_BASE_URL",
+        required_when=lambda _settings: True,
+        validate=_validate_base_url,
+        missing_message=(
+            "AGORA_CMS_BASE_URL is not configured. Set it to the public URL "
+            "of this CMS (e.g. https://agora.example.com). The image-build "
+            "API and any setup-link emails depend on it."
+        ),
+    ),
+)
+
+
+def detect_missing_deploy_config(settings) -> list[DeployConfigFinding]:
+    """Return a finding for every required-for-shape setting that's missing or invalid.
+
+    Pure function — no I/O, no logging.  The registry pattern lets future
+    checks be one-liners and keeps tests trivial.
+    """
+    findings: list[DeployConfigFinding] = []
+    for check in _CHECKS:
+        if not check.required_when(settings):
+            continue
+        value = getattr(settings, check.setting, None)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            findings.append(DeployConfigFinding(
+                setting=check.setting,
+                env_var=check.env_var,
+                message=check.missing_message,
+            ))
+            continue
+        err = check.validate(str(value))
+        if err is not None:
+            findings.append(DeployConfigFinding(
+                setting=check.setting,
+                env_var=check.env_var,
+                message=err,
+            ))
+    return findings
+
+
+def warn_on_missing_deploy_config(
+    settings, logger: logging.Logger | None = None
+) -> list[DeployConfigFinding]:
+    """Emit a single loud ``ERROR`` log line per finding at startup.
+
+    We log at ``ERROR`` (not WARNING) deliberately: unlike default-secret
+    findings — which legitimate dev runs hit on purpose — a missing
+    deploy-shape setting in any environment that bothers to wire the
+    rest of the env is almost certainly a bicep/workflow regression
+    that the operator wants paged on, not a "this is fine" baseline.
+
+    We do NOT raise here: the rest of the app may still be useful (the
+    UI, /healthz, jobs whose handlers don't need the missing setting).
+    The post-deploy smoke probe will catch the same condition via
+    /healthz/system and fail the verify step.
+    """
+    log = logger or logging.getLogger("agora.cms.deploy_config")
+    findings = detect_missing_deploy_config(settings)
+    for f in findings:
+        log.error("deploy-config: %s", f.message)
+    return findings

--- a/cms/main.py
+++ b/cms/main.py
@@ -393,6 +393,8 @@ async def lifespan(app: FastAPI):
     # operators will actually see it. See cms/security.py for the list.
     from cms.security import warn_on_default_secrets
     warn_on_default_secrets(settings, logger)
+    from cms.deploy_config import warn_on_missing_deploy_config
+    warn_on_missing_deploy_config(settings, logger)
     init_db(settings)
     await wait_for_db()
     await run_migrations()
@@ -916,10 +918,27 @@ async def healthz_system(db: AsyncSession = Depends(get_db)):
             mcp_online = False
 
     overall_ok = db_ok and (not mcp_enabled or mcp_online)
+
+    # Deploy-shape config check.  Catches "container booted but a
+    # required-for-this-deployment-shape env var is missing", which
+    # otherwise only surfaces when a real user hits the affected code
+    # path.  See cms/deploy_config.py for the registry.
+    from cms.deploy_config import detect_missing_deploy_config
+    config_findings = detect_missing_deploy_config(get_settings())
+    config_ok = not config_findings
+    overall_ok = overall_ok and config_ok
+
     return {
         "status": "ok" if overall_ok else "degraded",
         "version": __version__,
         "db": {"ok": db_ok},
         "mcp": {"enabled": mcp_enabled, "ok": mcp_online},
         "smtp": {"configured": smtp_configured},
+        "config": {
+            "ok": config_ok,
+            "missing": [
+                {"setting": f.setting, "env_var": f.env_var, "message": f.message}
+                for f in config_findings
+            ],
+        },
     }

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -1,0 +1,94 @@
+"""Unit tests for cms.deploy_config."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from cms.deploy_config import (
+    DeployConfigFinding,
+    detect_missing_deploy_config,
+    warn_on_missing_deploy_config,
+)
+
+
+def _settings(**overrides):
+    base = {"base_url": "https://agora.example.com"}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_detect_no_findings_when_base_url_set():
+    assert detect_missing_deploy_config(_settings()) == []
+
+
+def test_detect_missing_base_url_when_none():
+    findings = detect_missing_deploy_config(_settings(base_url=None))
+    assert len(findings) == 1
+    f = findings[0]
+    assert isinstance(f, DeployConfigFinding)
+    assert f.setting == "base_url"
+    assert f.env_var == "AGORA_CMS_BASE_URL"
+    assert "not configured" in f.message
+
+
+def test_detect_missing_base_url_when_blank_string():
+    findings = detect_missing_deploy_config(_settings(base_url="   "))
+    assert len(findings) == 1
+    assert findings[0].env_var == "AGORA_CMS_BASE_URL"
+
+
+def test_detect_invalid_scheme():
+    findings = detect_missing_deploy_config(_settings(base_url="ftp://x.example.com"))
+    assert len(findings) == 1
+    assert "scheme" in findings[0].message
+
+
+def test_detect_missing_host():
+    findings = detect_missing_deploy_config(_settings(base_url="https://"))
+    assert len(findings) == 1
+    assert "host" in findings[0].message
+
+
+def test_detect_rejects_path():
+    findings = detect_missing_deploy_config(_settings(base_url="https://x.example.com/cms"))
+    assert len(findings) == 1
+    assert "origin only" in findings[0].message
+
+
+def test_detect_accepts_trailing_slash():
+    # Operator-friendly: the asset/setup-link code path strips it; we
+    # should not flag this as invalid.
+    assert detect_missing_deploy_config(_settings(base_url="https://x.example.com/")) == []
+
+
+def test_detect_accepts_port():
+    assert detect_missing_deploy_config(_settings(base_url="https://x.example.com:8443")) == []
+
+
+def test_detect_accepts_http_for_dev():
+    assert detect_missing_deploy_config(_settings(base_url="http://localhost:8000")) == []
+
+
+def test_detect_tolerates_missing_attr():
+    minimal = SimpleNamespace()
+    findings = detect_missing_deploy_config(minimal)
+    # Treated as "not configured" rather than raising.
+    assert len(findings) == 1
+    assert findings[0].setting == "base_url"
+
+
+def test_warn_emits_error_per_finding(caplog):
+    with caplog.at_level(logging.ERROR, logger="agora.cms.deploy_config"):
+        findings = warn_on_missing_deploy_config(_settings(base_url=None))
+    assert len(findings) == 1
+    error_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
+    assert any("AGORA_CMS_BASE_URL" in m for m in error_msgs)
+    assert all(m.startswith("deploy-config:") for m in error_msgs)
+
+
+def test_warn_silent_when_clean(caplog):
+    with caplog.at_level(logging.ERROR, logger="agora.cms.deploy_config"):
+        findings = warn_on_missing_deploy_config(_settings())
+    assert findings == []
+    assert not any(r.levelno == logging.ERROR for r in caplog.records)


### PR DESCRIPTION
# PR-A: Catch deploy-shape misconfig before traffic shifts

## Why

`AGORA_CMS_BASE_URL` was missing on prod cmsApp env after a recent
deploy. The container booted, `/healthz` and `/healthz/system` both
returned green, and the misconfig only surfaced when the first user
clicked **Build** — at which point `/api/imager/build` returned 503
and stayed broken until PR #525 admin-merged the bicep fix.

Two reasons nothing caught it:

1. `/healthz/system` only checks db / mcp / smtp — not the
   "required-for-this-deployment-shape" pydantic settings that
   specific code paths consume at request time.
2. (Out of scope here, see follow-up PR-B.) Container Apps revision
   mode is `Single`, so even if the post-deploy probe failed, traffic
   was already on the bad revision.

This PR closes gap (1) cheaply.

## What

- **`cms/deploy_config.py`** *(new)* — small registry of
  `DeployConfigCheck`s with `(setting, env_var, required_when,
  validate, missing_message)`. Today it has one entry (`base_url`);
  adding the next required-for-shape setting is a one-liner. Mirrors
  the existing `cms/security.py` pattern intentionally.

- **`cms/main.py` lifespan** — calls
  `warn_on_missing_deploy_config(settings, logger)` next to the
  existing `warn_on_default_secrets` call. Logs a single loud
  `ERROR deploy-config:` line per finding so it shows up immediately
  in `az containerapp logs show` after deploy, not when a user
  happens to click Build.

- **`cms/main.py` `/healthz/system`** — adds a `config:` subsystem
  block (`{ok, missing: [{setting, env_var, message}]}`) and degrades
  the overall `status` if any required-for-shape setting is missing
  or invalid.

- **`.github/workflows/publish-image.yml`** post-deploy smoke probe —
  on `status != "ok"`, prints which subsystem(s) caused the
  degradation (db / mcp / each missing config var with its message),
  so the operator doesn't have to dig through container logs to find
  out *what* is degraded.

- **`tests/test_deploy_config.py`** *(new)* — 12 cases covering the
  registry: missing/blank/invalid scheme/missing host/path-rejected,
  trailing-slash and ports accepted, missing-attr tolerance, and the
  ERROR-log-emission contract.

## What this would have caught

The original `AGORA_CMS_BASE_URL`-missing deploy:
`/healthz/system` would have returned `status: "degraded"` with
`config.missing[0].env_var = "AGORA_CMS_BASE_URL"`. The smoke probe
in `publish-image.yml` already fails the `verify` job on
`status != "ok"`, so the workflow would have failed and the version
on `main` would not have bumped — paging the operator instead of
breaking prod.

## Out of scope (follow-up PR-B)

Even with this PR, `Single` revision mode means a failed verify
doesn't roll back — the bad revision is already serving 100% traffic
by the time `verify` runs. PR-B switches to `Multiple` mode +
per-revision smoke probes so traffic doesn't shift until smoke
passes.

## Validation

- `pytest tests/test_deploy_config.py` — 12 passed.
- `pytest tests/test_security_defaults.py` — 8 passed (no regression
  in the sibling pattern).
- `python -c "from cms.main import app"` — module imports clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
