### PR TITLE
ci: skip deactivated revisions when capturing previous deploy

### DIFF
--- a/.github/workflows/deploy-goodwill.yml
+++ b/.github/workflows/deploy-goodwill.yml
@@ -82,8 +82,15 @@ jobs:
 
           fetch_prev() {
             local app="$1"
-            az containerapp show --name "$app" --resource-group "$RG" \
-              --query "properties.latestReadyRevisionName" -o tsv 2>/dev/null || true
+            # Pick the most recently created revision that is still active
+            # and healthy. We deliberately avoid latestReadyRevisionName
+            # because ACA can report a deactivated revision there, which
+            # would cause bicep to pin traffic at a phantom name. See
+            # the matching comment in publish-image.yml for the incident
+            # that motivated this.
+            az containerapp revision list --name "$app" --resource-group "$RG" \
+              --query "reverse(sort_by([?properties.active && properties.healthState=='Healthy'], &properties.createdTime))[0].name" \
+              -o tsv 2>/dev/null || true
           }
 
           PREV_CMS=$(fetch_prev "$CMS_APP")

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -171,12 +171,22 @@ jobs:
 
           fetch_prev() {
             local app="$1"
-            # latestReadyRevisionName is the one currently serving traffic in
-            # single-revision mode and the most recent successful deploy in
-            # multi-revision mode. Either way it's the revision we want to
-            # keep traffic on while the new one warms up.
-            az containerapp show --name "$app" --resource-group "$RG" \
-              --query "properties.latestReadyRevisionName" -o tsv 2>/dev/null || true
+            # The previous revision we want to keep traffic on while the new
+            # one warms up. We can't use latestReadyRevisionName because it
+            # can point at a deactivated revision; bicep would then pin
+            # traffic at that name and ACA will eventually GC it, leaving
+            # ingress pointed at a phantom (this bit us on the 1.37.188
+            # deploy — `mcp--v1-37-187` had been deactivated as part of
+            # an earlier recovery, but `latestReadyRevisionName` still
+            # reported it, so bicep set traffic = 187:100 / 189:0 and
+            # 189 was later GC'd because it had 0% traffic).
+            #
+            # Instead, list revisions and pick the most recently created
+            # one that is still active and healthy. Falls back to empty
+            # (bootstrap) when nothing qualifies, e.g. on a fresh app.
+            az containerapp revision list --name "$app" --resource-group "$RG" \
+              --query "reverse(sort_by([?properties.active && properties.healthState=='Healthy'], &properties.createdTime))[0].name" \
+              -o tsv 2>/dev/null || true
           }
 
           PREV_CMS=$(fetch_prev "$CMS_APP")


### PR DESCRIPTION
## Why

The 1.37.188 deploy failed verify and ended up deleting both new revisions. Root cause: `fetch_prev` used `properties.latestReadyRevisionName`, which ACA continues to report even after a revision has been deactivated.

The MCP container app had `agoracms-mcp--v1-37-187` deactivated by hand during the prior env-secret recovery. ACA still answered `latestReadyRevisionName=v1-37-187`, so bicep pinned traffic at `187:100 / 189:0`. Verify could not reach MCP (the 187 revision was a phantom), rollback deactivated 189, and then ACA GC'd the dead 187 too — leaving the MCP ingress with traffic pointed at a name that had no revision behind it. I had to `az containerapp ingress traffic set --revision-weight agoracms-mcp--v1-37-186=100` to recover.

## What

Replace `properties.latestReadyRevisionName` with a revision-list query that filters to `properties.active && properties.healthState=='Healthy'` and picks the most recently created one. Falls back to empty (bootstrap) when nothing qualifies. Same fix applied to `deploy-goodwill.yml` so the Goodwill tenant doesn't trip the same wire.

## Test plan

Verified the new JMESPath returns the expected revision in prod today:

```
$ az containerapp revision list --name agoracms-cms --resource-group agoracms-cms-rg \
    --query "reverse(sort_by([?properties.active && properties.healthState=='Healthy'], &properties.createdTime))[0].name" -o tsv
agoracms-cms--v1-37-186

$ az containerapp revision list --name agoracms-mcp --resource-group agoracms-cms-rg \
    --query "reverse(sort_by([?properties.active && properties.healthState=='Healthy'], &properties.createdTime))[0].name" -o tsv
agoracms-mcp--v1-37-186
```

Will be exercised end-to-end by the next publish-deploy chain triggered by this merge.
