### PR TITLE
fix(infra): cap CMS pg pool + raise pg max_connections to absorb load bursts

### DIFF
--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -60,6 +60,20 @@ resource sslConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@202
   }
 }
 
+// Raise max_connections from the B1ms default (50) to its supported ceiling.
+// 2 CMS replicas (5+5 pool each) + worker LISTEN + concurrent imager jobs
+// can transiently exceed 50 under load. 85 is the documented maximum for
+// the Burstable B1ms SKU and gives generous headroom for CI seed scripts
+// and ad-hoc admin connections. See incident at 2026-05-06T13-14Z.
+resource maxConnectionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
+  parent: postgresServer
+  name: 'max_connections'
+  properties: {
+    value: '85'
+    source: 'user-override'
+  }
+}
+
 output serverFqdn string = postgresServer.properties.fullyQualifiedDomainName
 output serverName string = postgresServer.name
 output databaseName string = database.name

--- a/shared/database.py
+++ b/shared/database.py
@@ -31,11 +31,21 @@ def init_db(settings: SharedSettings):
     # accompanying PR. ``pool_recycle`` proactively retires connections older
     # than 5 minutes so we don't accumulate ones the server has already
     # closed silently.
+    # Cap the connection pool so we don't exhaust Postgres' max_connections
+    # under bursty load. With 2 CMS replicas + worker LISTEN connection +
+    # imager Container-App-Job invocations, the SQLAlchemy default
+    # (pool_size=5, max_overflow=10 = 15/replica) was tripping the
+    # "remaining connection slots are reserved for roles with the
+    # SUPERUSER attribute" error against the B1ms Postgres' 50-slot
+    # ceiling. 5+5=10/replica leaves comfortable headroom even with
+    # max_connections raised to 85. See incident at 2026-05-06T13-14Z.
     _engine = create_async_engine(
         settings.database_url,
         echo=False,
         pool_pre_ping=True,
         pool_recycle=300,
+        pool_size=5,
+        max_overflow=5,
     )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 

--- a/tests/test_database_pool.py
+++ b/tests/test_database_pool.py
@@ -61,6 +61,53 @@ def test_init_db_enables_pool_pre_ping_and_recycle():
     )
 
 
+def test_init_db_caps_pool_size_and_overflow():
+    """``init_db`` must pass an explicit pool_size + max_overflow.
+
+    Without these the SQLAlchemy default (pool_size=5, max_overflow=10 =
+    15 connections/replica) blew past Postgres' 50-slot ceiling on the
+    B1ms server when 2 CMS replicas + worker + concurrent imager jobs
+    were active, surfacing as
+    ``asyncpg.exceptions.TooManyConnectionsError``. See incident at
+    2026-05-06T13-14Z.
+
+    Pinning these here so a future refactor can't silently regress to
+    the default.
+    """
+    from shared import database as shared_db
+    from unittest.mock import MagicMock, patch
+
+    captured = {}
+
+    def _spy_create_async_engine(url, **kwargs):
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    settings = MagicMock()
+    settings.database_url = "postgresql+asyncpg://u:p@host/db"
+
+    with patch.object(shared_db, "create_async_engine", side_effect=_spy_create_async_engine), \
+         patch.object(shared_db, "async_sessionmaker", return_value=MagicMock()):
+        shared_db.init_db(settings)
+
+    kwargs = captured["kwargs"]
+    pool_size = kwargs.get("pool_size")
+    max_overflow = kwargs.get("max_overflow")
+    assert isinstance(pool_size, int) and pool_size > 0, (
+        "init_db must pass an explicit positive pool_size; the default "
+        "of 5 + 10-overflow = 15/replica overruns Postgres B1ms's 50-slot "
+        "ceiling under load."
+    )
+    assert isinstance(max_overflow, int) and max_overflow >= 0, (
+        "init_db must pass an explicit max_overflow."
+    )
+    assert pool_size + max_overflow <= 10, (
+        f"pool_size+max_overflow={pool_size + max_overflow} is too large; "
+        f"with 2 CMS replicas + worker + concurrent imager jobs this "
+        f"trips Postgres' max_connections under load. Keep total <= 10."
+    )
+
+
 # ── Compose hardening ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
# fix(infra): cap CMS pg pool + raise pg max_connections to absorb load bursts

## Incident

2026-05-06 ~13:08-14:04 UTC: Sev2 alert "CMS dependency failures on
agoracms-env-ai" fired and auto-resolved as load receded. Root cause:

```
asyncpg.exceptions.TooManyConnectionsError:
remaining connection slots are reserved for roles with the SUPERUSER attribute
```

66 occurrences in 56 minutes. Affected endpoints: `POST /internal/wps/events`
(40), `GET /api/notifications/count` (12), `GET /api/system/health` (11),
`POST /api/devices/connect-token` (2), `GET /api/mcp/auth` (1) -- all 500s.
Both CMS replicas (already on `v1-37-164`) hit it, so this was *not* a
blue/green deploy overlap; it is a steady-state capacity issue.

## The math

- `agoracms-pg` is **Standard_B1ms** with **`max_connections=50`** (~47 usable
  after Postgres' superuser reserve).
- CMS used SQLAlchemy `create_async_engine` defaults: `pool_size=5 +
  max_overflow=10` = **15 conns/replica**.
- 2 CMS replicas (30) + worker LISTEN (1-2) + ad-hoc imager Container Apps
  Job invocations (each spinning up its own engine) easily crosses 47 under
  burst load.

## Fix (two-pronged)

### 1. `shared/database.py`: cap CMS pool

Pin `pool_size=5, max_overflow=5` (= 10/replica). With 2 replicas this is
20 max. Plenty of headroom against the new 85-slot ceiling, but tight enough
that a runaway replica can't monopolise the server.

### 2. `infra/modules/postgres.bicep`: raise `max_connections` to 85

85 is the documented maximum for the Burstable B1ms SKU. This absorbs:
- 2 CMS replicas x 10 = 20
- worker LISTEN + worker pool = ~10
- 2-3 concurrent imager jobs x 10 = 20-30
- CI seed scripts, ad-hoc admin = ~10

with comfortable buffer.

## Tests

`tests/test_database_pool.py`: new regression test
`test_init_db_caps_pool_size_and_overflow` pinning explicit `pool_size +
max_overflow <= 10` so a future refactor can't silently regress to the
default and re-introduce this incident.

3 passed locally (the existing pre-ping/recycle test + compose restart-policy
test + new pool-cap test).

## Notes

- The Bicep change requires a Postgres server restart to take effect for
  `max_connections`. The deploy workflow will roll the CA replicas; the PG
  flexible-server config push should be picked up on the next maintenance
  window or when the deploy template explicitly applies it. Verify
  post-deploy with `az postgres flexible-server parameter show -n
  max_connections` showing `85`.
- Separate concern surfaced during diagnosis: the post-deploy check should
  have caught the AGORA_CMS_BASE_URL break (different incident, different
  PR).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
