### PR TITLE
Fix publish-image.yml YAML broken by #527 heredoc

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -374,29 +374,15 @@ jobs:
             echo "::error::/healthz/system returned HTTP $CODE"
             fail=1
           else
-            # Parse the JSON and fail on any degraded subsystem.
+            # Parse the JSON and fail on any degraded subsystem.  The
+            # helper script surfaces which subsystem(s) caused the
+            # degradation so the operator doesn't need to dig through
+            # container logs.  Lives in scripts/ to keep the workflow
+            # YAML free of heredocs (which break run: | indentation).
             STATUS=$(python3 -c "import json; d=json.load(open('/tmp/sys.json')); print(d.get('status','?'))")
             if [ "$STATUS" != "ok" ]; then
               echo "::error::/healthz/system reported status=$STATUS"
-              # Surface which subsystem(s) failed so the operator
-              # doesn't need to dig through container logs to find
-              # out *what* is degraded.  Keeps blast-radius small
-              # for future degradation modes.
-              python3 - <<'PY' /tmp/sys.json
-import json, sys
-d = json.load(open(sys.argv[1]))
-db = d.get("db", {})
-mcp = d.get("mcp", {})
-smtp = d.get("smtp", {})
-cfg = d.get("config", {})
-if not db.get("ok", True):
-    print("::error::  db: not OK")
-if mcp.get("enabled") and not mcp.get("ok", True):
-    print("::error::  mcp: enabled but not reachable")
-if not cfg.get("ok", True):
-    for m in cfg.get("missing", []):
-        print(f"::error::  config: {m.get('env_var','?')} -- {m.get('message','?')}")
-PY
+              python3 scripts/explain_healthz_system.py /tmp/sys.json || true
               fail=1
             fi
           fi

--- a/scripts/explain_healthz_system.py
+++ b/scripts/explain_healthz_system.py
@@ -1,0 +1,49 @@
+"""Pretty-print which subsystems caused /healthz/system to degrade.
+
+Used by the post-deploy smoke probe in
+``.github/workflows/publish-image.yml`` to surface the *cause* of a
+degraded status (missing env var, dead MCP, etc.) directly in the
+workflow log as ``::error::`` annotations, instead of forcing the
+operator to dig through container logs.
+
+Lives as a real file (rather than a heredoc inside the workflow YAML)
+because heredoc bodies inside ``run: |`` blocks must match the script's
+indentation, which is fragile and easy to break.
+
+Usage:  ``python3 scripts/explain_healthz_system.py /tmp/sys.json``
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(path: str) -> int:
+    with open(path) as f:
+        data = json.load(f)
+
+    db = data.get("db", {}) or {}
+    mcp = data.get("mcp", {}) or {}
+    cfg = data.get("config", {}) or {}
+
+    if not db.get("ok", True):
+        print("::error::  db: not OK")
+
+    if mcp.get("enabled") and not mcp.get("ok", True):
+        print("::error::  mcp: enabled but not reachable")
+
+    if not cfg.get("ok", True):
+        for m in cfg.get("missing", []) or []:
+            env_var = m.get("env_var", "?")
+            message = m.get("message", "?")
+            print(f"::error::  config: {env_var} -- {message}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: explain_healthz_system.py PATH_TO_SYS_JSON", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
# PR-A-fix: repair publish-image.yml YAML broken by #527

PR #527's smoke-probe heredoc had its body flush-left inside a
``run: |`` block, which terminates the YAML scalar early and makes the
whole `publish-image.yml` workflow unparseable.  Effect: `Publish &
Deploy` for commit `82799bc` showed `conclusion: failure` with
`total_jobs: 0` -- the workflow never started, so the new
deploy-config check from #527 is on `main` but never made it into a
container image.

Fix:

- **`.github/workflows/publish-image.yml`** -- replace the heredoc-in-
  `run:|` (the source of the indentation trap) with a single call to a
  proper script file.
- **`scripts/explain_healthz_system.py`** *(new)* -- the same logic
  that was previously inlined; now lives as a real Python file so YAML
  indentation can never break it again.

Validation:

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish-image.yml', encoding='utf-8'))"` -- parses clean.
- The script's behaviour is unchanged: same `::error::` annotations
  for db / mcp / each missing config var.
- Once this lands, the next deploy will roll out PR #527's
  `deploy_config` checks for real.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
