### PR TITLE
feat(imager): wifi credentials and fleet CRUD UI

### DIFF
--- a/alembic/versions/0023_provisioned_wifi.py
+++ b/alembic/versions/0023_provisioned_wifi.py
@@ -1,0 +1,45 @@
+"""Add wifi_ssid and wifi_psk columns to provisioned_images.
+
+Carries the per-build WiFi credentials chosen by the operator. Both
+columns are nullable; the build endpoint enforces that they are either
+both set or both NULL. They are NOT cleared on terminal success
+(unlike ``fleet_env_payload``) -- the Built Images UI surfaces the
+SSID/PSK in a tooltip so the operator can recover credentials baked
+into a downloaded image.
+
+Revision ID: 0023
+Revises: 0022
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "provisioned_images",
+        sa.Column("wifi_ssid", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "provisioned_images",
+        sa.Column("wifi_psk", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Project policy (test_migration_policy.py): every downgrade must
+    # raise NotImplementedError. Real downgrades are dangerous in
+    # production rollback (data loss / FK ordering / re-upgrade
+    # back-fill) and the project has chosen to invest in forward
+    # migrations only.
+    raise NotImplementedError(
+        "Downgrade of 0023 is intentionally not implemented per project policy."
+    )

--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -47,7 +47,7 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -148,6 +148,11 @@ class ProvisionedImageOut(BaseModel):
     SAS URL on each click -- the SAS embedded at build time is not
     used).  ``None`` only for legacy rows pre-dating the
     ``provisioning_job_id`` column; UI should disable Download.
+
+    ``wifi_ssid`` / ``wifi_psk`` are the cleartext WiFi creds baked
+    into the image, surfaced so the operator can recover them via the
+    Built Images tooltip.  Both ``None`` means the image carries no
+    wifi creds.
     """
 
     id: uuid.UUID
@@ -163,6 +168,8 @@ class ProvisionedImageOut(BaseModel):
     created_at: datetime
     built_at: datetime | None
     expires_at: datetime | None
+    wifi_ssid: str | None = None
+    wifi_psk: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -171,6 +178,26 @@ class BuildBody(BaseModel):
     base_image_id: uuid.UUID
     fleet_id: str = Field(..., min_length=1, max_length=64)
     output_name: str = Field(..., min_length=1, max_length=255)
+    # Optional WiFi credentials. Both must be provided or both omitted
+    # (validated below). SSID limit per IEEE 802.11; PSK limit per WPA
+    # passphrase (8-63 ASCII) or 64-hex pre-shared key. We don't
+    # enforce 8-63 for passphrase here because NetworkManager accepts
+    # both forms transparently and we'd rather not reject the 64-hex
+    # form for users who paste a pre-computed PSK.
+    wifi_ssid: str | None = Field(default=None, min_length=1, max_length=32)
+    wifi_psk: str | None = Field(default=None, min_length=8, max_length=64)
+
+    @model_validator(mode="after")
+    def _check_wifi_pair(self) -> "BuildBody":
+        # Both-or-neither: pre-validate at the schema layer so the
+        # build endpoint can assume a coherent pair.  Using
+        # @model_validator (vs model_post_init) so pydantic surfaces
+        # the failure as 422 instead of a generic 500.
+        if (self.wifi_ssid is None) != (self.wifi_psk is None):
+            raise ValueError(
+                "wifi_ssid and wifi_psk must be provided together or both omitted"
+            )
+        return self
 
 
 class ImagerSettingsOut(BaseModel):
@@ -307,7 +334,13 @@ def _derive_device_ws_url(base_url: str) -> str:
 
 
 def _fleet_env_payload(
-    cms_url: str, fleet_id: str, fleet_secret: bytes, device_transport: str
+    cms_url: str,
+    fleet_id: str,
+    fleet_secret: bytes,
+    device_transport: str,
+    *,
+    wifi_ssid: str | None = None,
+    wifi_psk: str | None = None,
 ) -> bytes:
     """Render the ``agora-fleet.env`` body the worker will inject.
 
@@ -331,15 +364,30 @@ def _fleet_env_payload(
     was caused by writing the key as ``AGORA_FLEET_SECRET=<b64>``,
     which the firmware silently dropped (wrong key name, wrong
     encoding) leaving the device unable to authenticate.
+
+    When ``wifi_ssid`` and ``wifi_psk`` are both provided, additional
+    ``AGORA_WIFI_SSID`` / ``AGORA_WIFI_PASS`` lines are appended.  The
+    firmware-side allow-list pins these exact key names (NOT
+    ``AGORA_WIFI_PASSPHRASE``) and the provisioner script writes a
+    NetworkManager ``.nmconnection`` file from them on first boot.
+    Either both must be set or both must be omitted; the build endpoint
+    enforces this before calling.  Devices that have no wifi hardware
+    silently no-op the connection file (firmware probes
+    ``/sys/class/ieee80211``), so leftover wifi env on a wired-only Pi
+    is harmless.
     """
     fw_transport = "direct" if device_transport == "local" else device_transport
     secret_hex = fleet_secret.hex()
