### PR TITLE
feat(imager): move row Delete actions into a kebab menu

### DIFF
--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -475,6 +475,10 @@
         try {
             var rows = await jsonFetch('/api/imager/provisioned-images');
             if (myReq !== loadBuiltImagesReq) return;  // superseded by a newer call
+            // Don't trample an open kebab popover -- the user is mid-
+            // interaction with it.  Sig isn't updated, so the next
+            // auto-refresh tick re-evaluates once the popover is closed.
+            if (tbody.querySelector('.kebab-menu:popover-open')) return;
             var list = rows || [];
             var sig = list.map(function(r) {
                 return [r.id, r.status, r.expires_at, r.output_size, r.download_job_id,
@@ -494,10 +498,21 @@
                     ? '<a class="btn btn-primary btn-sm" href="/api/imager/download/' +
                       encodeURIComponent(r.download_job_id) + '" download>Download</a>'
                     : '<span class="text-muted" style="font-size:0.8rem;">unavailable</span>';
-                var delBtn = canManage
-                    ? '<button class="btn btn-secondary btn-sm" data-built-delete="' +
-                      escHtml(r.id) + '" data-built-name="' + escHtml(r.output_name) + '">Delete</button>'
-                    : '';
+                // Kebab (Delete only for now) -- matches the shared
+                // pattern from _macros.html / .btn-kebab CSS / the
+                // global popover positioning in app.js.
+                var actions = dlBtn;
+                if (canManage) {
+                    var kid = 'kebab-built-' + Math.floor(Math.random() * 1e12);
+                    actions += ' ' +
+                        '<button type="button" class="btn-kebab" popovertarget="' + kid +
+                            '" aria-haspopup="menu" aria-label="Actions">\u22ee</button>' +
+                        '<div id="' + kid + '" popover class="kebab-menu" role="menu">' +
+                            '<button type="button" role="menuitem" class="kebab-item-danger" ' +
+                                'data-built-delete="' + escHtml(r.id) +
+                                '" data-built-name="' + escHtml(r.output_name) + '">Delete</button>' +
+                        '</div>';
+                }
                 var base = (r.base_variant || r.base_version)
                     ? escHtml((r.base_variant || '?') + ' / ' + (r.base_version || '?'))
                     : '<span class="text-muted">deleted</span>';
@@ -528,7 +543,7 @@
                     '<td>' + statusCell + '</td>' +
                     '<td>' + fmtBytes(r.output_size) + '</td>' +
                     '<td>' + fmtDate(r.built_at || r.created_at) + '</td>' +
-                    '<td style="text-align:right;">' + dlBtn + ' ' + delBtn + '</td>' +
+                    '<td style="text-align:right;">' + actions + '</td>' +
                     '</tr>';
             }).join('');
             // Wire up delete buttons (admin only).
@@ -900,6 +915,14 @@
         try {
             var bases = await jsonFetch('/api/imager/base-images');
             if (myReq !== loadBaseImagesReq) return;  // superseded
+            // Don't trample an open kebab popover -- the user is mid-
+            // interaction with it.  Reschedule a poll so progress on
+            // any IMPORTING row keeps moving once the popover closes.
+            if (tbody.querySelector('.kebab-menu:popover-open')) {
+                var anyImportingNow = (bases || []).some(function(b) { return statusUp(b.status) === 'IMPORTING'; });
+                if (anyImportingNow) scheduleBasesPoll();
+                return;
+            }
             if (!bases || bases.length === 0) {
                 basesLastStatus = {};
                 tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No base images cached. Click "Import from catalog…" to add one.</td></tr>';
@@ -909,8 +932,20 @@
             tbody.innerHTML = bases.map(function(b) {
                 var sha = b.sha256 ? b.sha256.slice(0, 12) + '…' : '—';
                 var shaTitle = b.sha256 ? ' title="' + escHtml(b.sha256) + '"' : '';
-                var del = statusUp(b.status) === 'IMPORTING' ? '' :
-                    '<button type="button" class="btn btn-sm btn-danger-subtle" data-delete-base="' + escHtml(b.id) + '">Delete</button>';
+                // No actions while IMPORTING: matches the prior
+                // hide-Delete behaviour and keeps an empty kebab from
+                // appearing.
+                var del = '';
+                if (statusUp(b.status) !== 'IMPORTING') {
+                    var kid = 'kebab-base-' + Math.floor(Math.random() * 1e12);
+                    del =
+                        '<button type="button" class="btn-kebab" popovertarget="' + kid +
+                            '" aria-haspopup="menu" aria-label="Actions">\u22ee</button>' +
+                        '<div id="' + kid + '" popover class="kebab-menu" role="menu">' +
+                            '<button type="button" role="menuitem" class="kebab-item-danger" ' +
+                                'data-delete-base="' + escHtml(b.id) + '">Delete</button>' +
+                        '</div>';
+                }
                 var statusCell;
                 if (statusUp(b.status) === 'IMPORTING') {
                     statusCell = progressBadgeHtml('IMPORTING', b.progress_stage, b.progress_pct);


### PR DESCRIPTION
Both the **Built Images** and **Base Images** panels now expose Delete via the shared kebab (⋮) menu pattern (popover-based, defined in 	emplates/_macros.html + .btn-kebab / .kebab-menu CSS + positionKebab() in pp.js) instead of as a standalone Delete button per row.

* **Built Images** -- Download remains the primary CTA; Delete is the only item in the kebab (admin-only, same auth gate as before).
* **Base Images** -- Delete is the only kebab item; the kebab is hidden entirely while the row is `IMPORTING` (matching the prior hide-the-Delete-button behaviour, and avoiding an empty kebab).

Both renderers now skip the auto-refresh re-render when an open kebab popover is detected in their tbody, so progress polls (15s built / 4s bases) no longer rip the popover out from under the user mid-interaction. Sig isn't updated in that case so the next tick will re-render once the popover closes; the bases poller reschedules itself if any `IMPORTING` row is still in flight.

The existing `data-built-delete` / `data-delete-base` attributes are kept on the kebab menu items, so the existing `addEventListener` wiring and optimistic-DOM-removal logic continue to work without modification.

### Test plan

* All 158 imager tests pass locally (`test_imager.py`, `test_imager_api.py`, `test_imager_catalog_normalize.py`, `test_imager_handlers.py`, `test_imager_schema.py`, `test_imager_settings.py`, `test_imager_ui.py`).
* No tests assert on the previous Delete-button markup (verified via grep).
* Smoke-tested in docker compose: kebab opens/closes/light-dismisses correctly on both panels; Delete still triggers the existing confirm dialog and optimistic row removal.