### PR TITLE
ci: scope verify job to production environment

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -267,6 +267,7 @@ jobs:
   verify:
     needs: [publish, deploy]
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Scopes the `verify` job in `publish-image.yml` to `environment: production`.

## Why
We are moving prod-only secrets/vars out of the repo scope into the `production` environment scope. The `deploy` job is already env-scoped. `verify` was the only other job that reads prod secrets (`AZURE_*`, `AZURE_RESOURCE_GROUP`) but had no environment, so it would silently fail to read env-scoped values once we delete the repo-level ones.

`bump-main` only uses `VERSION_BUMP_TOKEN` (a repo-wide CI primitive) so it stays repo-level and does not need an environment.

## Follow-up after merge
1. Delete repo-level secrets that have been mirrored to the `production` environment.
2. Delete orphan `FLEET_REGISTER_SECRET_TEST_FLEET_1` and `ACR_REGISTRY`.
3. Trigger a deploy to confirm verify+deploy work with env-scoped values.