### PR TITLE
infra: provision Web PubSub + agora hub from bicep, drop WPS_CONNECTION_STRING secret

### DIFF
--- a/.github/workflows/deploy-goodwill.yml
+++ b/.github/workflows/deploy-goodwill.yml
@@ -11,8 +11,11 @@ name: Deploy Goodwill
 #   * Environment secrets:
 #       AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
 #       POSTGRES_ADMIN_PASSWORD, CMS_SECRET_KEY, CMS_ADMIN_PASSWORD,
-#       WPS_CONNECTION_STRING, ADMIN_PRINCIPAL_ID,
+#       ADMIN_PRINCIPAL_ID,
 #       AGORA_CMS_ISSUES_TOKEN (optional)
+#     The Web PubSub resource and "agora" hub are provisioned by
+#     main.bicep — its connection string is read from listKeys() at
+#     deploy time, so no WPS_CONNECTION_STRING secret is needed.
 #   * Environment variables:
 #       INFRA_PREFIX=agoragw, AZURE_RESOURCE_GROUP=agoragw-cms-rg,
 #       ALERT_EMAIL (optional), CMS_CUSTOM_DOMAIN (optional),
@@ -127,7 +130,6 @@ jobs:
               postgresAdminPassword='${{ secrets.POSTGRES_ADMIN_PASSWORD }}' \
               cmsSecretKey='${{ secrets.CMS_SECRET_KEY }}' \
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
-              wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
               githubIssuesToken='${{ secrets.AGORA_CMS_ISSUES_TOKEN }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=${{ inputs.deployRoleAssignments }} \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -42,17 +42,17 @@ param cmsAdminUsername string = 'admin'
 @secure()
 param cmsAdminPassword string
 
-@description('Azure Web PubSub connection string for device transport (required in prod). When empty, CMS falls back to direct websocket mode.')
-@secure()
-param wpsConnectionString string = ''
-
 @description('GitHub personal access token used by the "Report an issue" feature to file issues against the configured repo. When empty, the report-issue button is hidden.')
 @secure()
 param githubIssuesToken string = ''
 
-@description('Device transport mode: "wps" (multi-replica safe, routes via Azure Web PubSub) or "local" (direct CMS→device websockets, single-replica only).')
+@description('Device transport mode: "wps" (multi-replica safe, routes via Azure Web PubSub — provisioned and wired by this template) or "local" (direct CMS→device websockets, single-replica only — skips the WPS resource entirely).')
 @allowed(['wps', 'local'])
 param deviceTransport string = 'wps'
+
+@description('Web PubSub SKU when deviceTransport=wps. Free_F1 covers hundreds of concurrent devices; bump to Standard_S1 for >1k connections, custom domains, or revenue-bearing prod.')
+@allowed(['Free_F1', 'Standard_S1'])
+param webPubSubSku string = 'Free_F1'
 
 @description('CMS container image (e.g., ghcr.io/sslivins/agora-cms:1.12.34). Defaults to the latest GHCR tag.')
 param cmsImage string = 'ghcr.io/sslivins/agora-cms:latest'
@@ -112,6 +112,7 @@ var containerAppsEnvName = '${prefix}-env'
 var cmsAppName = '${prefix}-cms'
 var mcpAppName = '${prefix}-mcp'
 var workerJobName = '${prefix}-worker'
+var webPubSubName = '${prefix}-cms-wps'
 
 // ── Networking ──
 module networking 'modules/networking.bicep' = {
@@ -155,6 +156,22 @@ module keyVault 'modules/keyVault.bicep' = {
     keyVaultName: keyVaultName
     adminPrincipalId: adminPrincipalId
     deployRoleAssignments: deployRoleAssignments
+    tags: tags
+  }
+}
+
+// ── Web PubSub (device transport) ──
+// Provisioned only in WPS mode. The hub itself is created below,
+// AFTER containerApps, so its event-handler URL can reference the
+// env's generated defaultDomain. Splitting resource and hub into
+// two modules keeps a clean single-pass deploy with no manual
+// `az webpubsub` steps.
+module webPubSub 'modules/webPubSub.bicep' = if (deviceTransport == 'wps') {
+  name: 'webPubSub'
+  params: {
+    location: location
+    webPubSubName: webPubSubName
+    skuName: webPubSubSku
     tags: tags
   }
 }
