### PR TITLE
fix(devices): restore Pending Devices card so bootstrap-v2 registrations are visible

### DIFF
--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -144,42 +144,6 @@ tr.row-flash.row-flash-maintenance > td { animation-name: row-flash-maintenance;
 {{ macros.triage_bar(fleet_counts, active_alert, user_perms) }}
 {% endif %}
 
-{# ── Pending Devices (unadopted bootstrap-v2 registrations) ──
-   Bootstrap-v2 stores un-adopted device registrations in the
-   `pending_registrations` table, NOT in `devices` with status=PENDING.
-   The `devices` query in cms/ui.py never joins that table, so without
-   this dedicated card those rows are invisible to operators.
-   PR #478 ("Phase D") retired this card with the intent of merging
-   pending rows into the Ungrouped Devices table, but the data flow
-   was never wired up — restored here as a bug fix.
-   Populated by the pollPendingOnce() JS below from /api/devices/pending. #}
-{% if 'devices:manage' in user_perms %}
-<div class="card" id="pending-devices-card" style="display: none;">
-    <div style="display: flex; gap: 0.75rem; align-items: center; margin: 0 0 0.5rem 0;">
-        <h2 style="margin: 0;">Pending Devices</h2>
-        <button class="btn btn-primary" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
-    </div>
-    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
-        Devices that have registered with the CMS but haven't been adopted yet.
-        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
-    </p>
-    <div class="table-wrap">
-        <table>
-            <thead>
-                <tr>
-                    <th>Device ID</th>
-                    <th>Firmware</th>
-                    <th>IP</th>
-                    <th>Registered</th>
-                    <th style="width: 1%; white-space: nowrap;">Actions</th>
-                </tr>
-            </thead>
-            <tbody id="pending-devices-tbody"></tbody>
-        </table>
-    </div>
-</div>
-{% endif %}
-
 {# ── Device Groups (expandable) ── #}
 {% if 'groups:read' in user_perms %}
 <div class="card">
@@ -228,6 +192,44 @@ tr.row-flash.row-flash-maintenance > td { animation-name: row-flash-maintenance;
         </table>
     </div>
 </div>
+
+{# ── Pending Devices (unadopted bootstrap-v2 registrations) ──
+   Bootstrap-v2 stores un-adopted device registrations in the
+   `pending_registrations` table, NOT in `devices` with status=PENDING.
+   The `devices` query in cms/ui.py never joins that table, so without
+   this dedicated card those rows are invisible to operators.
+   PR #478 ("Phase D") retired this card with the intent of merging
+   pending rows into the Ungrouped Devices table, but the data flow
+   was never wired up -- restored here as a bug fix.
+   Rendered LAST so the e2e layout tests' `document.querySelector('.card')`
+   continues to find the Device Groups card first.
+   Populated by the pollPendingOnce() JS below from /api/devices/pending. #}
+{% if 'devices:manage' in user_perms %}
+<div class="card" id="pending-devices-card" style="display: none;">
+    <div style="display: flex; gap: 0.75rem; align-items: center; margin: 0 0 0.5rem 0;">
+        <h2 style="margin: 0;">Pending Devices</h2>
+        <button class="btn btn-primary" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
+    </div>
+    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
+        Devices that have registered with the CMS but haven't been adopted yet.
+        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
+    </p>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Device ID</th>
+                    <th>Firmware</th>
+                    <th>IP</th>
+                    <th>Registered</th>
+                    <th style="width: 1%; white-space: nowrap;">Actions</th>
+                </tr>
+            </thead>
+            <tbody id="pending-devices-tbody"></tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
 {% endif %}{# end groups:read #}
 {% endblock %}
 

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -144,9 +144,41 @@ tr.row-flash.row-flash-maintenance > td { animation-name: row-flash-maintenance;
 {{ macros.triage_bar(fleet_counts, active_alert, user_perms) }}
 {% endif %}
 
-{# Phase D: Pending devices now flow into the Ungrouped Devices section
-   below as full rich device_row rendering (with the Adopt kebab item).
-   The dedicated Pending Devices card has been retired. #}
+{# ── Pending Devices (unadopted bootstrap-v2 registrations) ──
+   Bootstrap-v2 stores un-adopted device registrations in the
+   `pending_registrations` table, NOT in `devices` with status=PENDING.
+   The `devices` query in cms/ui.py never joins that table, so without
+   this dedicated card those rows are invisible to operators.
+   PR #478 ("Phase D") retired this card with the intent of merging
+   pending rows into the Ungrouped Devices table, but the data flow
+   was never wired up — restored here as a bug fix.
+   Populated by the pollPendingOnce() JS below from /api/devices/pending. #}
+{% if 'devices:manage' in user_perms %}
+<div class="card" id="pending-devices-card" style="display: none;">
+    <div style="display: flex; gap: 0.75rem; align-items: center; margin: 0 0 0.5rem 0;">
+        <h2 style="margin: 0;">Pending Devices</h2>
+        <button class="btn btn-primary" onclick="bootstrapAdoptDevice()" title="Adopt a new device by scanning the QR code on its splash screen or pasting its pairing code">Adopt Device</button>
+    </div>
+    <p class="text-muted" style="margin: 0 0 0.75rem 0;">
+        Devices that have registered with the CMS but haven't been adopted yet.
+        Unadopted registrations expire after {{ pending_ttl_hours }} hours.
+    </p>
+    <div class="table-wrap">
+        <table>
+            <thead>
+                <tr>
+                    <th>Device ID</th>
+                    <th>Firmware</th>
+                    <th>IP</th>
+                    <th>Registered</th>
+                    <th style="width: 1%; white-space: nowrap;">Actions</th>
+                </tr>
+            </thead>
+            <tbody id="pending-devices-tbody"></tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
 
 {# ── Device Groups (expandable) ── #}
 {% if 'groups:read' in user_perms %}

--- a/tests/test_pending_device_visibility.py
+++ b/tests/test_pending_device_visibility.py
@@ -234,3 +234,108 @@ class TestDevicesPageColumns:
         assert device_thead is not None
         th_count = device_thead.count("<th")
         assert th_count == 7
+
+
+# ── Bootstrap-v2 pending registrations card ──
+
+
+@pytest.mark.asyncio
+class TestPendingRegistrationsCard:
+    """Bootstrap-v2 stores un-adopted device registrations in the
+    `pending_registrations` table (not in `devices` with status=PENDING).
+    The /devices page must render the dedicated #pending-devices-card so
+    the JS poller can populate it from /api/devices/pending. PR #478
+    ("Phase D") accidentally removed this card while only intending to
+    consolidate dashboard duplicates; without it, every newly-flashed
+    device is invisible to operators until manually adopted by ID.
+    """
+
+    async def test_admin_sees_pending_devices_card(self, client):
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        assert 'id="pending-devices-card"' in resp.text, (
+            "Pending Devices card markup is missing from /devices. The "
+            "polling JS at the bottom of devices.html targets this DOM "
+            "id; without it, bootstrap-v2 pending registrations are "
+            "invisible in the UI."
+        )
+        assert 'id="pending-devices-tbody"' in resp.text
+
+    async def test_operator_does_not_see_pending_devices_card(self, operator_client):
+        resp = await operator_client.get("/devices")
+        assert resp.status_code == 200
+        assert 'id="pending-devices-card"' not in resp.text
+
+
+@pytest_asyncio.fixture
+async def seed_pending_registration(app):
+    """Insert a pending_registrations row (bootstrap-v2 un-adopted device).
+
+    Returns the device_id so tests can assert it shows up in API/UI flows.
+    """
+    from cms.database import get_db
+    from cms.models.pending_registration import PendingRegistration
+
+    factory = app.dependency_overrides[get_db]
+    device_id = "vis-test-pending-reg-001"
+    async for db in factory():
+        db.add(
+            PendingRegistration(
+                device_id=device_id,
+                pubkey="dGVzdC1wdWJrZXktYmFzZTY0",
+                pairing_secret_hash="a" * 64,
+                connection_metadata={"firmware_version": "1.11.35"},
+                ip_address="192.168.1.100",
+            )
+        )
+        await db.commit()
+        break
+    return device_id
+
+
+@pytest.mark.asyncio
+class TestPendingRegistrationsVisible:
+    """End-to-end check that a row in `pending_registrations` actually
+    surfaces in the UI flow. Regression guard for PR #478 ("Phase D"),
+    which retired the dedicated Pending Devices card without wiring its
+    data source (`pending_registrations`) into the Ungrouped Devices
+    list -- making every newly-flashed bootstrap-v2 device invisible.
+    """
+
+    async def test_pending_registration_appears_in_api_response(
+        self, client, seed_pending_registration
+    ):
+        """The /api/devices/pending endpoint that the card's JS polls
+        must return the row so the front-end can render it."""
+        resp = await client.get("/api/devices/pending")
+        assert resp.status_code == 200
+        items = resp.json().get("items", [])
+        device_ids = {item.get("device_id") for item in items}
+        assert seed_pending_registration in device_ids, (
+            f"Pending registration {seed_pending_registration!r} not "
+            f"returned by /api/devices/pending. Response items: {items!r}. "
+            "The Pending Devices card cannot render rows the API does "
+            "not return."
+        )
+
+    async def test_pending_registration_card_target_present_for_admin(
+        self, client, seed_pending_registration
+    ):
+        """Even when there are pending rows, the static template must
+        render the card markup (it starts hidden and is shown by JS).
+        Without this, the JS poller has no DOM to mount into and the
+        device is invisible regardless of what the API returns."""
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        assert 'id="pending-devices-card"' in resp.text
+        assert 'id="pending-devices-tbody"' in resp.text
+
+    async def test_operator_cannot_see_pending_registrations_api(
+        self, operator_client, seed_pending_registration
+    ):
+        """Bootstrap-v2 adoption is gated on devices:manage; operators
+        without it must get 403 from the API the card polls."""
+        resp = await operator_client.get("/api/devices/pending")
+        assert resp.status_code == 403
+
+


### PR DESCRIPTION
## Summary

PR #478 (Phase D) retired the dedicated Pending Devices card on /devices with the stated intent of merging pending rows into the Ungrouped Devices table — but the data plumbing for that change was never landed.

cms/ui.py still queries `select(Device)` only, while bootstrap-v2 stores un-adopted registrations in a **separate** `pending_registrations` table. Result: every device flashed with bootstrap-v2 firmware that successfully registers via `POST /api/devices/register` is invisible in the UI, **blocking adoption entirely**.

The polling JS in `devices.html` (`pollPendingOnce`, ~line 800) was left intact and still hits `GET /api/devices/pending` every 5s, but its DOM targets (`#pending-devices-card`, `#pending-devices-tbody`) were deleted — so the early-return at the top silently dropped every poll on the floor.

## Repro

1. Flash a Pi with v1.11.35 firmware, point it at prod CMS.
2. Pi boots, `/api/devices/register` returns 200, `cms-client` logs `Registered; polling /bootstrap-status until adopted`.
3. Open `/devices` as admin → device is nowhere on the page.

## Fix

Restore the card markup. The endpoint, JS poller, adopt/reject handlers, and `device_bootstrap` service code are all unchanged and already work — only the static template was missing.

## Tests

New `TestPendingRegistrationsVisible` class adds three explicit assertions:

1. A row inserted into `pending_registrations` is returned by `GET /api/devices/pending`.
2. The `#pending-devices-card` markup is present for users with `devices:manage`.
3. Operators without the permission get `403` from the API.

Verified: assertion (2) fails on main without this template change; passes with it. All 23 existing + new tests in `test_pending_device_visibility.py` green locally.

## Out of scope

- Migrating pending devices into the Ungrouped Devices table per the original Phase D intent. That requires server-side changes in `cms/ui.py` to union `pending_registrations` rows into the `devices` list (or a follow-up template refactor that fetches client-side and injects rows into the existing ungrouped tbody). Restoring the dedicated card is the minimum viable fix to unblock adoption today; the visual consolidation can land in a follow-up PR without urgency.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>