### PR TITLE
fix(devices): restart Pending Devices poller (follow-up to #535)

### DIFF
--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -706,11 +706,6 @@ window._adoptionProfiles = [
 
     setInterval(pollDevicesOnce, 5000);
     setInterval(pollGroupsOnce, 5000);
-    {% if 'devices:manage' in user_perms %}
-    // Pending devices now render server-side in the Ungrouped section.
-    // Action handlers reload the page to pick up adoption status changes.
-    window._refreshPending = () => { location.reload(); };
-    {% endif %}
 
     // Keep the /devices Device Groups card in sync across replicas without
     // a full page reload. Added as part of #87: when session A creates or
@@ -885,6 +880,11 @@ window._adoptionProfiles = [
     // Expose for action handlers (adopt/reject) to request an immediate
     // repopulate instead of waiting up to 5s for the next poll cycle.
     window._refreshPending = () => pollPendingOnce();
+    // Kick off the polling cycle. PR #478 deleted the scheduler when it
+    // retired the card; this restores it alongside the card markup so
+    // unadopted bootstrap-v2 registrations actually appear in the UI.
+    pollPendingOnce();
+    setInterval(pollPendingOnce, 5000);
     {% endif %}
 })();
 

--- a/tests/test_pending_device_visibility.py
+++ b/tests/test_pending_device_visibility.py
@@ -266,6 +266,25 @@ class TestPendingRegistrationsCard:
         assert resp.status_code == 200
         assert 'id="pending-devices-card"' not in resp.text
 
+    async def test_pending_poller_is_scheduled(self, client):
+        """The card markup is useless without the JS poller actually
+        running on a timer. PR #478 also gutted the scheduler; the
+        function was left defined but never invoked, so the card stayed
+        permanently hidden even when /api/devices/pending returned rows.
+        """
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "function pollPendingOnce" in body
+        assert "setInterval(pollPendingOnce" in body, (
+            "pollPendingOnce is defined but never scheduled on a timer; "
+            "the Pending Devices card will never populate."
+        )
+        # Initial kickoff so the card appears on first load, not 5s later.
+        # Match either bare call or as part of an arrow function ΓÇö the
+        # important thing is *something* invokes it at startup.
+        assert "pollPendingOnce()" in body
+
 
 @pytest_asyncio.fixture
 async def seed_pending_registration(app):


### PR DESCRIPTION
## Why

PR #535 restored the `#pending-devices-card` markup, but the bug isn't fully fixed: the JS poller that populates the card is **defined but never called**. PR #478 deleted both the card *and* the scheduler when it retired the v1 pending UI; #535 only put the markup back.

Verified against prod (cms 1.37.168) just now:
- `GET /api/devices/pending` returns the real Pi 192.168.1.100 registration ✓
- Rendered `/devices` HTML contains `id="pending-devices-card"` ✓
- Rendered HTML contains `function pollPendingOnce` ✓
- Rendered HTML has **no** `setInterval(pollPendingOnce, ...)` ✗ ← bug
- Card stays `display:none` forever; pending devices invisible.

## What

1. Remove the leftover stub from PR #478 that overrode `window._refreshPending` to do a full page reload.
2. Schedule the poller properly: one immediate call + `setInterval(pollPendingOnce, 5000)`.
3. New regression test `test_pending_poller_is_scheduled` — fails on stock `main`, passes with this change.

## Out of scope

Long-term plan to merge `pending_registrations` into the Ungrouped Devices server-side (PR #478's stated intent) is still deferred.