### PR TITLE
ci: drop wpsConnectionString from publish-image deploy params (#559 follow-up)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -223,7 +223,6 @@ jobs:
               postgresAdminPassword='${{ secrets.POSTGRES_ADMIN_PASSWORD }}' \
               cmsSecretKey='${{ secrets.CMS_SECRET_KEY }}' \
               cmsAdminPassword='${{ secrets.CMS_ADMIN_PASSWORD }}' \
-              wpsConnectionString='${{ secrets.WPS_CONNECTION_STRING }}' \
               githubIssuesToken='${{ secrets.AGORA_CMS_ISSUES_TOKEN }}' \
               adminPrincipalId='${{ secrets.ADMIN_PRINCIPAL_ID }}' \
               deployRoleAssignments=false \


### PR DESCRIPTION
## What

PR #559 removed the wpsConnectionString `@secure()` param from infra/main.bicep (the connection string is now derived at deploy time from webPubSub.outputs.connectionString via listKeys()). `deploy-goodwill.yml` was updated in that same PR but the symmetric change to `publish-image.yml` (the prod auto-deploy path that fires on every successful Smoke Test on `main`) was missed.

## Symptom

Run [25837878312](https://github.com/sslivins/agora-cms/actions/runs/25837878312) (Publish & Deploy on the bicep-merge commit) failed with:

```
ERROR: unrecognized template parameter 'wpsConnectionString'.
Allowed parameters: adminPrincipalId, alertEmail, cmsAdminPassword,
cmsAdminUsername, cmsCpu, cmsImage, cmsMemory, cmsRevisionSuffix,
cmsSecretKey, deployRoleAssignments, deviceTransport,
githubIssuesToken, location, mcpImage, mcpRevisionSuffix,
postgresAdminLogin, postgresAdminPassword, prefix,
previousCmsRevisionName, previousMcpRevisionName, webPubSubSku,
workerCpu, workerImage, workerMemory
```

## Impact

- **No prod traffic loss** -- prod is still serving on revision `agoracms-cms--v1-37-192`. The image publish step runs before the bicep step, so the new `v1-37-193` image was pushed to GHCR but the new revision was never created.
- This commit re-runs cleanly: Smoke Test green -> publish-image fires -> deploy step now succeeds.

## Why admin-merge

Identical justification to PR #559: tests don't exercise this workflow path. `test`/`e2e`/`alembic-check`/`migration-safety`/`gitleaks` are all unrelated to this one-line CI removal.