### PR TITLE
feat(imager): live progress on import + provision; fix delete-refresh race

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -127,6 +127,11 @@ class BaseImageOut(BaseModel):
     is_default: bool
     imported_at: datetime | None
     created_at: datetime
+    # In-flight progress, populated for ``IMPORTING`` rows from the
+    # latest in-flight :class:`Job` of type ``IMAGE_IMPORT``.  Both
+    # default to "no progress yet" so READY / FAILED rows are unaffected.
+    progress_stage: str = ""
+    progress_pct: int | None = None
 
     model_config = {"from_attributes": True}
 
@@ -170,6 +175,11 @@ class ProvisionedImageOut(BaseModel):
     expires_at: datetime | None
     wifi_ssid: str | None = None
     wifi_psk: str | None = None
+    # In-flight progress, populated for ``PROVISIONING`` rows from the
+    # latest in-flight :class:`Job` of type ``IMAGE_PROVISION``.  Both
+    # default to "no progress yet" so READY / FAILED rows are unaffected.
+    progress_stage: str = ""
+    progress_pct: int | None = None
 
     model_config = {"from_attributes": True}
 
@@ -265,6 +275,44 @@ def _allowlist(settings: Settings) -> set[str]:
 
 def _base_image_to_out(bi: BaseImage) -> BaseImageOut:
     return BaseImageOut.model_validate(bi)