-    return (
+    out = (
         f"AGORA_CMS_URL={cms_url}\n"
         f"AGORA_CMS_TRANSPORT={fw_transport}\n"
         f"AGORA_FLEET_ID={fleet_id}\n"
         f"AGORA_FLEET_SECRET_HEX={secret_hex}\n"
-    ).encode("utf-8")
+    )
+    if wifi_ssid and wifi_psk:
+        out += f"AGORA_WIFI_SSID={wifi_ssid}\n"
+        out += f"AGORA_WIFI_PASS={wifi_psk}\n"
+    return out.encode("utf-8")
 
 
 # ── Endpoints ────────────────────────────────────────────────────
@@ -777,7 +825,12 @@ async def build_provisioned_image(
 
     try:
         payload = _fleet_env_payload(
-            cms_url, body.fleet_id, secret, settings.device_transport
+            cms_url,
+            body.fleet_id,
+            secret,
+            settings.device_transport,
+            wifi_ssid=body.wifi_ssid,
+            wifi_psk=body.wifi_psk,
         )
     except ValueError as exc:
         raise HTTPException(
@@ -797,6 +850,11 @@ async def build_provisioned_image(
         output_name=body.output_name,
         fleet_env_payload=payload,
         fleet_id=body.fleet_id,
+        # Persist wifi creds so the Built Images tooltip can show them
+        # after the build completes (these survive the
+        # ``fleet_env_payload`` clear on terminal success).
+        wifi_ssid=body.wifi_ssid,
+        wifi_psk=body.wifi_psk,
         built_by=user.id,
         status=ProvisionedImageStatus.PROVISIONING.value,
     )
@@ -806,13 +864,15 @@ async def build_provisioned_image(
     await audit_log(
         db, user=user, action="imager.build",
         resource_type="provisioned_image", resource_id=str(pi.id),
-        # NEVER include the secret here.
+        # NEVER include the secret here. Also intentionally omit wifi_psk;
+        # the SSID alone is fine to include for trace usefulness.
         details={
             "base_image_id": str(bi.id),
             "variant": bi.variant,
             "version": bi.version,
             "fleet_id": body.fleet_id,
             "output_name": body.output_name,
+            "wifi_ssid": body.wifi_ssid,
         },
         request=request,
     )

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -17,7 +17,12 @@
 {% if imager_can_build %}
 {# ── Build section ─────────────────────────────────────────────── #}
 <div class="card" data-imager-build style="margin-bottom:1rem;">
-    <h3 style="margin-top:0;">Build Image</h3>
+    <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
+        <h3 style="margin-top:0;">Build Image</h3>
+        {% if imager_can_manage %}
+        <button id="imagerManageFleetsBtn" type="button" class="btn btn-secondary btn-sm">Manage fleets…</button>
+        {% endif %}
+    </div>
     <p class="text-muted" style="margin-top:0;">
         Choose a fleet and base image, then build a pre-provisioned <code>.img.xz</code>
         ready to flash to an SD card. The output is available for download for
@@ -49,8 +54,40 @@
                 <button type="submit" id="imagerBuildBtn" class="btn btn-primary">Build image</button>
             </div>
         </div>
+        {# Optional Wi-Fi credentials. Both fields must be filled or both
+           empty -- enforced client-side and on the server.  Devices
+           without a wifi module silently no-op the credentials, so it's
+           safe to leave them set even for wired-only fleets. #}
+        <div class="form-row" style="gap:0.75rem; flex-wrap:wrap; align-items:flex-end; margin-top:0.5rem;">
+            <div class="form-group" style="flex:1; min-width:180px; margin-bottom:0;">
+                <label for="imagerWifiSsid">
+                    Wi-Fi SSID <span class="text-muted" style="font-weight:normal;">(optional)</span>
+                </label>
+                <input id="imagerWifiSsid" name="wifi_ssid" type="text"
+                       maxlength="32" autocomplete="off"
+                       placeholder="MyNetwork">
+            </div>
+            <div class="form-group" style="flex:1; min-width:200px; margin-bottom:0;">
+                <label for="imagerWifiPsk">
+                    Wi-Fi password <span class="text-muted" style="font-weight:normal;">(optional)</span>
+                </label>
+                <div style="display:flex; gap:0.25rem; align-items:stretch;">
+                    <input id="imagerWifiPsk" name="wifi_psk" type="password"
+                           minlength="8" maxlength="64" autocomplete="new-password"
+                           placeholder="passphrase or 64-hex PSK"
+                           style="flex:1;">
+                    <button type="button" id="imagerWifiPskToggle" class="btn btn-secondary btn-sm"
+                            title="Show/hide password" aria-label="Show/hide password"
+                            style="flex:0 0 auto;">👁</button>
+                </div>
+            </div>
+        </div>
         <div style="margin-top:0.5rem; display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
             <small class="text-muted">Filename must end in <code>.img.xz</code>. No slashes.</small>
+            <small class="text-muted">
+                Wi-Fi: leave both blank to skip; otherwise both fields are required.
+                Devices with no wifi hardware ignore these credentials.
+            </small>
             <span id="imagerBuildHint" class="text-muted" style="font-size:0.85rem;"></span>
         </div>
     </form>
@@ -86,6 +123,7 @@
                     <th>Output filename</th>
                     <th>Fleet</th>
                     <th>Base</th>
+                    <th>Wi-Fi</th>
                     <th>Status</th>
                     <th>Size</th>
                     <th>Built</th>
@@ -93,7 +131,7 @@
                 </tr>
             </thead>
             <tbody id="imagerBuiltTbody">
-                <tr><td colspan="7" class="empty-state text-muted">Loading…</td></tr>
+                <tr><td colspan="8" class="empty-state text-muted">Loading…</td></tr>
             </tbody>
         </table>
     </div>
@@ -173,6 +211,25 @@
         </div>
         <div class="modal-actions">
             <button type="button" class="btn btn-secondary" onclick="imagerCloseCatalog()">Close</button>
+        </div>
+    </div>
+</div>
+
+{# ── Manage fleets modal ───────────────────────────────────────── #}
+<div id="imagerFleetsModal" class="modal-overlay" style="display:none;">
+    <div class="modal-box" style="max-width:560px;">
+        <h3 style="margin-top:0;">Manage Fleets</h3>
+        <p class="text-muted" style="margin-top:0;">
+            Each fleet has its own HMAC secret. The secret is generated on
+            create and never displayed -- it is only baked into freshly-built
+            images. Deleting a fleet revokes the credential for any Pi that
+            hasn't yet completed first-boot registration.
+        </p>
+        <div id="imagerFleetsBody" style="max-height:60vh; overflow:auto;">
+            <p class="empty-state text-muted">Loading…</p>
+        </div>
+        <div class="modal-actions">
+            <button type="button" class="btn btn-secondary" id="imagerFleetsCloseBtn">Close</button>
         </div>
     </div>
 </div>
@@ -264,6 +321,13 @@
                     fleetsCache.map(function(f) {
                         return '<option value="' + escHtml(f.fleet_id) + '">' + escHtml(f.fleet_id) + '</option>';
                     }).join('');
+            }
+            // "+ Create new fleet…" sentinel option (admins only). The
+            // change handler below intercepts this value, opens the
+            // create flow, and resets the select to its previous value
+            // -- the sentinel is never submitted.
+            if (canManage) {
+                fleetSel.innerHTML += '<option value="__create__">+ Create new fleet…</option>';
             }
 
             baseSel.innerHTML = '';
@@ -368,12 +432,13 @@
             var rows = await jsonFetch('/api/imager/provisioned-images');
             var list = rows || [];
             var sig = list.map(function(r) {
-                return [r.id, r.status, r.expires_at, r.output_size, r.download_job_id].join('|');
+                return [r.id, r.status, r.expires_at, r.output_size, r.download_job_id,
+                        r.wifi_ssid || '', r.wifi_psk || ''].join('|');
             }).join(',');
             if (sig === lastBuiltSig) return;
             lastBuiltSig = sig;
             if (list.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No built images yet.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="8" class="empty-state text-muted">No built images yet.</td></tr>';
                 return;
             }
             tbody.innerHTML = list.map(function(r) {
@@ -390,10 +455,24 @@
                 var base = (r.base_variant || r.base_version)
                     ? escHtml((r.base_variant || '?') + ' / ' + (r.base_version || '?'))
                     : '<span class="text-muted">deleted</span>';
+                // Wi-Fi cell: tooltip exposes the cleartext SSID + PSK so
+                // an operator can recover them after the build.  We
+                // intentionally do NOT show the PSK on screen by default
+                // -- it's a low-value secret but still a secret.
+                var wifiCell;
+                if (r.wifi_ssid) {
+                    var tip = 'SSID: ' + r.wifi_ssid + '\nPassword: ' + (r.wifi_psk || '');
+                    wifiCell = '<span title="' + escHtml(tip) + '" ' +
+                               'style="cursor:help; border-bottom:1px dotted currentColor;">' +
+                               escHtml(r.wifi_ssid) + '</span>';
+                } else {
+                    wifiCell = '<span class="text-muted">—</span>';
+                }
                 return '<tr>' +
                     '<td><code>' + escHtml(r.output_name) + '</code></td>' +
                     '<td>' + escHtml(r.fleet_id || '—') + '</td>' +
                     '<td>' + base + '</td>' +
+                    '<td>' + wifiCell + '</td>' +
                     '<td><span class="' + statusBadgeClass(r.status) + '">' + escHtml(r.status) + '</span></td>' +
                     '<td>' + fmtBytes(r.output_size) + '</td>' +
                     '<td>' + fmtDate(r.built_at || r.created_at) + '</td>' +
@@ -408,7 +487,7 @@
             });
         } catch (e) {
             lastBuiltSig = '';
-            tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">' +
+            tbody.innerHTML = '<tr><td colspan="8" class="empty-state text-muted">' +
                 escHtml('Failed to load built images: ' + (e.message || e)) + '</td></tr>';
         }
     }
@@ -515,14 +594,37 @@
         var fleetId = $('#imagerFleetSelect', buildSection).value;
         var baseId = $('#imagerBaseSelect', buildSection).value;
         var name = $('#imagerOutputName', buildSection).value.trim();
+        var ssidEl = $('#imagerWifiSsid', buildSection);
+        var pskEl = $('#imagerWifiPsk', buildSection);
+        var ssid = ssidEl ? ssidEl.value.trim() : '';
+        var psk = pskEl ? pskEl.value : '';
         if (!fleetId || !baseId || !name) { toast('Please complete all fields', 'error'); return; }
+        if (fleetId === '__create__') {
+            // Sanity: shouldn't happen because the change handler resets
+            // the value before submission, but belt-and-suspenders.
+            toast('Pick a fleet (or create one first)', 'error');
+            return;
+        }
         if (!/\.img\.xz$/.test(name)) { toast('Output must end in .img.xz', 'error'); return; }
+        if (!!ssid !== !!psk) {
+            toast('Wi-Fi: provide both SSID and password, or leave both blank', 'error');
+            return;
+        }
+        if (psk && (psk.length < 8 || psk.length > 64)) {
+            toast('Wi-Fi password must be 8-63 chars (or a 64-char hex PSK)', 'error');
+            return;
+        }
         btn.disabled = true;
         try {
+            var body = { fleet_id: fleetId, base_image_id: baseId, output_name: name };
+            if (ssid && psk) {
+                body.wifi_ssid = ssid;
+                body.wifi_psk = psk;
+            }
             var job = await jsonFetch('/api/imager/build', {
                 method: 'POST',
                 headers: { 'content-type': 'application/json' },
-                body: JSON.stringify({ fleet_id: fleetId, base_image_id: baseId, output_name: name }),
+                body: JSON.stringify(body),
             });
             renderJobCard(job);
             startPolling(job.job_id);
@@ -532,6 +634,120 @@
             loadFleetsAndBases();
         } finally {
             btn.disabled = false;
+        }
+    }
+
+    // ── Fleet create / manage modals ───────────────────────────
+    var lastFleetSelectValue = '';
+
+    async function handleFleetCreateSentinel(sel) {
+        // Triggered when the operator picks "+ Create new fleet…" in
+        // the build form's fleet select. Prompts for an id, POSTs to
+        // /api/imager/fleets, then refreshes the dropdown and
+        // re-selects the new id.  Falls back to the previously-selected
+        // value on cancel/error so the form isn't stuck on the sentinel.
+        var newId = await showPrompt(
+            'Enter a fleet ID (letters, digits, dot, underscore, dash; 1-64 chars).',
+            ''
+        );
+        // Always restore the previous value first; we'll overwrite if create succeeds.
+        sel.value = lastFleetSelectValue || '';
+        if (newId === null) return;
+        var trimmed = String(newId).trim();
+        if (!trimmed) { toast('Fleet ID cannot be empty', 'error'); return; }
+        if (!/^[A-Za-z0-9._-]{1,64}$/.test(trimmed)) {
+            toast('Invalid fleet ID -- use letters, digits, dot, underscore, dash', 'error');
+            return;
+        }
+        try {
+            await jsonFetch('/api/imager/fleets', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ fleet_id: trimmed }),
+            });
+            toast('Fleet "' + trimmed + '" created', 'success');
+            await loadFleetsAndBases();
+            // Re-select the freshly-created fleet so the form is ready.
+            var sel2 = $('#imagerFleetSelect', buildSection);
+            if (sel2) {
+                sel2.value = trimmed;
+                lastFleetSelectValue = trimmed;
+                autoFillName();
+            }
+        } catch (e) {
+            if (e.status === 409) {
+                toast('Fleet "' + trimmed + '" already exists', 'error');
+            } else {
+                toast('Create failed: ' + (e.message || e), 'error');
+            }
+        }
+    }
+
+    async function openManageFleetsModal() {
+        var modal = $('#imagerFleetsModal');
+        var body = $('#imagerFleetsBody');
+        if (!modal || !body) return;
+        body.innerHTML = '<p class="empty-state text-muted">Loading…</p>';
+        modal.style.display = '';
+        try {
+            var fleets = await jsonFetch('/api/imager/fleets');
+            renderFleetsModalBody(fleets || []);
+        } catch (e) {
+            body.innerHTML = '<p class="empty-state text-muted">Failed to load: ' +
+                escHtml(e.message || e) + '</p>';
+        }
+    }
+
+    function closeManageFleetsModal() {
+        var modal = $('#imagerFleetsModal');
+        if (modal) modal.style.display = 'none';
+    }
+
+    function renderFleetsModalBody(fleets) {
+        var body = $('#imagerFleetsBody');
+        if (!body) return;
+        if (fleets.length === 0) {
+            body.innerHTML = '<p class="empty-state text-muted">No fleets configured. ' +
+                'Pick "+ Create new fleet…" in the Build form to add one.</p>';
+            return;
+        }
+        body.innerHTML = '<table style="width:100%;">' +
+            '<thead><tr><th>Fleet ID</th><th style="width:7rem; text-align:right;">Actions</th></tr></thead>' +
+            '<tbody>' +
+            fleets.map(function(f) {
+                return '<tr>' +
+                    '<td><code>' + escHtml(f.fleet_id) + '</code></td>' +
+                    '<td style="text-align:right;">' +
+                    '<button type="button" class="btn btn-sm btn-danger-subtle" data-fleet-delete="' +
+                    escHtml(f.fleet_id) + '">Delete</button>' +
+                    '</td></tr>';
+            }).join('') +
+            '</tbody></table>';
+        body.querySelectorAll('[data-fleet-delete]').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                deleteFleet(btn.getAttribute('data-fleet-delete'));
+            });
+        });
+    }
+
+    async function deleteFleet(fleetId) {
+        var ok = await showConfirm(
+            'Delete fleet "' + fleetId + '"?\n\n' +
+            'This revokes the HMAC secret. Pis already flashed with this ' +
+            "fleet that haven't yet completed first-boot registration will " +
+            'fail to register. Already-registered Pis are unaffected.'
+        );
+        if (!ok) return;
+        try {
+            await jsonFetch('/api/imager/fleets/' + encodeURIComponent(fleetId), {
+                method: 'DELETE',
+            });
+            toast('Deleted fleet "' + fleetId + '"', 'success');
+            // Refresh modal AND build form fleet dropdown.
+            await openManageFleetsModal();
+            loadFleetsAndBases();
+        } catch (e) {
+            toast('Delete failed: ' + (e.message || e), 'error');
         }
     }
 
