### PR TITLE
fix(auth): lock setup_completed=false when seeding admin

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -431,6 +431,9 @@ async def ensure_admin_credentials(db: AsyncSession, settings: Settings) -> None
     Migration path:
     1. If a User with the admin username already exists, optionally reset password.
     2. If no User exists yet, create one with the Admin role and env-var credentials.
+       Also explicitly mark cms_settings.setup_completed='false' so subsequent
+       boots cannot trip the upgrade-detection heuristic in cms/main.py — see the
+       block-comment on the seed below.
     3. Keep cms_settings in sync for any legacy code that still reads them.
     """
     # Ensure built-in Admin role exists (should be seeded by _seed_roles first)
@@ -462,6 +465,23 @@ async def ensure_admin_credentials(db: AsyncSession, settings: Settings) -> None
         db.add(admin_user)
         await db.commit()
         _log.info("Created admin user: %s", settings.admin_username)
+
+        # Lock the OOBE wizard open. The upgrade-detection heuristic in
+        # cms/main.py treats "admin user exists AND setup_completed is None"
+        # as proof that this is a deployment upgrading from a pre-wizard
+        # version, and auto-marks setup_completed=true. That heuristic
+        # works fine on a single boot, but on boot 2 of any *fresh* deploy
+        # both conditions are trivially true (we just seeded the admin on
+        # boot 1 and the operator hasn't reached the wizard yet), so the
+        # wizard gets auto-skipped forever. Pinning setup_completed='false'
+        # at seed-time means subsequent boots see a non-None value and
+        # the heuristic correctly does nothing.
+        if await get_setting(db, SETTING_SETUP_COMPLETED) is None:
+            await set_setting(db, SETTING_SETUP_COMPLETED, "false")
+            await db.commit()
+            _log.info(
+                "Marked setup_completed=false; OOBE wizard will run on next login"
+            )
     else:
         # Ensure email is set (migration for existing admin users)
         if not admin_user.email:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,6 +128,31 @@ async def _wait_for_scheduler_lease_async(engine: AsyncEngine, deadline: float) 
     raise RuntimeError(f"scheduler lease never acquired: {last_err}")
 
 
+async def _mark_setup_completed_async(engine: AsyncEngine) -> None:
+    """Write ``cms_settings.setup_completed='true'`` so the OOBE wizard
+    is skipped for the integration tests.
+
+    Historically these tests piggybacked on the upgrade-detection
+    heuristic in ``cms/main.py`` to auto-skip the wizard: boot 1 of
+    the CMS container seeded the admin without writing
+    ``setup_completed``, then boot 2 of the heuristic saw "admin exists
+    + flag is None" and marked it true. That behaviour was a real bug
+    in production (it slammed the wizard shut on every fresh deploy)
+    and was fixed by ``ensure_admin_credentials`` now pinning the flag
+    to ``'false'`` at seed time. With the bug fixed we have to mark
+    OOBE complete ourselves; ``compose --wait`` only blocks on
+    ``/healthz``, not on a usable wizard, and we don't want every test
+    to pre-walk the multi-step setup flow.
+    """
+    upsert = text(
+        "INSERT INTO cms_settings (key, value) "
+        "VALUES ('setup_completed', 'true') "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+    )
+    async with engine.begin() as conn:
+        await conn.execute(upsert)
+
+
 def _wait_for_scheduler_lease_sync(deadline: float) -> None:
     """Session-scoped leader-ready check on its own transient engine.
 
@@ -136,10 +161,15 @@ def _wait_for_scheduler_lease_sync(deadline: float) -> None:
     owns it — pytest-asyncio gives each test its own loop, and a
     session-scoped asyncpg engine would otherwise yield
     'attached to a different loop' failures on teardown.
