### PR TITLE
fix(imager): refresh base-image dropdown when set of READY bases changes

### DIFF
--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -875,21 +875,49 @@
     }
 
     function notifyBaseTransitions(bases) {
+        // Track whether the *set of READY bases* changed, so we can
+        // refresh the build form's base-image dropdown.  Without this,
+        // a freshly-imported variant doesn't appear in the dropdown
+        // until the user manually refreshes the page.
+        var readySetChanged = false;
         bases.forEach(function(b) {
             var prev = basesLastStatus[b.id];
             var cur = statusUp(b.status);
             if (prev === 'IMPORTING' && cur !== 'IMPORTING') {
                 if (cur === 'READY') {
                     toast('Import complete: ' + b.variant + ' / ' + b.version, 'success');
+                    readySetChanged = true;
                 } else if (cur === 'FAILED') {
                     var msg = b.error_message ? (': ' + b.error_message) : '';
                     toast('Import failed: ' + b.variant + ' / ' + b.version + msg, 'error');
                 }
             }
+            // Brand-new row that's already READY (e.g. imported in
+            // another tab while we were watching, or a sync-import
+            // that landed before our first poll).  Treat as a set
+            // change so the dropdown picks it up.
+            if (prev === undefined && cur === 'READY') {
+                readySetChanged = true;
+            }
+        });
+        // READY rows that disappeared (deleted in another tab).
+        var nextIds = {};
+        bases.forEach(function(b) { nextIds[b.id] = true; });
+        Object.keys(basesLastStatus).forEach(function(id) {
+            if (basesLastStatus[id] === 'READY' && !nextIds[id]) {
+                readySetChanged = true;
+            }
         });
         var next = {};
         bases.forEach(function(b) { next[b.id] = statusUp(b.status); });
         basesLastStatus = next;
+        if (readySetChanged && buildSection) {
+            // Refresh the build form's base-image dropdown so the new
+            // (or removed) variant shows up without a manual page
+            // refresh.  Fire-and-forget -- ``loadFleetsAndBases`` has
+            // its own error handling.
+            loadFleetsAndBases();
+        }
     }
 
     async function loadBaseImages() {
@@ -901,7 +929,10 @@
             var bases = await jsonFetch('/api/imager/base-images');
             if (myReq !== loadBaseImagesReq) return;  // superseded
             if (!bases || bases.length === 0) {
-                basesLastStatus = {};
+                // Run the transition detector even on empty -- it'll
+                // notice that any previously-known READY rows are now
+                // gone and refresh the build form's dropdown.
+                notifyBaseTransitions([]);
                 tbody.innerHTML = '<tr><td colspan="7" class="empty-state text-muted">No base images cached. Click "Import from catalog…" to add one.</td></tr>';
                 return;
             }


### PR DESCRIPTION
The build form's base-image dropdown is populated by `loadFleetsAndBases()` (which filters `GET /api/imager/base-images` to `status === 'READY'`) on page init, after fleet create/delete, and after build-submit-error. But it was *not* refreshed when a base transitioned IMPORTING -> READY in `notifyBaseTransitions`, so a freshly-imported variant didn't appear in the dropdown until the user manually refreshed the page.

### Fix

Adds a `readySetChanged` flag to `notifyBaseTransitions` that fires `loadFleetsAndBases()` whenever the set of READY bases changes between two polls:

- `IMPORTING -> READY` (the user-visible bug)
- Brand-new rows that arrive already READY (e.g. imported in another tab, or a sync-import that landed before our first poll)
- READY rows that vanish (deleted elsewhere)

Also: the empty-list short-circuit in `loadBaseImages` previously reset `basesLastStatus` and bailed *before* `notifyBaseTransitions`, so deleting the very last READY base in another tab also wouldn't clear it from the dropdown. Now the empty case calls `notifyBaseTransitions([])` so the disappear-detector runs.

### Test plan

* All 158 imager tests pass (`test_imager.py`, `test_imager_api.py`, `test_imager_catalog_normalize.py`, `test_imager_handlers.py`, `test_imager_schema.py`, `test_imager_settings.py`, `test_imager_ui.py`).
* No tests asserted on the dropdown-after-import flow (verified via grep) so no test churn.
* Smoke-tested in docker compose: imported a new variant; once it goes READY the toast fires and the build form's dropdown shows the new option without a page refresh.

### Stacking note

Independent of #547 (kebab-menu PR, currently mid-flight). Touches a different function in the same file; will rebase cleanly when #547 lands.