+
+
+_IN_FLIGHT_JOB_STATUSES = (JobStatus.PENDING, JobStatus.PROCESSING)
+
+
+async def _latest_in_flight_progress(
+    db: AsyncSession,
+    job_type: JobType,
+    target_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, tuple[str, int | None]]:
+    """Return ``{target_id: (progress_stage, progress_pct)}`` for in-flight jobs.
+
+    One DB round-trip regardless of how many target IDs are passed.
+    For each target, the *latest-by-created_at* in-flight job (PENDING
+    or PROCESSING) wins -- a finished previous attempt does not bleed
+    its stage into the surface.  Targets without an in-flight job are
+    omitted from the result entirely.
+    """
+    if not target_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(Job.target_id, Job.progress_stage, Job.progress_pct, Job.created_at)
+            .where(
+                Job.type == job_type,
+                Job.status.in_(_IN_FLIGHT_JOB_STATUSES),
+                Job.target_id.in_(target_ids),
+            )
+            .order_by(Job.target_id, Job.created_at.desc())
+        )
+    ).all()
+    out: dict[uuid.UUID, tuple[str, int | None]] = {}
+    for target_id, stage, pct, _created_at in rows:
+        # Sorted target_id ASC, created_at DESC -- first row per target
+        # is the latest in-flight job.
+        if target_id not in out:
+            out[target_id] = (stage or "", pct)
+    return out
 
 
 def _resolve_catalog_entry(
@@ -586,7 +634,22 @@ async def list_base_images(
     result = await db.execute(
         select(BaseImage).order_by(BaseImage.created_at.desc())
     )
-    return [_base_image_to_out(bi) for bi in result.scalars().all()]
+    bases = list(result.scalars().all())
+    importing_ids = [
+        bi.id for bi in bases if bi.status == BaseImageStatus.IMPORTING.value
+    ]
+    progress = await _latest_in_flight_progress(
+        db, JobType.IMAGE_IMPORT, importing_ids
+    )
+    out: list[BaseImageOut] = []
+    for bi in bases:
+        item = _base_image_to_out(bi)
+        info = progress.get(bi.id)
+        if info is not None:
+            item.progress_stage = info[0]
+            item.progress_pct = info[1]
+        out.append(item)
+    return out
 
 
 @router.post("/base-images", response_model=BaseImageOut)
@@ -924,24 +987,36 @@ async def list_provisioned_images(
             .limit(200)
         )
     ).scalars().all()
-    return [
-        ProvisionedImageOut(
-            id=pi.id,
-            output_name=pi.output_name,
-            fleet_id=pi.fleet_id,
-            base_image_id=pi.base_image_id,
-            base_variant=pi.base_variant,
-            base_version=pi.base_version,
-            status=pi.status,
-            blob_path=pi.blob_path,
-            output_size=pi.output_size,
-            download_job_id=pi.provisioning_job_id,
-            created_at=pi.created_at,
-            built_at=pi.built_at,
-            expires_at=pi.expires_at,
-        )
-        for pi in rows
+    rows = list(rows)
+    provisioning_ids = [
+        pi.id for pi in rows if pi.status == ProvisionedImageStatus.PROVISIONING.value
     ]
+    progress = await _latest_in_flight_progress(
+        db, JobType.IMAGE_PROVISION, provisioning_ids
+    )
+    out: list[ProvisionedImageOut] = []
+    for pi in rows:
+        info = progress.get(pi.id)
+        out.append(
+            ProvisionedImageOut(
+                id=pi.id,
+                output_name=pi.output_name,
+                fleet_id=pi.fleet_id,
+                base_image_id=pi.base_image_id,
+                base_variant=pi.base_variant,
+                base_version=pi.base_version,
+                status=pi.status,
+                blob_path=pi.blob_path,
+                output_size=pi.output_size,
+                download_job_id=pi.provisioning_job_id,
+                created_at=pi.created_at,
+                built_at=pi.built_at,
+                expires_at=pi.expires_at,
+                progress_stage=(info[0] if info is not None else ""),
+                progress_pct=(info[1] if info is not None else None),
+            )
+        )
+    return out
 
 
 @router.delete("/provisioned-images/{provisioned_image_id}", status_code=204)

--- a/cms/services/imager.py
+++ b/cms/services/imager.py
@@ -21,11 +21,17 @@ the unit tests that touch them skip via :func:`shutil.which`.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import shutil
 import subprocess
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
 
 # Name of the env file dropped onto the boot partition. Matches the
 # path the firmware reads at first boot
@@ -225,6 +231,92 @@ def read_fleet_env(
     return result.stdout.decode("utf-8")
 
 
+def _xz_uncompressed_size(xz_bin: str, xz_path: Path) -> int | None:
+    """Return the uncompressed size of ``xz_path`` in bytes, or ``None``.
+
+    Uses ``xz --robot -l`` whose machine-readable ``totals`` line has
+    the uncompressed-size in the 5th tab-separated field (1-indexed).
+    Returns ``None`` on any failure -- callers fall back to no-progress
+    mode which just shows the stage name without a percentage.
+    """
+    try:
+        result = subprocess.run(
+            [xz_bin, "--robot", "-l", str(xz_path)],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    text = result.stdout.decode("utf-8", errors="replace")
+    for line in text.splitlines():
+        if line.startswith("totals\t"):
+            parts = line.split("\t")
+            if len(parts) >= 5:
+                try:
+                    return int(parts[4])
+                except ValueError:
+                    return None
+    return None
+
+
+_ProgressCb = Callable[[str, int], None]
+
+
+def _start_size_watcher(
+    target_path: Path,
+    expected_size: int,
+    *,
+    base_pct: int,
+    end_pct: int,
+    stage: str,
+    progress_cb: _ProgressCb,
+) -> tuple[threading.Thread, threading.Event]:
+    """Spawn a daemon thread that polls ``target_path`` size at 1 Hz.
+
+    Emits ``progress_cb(stage, pct)`` whenever the projected pct
+    advances by at least 1.  Pct is clamped to ``[base_pct, end_pct - 1]``
+    while the operation is running so we never report 100% before the
+    underlying subprocess actually exits.
+
+    The caller is responsible for setting the returned ``threading.Event``
+    once the subprocess has finished; the thread will exit on the next
+    tick (within 1 s).
+    """
+    stop = threading.Event()
+
+    def _watch() -> None:
+        last_pct = -1
+        # Call once with the floor so the UI flips to the new stage
+        # immediately, before the first second of polling has elapsed.
+        try:
+            progress_cb(stage, base_pct)
+        except Exception:
+            logger.debug("progress_cb floor emit raised", exc_info=True)
+        last_pct = base_pct
+        while not stop.is_set():
+            try:
+                cur = target_path.stat().st_size if target_path.exists() else 0
+            except OSError:
+                cur = 0
+            span = end_pct - base_pct
+            denom = max(1, expected_size)
+            projected = base_pct + int(cur * span / denom)
+            projected = max(base_pct, min(end_pct - 1, projected))
+            if projected != last_pct:
+                try:
+                    progress_cb(stage, projected)
+                except Exception:
+                    logger.debug("progress_cb raised", exc_info=True)
+                last_pct = projected
+            if stop.wait(timeout=1.0):
+                break
+
+    t = threading.Thread(target=_watch, name=f"xz-progress-{stage}", daemon=True)
+    t.start()
+    return t, stop
+
+
 def build_provisioned(
     base_xz_path: Path,
     fleet_env_text: str,
@@ -232,6 +324,7 @@ def build_provisioned(
     *,
     output_name: str | None = None,
     tools: _Tools | None = None,
+    progress_cb: _ProgressCb | None = None,
 ) -> Path:
     """Decompress, inject, recompress.
 
@@ -242,8 +335,20 @@ def build_provisioned(
     function returns or raises, so a crashed build does not leave
     unprotected secrets on disk.
 
-    ``output_name`` must be a plain ``foo.img.xz`` basename — no path
+    ``output_name`` must be a plain ``foo.img.xz`` basename -- no path
     separators, no ``..``. Path traversal is rejected.
+
+    ``progress_cb`` is an optional ``(stage: str, pct: int) -> None``
+    callback invoked from a background thread roughly once per second
+    during the long-running xz decompress / compress phases.  Stages:
+
+    * ``decompressing`` -- pct ramps 35..54 as the raw ``.img`` grows.
+    * ``injecting``     -- single tick at 56 (mcopy is sub-second).
+    * ``compressing``   -- pct ramps 58..81 as the recompressed
+      ``.img.xz`` grows.
+
+    Exceptions raised by ``progress_cb`` are swallowed -- progress is
+    observability, not correctness.
     """
     if output_name is not None and not _SAFE_OUTPUT_RE.fullmatch(output_name):
         raise ImagerError(
@@ -267,25 +372,73 @@ def build_provisioned(
     final_xz = scratch_dir / (output_name or f"{stem}.provisioned.img.xz")
     produced_xz = work_img.with_suffix(work_img.suffix + ".xz")
 
+    # ----- progress configuration -----
+    # The worker emits 35 ("building") and 85 ("uploading") around our
+    # call site, so the xz stages live inside (35, 85).  Splitting it
+    # 35..55 / 56 / 58..82 leaves a few points before the "uploading"
+    # tick so the UI motion is always monotonic.
+    DECOMPRESS_BASE = 35
+    DECOMPRESS_END = 55
+    INJECT_PCT = 56
+    COMPRESS_BASE = 58
+    COMPRESS_END = 82
+
+    def _emit(stage: str, pct: int) -> None:
+        if progress_cb is None:
+            return
+        try:
+            progress_cb(stage, pct)
+        except Exception:
+            logger.debug("progress_cb raised", exc_info=True)
+
+    expected_uncompressed = (
+        _xz_uncompressed_size(tools.xz, base_xz_path) if progress_cb else None
+    )
+    expected_recompressed = base_xz_path.stat().st_size if progress_cb else 0
+
     try:
-        # 1. Decompress base.xz → work.img
-        with work_img.open("wb") as out_fh:
-            try:
-                subprocess.run(
+        # 1. Decompress base.xz -> work.img
+        watcher_t: threading.Thread | None = None
+        watcher_stop: threading.Event | None = None
+        if progress_cb is not None and expected_uncompressed:
+            watcher_t, watcher_stop = _start_size_watcher(
+                work_img,
+                expected_uncompressed,
+                base_pct=DECOMPRESS_BASE,
+                end_pct=DECOMPRESS_END,
+                stage="decompressing",
+                progress_cb=_emit,
+            )
+        else:
+            _emit("decompressing", DECOMPRESS_BASE)
+
+        try:
+            with work_img.open("wb") as out_fh:
+                proc = subprocess.Popen(
                     [tools.xz, "-d", "-c", "--threads=0", str(base_xz_path)],
                     stdout=out_fh,
                     stderr=subprocess.PIPE,
-                    check=True,
-                    timeout=1200,
                 )
-            except subprocess.CalledProcessError as exc:
+                try:
+                    _stdout, stderr = proc.communicate(timeout=1200)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    raise ImagerError("xz decompress timed out")
+            if proc.returncode != 0:
                 raise ImagerError(
-                    f"xz decompress failed: {_stderr_text(exc.stderr)}"
-                ) from exc
-            except subprocess.TimeoutExpired as exc:
-                raise ImagerError("xz decompress timed out") from exc
+                    f"xz decompress failed: {_stderr_text(stderr)}"
+                )
+        finally:
+            if watcher_stop is not None:
+                watcher_stop.set()
+            if watcher_t is not None:
+                watcher_t.join(timeout=2)
 
-        # 2. Inject fleet env
+        _emit("decompressing", DECOMPRESS_END)
+
+        # 2. Inject fleet env (sub-second, no watcher).
+        _emit("injecting", INJECT_PCT)
         inject_fleet_env(work_img, fleet_env_text, tools=tools)
 
         # 3. Recompress at -1 (fastest reasonable) with all CPUs.
@@ -294,23 +447,48 @@ def build_provisioned(
         for stale in {produced_xz, final_xz}:
             if stale.exists():
                 stale.unlink()
-        try:
-            subprocess.run(
-                [tools.xz, "-z", "-1", "--threads=0", "--keep", str(work_img)],
-                check=True,
-                capture_output=True,
-                timeout=1800,
+
+        watcher_t = None
+        watcher_stop = None
+        if progress_cb is not None and expected_recompressed > 0:
+            watcher_t, watcher_stop = _start_size_watcher(
+                produced_xz,
+                expected_recompressed,
+                base_pct=COMPRESS_BASE,
+                end_pct=COMPRESS_END,
+                stage="compressing",
+                progress_cb=_emit,
             )
-        except subprocess.CalledProcessError as exc:
-            raise ImagerError(
-                f"xz compress failed: {_stderr_text(exc.stderr)}"
-            ) from exc
-        except subprocess.TimeoutExpired as exc:
-            raise ImagerError("xz compress timed out") from exc
+        else:
+            _emit("compressing", COMPRESS_BASE)
+
+        try:
+            proc = subprocess.Popen(
+                [tools.xz, "-z", "-1", "--threads=0", "--keep", str(work_img)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                _stdout, stderr = proc.communicate(timeout=1800)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                raise ImagerError("xz compress timed out")
+            if proc.returncode != 0:
+                raise ImagerError(
+                    f"xz compress failed: {_stderr_text(stderr)}"
+                )
+        finally:
+            if watcher_stop is not None:
+                watcher_stop.set()
+            if watcher_t is not None:
+                watcher_t.join(timeout=2)
+
+        _emit("compressing", COMPRESS_END)
 
         if produced_xz != final_xz:
             produced_xz.replace(final_xz)
         return final_xz
     finally:
-        # The raw image carries fleet secrets — never leave it behind.
+        # The raw image carries fleet secrets -- never leave it behind.
         work_img.unlink(missing_ok=True)

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -184,8 +184,6 @@
         per CMS instance and reused for every build.
     </p>
 
-    <div id="imagerImportProgress" style="display:none; margin:0.75rem 0;"></div>
-
     <div class="table-wrap">
         <table id="imagerBaseTable" style="width:100%;">
             <thead>
@@ -300,6 +298,25 @@
         if (s === 'CANCELLED') return 'badge badge-cancelled';
         if (s === 'PROCESSING' || s === 'IMPORTING') return 'badge badge-processing';
         return 'badge badge-pending';
+    }
+
+    // Render a status cell for an in-flight imager row.  When ``pct``
+    // is null, fall back to the plain processing badge (no motion);
+    // otherwise emit the same gradient-fill ``badge-progress`` markup
+    // that assets.html / _macros.html use for Transcoding / Capturing,
+    // so all in-flight UIs share one motion language.
+    function progressBadgeHtml(label, stage, pct) {
+        var safeLabel = escHtml(label);
+        if (pct == null) {
+            var stageTip = stage ? ' title="' + escHtml(stage.replace(/_/g, ' ')) + '"' : '';
+            return '<span class="badge badge-processing"' + stageTip + '>' + safeLabel + '</span>';
+        }
+        var clamped = Math.max(0, Math.min(100, Math.round(pct)));
+        var tip = stage
+            ? ' title="' + escHtml(stage.replace(/_/g, ' ') + ' ' + clamped + '%') + '"'
+            : ' title="' + clamped + '%"';
+        return '<span class="badge badge-progress" style="--pct: ' + clamped + '%"' + tip + '>' +
+            safeLabel + ' ' + clamped + '%</span>';
     }
 
     // ── Build section ─────────────────────────────────────────
@@ -430,6 +447,12 @@
 
     var BUILT_AUTO_REFRESH_MS = 15000;
     var lastBuiltSig = '';
+    // Monotonic request token: each call to ``loadBuiltImages`` bumps
+    // this; on resolve, if its token is no longer current, the result
+    // is dropped.  Prevents a slow auto-refresh GET from overwriting
+    // the post-delete render with stale data (which made deletes
+    // appear to "not stick" until the user refreshed manually).
+    var loadBuiltImagesReq = 0;
     var builtAutoRefreshTimer = null;
 
     function clearBuiltAutoRefreshTimer() {
@@ -448,12 +471,15 @@
     async function loadBuiltImages() {
         if (!builtSection) return;
         var tbody = $('#imagerBuiltTbody', builtSection);
+        var myReq = ++loadBuiltImagesReq;
         try {
             var rows = await jsonFetch('/api/imager/provisioned-images');
+            if (myReq !== loadBuiltImagesReq) return;  // superseded by a newer call
             var list = rows || [];
             var sig = list.map(function(r) {
                 return [r.id, r.status, r.expires_at, r.output_size, r.download_job_id,
-                        r.wifi_ssid || '', r.wifi_psk || ''].join('|');
+                        r.wifi_ssid || '', r.wifi_psk || '',
+                        r.progress_stage || '', r.progress_pct == null ? '' : r.progress_pct].join('|');
             }).join(',');
             if (sig === lastBuiltSig) return;
             lastBuiltSig = sig;
@@ -488,12 +514,18 @@
                 } else {
                     wifiCell = '<span class="text-muted">—</span>';
                 }
-                return '<tr>' +
+                var statusCell;
+                if (status === 'PROVISIONING') {
+                    statusCell = progressBadgeHtml('PROVISIONING', r.progress_stage, r.progress_pct);
+                } else {
+                    statusCell = '<span class="' + statusBadgeClass(r.status) + '">' + escHtml(r.status) + '</span>';
+                }
+                return '<tr data-built-row="' + escHtml(r.id) + '">' +
                     '<td><code>' + escHtml(r.output_name) + '</code></td>' +
                     '<td>' + escHtml(r.fleet_id || '—') + '</td>' +
                     '<td>' + base + '</td>' +
                     '<td>' + wifiCell + '</td>' +
-                    '<td><span class="' + statusBadgeClass(r.status) + '">' + escHtml(r.status) + '</span></td>' +
+                    '<td>' + statusCell + '</td>' +
                     '<td>' + fmtBytes(r.output_size) + '</td>' +
                     '<td>' + fmtDate(r.built_at || r.created_at) + '</td>' +
                     '<td style="text-align:right;">' + dlBtn + ' ' + delBtn + '</td>' +
@@ -506,6 +538,7 @@
                 });
             });
         } catch (e) {
+            if (myReq !== loadBuiltImagesReq) return;
             lastBuiltSig = '';
             tbody.innerHTML = '<tr><td colspan="8" class="empty-state text-muted">' +
                 escHtml('Failed to load built images: ' + (e.message || e)) + '</td></tr>';
@@ -519,6 +552,21 @@
                 method: 'DELETE',
             });
             toast('Deleted ' + name, 'success');
+            // Optimistic DOM removal: the API confirmed the delete
+            // (204), so drop the row immediately.  This keeps the UI
+            // correct even if the post-delete refresh GET later fails
+            // or is preempted; the request-token guard in
+            // ``loadBuiltImages`` handles the parallel-GET race that
+            // was causing deletes to occasionally appear to "not
+            // stick".
+            if (builtSection) {
+                var tr = builtSection.querySelector('tr[data-built-row="' + CSS.escape(id) + '"]');
+                if (tr) tr.remove();
+                var tbody = $('#imagerBuiltTbody', builtSection);
+                if (tbody && tbody.children.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="8" class="empty-state text-muted">No built images yet.</td></tr>';
+                }
+            }
             lastBuiltSig = '';
             loadBuiltImages();
         } catch (e) {
@@ -534,28 +582,55 @@
         var prog = $('#imagerJobProgress', buildSection);
         var errBox = $('#imagerJobError', buildSection);
         card.style.display = '';
-        badge.className = statusBadgeClass(job.status);
-        badge.textContent = job.status;
+        var jobS = statusUp(job.status);
+        var inFlight = (jobS === 'PENDING' || jobS === 'PROCESSING');
+        // Replace the badge element each render so we can swap to/from
+        // ``badge-progress`` (a gradient fill) cleanly.  We re-use the
+        // original element id so the rest of the wiring still works.
+        var newBadge;
+        if (inFlight && job.progress_pct != null) {
+            // Job card label is the upper-cased status so the user
+            // doesn't lose the "PROCESSING" word; the progress fills
+            // the badge with a 0..100 gradient.
+            var pct = Math.max(0, Math.min(100, Math.round(job.progress_pct)));
+            var stage = (job.progress_stage || '').replace(/_/g, ' ');
+            var tip = stage ? (stage + ' ' + pct + '%') : (pct + '%');
+            newBadge = document.createElement('span');
+            newBadge.id = 'imagerJobStatusBadge';
+            newBadge.className = 'badge badge-progress';
+            newBadge.style.setProperty('--pct', pct + '%');
+            newBadge.title = tip;
+            newBadge.textContent = job.status + ' ' + pct + '%';
+        } else {
+            newBadge = document.createElement('span');
+            newBadge.id = 'imagerJobStatusBadge';
+            newBadge.className = statusBadgeClass(job.status);
+            newBadge.textContent = job.status;
+        }
+        badge.parentNode.replaceChild(newBadge, badge);
         var metaParts = ['Job ' + job.job_id.slice(0, 8)];
         if (job.output_name) metaParts.push(escHtml(job.output_name));
         if (job.created_at) metaParts.push('started ' + fmtDate(job.created_at));
         meta.innerHTML = metaParts.join(' \u00b7 ');
         var progLine = formatJobProgress(job);
-        if (progLine) {
+        // The badge already shows pct + stage when we have a number, so
+        // hide the redundant sub-line in that case.  Fall back to the
+        // text line only when pct is unknown (e.g. before the worker
+        // emits its first tick).
+        if (progLine && job.progress_pct == null) {
             prog.style.display = '';
             prog.textContent = progLine;
         } else {
             prog.style.display = 'none';
             prog.textContent = '';
         }
-        if (statusUp(job.status) === 'DONE') {
+        if (jobS === 'DONE') {
             errBox.style.display = 'none';
         }
-        var js = statusUp(job.status);
-        if (js === 'FAILED' || js === 'CANCELLED') {
+        if (jobS === 'FAILED' || jobS === 'CANCELLED') {
             errBox.style.display = '';
             errBox.textContent = job.error_message || 'Build did not complete.';
-        } else if (js !== 'DONE') {
+        } else if (jobS !== 'DONE') {
             errBox.style.display = 'none';
         }
     }
@@ -772,71 +847,19 @@
     }
 
     // ── Manage section: base image list ───────────────────────
-    var importJobsCache = {}; // job_id -> { variant, version }
-
-    function renderImportProgress() {
-        if (!manageSection) return;
-        var box = $('#imagerImportProgress', manageSection);
-        var ids = Object.keys(importJobsCache);
-        if (ids.length === 0) { box.style.display = 'none'; box.innerHTML = ''; return; }
-        box.style.display = '';
-        box.innerHTML = ids.map(function(id) {
-            var info = importJobsCache[id];
-            var sub = '';
-            var stage = (info.progress_stage || '').replace(/_/g, ' ');
-            var pct = (info.progress_pct == null) ? null : Math.max(0, Math.min(100, info.progress_pct));
-            if (stage && pct != null) sub = stage + ' \u00b7 ' + pct + '%';
-            else if (stage) sub = stage;
-            else if (pct != null) sub = pct + '%';
-            return '<div class="card-highlight" style="padding:0.5rem 0.75rem; margin-bottom:0.25rem;">' +
-                '<span class="badge badge-processing">IMPORTING</span> ' +
-                escHtml(info.variant) + ' / ' + escHtml(info.version) +
-                ' <span class="text-muted" style="font-size:0.8rem;">(job ' + id.slice(0, 8) + ')</span>' +
-                (sub ? '<div class="text-muted" style="font-size:0.8rem; margin-top:0.2rem;">' + escHtml(sub) + '</div>' : '') +
-                '</div>';
-        }).join('');
-    }
-
-    function pollImportJob(jobId, info) {
-        importJobsCache[jobId] = info;
-        renderImportProgress();
-        var t = setInterval(async function() {
-            if (document.hidden) return;
-            try {
-                var job = await jsonFetch('/api/imager/jobs/' + encodeURIComponent(jobId));
-                // Refresh progress for the in-flight card.
-                var cur = importJobsCache[jobId];
-                if (cur) {
-                    cur.progress_stage = job.progress_stage || '';
-                    cur.progress_pct = job.progress_pct;
-                    renderImportProgress();
-                }
-                if (isTerminal(job.status)) {
-                    clearInterval(t);
-                    delete importJobsCache[jobId];
-                    renderImportProgress();
-                    loadBaseImages();
-                    if (buildSection) loadFleetsAndBases();
-                    if (statusUp(job.status) === 'DONE') {
-                        toast('Imported ' + info.variant + ' / ' + info.version, 'success');
-                    } else {
-                        toast('Import failed: ' + (job.error_message || job.status), 'error');
-                    }
-                }
-            } catch (e) {
-                if (e.status === 404) {
-                    clearInterval(t);
-                    delete importJobsCache[jobId];
-                    renderImportProgress();
-                }
-            }
-        }, 3000);
-    }
+    // (Per-import "card" tracker was retired in the imager-progress
+    // revamp; the IMPORTING row in the base-image table now carries
+    // its own gradient-fill badge fed by ``progress_pct`` /
+    // ``progress_stage`` straight off the API row.)
 
     // Auto-refresh state for in-flight imports.
     var basesPollTimer = null;
     var basesLastStatus = {};
     var BASES_POLL_MS = 4000;
+    // Monotonic request token — see ``loadBuiltImagesReq`` for the
+    // full rationale.  Prevents an in-flight auto-refresh GET from
+    // overwriting the table state right after a delete.
+    var loadBaseImagesReq = 0;
 
     function clearBasesPollTimer() {
         if (basesPollTimer) { clearTimeout(basesPollTimer); basesPollTimer = null; }
@@ -873,8 +896,10 @@
         if (!manageSection) return;
         clearBasesPollTimer();
         var tbody = $('#imagerBaseTbody', manageSection);
+        var myReq = ++loadBaseImagesReq;
         try {
             var bases = await jsonFetch('/api/imager/base-images');
+            if (myReq !== loadBaseImagesReq) return;  // superseded
             if (!bases || bases.length === 0) {
                 basesLastStatus = {};
                 tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No base images cached. Click "Import from catalog…" to add one.</td></tr>';
@@ -886,10 +911,16 @@
                 var shaTitle = b.sha256 ? ' title="' + escHtml(b.sha256) + '"' : '';
                 var del = statusUp(b.status) === 'IMPORTING' ? '' :
                     '<button type="button" class="btn btn-sm btn-danger-subtle" data-delete-base="' + escHtml(b.id) + '">Delete</button>';
-                return '<tr>' +
+                var statusCell;
+                if (statusUp(b.status) === 'IMPORTING') {
+                    statusCell = progressBadgeHtml('IMPORTING', b.progress_stage, b.progress_pct);
+                } else {
+                    statusCell = '<span class="' + statusBadgeClass(b.status) + '">' + escHtml(b.status) + '</span>';
+                }
+                return '<tr data-base-row="' + escHtml(b.id) + '">' +
                     '<td>' + escHtml(b.variant) + '</td>' +
                     '<td>' + escHtml(b.version) + (b.is_default ? ' <span class="badge badge-builtin">default</span>' : '') + '</td>' +
-                    '<td><span class="' + statusBadgeClass(b.status) + '">' + escHtml(b.status) + '</span></td>' +
+                    '<td>' + statusCell + '</td>' +
                     '<td>' + fmtBytes(b.size_bytes) + '</td>' +
                     '<td title="' + escHtml(b.imported_at || '') + '">' + fmtDate(b.imported_at) + '</td>' +
                     '<td><code style="font-size:0.75rem;"' + shaTitle + '>' + escHtml(sha) + '</code></td>' +
@@ -902,6 +933,7 @@
             var anyImporting = bases.some(function(b) { return statusUp(b.status) === 'IMPORTING'; });
             if (anyImporting) scheduleBasesPoll();
         } catch (e) {
+            if (myReq !== loadBaseImagesReq) return;
             tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">Failed to load: ' + escHtml(e.message || e) + '</td></tr>';
             // Retry on transient failures so the UI recovers without a manual refresh.
             scheduleBasesPoll();
@@ -913,6 +945,19 @@
         try {
             await jsonFetch('/api/imager/base-images/' + encodeURIComponent(id), { method: 'DELETE' });
             toast('Base image deleted', 'success');
+            // Optimistic DOM removal — see deleteBuiltImage for the
+            // full rationale.  The 204 response means the row is gone
+            // server-side; drop it from the table immediately so the
+            // user sees the delete take effect even if the post-
+            // delete refresh loses the race.
+            if (manageSection) {
+                var tr = manageSection.querySelector('tr[data-base-row="' + CSS.escape(id) + '"]');
+                if (tr) tr.remove();
+                var tbody = $('#imagerBaseTbody', manageSection);
+                if (tbody && tbody.children.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No base images cached. Click "Import from catalog…" to add one.</td></tr>';
+                }
+            }
             loadBaseImages();
             if (buildSection) loadFleetsAndBases();
         } catch (e) {

--- a/tests/test_imager.py
+++ b/tests/test_imager.py
@@ -310,6 +310,96 @@ def test_build_provisioned_end_to_end(tmp_path: Path):
 
 
 @needs_imager_tools
+def test_build_provisioned_emits_progress(tmp_path: Path):
+    """Watcher threads emit monotonic, in-bounds progress for both xz stages.
+
+    Pins the wire contract that ``worker.imager_handlers`` and the
+    ``imager.html`` UI rely on:
+
+    * Both ``decompressing`` and ``compressing`` stages fire at least
+      once -- the imager-progress revamp explicitly exists to
+      eliminate the multi-minute black-hole at 35%.
+    * Pct values are non-decreasing within each stage and never spill
+      past their stage's end constant before the next stage starts.
+    """
+    base_img = _make_partitioned_fat_image(tmp_path / "agora-base-v1.img")
+    subprocess.run(
+        ["xz", "-z", "-1", "--keep", str(base_img)],
+        check=True,
+        capture_output=True,
+    )
+    base_xz = tmp_path / "agora-base-v1.img.xz"
+    assert base_xz.exists()
+
+    events: list[tuple[str, int]] = []
+
+    def cb(stage: str, pct: int) -> None:
+        events.append((stage, pct))
+
+    out = build_provisioned(
+        base_xz,
+        "AGORA_FLEET_ID=p\nAGORA_FLEET_SECRET=q\n",
+        tmp_path / "scratch",
+        progress_cb=cb,
+    )
+    assert out.is_file()
+
+    stages_seen = {stage for stage, _ in events}
+    assert "decompressing" in stages_seen
+    assert "compressing" in stages_seen
+
+    decompress_pcts = [p for s, p in events if s == "decompressing"]
+    compress_pcts = [p for s, p in events if s == "compressing"]
+
+    # Watcher floor + final tick exist for each stage.
+    assert decompress_pcts, "expected at least one decompressing tick"
+    assert compress_pcts, "expected at least one compressing tick"
+
+    # Monotonic non-decreasing within each stage.
+    assert decompress_pcts == sorted(decompress_pcts)
+    assert compress_pcts == sorted(compress_pcts)
+
+    # In-bounds: decompress stays within 35..55, compress within 58..82
+    # (matches the constants in ``cms/services/imager.py``).
+    assert all(35 <= p <= 55 for p in decompress_pcts)
+    assert all(58 <= p <= 82 for p in compress_pcts)
+
+    # Compress stage starts after decompress finishes (callback ordering).
+    decompress_idx = max(i for i, (s, _) in enumerate(events) if s == "decompressing")
+    compress_idx = min(i for i, (s, _) in enumerate(events) if s == "compressing")
+    assert decompress_idx < compress_idx
+
+
+@needs_imager_tools
+def test_build_provisioned_swallows_progress_callback_errors(tmp_path: Path):
+    """A throwing progress callback never propagates into the build path.
+
+    Progress is observability, not correctness -- a bad callback (e.g.
+    a transient DB failure inside ``_set_progress``) must not crash
+    the multi-minute imager pipeline and leave a half-built file.
+    """
+    base_img = _make_partitioned_fat_image(tmp_path / "agora-base-v1.img")
+    subprocess.run(
+        ["xz", "-z", "-1", "--keep", str(base_img)],
+        check=True,
+        capture_output=True,
+    )
+    base_xz = tmp_path / "agora-base-v1.img.xz"
+
+    def boom(stage: str, pct: int) -> None:
+        raise RuntimeError("simulated DB failure")
+
+    out = build_provisioned(
+        base_xz,
+        "AGORA_FLEET_ID=p\nAGORA_FLEET_SECRET=q\n",
+        tmp_path / "scratch",
+        progress_cb=boom,
+    )
+    assert out.is_file()
+    assert out.stat().st_size > 0
+
+
+@needs_imager_tools
 def test_build_provisioned_missing_base_raises(tmp_path: Path):
     with pytest.raises(ImagerError, match="base image not found"):
         build_provisioned(

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -389,6 +389,55 @@ async def test_list_base_images(client, db_session, imager_settings):
     # auto-refresh, transition toasts, dropdown filters, etc.
     statuses = sorted(b["status"] for b in data)
     assert statuses == ["importing", "ready"]
+    # Progress fields default to empty stage / null pct when no
+    # in-flight job is present.
+    for row in data:
+        assert row["progress_stage"] == ""
+        assert row["progress_pct"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_base_images_surfaces_in_flight_progress(
+    client, db_session, imager_settings,
+):
+    """IMPORTING rows expose the latest in-flight import job's progress.
+
+    The ``imager.html`` table renders a ``badge-progress`` cell when
+    ``progress_pct`` is non-null; this test pins the wire contract so
+    UI-side renderers can rely on the field always being there for
+    in-flight rows.
+    """
+    importing = BaseImage(variant="pi5", version="v9", status=BaseImageStatus.IMPORTING.value)
+    ready = BaseImage(variant="pi4", version="v9", status=BaseImageStatus.READY.value)
+    db_session.add_all([importing, ready])
+    await db_session.flush()
+    # In-flight job for the importing row.
+    db_session.add(Job(
+        type=JobType.IMAGE_IMPORT,
+        target_id=importing.id,
+        status=JobStatus.PROCESSING,
+        progress_stage="downloading",
+        progress_pct=42,
+    ))
+    # Old, terminal job for the same row -- must not be picked up.
+    db_session.add(Job(
+        type=JobType.IMAGE_IMPORT,
+        target_id=importing.id,
+        status=JobStatus.FAILED,
+        progress_stage="aborted",
+        progress_pct=99,
+    ))
+    await db_session.commit()
+
+    resp = await client.get("/api/imager/base-images")
+    assert resp.status_code == 200
+    rows = {r["variant"]: r for r in resp.json()}
+    # In-flight row exposes the live job's progress.
+    assert rows["pi5"]["progress_stage"] == "downloading"
+    assert rows["pi5"]["progress_pct"] == 42
+    # Terminal/READY rows do not surface stale progress.
+    assert rows["pi4"]["progress_stage"] == ""
+    assert rows["pi4"]["progress_pct"] is None
 
 
 # ── Base-image delete ──────────────────────────────────────────────
@@ -1117,6 +1166,68 @@ async def test_list_provisioned_images_returns_rows_newest_first(
     assert row["fleet_id"] == "fleet-test"
     assert row["output_size"] == 23456
     assert row["status"] == ProvisionedImageStatus.READY.value
+
+
+@pytest.mark.asyncio
+async def test_list_provisioned_images_surfaces_in_flight_progress(
+    client, db_session, imager_settings,
+):
+    """PROVISIONING rows expose the latest in-flight provision job's progress.
+
+    Mirrors the base-image test: drives the ``badge-progress`` render
+    on the built-images panel.  Pins both the field shape and the
+    "ignore terminal jobs" behavior of ``_latest_in_flight_progress``.
+    """
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+
+    building = ProvisionedImage(
+        base_image_id=bi.id,
+        base_variant="pi5",
+        base_version="v1",
+        output_name="building.img.xz",
+        fleet_id="fleet-test",
+        status=ProvisionedImageStatus.PROVISIONING.value,
+    )
+    ready = ProvisionedImage(
+        base_image_id=bi.id,
+        base_variant="pi5",
+        base_version="v1",
+        output_name="ready.img.xz",
+        fleet_id="fleet-test",
+        status=ProvisionedImageStatus.READY.value,
+        blob_path="provisioned/ready.img.xz",
+        output_size=23456,
+    )
+    db_session.add_all([building, ready])
+    await db_session.flush()
+    # Live PROCESSING job for the in-flight row.
+    db_session.add(Job(
+        type=JobType.IMAGE_PROVISION,
+        target_id=building.id,
+        status=JobStatus.PROCESSING,
+        progress_stage="compressing",
+        progress_pct=72,
+    ))
+    # Older terminal job for the same target -- must not be picked.
+    db_session.add(Job(
+        type=JobType.IMAGE_PROVISION,
+        target_id=building.id,
+        status=JobStatus.DONE,
+        progress_stage="archived",
+        progress_pct=100,
+    ))
+    await db_session.commit()
+
+    resp = await client.get("/api/imager/provisioned-images")
+    assert resp.status_code == 200
+    rows = {r["output_name"]: r for r in resp.json()}
+    # In-flight row exposes live progress; terminal row does not.
+    assert rows["building.img.xz"]["progress_stage"] == "compressing"
+    assert rows["building.img.xz"]["progress_pct"] == 72
+    assert rows["ready.img.xz"]["progress_stage"] == ""
+    assert rows["ready.img.xz"]["progress_pct"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_imager_handlers.py
+++ b/tests/test_imager_handlers.py
@@ -486,11 +486,17 @@ async def test_provision_happy_path(
     await db_session.commit()
     await db_session.refresh(pi)
 
-    def fake_build_provisioned(base_xz_path, fleet_env_text, scratch_dir, output_name):
+    def fake_build_provisioned(base_xz_path, fleet_env_text, scratch_dir, output_name, progress_cb=None):
         # Verify handler passed the right things
         assert Path(base_xz_path).read_bytes() == base_bytes
         assert "AGORA_DEVICE_API_KEY" in fleet_env_text
         assert output_name == "agora-pi5-fleet42.img.xz"
+        # Handler must wire a progress callback so the UI can render
+        # gradient-fill badges during the multi-minute xz pipeline;
+        # ``test_imager.py::test_build_provisioned_emits_progress``
+        # pins the callback's wire contract end-to-end.
+        assert callable(progress_cb)
+        progress_cb("decompressing", 40)  # exercise the bridge
         out = Path(scratch_dir) / output_name
         out.write_bytes(b"final-image-payload")
         return out

--- a/worker/imager_handlers.py
+++ b/worker/imager_handlers.py
@@ -882,6 +882,24 @@ async def provision_image_by_id(
             session_factory, provisioned_id,
             JobType.IMAGE_PROVISION, "building", 35,
         )
+
+        # Bridge the synchronous progress callback (called from a
+        # daemon thread inside build_provisioned) to the asyncio
+        # progress writer.  ``run_coroutine_threadsafe`` is the
+        # canonical way to schedule a coroutine on a foreign loop --
+        # we don't await the future because progress is fire-and-
+        # forget; ``_set_progress`` swallows DB errors itself.
+        loop = asyncio.get_running_loop()
+
+        def progress_cb(stage: str, pct: int) -> None:
+            asyncio.run_coroutine_threadsafe(
+                _set_progress(
+                    session_factory, provisioned_id,
+                    JobType.IMAGE_PROVISION, stage, pct,
+                ),
+                loop,
+            )
+
         try:
             output_path: Path = await asyncio.to_thread(
                 build_provisioned,
@@ -889,6 +907,7 @@ async def provision_image_by_id(
                 fleet_env_text,
                 scratch,
                 output_name=output_name,
+                progress_cb=progress_cb,
             )
         except ImagerError as e:
             # ImagerError covers (a) input validation (output_name,


### PR DESCRIPTION
## Why

The imager tab UX was opaque on long-running operations:
1. **Importing** showed a static `IMPORTING` badge for ~30 s with no progress signal.
2. **Building** advanced to `35%` and then sat there for several minutes (two `xz` subprocesses with no intermediate signal) before jumping to `85%` and finally `100%`.
3. **Deleting a built image** sometimes appeared not to take effect until the user manually refreshed -- the post-delete GET could lose a race against the 15 s auto-refresh.

This PR fixes all three.

## What changed

### Live progress (imports + builds)
- `BaseImageOut` and `ProvisionedImageOut` now expose `progress_stage` / `progress_pct`, populated from the latest in-flight `IMAGE_IMPORT` / `IMAGE_PROVISION` `Job` row in a single SQL round-trip per list response.
- `build_provisioned` was instrumented with optional `progress_cb`. `xz --robot -l` gives us the decompress target size; a 1 Hz daemon thread polls the output file's size and projects a pct into a stage-bounded range (decompress 35..55, inject 56, compress 58..82). End ticks fire explicitly after each subprocess returns.
- The worker bridges the sync callback to `_set_progress` via `asyncio.run_coroutine_threadsafe`.
- The base-image and built-image tables (and the build job card) now render the same `badge-progress` gradient-fill markup the assets page already uses for transcoding/capturing, with the stage in the tooltip.

### Delete-refresh race fix
- `loadBaseImages` and `loadBuiltImages` now use a monotonic request-token guard so an in-flight auto-refresh GET that pre-dates the user's Delete click can't paint stale data over the correct post-delete state.
- `deleteBase` / `deleteBuiltImage` also do optimistic DOM removal after the 204 so the row vanishes instantly even if the post-delete refresh GET fails.

### Cleanup
- Removed dead code: the orphan `<div id="imagerImportProgress">` banner and the never-invoked `importJobsCache` / `renderImportProgress` / `pollImportJob` block (~60 lines).

## Tests

- `test_build_provisioned_emits_progress`: both decompress + compress stages fire, pcts are monotonic and stay within their stage bounds.
- `test_build_provisioned_swallows_progress_callback_errors`: a throwing callback never crashes the build path (progress is observability, not correctness).
- `test_list_base_images_surfaces_in_flight_progress` + `test_list_provisioned_images_surfaces_in_flight_progress`: list endpoints expose live progress on in-flight rows and never leak terminal-job state onto READY rows.
- `test_provision_happy_path`: handler now passes a callable `progress_cb` end-to-end.

All 120 imager-related tests pass locally (`cms`, `api`, `handlers`).

## No-migration confirmation

`Job.progress_stage` (Text NOT NULL default '') and `Job.progress_pct` (Integer nullable) already exist on the model; no Alembic changes were needed.