@@ -211,7 +228,10 @@ module containerApps 'modules/containerApps.bicep' = {
     keyVaultUri: keyVault.outputs.keyVaultUri
 
     // Device transport (Azure Web PubSub)
-    wpsConnectionString: wpsConnectionString
+    // Connection string flows directly from the WPS module's listKeys()
+    // output — no GH secret, no manual key plumbing. Empty string in
+    // local mode (containerApps tolerates an empty value).
+    wpsConnectionString: deviceTransport == 'wps' ? webPubSub.outputs.connectionString : ''
     deviceTransport: deviceTransport
 
     // Report-issue feature (GitHub)
@@ -243,6 +263,21 @@ resource mcpKeyVaultRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
     principalId: containerApps.outputs.mcpPrincipalId
     principalType: 'ServicePrincipal'
+  }
+}
+
+// ── Web PubSub hub ("agora") ──
+// Deployed AFTER containerApps so the event-handler URL can use the
+// CMS's actual FQDN (built from cmsAppName + the env's generated
+// defaultDomain). Without this hub, Azure accepts device WSS but
+// never POSTs sys.connected to the CMS webhook, so every device
+// shows offline forever.
+module webPubSubHub 'modules/webPubSubHub.bicep' = if (deviceTransport == 'wps') {
+  name: 'webPubSubHub'
+  params: {
+    webPubSubName: webPubSub.outputs.name
+    hubName: 'agora'
+    cmsFqdn: '${cmsAppName}.${containerApps.outputs.environmentDefaultDomain}'
   }
 }
 

--- a/infra/modules/webPubSub.bicep
+++ b/infra/modules/webPubSub.bicep
@@ -1,0 +1,47 @@
+// ──────────────────────────────────────────────────────────────
+// webPubSub.bicep — Azure Web PubSub resource
+//
+// Provides the routing fabric for fanning device events across
+// multiple CMS replicas (AGORA_CMS_DEVICE_TRANSPORT=wps mode).
+// The "agora" hub itself is created in webPubSubHub.bicep, after
+// the Container Apps env exists — the hub's event-handler URL
+// points at the CMS, so the two have to be sequenced.
+//
+// Auth model: connection-string only (disableLocalAuth=false). The
+// CMS uses the access key to mint per-device JWT client tokens
+// (cms.services.wps_transport.get_client_access_token); devices
+// connect with that JWT, so the hub itself denies anonymous.
+// ──────────────────────────────────────────────────────────────
+
+param location string
+param webPubSubName string
+
+@allowed(['Free_F1', 'Standard_S1'])
+param skuName string = 'Free_F1'
+
+param skuCapacity int = 1
+param tags object = {}
+
+resource webPubSub 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
+  name: webPubSubName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    capacity: skuCapacity
+  }
+  properties: {
+    disableLocalAuth: false
+    publicNetworkAccess: 'Enabled'
+    tls: {
+      clientCertEnabled: false
+    }
+  }
+}
+
+output name string = webPubSub.name
+output id string = webPubSub.id
+output hostName string = webPubSub.properties.hostName
+
+@secure()
+output connectionString string = webPubSub.listKeys().primaryConnectionString

--- a/infra/modules/webPubSubHub.bicep
+++ b/infra/modules/webPubSubHub.bicep
@@ -1,0 +1,54 @@
+// ──────────────────────────────────────────────────────────────
+// webPubSubHub.bicep — "agora" hub + CMS event handler
+//
+// Without this child resource, devices can open WSS to the WPS
+// resource but Azure has no event handler to fire — the CMS
+// webhook (/internal/wps/events) never sees sys.connected /
+// sys.disconnected, so every device shows offline forever.
+//
+// This module is intentionally split from webPubSub.bicep so the
+// hub can deploy AFTER the Container Apps env exists (the
+// event-handler URL embeds the env's generated defaultDomain).
+// Bicep handles the dependency implicitly via the cmsFqdn input.
+//
+// Hub name MUST match cms.config.AppConfig.wps_hub (currently
+// "agora"). Keep both sides aligned when changing.
+// ──────────────────────────────────────────────────────────────
+
+param webPubSubName string
+
+@description('Hub name — must match cms.config.AppConfig.wps_hub.')
+param hubName string = 'agora'
+
+@description('Public FQDN of the CMS Container App, e.g. "agoragw-cms.yellowdune-84efd1e7.westus2.azurecontainerapps.io". Used to build the event-handler URL Azure POSTs CloudEvents to.')
+param cmsFqdn string
+
+resource webPubSub 'Microsoft.SignalRService/webPubSub@2024-03-01' existing = {
+  name: webPubSubName
+}
+
+resource hub 'Microsoft.SignalRService/webPubSub/hubs@2024-03-01' = {
+  parent: webPubSub
+  name: hubName
+  properties: {
+    // Devices present a CMS-minted JWT in the connect_token query
+    // param, so anonymous connections must be refused outright.
+    anonymousConnectPolicy: 'deny'
+    eventHandlers: [
+      {
+        urlTemplate: 'https://${cmsFqdn}/internal/wps/events'
+        userEventPattern: '*'
+        systemEvents: [
+          'connected'
+          'disconnected'
+        ]
+        // No auth header — Azure signs the request with the WPS
+        // access key (the same one in the connection string the
+        // CMS holds), and the webhook verifies via ce-signature.
+      }
+    ]
+  }
+}
+
+output hubName string = hub.name
+output hubId string = hub.id


