### PR TITLE
feat(imager): show stage and percent progress for import and build jobs

### DIFF
--- a/alembic/versions/0020_jobs_progress.py
+++ b/alembic/versions/0020_jobs_progress.py
@@ -1,0 +1,50 @@
+"""jobs: add progress_stage / progress_pct columns
+
+The imager build + import flows take several minutes, and today the UI
+polls a job that only ever transitions PENDING -> PROCESSING -> DONE,
+so the user sees a silent spinner for the whole pipeline.  These two
+columns let the worker emit coarse stage labels (e.g. ``downloading``,
+``building``, ``uploading``) and an optional 0-100 percent estimate
+that the UI can render under the status badge.
+
+Both columns are additive and nullable / defaulted, so deploys are
+safe in either order: an old worker leaves them empty (UI falls back
+to the existing badge); a new worker writes to them and an old API is
+unaffected because the columns aren't selected.
+
+Revision ID: 0020
+Revises: 0019
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "progress_stage",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("progress_pct", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "downgrade not implemented; restore from backup if rollback required"
+    )

--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -157,6 +157,12 @@ class JobStatusOut(BaseModel):
     error_message: str
     created_at: datetime
     completed_at: datetime | None
+    # Coarse progress fields populated by the imager worker handlers.
+    # ``progress_stage`` is a short label ("downloading", "building",
+    # "uploading", ...).  ``progress_pct`` is an optional 0-100
+    # estimate; ``None`` means "unknown -- show indeterminate UI".
+    progress_stage: str = ""
+    progress_pct: int | None = None
     # Populated only for terminal-success IMAGE_PROVISION jobs.
     download_url: str | None = None
     output_name: str | None = None
@@ -682,6 +688,8 @@ async def build_provisioned_image(
         error_message=job.error_message,
         created_at=job.created_at,
         completed_at=job.completed_at,
+        progress_stage=job.progress_stage or "",
+        progress_pct=job.progress_pct,
         output_name=pi.output_name,
     )
 
@@ -713,6 +721,8 @@ async def get_job_status(
         error_message=job.error_message,
         created_at=job.created_at,
         completed_at=job.completed_at,
+        progress_stage=job.progress_stage or "",
+        progress_pct=job.progress_pct,
     )
 
     if job.type == JobType.IMAGE_PROVISION and job.status == JobStatus.DONE:

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -59,6 +59,7 @@
                 <strong>Current build (this tab)</strong>
                 <span id="imagerJobStatusBadge" class="badge"></span>
                 <div id="imagerJobMeta" class="text-muted" style="font-size:0.8rem; margin-top:0.25rem;"></div>
+                <div id="imagerJobProgress" class="text-muted" style="font-size:0.8rem; margin-top:0.25rem; display:none;"></div>
             </div>
             <div style="display:flex; gap:0.5rem;">
                 <a id="imagerJobDownload" class="btn btn-primary" style="display:none;" download>Download .img.xz</a>
@@ -295,11 +296,27 @@
         try { return sessionStorage.getItem(SS_KEY); } catch (e) { return null; }
     }
 
+    function formatJobProgress(job) {
+        // Returns a short human-readable line, or '' to hide the
+        // progress sub-line entirely.  We only show it while the job
+        // is in flight (PENDING / PROCESSING) -- once it lands, the
+        // status badge tells the whole story.
+        var s = statusUp(job.status);
+        if (s !== 'PENDING' && s !== 'PROCESSING') return '';
+        var stage = (job.progress_stage || '').replace(/_/g, ' ');
+        var pct = (job.progress_pct == null) ? null : Math.max(0, Math.min(100, job.progress_pct));
+        if (!stage && pct == null) return '';
+        if (stage && pct != null) return stage + ' \u00b7 ' + pct + '%';
+        if (stage) return stage;
+        return pct + '%';
+    }
+
     function renderJobCard(job) {
         if (!buildSection) return;
         var card = $('#imagerJobCard', buildSection);
         var badge = $('#imagerJobStatusBadge', buildSection);
         var meta = $('#imagerJobMeta', buildSection);
+        var prog = $('#imagerJobProgress', buildSection);
         var dl = $('#imagerJobDownload', buildSection);
         var errBox = $('#imagerJobError', buildSection);
         card.style.display = '';
@@ -308,7 +325,15 @@
         var metaParts = ['Job ' + job.job_id.slice(0, 8)];
         if (job.output_name) metaParts.push(escHtml(job.output_name));
         if (job.created_at) metaParts.push('started ' + fmtDate(job.created_at));
-        meta.innerHTML = metaParts.join(' · ');
+        meta.innerHTML = metaParts.join(' \u00b7 ');
+        var progLine = formatJobProgress(job);
+        if (progLine) {
+            prog.style.display = '';
+            prog.textContent = progLine;
+        } else {
+            prog.style.display = 'none';
+            prog.textContent = '';
+        }
         if (statusUp(job.status) === 'DONE') {
             dl.style.display = '';
             dl.href = '/api/imager/download/' + encodeURIComponent(job.job_id);
@@ -409,10 +434,17 @@
         box.style.display = '';
         box.innerHTML = ids.map(function(id) {
             var info = importJobsCache[id];
+            var sub = '';
+            var stage = (info.progress_stage || '').replace(/_/g, ' ');
+            var pct = (info.progress_pct == null) ? null : Math.max(0, Math.min(100, info.progress_pct));
+            if (stage && pct != null) sub = stage + ' \u00b7 ' + pct + '%';
+            else if (stage) sub = stage;
+            else if (pct != null) sub = pct + '%';
             return '<div class="card-highlight" style="padding:0.5rem 0.75rem; margin-bottom:0.25rem;">' +
                 '<span class="badge badge-processing">IMPORTING</span> ' +
                 escHtml(info.variant) + ' / ' + escHtml(info.version) +
                 ' <span class="text-muted" style="font-size:0.8rem;">(job ' + id.slice(0, 8) + ')</span>' +
+                (sub ? '<div class="text-muted" style="font-size:0.8rem; margin-top:0.2rem;">' + escHtml(sub) + '</div>' : '') +
                 '</div>';
         }).join('');
     }
@@ -424,6 +456,13 @@
             if (document.hidden) return;
             try {
                 var job = await jsonFetch('/api/imager/jobs/' + encodeURIComponent(jobId));
+                // Refresh progress for the in-flight card.
+                var cur = importJobsCache[jobId];
+                if (cur) {
+                    cur.progress_stage = job.progress_stage || '';
+                    cur.progress_pct = job.progress_pct;
+                    renderImportProgress();
+                }
                 if (isTerminal(job.status)) {
                     clearInterval(t);
                     delete importJobsCache[jobId];

--- a/shared/models/job.py
+++ b/shared/models/job.py
@@ -74,7 +74,19 @@ class Job(Base):
     )
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    # Cooperative cancellation flag.  Set by CMS when the target asset is
+    # Coarse-grained progress for UI polling.  ``progress_stage`` is a
+    # short worker-defined label (e.g. ``downloading``, ``building``,
+    # ``uploading``).  ``progress_pct`` is an optional 0-100 estimate;
+    # NULL means "unknown / no estimate yet" (distinct from 0%).
+    # Used by the imager build + import flows so the UI is not silent
+    # for several minutes between PROCESSING and DONE.  Other job
+    # types may leave these at their defaults.
+    progress_stage: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
+    progress_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Cooperative cancellation flag.Set by CMS when the target asset is
     # soft-deleted; the worker heartbeat loop reads this and aborts ffmpeg
     # within one heartbeat cycle.  Jobs that have not yet started see it in
     # the pre-transcode guard and no-op.

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -114,6 +114,12 @@ _BASE_BLOB_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/base\.img\.xz
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 # Bound the chunked download buffer.
 _DOWNLOAD_CHUNK_BYTES = 1 << 20  # 1 MiB
+# Emit a progress-callback tick at most every N bytes during long
+# downloads.  Coarse on purpose: we update the DB row only when the
+# tick fires, not on every 1 MiB chunk.  64 MiB ~= a tick every few
+# seconds on a 100 Mb/s link, which gives the UI a fluid pct without
+# DB write amplification.
+_DOWNLOAD_PROGRESS_TICK_BYTES = 64 << 20  # 64 MiB
 
 
 # ── Internal helpers ──────────────────────────────────────────────
@@ -191,6 +197,46 @@ async def _set_provisioned_terminal(
         # failures leave it in place because the next attempt needs it.
         row.fleet_env_payload = None
         await db.commit()
+
+
+async def _set_progress(
+    session_factory: Any,
+    target_id: uuid.UUID,
+    job_type: JobType,
+    stage: str,
+    pct: int | None = None,
+) -> None:
+    """Update progress fields on the latest job for ``target_id``.
+
+    Best-effort: if the job row can't be found (e.g. tests that don't
+    create a Job alongside the imager target row) or the DB call
+    fails, we swallow the error so a progress hiccup never breaks the
+    actual import / provision pipeline.
+
+    ``pct`` is clamped to 0..100; ``None`` leaves the column NULL.
+    The UI uses NULL to mean "unknown -- show indeterminate spinner",
+    distinct from 0% which means "just started".
+    """
+    try:
+        async with session_factory() as db:
+            job = (await db.execute(
+                select(Job)
+                .where(Job.target_id == target_id, Job.type == job_type)
+                .order_by(Job.created_at.desc())
+                .limit(1)
+            )).scalar_one_or_none()
+            if job is None:
+                return
+            job.progress_stage = stage[:64]
+            if pct is not None:
+                job.progress_pct = max(0, min(100, int(pct)))
+            await db.commit()
+    except Exception as e:
+        # Progress is observability, not correctness.  Log and move on.
+        logger.debug(
+            "progress update for %s/%s -> %r/%s ignored: %s",
+            target_id, job_type, stage, pct, e,
+        )
 
 
 # Return values for ``mark_target_failed_on_exhaustion``.  The dispatcher
@@ -312,6 +358,7 @@ async def _download_with_sha(
     expected_size_bytes: int | None,
     allowlist: set[str],
     client: httpx.AsyncClient,
+    progress_cb: Any = None,
 ) -> tuple[str, int]:
     """Stream ``url`` to ``dest`` while hashing.
 