@@ -872,9 +1088,42 @@
         form.addEventListener('submit', submitBuild);
         var nameInput = $('#imagerOutputName', buildSection);
         nameInput.addEventListener('input', function() { nameInput.dataset.userEdited = '1'; });
-        $('#imagerFleetSelect', buildSection).addEventListener('change', autoFillName);
+        var fleetSelEl = $('#imagerFleetSelect', buildSection);
+        fleetSelEl.addEventListener('change', function() {
+            // Intercept the "+ Create new fleet…" sentinel before
+            // running the auto-fill / form-state logic, so the form
+            // never carries the placeholder value forward.
+            if (fleetSelEl.value === '__create__') {
+                handleFleetCreateSentinel(fleetSelEl);
+                return;
+            }
+            lastFleetSelectValue = fleetSelEl.value;
+            autoFillName();
+        });
         $('#imagerBaseSelect', buildSection).addEventListener('change', autoFillName);
         $('#imagerJobDismiss', buildSection).addEventListener('click', dismissJobCard);
+
+        // Wi-Fi password show/hide toggle.
+        var pskToggle = $('#imagerWifiPskToggle', buildSection);
+        var pskInput = $('#imagerWifiPsk', buildSection);
+        if (pskToggle && pskInput) {
+            pskToggle.addEventListener('click', function() {
+                pskInput.type = (pskInput.type === 'password') ? 'text' : 'password';
+            });
+        }
+
+        // Manage Fleets modal (admin only).
+        var mgrBtn = $('#imagerManageFleetsBtn');
+        if (mgrBtn) mgrBtn.addEventListener('click', openManageFleetsModal);
+        var mgrClose = $('#imagerFleetsCloseBtn');
+        if (mgrClose) mgrClose.addEventListener('click', closeManageFleetsModal);
+        var mgrModal = $('#imagerFleetsModal');
+        if (mgrModal) {
+            mgrModal.addEventListener('click', function(e) {
+                if (e.target === mgrModal) closeManageFleetsModal();
+            });
+        }
+
         loadFleetsAndBases();
         // Resume any in-flight job from a prior page load.
         var resumeId = loadActiveJob();