### PR DESCRIPTION
## Why

`infra/main.bicep` accepted a `wpsConnectionString` `@secure()` param and stored it as a GitHub environment secret (`WPS_CONNECTION_STRING`), but the Web PubSub *resource* and its `agora` *hub* were both manual `az webpubsub create` / `az webpubsub hub create` steps for every environment. Goodwill onboarding skipped the hub-create step. Devices could open a websocket to Azure WPS just fine, but Azure had no event handler to forward `sys.connected` / `sys.disconnected` / `user.*` to the CMS webhook at `/internal/wps/events` — so presence rows never flipped to `online` and the CMS UI showed every device offline forever even though the player was up and the WSS was healthy.

User feedback was explicit: no workaround, fix it so a fresh-subscription deploy works end-to-end, and don't keep the connection string as a secret.

## What

Two new modules wired into `main.bicep` conditionally on `deviceTransport == 'wps'`:

### `infra/modules/webPubSub.bicep`
Creates the WPS resource. Emits the connection string from `listKeys()` as a `@secure()` output. Mirrors the pattern `storage.bicep` already uses for the storage account key.

```bicep
@secure()
output connectionString string = webPubSub.listKeys().primaryConnectionString
```

### `infra/modules/webPubSubHub.bicep`
Creates the `agora` hub (matching `cms/config.py: wps_hub`) with a single event handler at `https://${cmsFqdn}/internal/wps/events`, system events `connected` + `disconnected`, `user.*` pattern, and `anonymousConnectPolicy: 'deny'` since devices auth via JWT.

### `main.bicep`
- WPS module deploys **before** `containerApps` so its connection string can flow into the CMS as a secret.
- Hub module deploys **after** `containerApps` so the event handler can target the CMS app's `defaultDomain` FQDN. Splitting into two modules breaks the otherwise-circular dependency.
- `wpsConnectionString` `@secure()` param is dropped entirely. The secret is derived from `listKeys()` at deploy time and never leaves the bicep.
- New `webPubSubSku` param (`Free_F1` | `Standard_S1`, default `Free_F1`) so each env can opt up.

### `.github/workflows/deploy-goodwill.yml`
- `WPS_CONNECTION_STRING` removed from required-secrets header comment.
- Removed from `az deployment group create` invocation.

## Compile

```
WARNING BCP318 main.bicep(234,62): module | null may be null
WARNING BCP318 main.bicep(278,29): module | null may be null
WARNING outputs-should-not-contain-secrets storage.bicep(91,35) (pre-existing)
exit 0
```

The two `BCP318` warnings are bicep static-analyzer false positives — both consumer sites are gated on the same `deviceTransport == 'wps'` condition as the WPS module's own `if`, so at deploy time either both modules deploy or neither does. The runtime behavior is safe; bicep just can't prove the link statically.

## Goodwill cutover (no data migration needed)

Existing `agoragw-cms-wps` already matches the `${prefix}-cms-wps` naming formula bicep generates, and every property bicep sets matches the live config exactly:

| property | live | bicep |
|---|---|---|
| sku | `Free_F1` | `Free_F1` |
| location | `westus2` | `westus2` |
| `disableLocalAuth` | `false` | `false` |
| `publicNetworkAccess` | `Enabled` | `Enabled` |
| `tls.clientCertEnabled` | `false` | `false` |

Adoption is a no-op on the resource and purely additive for the missing `agora` hub.

After this PR merges and the next `deploy-goodwill` run completes:

1. **Verify the hub exists** —
   ```bash
   az webpubsub hub list --subscription 9e09ebcd-8a09-4696-86c5-6385299f1113 \
     -g agoragw-cms-rg -n agoragw-cms-wps -o table
   ```
   Should show `agora` with the event handler URL pointing at the CMS container app FQDN.
2. **Bounce a Pi** so it re-WSS-connects (existing connections won't fire `sys.connected` retroactively). Presence row should flip to `online` within seconds.
3. **Delete `WPS_CONNECTION_STRING` from the `seattle-goodwill` GitHub environment** — no longer used.

## Prod safety

`prod` deploy is **not gated** by this PR (it deploys via a separate workflow). Before applying bicep to prod, verify prod's WPS resource is named `${prod-prefix}-cms-wps`. If it isn't, the new bicep would create a duplicate WPS resource alongside the existing one and devices would lose the connection-string mid-deploy. Tracked as `cms-wps-prod-hub-audit`.

## Related

- Closes the structural half of the Goodwill WPS infra gap (workaround todo `cms-wps-hub-create-goodwill` is rejected in favor of this).
- Likely fixes `cms-bug-device-offline-while-connected` once Goodwill re-deploys, since both have the same root cause.