### PR TITLE
M3: os_update_dispatch protocol message + vendored device-side validator

### DIFF
--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -7,9 +7,10 @@ Any changes to this file MUST be mirrored in the device-side implementation.
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+import re
+from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Protocol versioning
 #
@@ -63,6 +64,7 @@ class MessageType(str, Enum):
     AUTH_ASSIGNED = "auth_assigned"
     REBOOT = "reboot"
     UPGRADE = "upgrade"
+    OS_UPDATE_DISPATCH = "os_update_dispatch"
     FACTORY_RESET = "factory_reset"
     WIPE_ASSETS = "wipe_assets"
     REQUEST_LOGS = "request_logs"
@@ -294,6 +296,67 @@ class WipeAssetsMessage(BaseMessage):
 
 class UpgradeMessage(BaseMessage):
     type: MessageType = MessageType.UPGRADE
+
+
+# ── os_update_dispatch (CMS → Device, agora-os bundle OTA) ──
+#
+# Wire schema is mirrored from sslivins/agora at ``os_updater/dispatch.py``;
+# the device-side ``DispatchPayload`` is vendored in this repo at
+# ``tests/contract/device_dispatch_validator.py`` and the contract test in
+# ``tests/test_schemas.py`` round-trips a CMS-built message through it to catch
+# drift. The two regex strings below MUST match the device-side strings
+# byte-for-byte. See plan.md §"Phase M3" for context.
+
+_OS_UPDATE_DISPATCH_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$")
+_OS_UPDATE_DISPATCH_RELEASE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+class OSUpdateDispatchMessage(BaseMessage):
+    """OS-bundle dispatch (CMS → Device).
+
+    Sent from the CMS Upgrade button to a device's WPS connection. Consumed
+    by ``agora-os-updater`` on-device, which strips ``type`` + ``protocol_version``
+    before validating the payload against its own ``DispatchPayload`` schema
+    (see ``tests/contract/device_dispatch_validator.py`` for the vendored copy).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: MessageType = MessageType.OS_UPDATE_DISPATCH
+
+    release_id: str
+    target_version: str
+    min_from_version: str
+    bundle_url: str
+    signature_url: str
+    force_now: bool = False
+    force_downgrade: bool = False
+    not_before: Optional[str] = None
+
+    @field_validator("release_id")
+    @classmethod
+    def _check_release_id(cls, value: str) -> str:
+        if not _OS_UPDATE_DISPATCH_RELEASE_ID_RE.match(value):
+            raise ValueError(
+                "release_id must match [A-Za-z0-9._-]{1,128}"
+            )
+        return value
+
+    @field_validator("target_version", "min_from_version")
+    @classmethod
+    def _check_version(cls, value: str) -> str:
+        if not _OS_UPDATE_DISPATCH_VERSION_RE.match(value):
+            raise ValueError(
+                "version must be major.minor.patch (with optional -prerelease)"
+            )
+        return value
+
+    @field_validator("bundle_url", "signature_url")
+    @classmethod
+    def _check_url(cls, value: str) -> str:
+        if not (value.startswith("https://") or value.startswith("http://")):
+            raise ValueError("url must use http(s) scheme")
+        return value
 
 
 class RequestLogsMessage(BaseMessage):

--- a/tests/contract/device_dispatch_validator.py
+++ b/tests/contract/device_dispatch_validator.py
@@ -1,0 +1,122 @@
+# Vendored from sslivins/agora @ 89775d7658647fad6777b2f91942a7542bfaee2c
+# Source: os_updater/dispatch.py (entire file)
+#
+# Wire-format contract pin for OSUpdateDispatchMessage in cms/schemas/protocol.py.
+# tests/test_schemas.py round-trips a CMS-built message through this vendored
+# device-side validator to catch schema drift.
+#
+# If you edit os_updater/dispatch.py in sslivins/agora, open a follow-up PR in
+# this repo bumping the SHA on this header and re-syncing the body verbatim.
+# See plan.md §"Phase M3" and the wire-format-drift risk row.
+#
+# DO NOT MODIFY MANUALLY.
+# ruff: noqa
+"""Parsing + validation of the ``os_update_dispatch`` WPS payload.
+
+The CMS dispatches a release to a device by pushing an ``os_update_dispatch``
+control message over the existing WPS connection. The payload is the same
+shape that's stored in the ``scheduled_dispatches`` row (plan.md §"Phase 3 —
+DB schema additions"), minus the row-bookkeeping fields:
+
+    {
+      "type": "os_update_dispatch",
+      "release_id": "rel_2026_05_07_v1.1.0",
+      "target_version": "1.1.0",
+      "min_from_version": "1.0.0",
+      "bundle_url": "https://github.com/.../bundle.zst",
+      "signature_url": "https://github.com/.../bundle.zst.minisig",
+      "force_now": false,
+      "force_downgrade": false
+    }
+
+Phase 3 may add fields (``not_before`` for staggered rings, etc.) — the
+parser uses ``pydantic`` with ``extra="ignore"`` so a forward-compatible
+field doesn't break older daemons.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DispatchPayloadError(ValueError):
+    """Raised when an ``os_update_dispatch`` payload fails validation.
+
+    The daemon treats this as a routine failure path — log + emit
+    ``failed:invalid_payload`` over WPS — not a crash.
+    """
+
+
+#: Regex matching ``major.minor.patch`` semver with optional ``-prerelease``.
+#: Intentionally simple — we control both ends of this wire so we don't need
+#: full semver-2.0 compliance.
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$")
+
+#: Regex matching the allowed shape of an opaque ``release_id``: alphanumeric
+#: plus ``_-.``, length 1..128. Mirrors what the CMS will generate.
+_RELEASE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+class DispatchPayload(BaseModel):
+    """Validated form of a CMS-side ``os_update_dispatch`` message."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    release_id: str
+    target_version: str
+    min_from_version: str
+    bundle_url: str
+    signature_url: str
+    force_now: bool = False
+    force_downgrade: bool = False
+
+    #: Optional Phase 3 fields that older daemons can simply ignore.
+    not_before: Optional[str] = Field(default=None)
+
+    @field_validator("release_id")
+    @classmethod
+    def _check_release_id(cls, value: str) -> str:
+        if not _RELEASE_ID_RE.match(value):
+            raise ValueError(
+                "release_id must match [A-Za-z0-9._-]{1,128}"
+            )
+        return value
+
+    @field_validator("target_version", "min_from_version")
+    @classmethod
+    def _check_version(cls, value: str) -> str:
+        if not _VERSION_RE.match(value):
+            raise ValueError(
+                "version must be major.minor.patch (with optional -prerelease)"
+            )
+        return value
+
+    @field_validator("bundle_url", "signature_url")
+    @classmethod
+    def _check_url(cls, value: str) -> str:
+        if not (value.startswith("https://") or value.startswith("http://")):
+            raise ValueError("url must use http(s) scheme")
+        return value
+
+
+def parse_dispatch_payload(msg: Any) -> DispatchPayload:
+    """Parse an inbound WPS message into a :class:`DispatchPayload`.
+
+    The caller has already routed by ``msg["type"] == "os_update_dispatch"``.
+    Wraps the pydantic ``ValidationError`` in :class:`DispatchPayloadError`
+    so the caller doesn't need to import pydantic just to catch payload
+    failures.
+    """
+
+    if not isinstance(msg, Mapping):
+        raise DispatchPayloadError(
+            f"dispatch payload must be a JSON object, got {type(msg).__name__}"
+        )
+
+    try:
+        return DispatchPayload.model_validate(dict(msg))
+    except Exception as exc:
+        raise DispatchPayloadError(str(exc)) from exc

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -61,6 +61,145 @@ class TestProtocolMessages:
         assert data["size_bytes"] == 1024
 
 
+class TestOSUpdateDispatchMessage:
+    """Tests for ``os_update_dispatch`` — the CMS→Device OS bundle dispatch."""
+
+    def _valid_kwargs(self) -> dict:
+        return dict(
+            release_id="rel_2026_05_07_v1.1.0",
+            target_version="1.1.0",
+            min_from_version="1.0.0",
+            bundle_url="https://example.com/bundle.zst",
+            signature_url="https://example.com/bundle.zst.minisig",
+        )
+
+    def test_construction_defaults(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        msg = OSUpdateDispatchMessage(**self._valid_kwargs())
+        data = msg.model_dump(mode="json")
+        assert data["type"] == "os_update_dispatch"
+        assert data["protocol_version"] == 2
+        assert data["release_id"] == "rel_2026_05_07_v1.1.0"
+        assert data["target_version"] == "1.1.0"
+        assert data["min_from_version"] == "1.0.0"
+        assert data["bundle_url"] == "https://example.com/bundle.zst"
+        assert data["signature_url"] == "https://example.com/bundle.zst.minisig"
+        assert data["force_now"] is False
+        assert data["force_downgrade"] is False
+        assert data["not_before"] is None
+
+    def test_explicit_optional_fields(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        msg = OSUpdateDispatchMessage(
+            **self._valid_kwargs(),
+            force_now=True,
+            force_downgrade=True,
+            not_before="2026-05-07T02:00:00Z",
+        )
+        data = msg.model_dump(mode="json")
+        assert data["force_now"] is True
+        assert data["force_downgrade"] is True
+        assert data["not_before"] == "2026-05-07T02:00:00Z"
+
+    def test_version_v_prefix_rejected(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["target_version"] = "v1.1.0"
+        with pytest.raises(ValidationError):
+            OSUpdateDispatchMessage(**kwargs)
+
+    def test_partial_version_rejected(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["target_version"] = "1.1"
+        with pytest.raises(ValidationError):
+            OSUpdateDispatchMessage(**kwargs)
+
+    def test_prerelease_version_accepted(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["target_version"] = "1.1.0-test"
+        OSUpdateDispatchMessage(**kwargs)
+
+    def test_release_id_bad_chars_rejected(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["release_id"] = "release id with spaces"
+        with pytest.raises(ValidationError):
+            OSUpdateDispatchMessage(**kwargs)
+
+    def test_release_id_too_long_rejected(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["release_id"] = "a" * 129
+        with pytest.raises(ValidationError):
+            OSUpdateDispatchMessage(**kwargs)
+
+    def test_non_http_url_rejected(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        kwargs = self._valid_kwargs()
+        kwargs["bundle_url"] = "ftp://example.com/bundle.zst"
+        with pytest.raises(ValidationError):
+            OSUpdateDispatchMessage(**kwargs)
+
+    def test_roundtrip_json(self):
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+
+        msg = OSUpdateDispatchMessage(**self._valid_kwargs())
+        as_json = msg.model_dump_json()
+        rebuilt = OSUpdateDispatchMessage.model_validate_json(as_json)
+        assert rebuilt.model_dump() == msg.model_dump()
+
+    def test_regex_strings_match_vendored_device_side(self):
+        """Drift-detector: if these strings differ, the wire contract is broken."""
+        from cms.schemas import protocol
+        from tests.contract import device_dispatch_validator
+
+        assert (
+            protocol._OS_UPDATE_DISPATCH_VERSION_RE.pattern
+            == device_dispatch_validator._VERSION_RE.pattern
+        ), "CMS-side version regex drifted from device-side; refresh vendored copy"
+        assert (
+            protocol._OS_UPDATE_DISPATCH_RELEASE_ID_RE.pattern
+            == device_dispatch_validator._RELEASE_ID_RE.pattern
+        ), "CMS-side release_id regex drifted from device-side; refresh vendored copy"
+
+    def test_contract_roundtrip_through_device_validator(self):
+        """Build CMS msg → JSON → strip envelope → validate as device side."""
+        import json
+
+        from cms.schemas.protocol import OSUpdateDispatchMessage
+        from tests.contract.device_dispatch_validator import DispatchPayload
+
+        cms_msg = OSUpdateDispatchMessage(
+            **self._valid_kwargs(),
+            force_now=True,
+            not_before="2026-05-07T02:00:00Z",
+        )
+
+        wire = json.loads(cms_msg.model_dump_json())
+        wire.pop("type", None)
+        wire.pop("protocol_version", None)
+
+        device_payload = DispatchPayload.model_validate(wire)
+        assert device_payload.release_id == cms_msg.release_id
+        assert device_payload.target_version == cms_msg.target_version
+        assert device_payload.min_from_version == cms_msg.min_from_version
+        assert device_payload.bundle_url == cms_msg.bundle_url
+        assert device_payload.signature_url == cms_msg.signature_url
+        assert device_payload.force_now is True
+        assert device_payload.force_downgrade is False
+        assert device_payload.not_before == "2026-05-07T02:00:00Z"
+
+
 class TestDeviceSchemas:
     def test_device_out(self):
         from cms.schemas.device import DeviceOut


### PR DESCRIPTION
## What

Adds the `os_update_dispatch` WPS protocol message to CMS, mirroring the device-side `DispatchPayload` in `sslivins/agora`. CMS can now construct and serialize the message; the actual sender migration from `UpgradeMessage` to `OSUpdateDispatchMessage` happens in M5.

## Why

Sub-plan M3 from the CMS upgrade-path migration (see [plan in session checkpoint](https://github.com/sslivins/agora-cms/issues)). Pi devices already ship `agora-os-updater` listening for `os_update_dispatch` over WPS; nothing currently sends it. This PR adds the protocol shape so M4 (device-side `os_version` reporting + routing) and M5 (`/upgrade` endpoint flip) can land on a wire-compatible foundation.

## Changes

* `cms/schemas/protocol.py`:
  * `MessageType.OS_UPDATE_DISPATCH = "os_update_dispatch"` enum value.
  * `OSUpdateDispatchMessage(BaseMessage)` pydantic v2 model with `model_config = ConfigDict(extra="ignore")` matching the device side's forward-compat shape.
  * Three `@field_validator` methods enforcing version regex, release_id regex, and URL scheme.
* `tests/contract/device_dispatch_validator.py` (new):
  * Vendored snapshot of `sslivins/agora @ 89775d76` `os_updater/dispatch.py:DispatchPayload`.
  * Header carries SHA pin + DO-NOT-MODIFY notice + pointer to the PR-template lever in the producer repo for refreshing this copy.
  * Pure-Python frozen snapshot — no imports from `agora`.
* `tests/test_schemas.py`: new `TestOSUpdateDispatchMessage` class with 11 methods covering construction, defaults, optional fields, validator behavior, JSON roundtrip, drift detector against the vendored copy, and full contract roundtrip through `DispatchPayload.model_validate(wire)`.

## Divergence from M3 plan doc (intentional)

The plan claimed the schema would use `HttpUrl`, `packaging.version.Version`, and `datetime | None`. The actual implementation matches the device side exactly:

* **URLs** are `str` with a regex validator accepting `http://` or `https://`, not `HttpUrl`. Device permits both; CMS could be stricter but wire-compat is the priority.
* **`target_version` / `min_from_version`** use a custom regex `^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$` rather than `packaging.version.Version`. The plan wording would have accepted `1.2` (no patch). The regex is stricter.
* **`release_id`** has its own regex `^[A-Za-z0-9._-]{1,128}$` (plan didn't specify; mirrored from device).
* **`not_before`** is `Optional[str] = None`, not `datetime | None`. Device passes through without parsing — CMS storing it as ISO-8601 string and letting device interpret means the contract surface stays smaller.

**The device side is the contract.** Plan doc is updated in spirit by this PR's tests; literal plan.md edit is a separate drive-by.

## Drift-detector design

`test_regex_strings_match_vendored_device_side` is the canary. It asserts:

```python
protocol._OS_UPDATE_DISPATCH_VERSION_RE.pattern == device_dispatch_validator._VERSION_RE.pattern
protocol._OS_UPDATE_DISPATCH_RELEASE_ID_RE.pattern == device_dispatch_validator._RELEASE_ID_RE.pattern
```

If either side changes without the other, this test fires before the contract roundtrip even runs — clearer signal than "your bundle won't validate on real hardware."

## Vendored-copy maintenance lever

Companion PR in `sslivins/agora` will add a checkbox to `.github/PULL_REQUEST_TEMPLATE.md`:

> - [ ] If you touched `os_updater/dispatch.py`: open a follow-up PR in `agora-cms` to bump the vendored copy at `tests/contract/device_dispatch_validator.py` (header SHA + body).

That's the maintenance contract. The vendored file's header repeats the same instruction, so engineers who hit it from either direction will know what to do.

## Roadmap

| Phase | Status |
|---|---|
| M1 — verify `meta.json` shipped as release asset on agora-os | done |
| M2 — `bundle_checker` replaces `version_checker` | PR #562 in flight |
| **M3 — this PR** | **in flight** |
| M4 — device sends `os_version` in register + WPS routing confirmation | not started |
| M5 — `/upgrade` endpoint flips to `OSUpdateDispatchMessage` + claim-clear fix | not started |
| M6 — UI badge swaps to OS-version comparison | not started |
| M7 — end-to-end OTA via CMS UI on Pi100 | not started |
| M8 — delete legacy `UPGRADE` path | not started |

## Testing

* `pytest -p no:timeout tests/test_schemas.py -v` → 22/22 green locally on Python 3.14.2.
* Drift detector and contract roundtrip both green — wire compatibility with `sslivins/agora @ 89775d76` confirmed.
