### PR TITLE
fix(deploy): auto-deactivate stale revisions after promote; revert PG max_connections bump

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -478,6 +478,51 @@ jobs:
           flip "$MCP_APP" "$NEW_MCP_REV" "$PREV_MCP"
           echo "✅ Traffic flipped — $NEW_CMS_REV is now serving production"
 
+      # Container Apps "Active" revisions keep their minReplicas pods running
+      # regardless of traffic weight. Without this step, every deploy adds
+      # 2 idle CMS pods (and 1 idle MCP pod) that still hold open Postgres
+      # connections — the structural cause of the 2026-05-06T13-14Z Sev2
+      # (4 stacked active revisions × 2 replicas exhausted PG max_connections=50).
+      # Keep the new revision (currently serving) and the immediate previous
+      # one (one-click rollback target via "az containerapp ingress traffic
+      # set --revision-weight $prev=100"); deactivate everything else.
+      - name: Deactivate stale revisions
+        if: steps.health.outputs.status == 'ok' && steps.smoke.outputs.smoke == 'ok'
+        run: |
+          set -uo pipefail
+          CMS_APP="${{ vars.INFRA_PREFIX }}-cms"
+          MCP_APP="${{ vars.INFRA_PREFIX }}-mcp"
+          RG="${{ env.AZURE_RESOURCE_GROUP }}"
+          NEW_CMS_REV='${{ needs.deploy.outputs.new_cms_revision }}'
+          NEW_MCP_REV='${{ needs.deploy.outputs.new_mcp_revision }}'
+          PREV_CMS='${{ needs.deploy.outputs.previous_cms_revision }}'
+          PREV_MCP='${{ needs.deploy.outputs.previous_mcp_revision }}'
+
+          deactivate_stale() {
+            local app="$1" keep_new="$2" keep_prev="$3"
+            echo "── deactivating stale revisions for $app (keeping $keep_new + $keep_prev) ──"
+            local stale
+            stale=$(az containerapp revision list \
+              --name "$app" --resource-group "$RG" \
+              --query "[?properties.active && name!='$keep_new' && name!='$keep_prev'].name" \
+              -o tsv 2>/dev/null || echo "")
+            if [ -z "$stale" ]; then
+              echo "  (none)"
+              return 0
+            fi
+            for rev in $stale; do
+              echo "  deactivating $rev"
+              az containerapp revision deactivate \
+                --name "$app" --resource-group "$RG" \
+                --revision "$rev" 2>&1 \
+                || echo "  (failed to deactivate $rev — continuing)"
+            done
+          }
+
+          deactivate_stale "$CMS_APP" "$NEW_CMS_REV" "$PREV_CMS"
+          deactivate_stale "$MCP_APP" "$NEW_MCP_REV" "$PREV_MCP"
+          echo "✅ Stale revisions deactivated — only current + previous remain warm"
+
       # Sad path: deactivate the new revisions so the previous ones keep
       # serving 100% of traffic.
       - name: Deactivate new revisions on failure

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -60,19 +60,13 @@ resource sslConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@202
   }
 }
 
-// Raise max_connections from the B1ms default (50) to its supported ceiling.
-// 2 CMS replicas (5+5 pool each) + worker LISTEN + concurrent imager jobs
-// can transiently exceed 50 under load. 85 is the documented maximum for
-// the Burstable B1ms SKU and gives generous headroom for CI seed scripts
-// and ad-hoc admin connections. See incident at 2026-05-06T13-14Z.
-resource maxConnectionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
-  parent: postgresServer
-  name: 'max_connections'
-  properties: {
-    value: '85'
-    source: 'user-override'
-  }
-}
+// max_connections is intentionally left at the B1ms default (50). The
+// 2026-05-06T13-14Z Sev2 was caused by stacked active Container App
+// revisions (each pinned to minReplicas=2) blowing past the 50-slot
+// ceiling, not by genuine load. The structural fix is in publish-image.yml
+// (auto-deactivate stale revisions after promote) plus the 5+5 SQLAlchemy
+// pool cap in shared/database.py — together they bound steady-state at
+// ~30 connections.
 
 output serverFqdn string = postgresServer.properties.fullyQualifiedDomainName
 output serverName string = postgresServer.name

--- a/shared/database.py
+++ b/shared/database.py
@@ -37,8 +37,10 @@ def init_db(settings: SharedSettings):
     # (pool_size=5, max_overflow=10 = 15/replica) was tripping the
     # "remaining connection slots are reserved for roles with the
     # SUPERUSER attribute" error against the B1ms Postgres' 50-slot
-    # ceiling. 5+5=10/replica leaves comfortable headroom even with
-    # max_connections raised to 85. See incident at 2026-05-06T13-14Z.
+    # ceiling. 5+5=10/replica keeps steady-state well under 50 once
+    # publish-image.yml's auto-deactivate-stale-revisions step prevents
+    # idle revision pods from accumulating. See incident at
+    # 2026-05-06T13-14Z.
     _engine = create_async_engine(
         settings.database_url,
         echo=False,


### PR DESCRIPTION
## Why now

The 2026-05-06T13-14Z Sev2 ( + 'asyncpg.TooManyConnectionsError' + ) wasn't real load — it was the blue/green deploy pattern from #529 stacking active Container App revisions. Each active revision is pinned to  + 'minReplicas=2' +  and keeps its DB pool open regardless of traffic weight. By alert time:

- 4 active CMS revisions × 2 replicas = **8 idle pods**
- 8 × default  + '5+10' +  SQLAlchemy pool ≈ **120 potential connections** vs PG  + 'max_connections=50' + 

#532 papered over this by raising  + 'max_connections' +  to 85 — the wrong fix. Stale revisions would have kept accumulating until 85 broke too.

## Real fix

After a successful blue/green promote, deactivate every active revision except the new one (currently serving) and the immediate previous one (one-click rollback target via  + 'z containerapp ingress traffic set --revision-weight =100' + ).

Steady state becomes: 2 active revisions × 2 replicas × 10-conn pool ≈ **~30 connections**, comfortably under the B1ms default 50.

## Changes

-  + '.github/workflows/publish-image.yml' +  — new  + 'Deactivate stale revisions' +  step in the  + 'erify' +  job, runs after traffic flip on the happy path. Soft-fails per-revision so one stuck deactivate doesn't break the deploy.
-  + 'infra/modules/postgres.bicep' +  — removed  + 'maxConnectionsConfig' +  resource (back to B1ms default 50).
-  + 'shared/database.py' +  — updated comment. Pool cap ( + '5+5' + ) preserved.

## Manual cleanup already done

5 stale revisions on prod ( + 'goracms-cms' +  +  + 'goracms-mcp' + ) deactivated by hand before this PR — we're already at 2 pods/app instead of 12. The workflow change ensures we never have to do that again.