+
+    The OOBE complete-flag is upserted before we wait for the
+    scheduler lease so the moment the lease drops, ``/api/*`` is
+    already unlocked for the test clients.
     """
     async def _run() -> None:
         eng = create_async_engine(HOST_DB_URL, pool_pre_ping=True)
         try:
+            await _mark_setup_completed_async(eng)
             await _wait_for_scheduler_lease_async(eng, deadline)
         finally:
             await eng.dispose()

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -450,3 +450,148 @@ async def test_fresh_install_does_not_set_flag(db_engine):
     # Verify: flag is still NOT set
     async with factory() as db:
         assert await get_setting(db, SETTING_SETUP_COMPLETED) is None
+
+
+# ── Regression: heuristic must not auto-skip OOBE on a fresh deploy ──
+#
+# The original bug: ``ensure_admin_credentials`` seeded an admin on boot 1
+# of a fresh deploy and left ``setup_completed`` as ``None``. On boot 2,
+# the upgrade-detection heuristic in ``cms/main.py`` saw "admin exists AND
+# setup_completed is None" and concluded this was a pre-wizard upgrade,
+# auto-marking ``setup_completed='true'`` and skipping OOBE forever.
+#
+# Fix: ``ensure_admin_credentials`` now writes ``setup_completed='false'``
+# whenever it creates the admin from scratch, locking the wizard open so
+# the heuristic on subsequent boots correctly does nothing.
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_locks_setup_completed_false(db_engine, tmp_path):
+    """``ensure_admin_credentials`` must explicitly set
+    ``setup_completed='false'`` on a fresh deploy so the upgrade heuristic
+    can't trip on subsequent boots."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from cms.auth import (
+        ensure_admin_credentials,
+        get_setting,
+        SETTING_SETUP_COMPLETED,
+    )
+    from cms.config import Settings
+    from cms.models.user import Role
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    settings = Settings(
+        database_url=str(db_engine.url),
+        secret_key="test-secret",
+        admin_username="admin",
+        admin_password="testpass",
+    )
+
+    # Pre-seed the Admin role (normally done by ``_seed_roles`` before
+    # ``ensure_admin_credentials`` runs in the lifespan).
+    async with factory() as db:
+        db.add(Role(
+            name="Admin", description="admin",
+            permissions=["*"], is_builtin=True,
+        ))
+        await db.commit()
+
+    # Fresh install: no admin user, no setup_completed flag.
+    async with factory() as db:
+        assert await get_setting(db, SETTING_SETUP_COMPLETED) is None
+
+    # Run ``ensure_admin_credentials`` (boot 1 of a fresh deploy).
+    async with factory() as db:
+        await ensure_admin_credentials(db, settings)
+
+    # Flag must now be 'false', not None — this is what blocks the
+    # upgrade heuristic on subsequent boots.
+    async with factory() as db:
+        assert await get_setting(db, SETTING_SETUP_COMPLETED) == "false"
+
+
+@pytest.mark.asyncio
+async def test_admin_seed_does_not_overwrite_completed_setup(db_engine, tmp_path):
+    """If ``setup_completed`` is already set, ``ensure_admin_credentials``
+    must not clobber it. Protects operators who completed OOBE then
+    triggered an admin re-seed (e.g. via ``AGORA_CMS_RESET_PASSWORD``)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from cms.auth import (
+        ensure_admin_credentials,
+        get_setting,
+        set_setting,
+        SETTING_SETUP_COMPLETED,
+    )
+    from cms.config import Settings
+    from cms.models.user import Role
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    settings = Settings(
+        database_url=str(db_engine.url),
+        secret_key="test-secret",
+        admin_username="admin",
+        admin_password="testpass",
+    )
+
+    async with factory() as db:
+        db.add(Role(
+            name="Admin", description="admin",
+            permissions=["*"], is_builtin=True,
+        ))
+        await set_setting(db, SETTING_SETUP_COMPLETED, "true")
+        await db.commit()
+
+    async with factory() as db:
+        await ensure_admin_credentials(db, settings)
+
+    async with factory() as db:
+        assert await get_setting(db, SETTING_SETUP_COMPLETED) == "true"
+
+
+@pytest.mark.asyncio
+async def test_legacy_upgrade_path_unaffected(db_engine, tmp_path):
+    """The pre-existing legacy-upgrade path (admin already in DB before
+    ``ensure_admin_credentials`` runs, no ``setup_completed`` flag) must
+    continue to work — that's what the heuristic in cms/main.py is for.
+    The fix above only writes the flag when admin is *created*; if admin
+    already exists, the flag stays ``None`` so the heuristic can fire."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from cms.auth import (
+        ensure_admin_credentials,
+        get_setting,
+        hash_password,
+        SETTING_SETUP_COMPLETED,
+    )
+    from cms.config import Settings
+    from cms.models.user import Role, User
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    settings = Settings(
+        database_url=str(db_engine.url),
+        secret_key="test-secret",
+        admin_username="admin",
+        admin_password="testpass",
+    )
+
+    # Simulate a legacy DB: admin already exists, no setup_completed.
+    async with factory() as db:
+        role = Role(
+            name="Admin", description="admin",
+            permissions=["*"], is_builtin=True,
+        )
+        db.add(role)
+        await db.flush()
+        db.add(User(
+            username="admin", email="legacy@example.com",
+            display_name="Legacy Admin", password_hash=hash_password("pw"),
+            role_id=role.id, is_active=True, must_change_password=False,
+        ))
+        await db.commit()
+
+    async with factory() as db:
+        await ensure_admin_credentials(db, settings)
+
+    # Flag must still be None so the upgrade heuristic in cms/main.py
+    # can run and mark it 'true'.
+    async with factory() as db:
+        assert await get_setting(db, SETTING_SETUP_COMPLETED) is None


### PR DESCRIPTION
## Problem

The upgrade-detection heuristic in `cms/main.py:434-453` fires on **boot 2** of any *fresh* deploy and slams the OOBE wizard shut forever:

1. Boot 1: heuristic finds no admin → no-op. `ensure_admin_credentials` then seeds the admin from `CMS_ADMIN_PASSWORD`. `setup_completed` stays `None`.
2. Boot 2: heuristic finds admin (from boot 1) AND `setup_completed is None` → concludes "must be a pre-wizard upgrade" → marks `setup_completed='true'`.
3. Operator's first login goes straight to `/dashboard`, never sees the wizard.

Hit live on the Goodwill tenant (`agoragw-cms`): manually flipping `cms_settings.setup_completed` back to `"false"` and restarting the revision restored the wizard.

## Fix

When `ensure_admin_credentials` seeds a fresh admin, also write `setup_completed='false'` so subsequent boots see a non-None value and the heuristic correctly does nothing. The heuristic itself is left intact, since it still serves the legitimate legacy-upgrade case (admin pre-existed in DB before the wizard feature shipped).

## Tests

- `test_fresh_install_locks_setup_completed_false` — asserts the CREATE branch writes the flag.
- `test_admin_seed_does_not_overwrite_completed_setup` — asserts an operator who completed OOBE then triggered an admin re-seed doesn't get the flag clobbered back to `'false'`.
- `test_legacy_upgrade_path_unaffected` — asserts the heuristic still has work to do when admin pre-existed.

All 22 tests in `tests/test_setup_wizard.py` pass locally.
