### PR TITLE
fix(imager): emit AGORA_FLEET_SECRET_HEX (hex) so firmware adopts

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -18,7 +18,7 @@ pipeline shipped in PRs 1–3:
   ``ProvisionedImage`` references it (FK is RESTRICT).
 * :http:post:`/api/imager/build` — enqueue an ``IMAGE_PROVISION``
   job that produces a generic enrollment image carrying
-  ``(AGORA_CMS_URL, AGORA_FLEET_ID, AGORA_FLEET_SECRET)``.  No
+  ``(AGORA_CMS_URL, AGORA_FLEET_ID, AGORA_FLEET_SECRET_HEX)``.  No
   per-device API key minting.
 * :http:get:`/api/imager/jobs/{job_id}` — poll job status.  Filtered
   to imager job types so non-imager jobs cannot be peeked through
@@ -36,6 +36,8 @@ re-flashes (Model A) are tracked as a future feature.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import re
 import uuid
 from datetime import datetime, timezone
@@ -283,13 +285,32 @@ def _fleet_env_payload(
     ``cms_url`` (only its scheme+netloc) to derive the API base for
     ``/api/devices/.../connect-token``; the ``/ws/device`` path is
     ignored, so the same URL form works for both modes.
+
+    ``fleet_secret`` is the **base64**-encoded secret as stored in
+    ``Settings.fleet_register_secrets[fleet_id]`` (see
+    ``cms/routers/bootstrap.py`` which does ``base64.b64decode`` to
+    recover the raw bytes).  The firmware-side
+    ``agora-fleet-provision.sh`` allow-lists the key
+    ``AGORA_FLEET_SECRET_HEX`` and hex-decodes the value, so we
+    re-encode here.  The 2026-05-06 incident on Pi 192.168.1.100
+    was caused by writing the key as ``AGORA_FLEET_SECRET=<b64>``,
+    which the firmware silently dropped (wrong key name, wrong
+    encoding) leaving the device unable to authenticate.
     """
     fw_transport = "direct" if device_transport == "local" else device_transport
+    try:
+        raw = base64.b64decode(fleet_secret, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(
+            "fleet_secret is not valid base64; "
+            "FLEET_REGISTER_SECRETS[<fleet_id>] must be base64-encoded raw bytes"
+        ) from exc
+    secret_hex = raw.hex()
     return (
         f"AGORA_CMS_URL={cms_url}\n"
         f"AGORA_CMS_TRANSPORT={fw_transport}\n"
         f"AGORA_FLEET_ID={fleet_id}\n"
-        f"AGORA_FLEET_SECRET={fleet_secret}\n"
+        f"AGORA_FLEET_SECRET_HEX={secret_hex}\n"
     ).encode("utf-8")
 
 
@@ -646,9 +667,18 @@ async def build_provisioned_image(
             detail=f"base image is not ready (status={bi.status})",
         )
 
-    payload = _fleet_env_payload(
-        cms_url, body.fleet_id, secret, settings.device_transport
-    )
+    try:
+        payload = _fleet_env_payload(
+            cms_url, body.fleet_id, secret, settings.device_transport
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"FLEET_REGISTER_SECRETS[{body.fleet_id!r}] is misconfigured: "
+                f"{exc}"
+            ),
+        ) from exc
 
     pi = ProvisionedImage(
         base_image_id=bi.id,

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -572,13 +572,64 @@ async def test_build_creates_provisioned_row_with_payload(
     assert "AGORA_CMS_URL=wss://cms.example.com/ws/device" in payload
     assert "AGORA_CMS_TRANSPORT=direct" in payload
     assert "AGORA_FLEET_ID=fleet-test" in payload
-    assert "AGORA_FLEET_SECRET=c2VjcmV0LWJhc2U2NA==" in payload  # gitleaks:allow
+    # Firmware (agora-fleet-provision.sh) allow-lists AGORA_FLEET_SECRET_HEX
+    # only and hex-decodes the value.  Stored secret is base64 of raw bytes
+    # (b"secret-base64") -> hex below.
+    assert "AGORA_FLEET_SECRET_HEX=7365637265742d626173653634" in payload
+    assert "AGORA_FLEET_SECRET=" not in payload.replace(
+        "AGORA_FLEET_SECRET_HEX=", ""
+    )
 
     # And a Job row was enqueued.
     job = (await db_session.execute(
         select(Job).where(Job.target_id == pi.id, Job.type == JobType.IMAGE_PROVISION)
     )).scalar_one()
     assert job.status == JobStatus.PENDING
+
+
+def test_fleet_env_payload_matches_firmware_allowlist():
+    """Regression for the 2026-05-06 ``test-fleet-1`` outage.
+
+    The firmware-side ``agora-fleet-provision.sh`` allow-lists exactly
+    three keys: ``AGORA_FLEET_ID``, ``AGORA_FLEET_SECRET_HEX``,
+    ``AGORA_BOOTSTRAP_V2``.  Anything else is dropped silently.  The
+    secret value is hex-decoded.
+
+    Pin the imager output so we can never again ship images where the
+    firmware silently drops the credential.
+    """
+    import base64
+
+    from cms.routers.imager import _fleet_env_payload
+
+    raw = b"\x00\x01\x02\x03decafbad" + b"x" * 20
+    secret_b64 = base64.b64encode(raw).decode()
+
+    out = _fleet_env_payload(
+        "wss://cms.example.com/ws/device", "fleet-x", secret_b64, "wps"
+    ).decode("utf-8")
+
+    # Key name must be the firmware-expected ``_HEX`` form.
+    assert "AGORA_FLEET_SECRET_HEX=" in out
+    # Pre-fix imager wrote ``AGORA_FLEET_SECRET=<base64>``.  Make sure
+    # neither the bad key NOR the base64 value leaks into the file.
+    lines = [ln for ln in out.splitlines() if "=" in ln]
+    keys = {ln.split("=", 1)[0] for ln in lines}
+    assert "AGORA_FLEET_SECRET" not in keys
+    assert secret_b64 not in out
+
+    # Value is hex(raw_bytes).
+    hex_line = next(ln for ln in lines if ln.startswith("AGORA_FLEET_SECRET_HEX="))
+    assert hex_line.split("=", 1)[1] == raw.hex()
+
+
+def test_fleet_env_payload_rejects_non_base64_secret():
+    from cms.routers.imager import _fleet_env_payload
+
+    with pytest.raises(ValueError, match="base64"):
+        _fleet_env_payload(
+            "wss://cms.example.com/ws/device", "fleet-x", "not!valid!b64", "wps"
+        )
 
 
 # ── Jobs / download ────────────────────────────────────────────────


### PR DESCRIPTION
## Why

A Pi flashed with the `test-fleet-1` test image (192.168.1.100,
agora-pi5-test-fleet-1-20260505.img.xz) couldn't adopt — looped on
HTTP 403 at `/ws/device`.

Root cause: the CMS imager wrote `/boot/firmware/agora-fleet.env`
with two contract violations vs the firmware-side
`agora-fleet-provision.sh` allow-list:

| Key the imager wrote          | Firmware allow-list      | Result    |
|-------------------------------|--------------------------|-----------|
| `AGORA_FLEET_SECRET=<b64>`  | `AGORA_FLEET_SECRET_HEX`| dropped  |
| `AGORA_CMS_URL=...`         | (not allow-listed)       | dropped  |
| `AGORA_CMS_TRANSPORT=...`   | (not allow-listed)       | dropped  |
| `AGORA_FLEET_ID=...`        | `AGORA_FLEET_ID`       | accepted |

After first boot the firmware *shreds* the source file, so the only
recovery is a re-flash from a corrected image.

## What

- Rename the secret key to `AGORA_FLEET_SECRET_HEX` (matches firmware).
- Re-encode the value from base64 -> hex (matches firmware decode).
  Stored secrets in `FLEET_REGISTER_SECRETS` remain base64 — this
  only changes the on-device representation.
- Surface a misconfigured (non-base64) `FLEET_REGISTER_SECRETS` entry
  as a 503 from `/api/imager/build` instead of a 500 stack.
- Add a regression test pinning the firmware contract end-to-end.

## What this does NOT change

- Firmware allow-list. `AGORA_CMS_URL` and `AGORA_CMS_TRANSPORT`
  are still emitted (and still dropped by firmware today). Treated as
  forward-compat hints; cheap to keep, and firmware can opt in by
  expanding its allow-list later. Calling that out as a follow-up.
- Existing `FLEET_REGISTER_SECRETS` storage format (still base64).
- Anything about the `AGORA_CMS_BASE_URL` env var on prod
  (separate gap; tracked).

## Verification

- `pytest tests/test_imager_api.py`: 42 passed (was 40 — 2 new tests).
- After deploy, re-flash the test Pi. Adoption should succeed via the
  bootstrap-v2 `/api/devices/register` HMAC flow (uses the same
  raw-bytes secret CMS already stores).