@@ -319,6 +366,11 @@ async def _download_with_sha(
     early if the running byte count exceeds ``expected_size_bytes``
     (avoids filling the disk on a malicious catalog).  Returns
     ``(actual_sha256_hex, actual_bytes)``.
+
+    ``progress_cb`` (optional): an awaitable ``async def cb(written,
+    total)`` invoked at most ~every ``_DOWNLOAD_PROGRESS_TICK_BYTES``
+    so the UI can show a percent estimate without us hammering the
+    DB on every 1 MiB chunk.
 
     Raises ``TerminalImagerError`` on hash mismatch / size mismatch /
     allowlist redirect violation.  Raises generic httpx errors on
@@ -350,6 +402,7 @@ async def _download_with_sha(
 
             hasher = hashlib.sha256()
             written = 0
+            next_progress_tick = _DOWNLOAD_PROGRESS_TICK_BYTES
             with dest.open("wb") as fh:
                 async for chunk in resp.aiter_bytes(_DOWNLOAD_CHUNK_BYTES):
                     if not chunk:
@@ -365,6 +418,14 @@ async def _download_with_sha(
                         )
                     hasher.update(chunk)
                     fh.write(chunk)
+                    if progress_cb is not None and written >= next_progress_tick:
+                        try:
+                            await progress_cb(written, expected_size_bytes)
+                        except Exception:
+                            pass
+                        next_progress_tick = (
+                            written + _DOWNLOAD_PROGRESS_TICK_BYTES
+                        )
             actual_sha = hasher.hexdigest()
             if actual_sha.lower() != expected_sha256.lower():
                 raise TerminalImagerError(
@@ -437,6 +498,10 @@ async def import_base_image_by_id(
         scratch = _scratch_dir(settings, "import", base_image_id)
         scratch.mkdir(parents=True, exist_ok=True)
 
+        await _set_progress(
+            session_factory, base_image_id, JobType.IMAGE_IMPORT, "preflight", 5
+        )
+
         # Free-space pre-flight (retryable -- another job may free disk soon).
         # Import is download->upload only: we stage the .img.xz on scratch,
         # SHA-stream-verify it (no extra copy), and stream-upload to blob.
@@ -491,9 +556,25 @@ async def import_base_image_by_id(
                 expected_size = None  # PR 4 may add expected_size_bytes col
 
             staged = scratch / "base.img.xz"
+
+            async def _import_dl_progress(written: int, total: int | None) -> None:
+                # Map bytes-downloaded to 10..85% of the overall job.
+                # Leaves headroom at the top for the upload step.
+                if total and total > 0:
+                    pct = 10 + int((written / total) * 75)
+                    await _set_progress(
+                        session_factory, base_image_id,
+                        JobType.IMAGE_IMPORT, "downloading", pct,
+                    )
+
+            await _set_progress(
+                session_factory, base_image_id,
+                JobType.IMAGE_IMPORT, "downloading", 10,
+            )
             actual_sha, actual_size = await _download_with_sha(
                 source_url, staged, expected_sha256, expected_size,
                 allowlist, client,
+                progress_cb=_import_dl_progress,
             )
 
         blob_path = f"{variant}/{version}/base.img.xz"
@@ -505,6 +586,10 @@ async def import_base_image_by_id(
                 f"contain disallowed characters)"
             )
 
+        await _set_progress(
+            session_factory, base_image_id,
+            JobType.IMAGE_IMPORT, "uploading", 90,
+        )
         await storage.upload_local_file(
             settings.base_image_cache_container,
             blob_path,
@@ -629,6 +714,11 @@ async def provision_image_by_id(
         scratch = _scratch_dir(settings, "build", provisioned_id)
         scratch.mkdir(parents=True, exist_ok=True)
 
+        await _set_progress(
+            session_factory, provisioned_id,
+            JobType.IMAGE_PROVISION, "preflight", 5,
+        )
+
         # Provisioning needs ~10 GiB headroom (xz + raw + output).
         free = await _free_bytes(scratch)
         if free < settings.imager_min_free_bytes:
@@ -640,6 +730,10 @@ async def provision_image_by_id(
 
         # Stage the base image locally.
         staged_base = scratch / "base.img.xz"
+        await _set_progress(
+            session_factory, provisioned_id,
+            JobType.IMAGE_PROVISION, "downloading_base", 10,
+        )
         await storage.download_to_file(
             settings.base_image_cache_container,
             base_blob_path,
@@ -647,6 +741,10 @@ async def provision_image_by_id(
         )
 
         # Defence in depth: blob bytes' SHA256 must still match the row.
+        await _set_progress(
+            session_factory, provisioned_id,
+            JobType.IMAGE_PROVISION, "verifying_base", 25,
+        )
         actual_base_sha = await _hash_file(staged_base)
         if actual_base_sha.lower() != base_sha256.lower():
             raise TerminalImagerError(
@@ -658,6 +756,10 @@ async def provision_image_by_id(
         # event loop so the dispatcher heartbeat keeps renewing the
         # queue lease.  build_provisioned validates output_name itself
         # and raises ImagerError on bad input or subprocess failure.
+        await _set_progress(
+            session_factory, provisioned_id,
+            JobType.IMAGE_PROVISION, "building", 35,
+        )
         try:
             output_path: Path = await asyncio.to_thread(
                 build_provisioned,
@@ -680,6 +782,10 @@ async def provision_image_by_id(
         actual_size = output_path.stat().st_size
 
         blob_path = f"{provisioned_id}/{output_name}"
+        await _set_progress(
+            session_factory, provisioned_id,
+            JobType.IMAGE_PROVISION, "uploading", 85,
+        )
         await storage.upload_local_file(
             settings.provisioned_container,
             blob_path,


### PR DESCRIPTION
## Why

The build/import flow has no progress signal between the initial
PROCESSING badge and the terminal DONE/FAILED badge. Big downloads
and pi-gen builds can sit there for many minutes silent. Users have
flagged this multiple times (e.g. job `c83b0ba7` triggered the
recent complaint). This adds a coarse-grained progress estimate so
the UI shows that work is happening.

Same gap on the long deploy workflow is noted as a follow-up but
out of scope here.

## What

**Schema (additive, deploy-order-safe):**
- New migration `0020_jobs_progress`: adds `progress_stage TEXT NOT
  NULL DEFAULT ''` and `progress_pct INTEGER NULL` to the shared
  `jobs` table.
- Old workers / old API can run against the new schema (they ignore
  the columns); new workers can run against the old schema only if
  the migration ran first, which is the normal order.
- `progress_pct = NULL` is distinct from `0` and means
  "unknown / indeterminate".

**Worker (`worker/imager_handlers.py`):**
- New `_set_progress(session_factory, target_id, job_type, stage,
  pct=None)` helper. Best-effort: swallows DB errors and missing
  rows so a progress hiccup never breaks a real job. Looks up the
  latest job for the target by `created_at` so we don't need to
  thread `job_id` through the existing handler signatures (test
  call sites unchanged).
- `_download_with_sha` grows an optional `progress_cb`. To avoid
  write-amplifying Postgres on a multi-GB download we throttle to
  one callback per 64 MiB (`_DOWNLOAD_PROGRESS_TICK_BYTES`).

**Stage labels:**
| Job | Stage transitions (pct) |
|---|---|
| Import | `preflight` (5) → `downloading` (10..85, byte-driven) → `uploading` (90) |
| Build | `preflight` (5) → `downloading_base` (10) → `verifying_base` (25) → `building` (35) → `uploading` (85) |

**API (`cms/routers/imager.py`):**
- `JobStatusOut` gains `progress_stage: str = ""` and
  `progress_pct: int | None = None`.
- Both construction sites (`/api/imager/build` response and
  `/api/imager/jobs/{id}`) populate them.

**UI (`cms/templates/imager.html`):**
- Build card: shows `"<stage> · <pct>%"` under the status badge
  while in flight; hides on terminal status.
- Import card: same sub-line under each in-flight import entry.

## Tests

- `pytest tests/test_imager_handlers.py tests/test_imager_api.py`:
  **70 passed** (no signature changes -> no test churn).
- Broader sweep `-k "job_status or jobs_get or imager"`:
  **167 passed, 6 skipped**.

## Rollout

1. Migration runs in release.
2. Old API revision keeps serving at 0 weight; new revision starts
   populating progress.
3. Once #529 lands (blue/green workflow), this PR also benefits
   from the per-revision health probes.

## Out of scope

- Step-summary lines for the deploy workflow (the deploy itself is
  long and silent — separate follow-up).
- Disk-overflow grace stage (tracked as a separate todo).
