### PR TITLE
fix(deploy-goodwill): drop bicepparam file from workflow

### DIFF
--- a/.github/workflows/deploy-goodwill.yml
+++ b/.github/workflows/deploy-goodwill.yml
@@ -122,7 +122,6 @@ jobs:
           az deployment group create \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
-            --parameters infra/parameters/goodwill.bicepparam \
             --parameters \
               prefix='${{ vars.INFRA_PREFIX }}' \
               postgresAdminPassword='${{ secrets.POSTGRES_ADMIN_PASSWORD }}' \


### PR DESCRIPTION
## Why

The first Goodwill tenant deploy failed with BCP258:

```
ERROR: infra/parameters/goodwill.bicepparam(1,7) : Error BCP258: The following parameters are declared in the Bicep file but are missing an assignment in the params file: `adminPrincipalId`, `cmsAdminPassword`, `cmsSecretKey`, `postgresAdminPassword`.
```

Bicep refuses to combine `--parameters file.bicepparam` with inline `--parameters key=value` overrides for *required* params. The bicepparam file leaves those secrets intentionally undeclared (passed at deploy time), so the static check trips.

`publish-image.yml` already has the right pattern — it omits the bicepparam file and inlines everything. Match it.

## What

- Drop the `--parameters infra/parameters/goodwill.bicepparam \` line from `.github/workflows/deploy-goodwill.yml`.
- Keep `infra/parameters/goodwill.bicepparam` in the tree — its header docs the manual deploy path, where the bicepparam file IS useful (no inline overrides).

## Why this is a behavioral no-op

Every value in `goodwill.bicepparam` is either:
- CLI-overridden by the workflow (`prefix` → `vars.INFRA_PREFIX`), or
- Identical to a default in `main.bicep` (`location` defaults to `resourceGroup().location` = westus2; `postgresAdminLogin = 'agoraadmin'`; `cmsAdminUsername = 'admin'`).

## Test plan

Re-run `deploy-goodwill.yml` after merge — that was failing pre-fix and is the canonical test.