### PR TITLE
fix(imager): sweep stale scratch dirs before counting disk-gate as a retry

### DIFF
--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -1068,3 +1068,98 @@ async def test_poison_helper_skips_when_status_is_not_in_flight(
         )).scalar_one()
     assert fresh.status == BaseImageStatus.READY.value
 
+
+
+# == Stale-scratch sweep (imager-disk-overflow-grace) ==
+
+
+def _seed_scratch_dir(
+    root: Path,
+    prefix: str,
+    target_id: uuid.UUID,
+    *,
+    age_seconds: float,
+    size_bytes: int = 0,
+) -> Path:
+    name = f"{prefix}-{target_id}-{uuid.uuid4().hex[:8]}"
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    if size_bytes:
+        (d / "leftover.bin").write_bytes(b"x" * size_bytes)
+    import os
+    st = d.stat()
+    os.utime(d, (st.st_atime - age_seconds, st.st_mtime - age_seconds))
+    return d
+
+
+def test_purge_sweeps_only_old_pattern_matching_dirs(tmp_path: Path) -> None:
+    root = tmp_path / "scratch"
+    root.mkdir()
+    stale1 = _seed_scratch_dir(root, "import", uuid.uuid4(), age_seconds=90 * 60, size_bytes=128)
+    stale2 = _seed_scratch_dir(root, "build", uuid.uuid4(), age_seconds=120 * 60, size_bytes=64)
+    fresh = _seed_scratch_dir(root, "import", uuid.uuid4(), age_seconds=0)
+    operator = root / "manual-debug-stuff"
+    operator.mkdir()
+    (operator / "notes.txt").write_bytes(b"hi")
+    (root / "stray.tmp").write_bytes(b"x")
+
+    removed, freed = imager_handlers._purge_stale_scratch_sync(root)
+    assert removed == 2
+    assert freed >= 128 + 64
+    assert not stale1.exists()
+    assert not stale2.exists()
+    assert fresh.exists()
+    assert operator.exists()
+    assert (operator / "notes.txt").exists()
+    assert (root / "stray.tmp").exists()
+
+
+def test_purge_excludes_named_self(tmp_path: Path) -> None:
+    root = tmp_path / "scratch"
+    root.mkdir()
+    self_dir = _seed_scratch_dir(root, "build", uuid.uuid4(), age_seconds=24 * 3600)
+    removed, _ = imager_handlers._purge_stale_scratch_sync(root, exclude_name=self_dir.name)
+    assert removed == 0
+    assert self_dir.exists()
+
+
+def test_purge_handles_missing_root(tmp_path: Path) -> None:
+    removed, freed = imager_handlers._purge_stale_scratch_sync(tmp_path / "nope")
+    assert removed == 0
+    assert freed == 0
+
+
+def test_purge_skips_recent_named_dir(tmp_path: Path) -> None:
+    root = tmp_path / "scratch"
+    root.mkdir()
+    fresh = _seed_scratch_dir(root, "import", uuid.uuid4(), age_seconds=10 * 60)
+    removed, _ = imager_handlers._purge_stale_scratch_sync(root)
+    assert removed == 0
+    assert fresh.exists()
+
+
+@pytest.mark.asyncio
+async def test_provision_low_disk_grace_still_fails_when_nothing_to_sweep(
+    db_session, session_factory, storage_backend, tmp_path
+):
+    """Sweep finds nothing and the original disk-gate behaviour holds:
+    return False (retryable), preserve PROVISIONING status + payload."""
+    settings = _make_settings(tmp_path, imager_min_free_bytes=10**18)
+    bi = await _make_ready_base(db_session, sha="a" * 64)
+    pi = ProvisionedImage(
+        base_image_id=bi.id, output_name="x.img.xz",
+        fleet_env_payload=b"k=v",
+    )
+    db_session.add(pi)
+    await db_session.commit()
+    await db_session.refresh(pi)
+
+    ok = await provision_image_by_id(session_factory, settings, pi.id)
+    assert ok is False
+
+    async with session_factory() as db:
+        fresh = (await db.execute(
+            select(ProvisionedImage).where(ProvisionedImage.id == pi.id)
+        )).scalar_one()
+    assert fresh.status == ProvisionedImageStatus.PROVISIONING.value
+    assert fresh.fleet_env_payload == b"k=v"

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -48,6 +48,7 @@ import hashlib
 import logging
 import re
 import shutil
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -142,6 +143,94 @@ async def _free_bytes(path: Path) -> int:
     can block on networked filesystems (Azure Files mount in prod).
     """
     return await asyncio.to_thread(lambda: shutil.disk_usage(path).free)
+
+
+# Scratch directories created by ``_scratch_dir`` follow the pattern
+# ``{prefix}-{target_uuid}-{8hex}``.  We use this regex to recognise our
+# own dirs in the scratch root when sweeping leftovers, so we never
+# rmtree something an operator dropped there by hand.
+_SCRATCH_DIR_RE = re.compile(
+    r"^(import|build)-[0-9a-fA-F-]{36}-[0-9a-fA-F]{8}$"
+)
+
+# A scratch dir whose mtime is older than this is considered abandoned
+# and safe to sweep.  Worker pods get killed at ``replicaTimeout`` (2h
+# in prod) and any in-flight build refreshes mtime within a few minutes
+# (downloads + extract steps both write).  One hour is well outside
+# that envelope.
+_SCRATCH_STALE_AGE_SECONDS = 60 * 60
+
+
+def _purge_stale_scratch_sync(
+    scratch_root: Path, exclude_name: str | None = None
+) -> tuple[int, int]:
+    """Remove abandoned per-attempt scratch directories.
+
+    Walks ``scratch_root`` and rmtree's each child directory whose
+    name matches the per-attempt scratch pattern AND whose mtime is
+    older than ``_SCRATCH_STALE_AGE_SECONDS``.  ``exclude_name`` (if
+    given) is never touched, so a worker can sweep around its own
+    in-flight scratch dir.
+
+    Best-effort: errors are logged at WARNING and never raised so a
+    permission glitch on a single dir doesn't kill the job.
+
+    Returns ``(num_removed, bytes_freed_estimate)``.  The byte count
+    is best-effort (we sum file sizes before rmtree); a partial
+    rmtree may report bytes that weren't actually freed.
+    """
+    if not scratch_root.exists():
+        return 0, 0
+    cutoff = time.time() - _SCRATCH_STALE_AGE_SECONDS
+    removed = 0
+    bytes_freed = 0
+    try:
+        children = list(scratch_root.iterdir())
+    except OSError as e:
+        logger.warning("Cannot iterate scratch root %s: %s", scratch_root, e)
+        return 0, 0
+    for child in children:
+        if not child.is_dir():
+            continue
+        if exclude_name is not None and child.name == exclude_name:
+            continue
+        if not _SCRATCH_DIR_RE.match(child.name):
+            continue
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > cutoff:
+            continue
+        size = 0
+        try:
+            for f in child.rglob("*"):
+                if f.is_file():
+                    try:
+                        size += f.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        shutil.rmtree(child, ignore_errors=True)
+        removed += 1
+        bytes_freed += size
+        logger.info(
+            "Swept stale imager scratch %s (mtime=%s, ~%d bytes)",
+            child.name,
+            datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat(),
+            size,
+        )
+    return removed, bytes_freed
+
+
+async def _purge_stale_scratch(
+    scratch_root: Path, exclude_name: str | None = None
+) -> tuple[int, int]:
+    """Async wrapper around :func:`_purge_stale_scratch_sync`."""
+    return await asyncio.to_thread(
+        _purge_stale_scratch_sync, scratch_root, exclude_name
+    )
 
 
 def _scratch_dir(settings: Any, prefix: str, target_id: uuid.UUID) -> Path:
@@ -517,12 +606,30 @@ async def import_base_image_by_id(
             needed = settings.imager_min_free_bytes
         free = await _free_bytes(scratch)
         if free < needed:
-            logger.warning(
-                "BaseImage %s import: free space %d below import threshold "
-                "%d (expected_size=%s) -- retry",
-                base_image_id, free, needed, expected_size,
+            # Grace path: try sweeping abandoned per-attempt scratch
+            # dirs from prior worker invocations and re-check.  Only
+            # return False (which burns one of the 3 retry attempts)
+            # if free space is still below the threshold after the
+            # sweep.  See ``_purge_stale_scratch`` for the safety
+            # heuristic (named pattern + stale mtime + exclude self).
+            removed, bytes_freed = await _purge_stale_scratch(
+                settings.resolved_imager_scratch_path,
+                exclude_name=scratch.name,
             )
-            return False
+            if removed:
+                logger.info(
+                    "BaseImage %s import: swept %d stale scratch dir(s) "
+                    "(~%d bytes freed) before re-checking disk gate",
+                    base_image_id, removed, bytes_freed,
+                )
+                free = await _free_bytes(scratch)
+            if free < needed:
+                logger.warning(
+                    "BaseImage %s import: free space %d below import threshold "
+                    "%d (expected_size=%s) -- retry",
+                    base_image_id, free, needed, expected_size,
+                )
+                return False
 
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
             # Resolve the catalog if the API didn't stamp source_url +
@@ -722,11 +829,26 @@ async def provision_image_by_id(
         # Provisioning needs ~10 GiB headroom (xz + raw + output).
         free = await _free_bytes(scratch)
         if free < settings.imager_min_free_bytes:
-            logger.warning(
-                "ProvisionedImage %s: free space %d below threshold %d -- retry",
-                provisioned_id, free, settings.imager_min_free_bytes,
+            # Grace path: see ``import_base_image_by_id`` -- sweep stale
+            # abandoned scratch dirs and re-check before counting this
+            # as a failed attempt.
+            removed, bytes_freed = await _purge_stale_scratch(
+                settings.resolved_imager_scratch_path,
+                exclude_name=scratch.name,
             )
-            return False
+            if removed:
+                logger.info(
+                    "ProvisionedImage %s: swept %d stale scratch dir(s) "
+                    "(~%d bytes freed) before re-checking disk gate",
+                    provisioned_id, removed, bytes_freed,
+                )
+                free = await _free_bytes(scratch)
+            if free < settings.imager_min_free_bytes:
+                logger.warning(
+                    "ProvisionedImage %s: free space %d below threshold %d -- retry",
+                    provisioned_id, free, settings.imager_min_free_bytes,
+                )
+                return False
 
         # Stage the base image locally.
         staged_base = scratch / "base.img.xz"


### PR DESCRIPTION
# fix(imager): sweep stale scratch dirs before counting disk-gate as a retry

## Problem

A previous user job (`5d1b0899...`) hit "exceeded retry limit (3)" because all
three Container Apps Job worker invocations saw the same disk-space pre-flight
gate trip:

    free space 9262465024 below threshold 10737418240

(~8.6 GiB free vs the 10 GiB `imager_min_free_bytes` threshold). The worker
runs as a single-shot `Container Apps Jobs` execution per attempt, but all
attempts share the same ephemeral disk on the underlying replica. When a
prior failed/abandoned worker invocation leaves a `import-<uuid>-<hex>` or
`build-<uuid>-<hex>` scratch dir behind, the next attempt starts already over
the gate and burns its retry slot without doing any real work.

## Fix

In `worker/imager_handlers.py`, when the disk-space gate trips:

1. Sweep stale scratch dirs from prior worker invocations
   (`(import|build)-{uuid}-{8hex}` pattern, `mtime` older than 1 hour,
   excluding the current attempt's own scratch dir).
2. Re-check `_free_bytes`.
3. Only return `False` (= consume a retry attempt) if we're *still* below
   the threshold.

This is wired into both disk-gate sites:
- import path (`import_base_image_by_id`, ~line 518)
- provision path (`provision_image_by_id`, ~line 724)

## Safety

- The sweep only touches dirs whose name matches the exact pattern that
  `_scratch_dir` produces (`(import|build)-<uuid>-<8hex>`). Operator-dropped
  debug dirs and stray files at the scratch root are left alone.
- `mtime > now - 3600s` skips anything in flight. Container Apps
  `replicaTimeout` is 2h and downloads/extracts refresh `mtime` within
  minutes, so 1h is well outside the in-flight envelope.
- `exclude_name=scratch.name` is belt-and-suspenders: the current attempt's
  dir is never a sweep candidate even if its mtime got backdated by clock
  skew or a snapshot restore.
- Errors during the sweep (`OSError`, missing root, permission denied on
  one dir) are swallowed — a permission glitch on a leftover dir must
  never break the real job.

## Tests

Added 5 unit tests covering:
- Pattern + age filter (only `(import|build)-<uuid>-<hex>` dirs older than
  1h get removed; operator dirs and stray files survive).
- `exclude_name` actually excludes.
- Missing root is a no-op.
- Recent dirs are skipped even when name matches.
- Provision low-disk grace path: when the sweep finds nothing, the original
  retryable behaviour holds — `provision_image_by_id` returns `False` and
  PROVISIONING status + payload are preserved.

`pytest tests/test_imager_handlers.py tests/test_imager_api.py
tests/test_imager.py -p no:timeout` → 94 passed, 6 skipped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