--- a/shared/models/imager.py
+++ b/shared/models/imager.py
@@ -225,6 +225,21 @@ class ProvisionedImage(Base):
     fleet_env_payload: Mapped[bytes | None] = mapped_column(
         LargeBinary, nullable=True,
     )
+    # Optional WiFi credentials baked into the image. ``wifi_ssid`` is
+    # the network name; ``wifi_psk`` is the WPA passphrase (8-63 ASCII
+    # chars) or 64-hex pre-shared key. Both NULL means the image carries
+    # no wifi creds and the device falls back to Ethernet / OOBE captive
+    # portal.  Either both columns are populated or both are NULL --
+    # enforced by the build endpoint.  Unlike ``fleet_env_payload``,
+    # these columns are NOT cleared on terminal success: the operator
+    # explicitly asked to be able to view the SSID/PSK from the Built
+    # Images list (tooltip) long after the build, which means we keep
+    # them around until row retention deletes the whole row.  Wifi
+    # creds are lower-value than the fleet HMAC (only let an attacker
+    # onto the local wifi, not impersonate Pis to the CMS), so the
+    # tradeoff is acceptable.  Never log either column.
+    wifi_ssid: Mapped[str | None] = mapped_column(Text, nullable=True)
+    wifi_psk: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Caller-supplied output filename.  Validated against
     # ``imager._SAFE_OUTPUT_RE`` before use.
     output_name: Mapped[str] = mapped_column(Text, nullable=False)

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -640,6 +640,109 @@ async def test_build_creates_provisioned_row_with_payload(
     assert pi.provisioning_job_id == job.id
 
 
+@pytest.mark.asyncio
+async def test_build_persists_wifi_columns_when_supplied(
+    client, db_session, imager_settings
+):
+    """End-to-end: wifi values flow from request -> payload -> row.
+
+    Pin the contract so a regression in the schema, the helper, or the
+    persistence step is caught immediately.  The columns are NOT
+    cleared on terminal success (unlike fleet_env_payload), so the
+    Built-Images Wi-Fi tooltip can keep showing them for the lifetime
+    of the row.
+    """
+    bi = BaseImage(variant="pi5", version="v1.11.35", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "kitchen-wifi.img.xz",
+            "wifi_ssid": "kitchen-net",
+            "wifi_psk": "hunter22hunter22",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    pi = (await db_session.execute(
+        select(ProvisionedImage).where(ProvisionedImage.base_image_id == bi.id)
+    )).scalar_one()
+    assert pi.wifi_ssid == "kitchen-net"
+    assert pi.wifi_psk == "hunter22hunter22"
+    payload = pi.fleet_env_payload.decode("utf-8")
+    assert "AGORA_WIFI_SSID=kitchen-net" in payload
+    assert "AGORA_WIFI_PASS=hunter22hunter22" in payload
+
+
+@pytest.mark.asyncio
+async def test_build_no_wifi_keeps_columns_null(client, db_session, imager_settings):
+    """Default path: omitting wifi leaves both columns NULL.
+
+    Distinguishes "no wifi requested" from "" -- empty strings would
+    confuse the Built-Images tooltip's truthy-check renderer.
+    """
+    bi = BaseImage(variant="pi5", version="v1.11.35", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/build",
+        json={
+            "base_image_id": str(bi.id),
+            "fleet_id": "fleet-test",
+            "output_name": "wired.img.xz",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    pi = (await db_session.execute(
+        select(ProvisionedImage).where(ProvisionedImage.base_image_id == bi.id)
+    )).scalar_one()
+    assert pi.wifi_ssid is None
+    assert pi.wifi_psk is None
+    assert b"AGORA_WIFI_" not in pi.fleet_env_payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload,reason",
+    [
+        ({"wifi_ssid": "net", "wifi_psk": None}, "ssid without psk"),
+        ({"wifi_ssid": None, "wifi_psk": "hunter22hunter22"}, "psk without ssid"),
+        ({"wifi_ssid": "net", "wifi_psk": ""}, "empty psk"),
+        ({"wifi_ssid": "", "wifi_psk": "hunter22hunter22"}, "empty ssid"),
+        ({"wifi_ssid": "net", "wifi_psk": "short"}, "psk under 8 chars"),
+        ({"wifi_ssid": "x" * 33, "wifi_psk": "hunter22hunter22"}, "ssid over 32 chars"),
+    ],
+)
+async def test_build_422_on_wifi_pair_mismatch(
+    client, db_session, imager_settings, payload, reason
+):
+    """Schema rejects half-set / out-of-range wifi pairs at the door.
+
+    Pushes the both-or-neither / length validation into pydantic so the
+    build endpoint can assume the values are coherent.  Without this,
+    a half-set pair would silently emit a payload the firmware refuses,
+    and the Pi would brick its first-boot wifi join.
+    """
+    bi = BaseImage(variant="pi5", version="v1.11.35", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.commit()
+
+    body = {
+        "base_image_id": str(bi.id),
+        "fleet_id": "fleet-test",
+        "output_name": "bad-wifi.img.xz",
+        **payload,
+    }
+    resp = await client.post("/api/imager/build", json=body)
+    assert resp.status_code == 422, f"{reason}: {resp.status_code} / {resp.text}"
+
+
 def test_fleet_env_payload_matches_firmware_allowlist():
     """Regression for the 2026-05-06 ``test-fleet-1`` outage.
 
@@ -670,6 +773,60 @@ def test_fleet_env_payload_matches_firmware_allowlist():
     # Value is hex(raw_bytes).
     hex_line = next(ln for ln in lines if ln.startswith("AGORA_FLEET_SECRET_HEX="))
     assert hex_line.split("=", 1)[1] == raw.hex()
+
+
+def test_fleet_env_payload_emits_wifi_when_provided():
+    """Wi-Fi env keys must match the firmware allow-list exactly.
+
+    Firmware (agora v1.11.35+) added ``AGORA_WIFI_SSID`` /
+    ``AGORA_WIFI_PASS`` to the agora-fleet-provision.sh allow-list.
+    Earlier design docs called the password key
+    ``AGORA_WIFI_PASSPHRASE`` -- the firmware spec is authoritative.
+
+    Pin the keys so the next person who edits the design doc can't
+    silently drift the wire format.
+    """
+    from cms.routers.imager import _fleet_env_payload
+
+    out = _fleet_env_payload(
+        "wss://cms.example.com/ws/device",
+        "fleet-x",
+        b"x" * 32,
+        "wps",
+        wifi_ssid="my-net",
+        wifi_psk="hunter22hunter22",
+    ).decode("utf-8")
+
+    assert "AGORA_WIFI_SSID=my-net" in out
+    assert "AGORA_WIFI_PASS=hunter22hunter22" in out
+    # Legacy mis-naming MUST NOT leak in.
+    assert "AGORA_WIFI_PASSPHRASE" not in out
+
+
+def test_fleet_env_payload_omits_wifi_when_unset():
+    """No wifi keys when neither / only one is provided.
+
+    Build endpoint enforces both-or-neither at the schema layer, but
+    pin the helper's behaviour too -- the helper is reachable directly
+    from worker / tests and must default to a clean payload.
+    """
+    from cms.routers.imager import _fleet_env_payload
+
+    base = _fleet_env_payload(
+        "wss://cms/ws/device", "f", b"x" * 32, "wps"
+    ).decode("utf-8")
+    assert "AGORA_WIFI_" not in base
+
+    # Only ssid -> still no wifi (defensive: should not happen via API).
+    only_ssid = _fleet_env_payload(
+        "wss://cms/ws/device", "f", b"x" * 32, "wps", wifi_ssid="net",
+    ).decode("utf-8")
+    assert "AGORA_WIFI_" not in only_ssid
+
+    only_psk = _fleet_env_payload(
+        "wss://cms/ws/device", "f", b"x" * 32, "wps", wifi_psk="hunter22hunter22",
+    ).decode("utf-8")
+    assert "AGORA_WIFI_" not in only_psk
 
 
 # ── Jobs / download ────────────────────────────────────────────────


### PR DESCRIPTION
PR3 of the Wi-Fi + fleet CRUD trilogy. Adds the operator-facing UI on top of the
DB plumbing from PR #541.

Builds on PR #541 (feat-fleets-db). If #541 has not landed when this opens, the
diff will show PR #541's commits as extras until #541 merges.

## Changes

**Build form (cms/templates/imager.html):**
- Wi-Fi SSID + PSK inputs (8-64 chars; both-or-neither validated client-side and 422-validated server-side)
- `+ Create new fleet...` sentinel option in fleet `<select>` (admin only) -> shows prompt -> POSTs to /api/imager/fleets -> refreshes
- `Manage fleets` button (admin only) opens modal with delete buttons per fleet (uses showConfirm)

**Built Images table:**
- New `Wi-Fi` column showing SSID; native `title=` tooltip exposes cleartext PSK on hover

**Backend (cms/routers/imager.py, shared/models/imager.py):**
- `ProvisionedImage.wifi_ssid` / `wifi_psk` columns (nullable; NOT cleared on terminal success so the tooltip keeps working)
- `BuildBody` gains the two fields; `@model_validator(mode="after")` enforces both-or-neither -> 422
- `_fleet_env_payload` emits `AGORA_WIFI_SSID` / `AGORA_WIFI_PASS` (matches firmware v1.11.35 wire format)
- Audit log records SSID only -- never PSK

**Migration:**
- `0023_provisioned_wifi.py` adds the two nullable Text columns; `downgrade()` raises NotImplementedError per project policy.

## Tests

5 new tests in tests/test_imager_api.py:
- `test_fleet_env_payload_emits_wifi_when_provided` -- pins WIFI_SSID / WIFI_PASS keys
- `test_fleet_env_payload_omits_wifi_when_unset`
- `test_build_persists_wifi_columns_when_supplied`
- `test_build_no_wifi_keeps_columns_null`
- `test_build_422_on_wifi_pair_mismatch` (parametrized x6: half-set / empty strings / length violations)

All 11 wifi/fleet_env_payload tests pass; all 81 imager tests pass.

## Notes

- Multi-replica safe: fleet CRUD is DB-row-locked from PR #541; wifi columns are
  per-row immutable post-write so no replica coherence concerns.
- Devices without wifi hardware are no-op'd by firmware (v1.11.35) when the env
  keys are present but the wlan interface is absent.
- 0022 migration_policy test failure is upstream (PR #541) and not addressed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>