### PR TITLE
Phase M4-CMS: persist os_version on register

### DIFF
--- a/alembic/versions/0024_devices_os_version.py
+++ b/alembic/versions/0024_devices_os_version.py
@@ -27,6 +27,13 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # server_default="" backfills existing rows so NOT NULL is legal,
+    # but we drop the DB-side default immediately afterwards to match
+    # this table's convention (sibling string columns like
+    # firmware_version, device_type, supported_codecs all use Python
+    # default="" with no server_default). Leaving server_default in
+    # place would cause alembic autogenerate to flag drift against
+    # the ORM model on every subsequent check run.
     op.add_column(
         "devices",
         sa.Column(
@@ -36,6 +43,7 @@ def upgrade() -> None:
             server_default="",
         ),
     )
+    op.alter_column("devices", "os_version", server_default=None)
     op.create_index("ix_devices_os_version", "devices", ["os_version"])
 
 

--- a/alembic/versions/0024_devices_os_version.py
+++ b/alembic/versions/0024_devices_os_version.py
@@ -1,0 +1,50 @@
+"""Add os_version column to devices.
+
+Phase M4-CMS of the agora-os bundle-OTA migration.  Devices on
+firmware ≥ M4-device report ``os_version`` in their register payload
+(the agora-os bundle version, sourced from ``/etc/agora/version``).
+``firmware_version`` continues to track the agora-app version.  This
+column is what M5 will use as the dispatch comparison key once the
+``/upgrade`` endpoint flips to ``os_update_dispatch``.
+
+Indexed because the rollout UI will need to filter / count devices
+by os_version (e.g. "how many devices are still on v0.0.16-test").
+
+Revision ID: 0024
+Revises: 0023
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "devices",
+        sa.Column(
+            "os_version",
+            sa.String(length=32),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.create_index("ix_devices_os_version", "devices", ["os_version"])
+
+
+def downgrade() -> None:
+    # Project policy (test_migration_policy.py): every downgrade must
+    # raise NotImplementedError. Real downgrades are dangerous in
+    # production rollback (data loss / FK ordering / re-upgrade
+    # back-fill) and the project has chosen to invest in forward
+    # migrations only.
+    raise NotImplementedError(
+        "Downgrade of 0024 is intentionally not implemented per project policy."
+    )

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -64,6 +64,7 @@ class Device(Base):
         UUID(as_uuid=True), ForeignKey("device_groups.id"), nullable=True
     )
     firmware_version: Mapped[str] = mapped_column(String(32), default="")
+    os_version: Mapped[str] = mapped_column(String(32), default="", index=True)
     storage_capacity_mb: Mapped[int] = mapped_column(Integer, default=0)
     storage_used_mb: Mapped[int] = mapped_column(Integer, default=0)
     device_type: Mapped[str] = mapped_column(String(100), default="")

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -128,6 +128,7 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                 name=device_name,
                 status=DeviceStatus.PENDING,
                 firmware_version=raw.get("firmware_version", ""),
+                os_version=raw.get("os_version", ""),
                 device_type=raw.get("device_type", ""),
                 supported_codecs=",".join(raw.get("supported_codecs", [])),
                 storage_capacity_mb=raw.get("storage_capacity_mb", 0),

--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -21,6 +21,7 @@ class DeviceOut(BaseModel):
     default_asset_id: Optional[uuid.UUID] = None
     timezone: Optional[str] = None
     firmware_version: str
+    os_version: str = ""
     device_type: str = ""
     supported_codecs: str = ""
     storage_capacity_mb: int

--- a/cms/services/device_register.py
+++ b/cms/services/device_register.py
@@ -161,6 +161,7 @@ async def register_known_device(
 
     # Refresh metadata from the register payload.
     device.firmware_version = raw.get("firmware_version", device.firmware_version)
+    device.os_version = raw.get("os_version", device.os_version)
     device.device_type = raw.get("device_type", device.device_type)
     reg_codecs = raw.get("supported_codecs")
     if reg_codecs is not None:

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -716,6 +716,10 @@
                 <span class="detail-value">{{ d.firmware_version or '—' }}{% if d.update_available and 'devices:manage' in user_perms %} <span class="badge badge-update">{{ latest_version }} available</span>{% endif %}</span>
             </div>
             <div class="detail-item">
+                <span class="detail-label">OS Version</span>
+                <span class="detail-value">{{ d.os_version or '—' }}</span>
+            </div>
+            <div class="detail-item">
                 <span class="detail-label">Storage</span>
                 <span class="detail-value" data-live-storage="{{ d.id }}" data-storage-detail data-storage-mb="{{ d.storage_capacity_mb }}" data-used-mb="{{ d.storage_used_mb }}">{{ fmt_storage(d.storage_used_mb) }} / {{ fmt_storage(d.storage_capacity_mb) }}</span>
             </div>

--- a/tests/integration/test_multireplica_mvp.py
+++ b/tests/integration/test_multireplica_mvp.py
@@ -94,9 +94,9 @@ async def _seed_device_and_schedule(
                 "INSERT INTO devices "
                 "(id, name, location, status, firmware_version, "
                 " storage_capacity_mb, storage_used_mb, device_type, "
-                " supported_codecs, registered_at, online, group_id, "
+                " supported_codecs, os_version, registered_at, online, group_id, "
                 " upgrade_started_at) "
-                "VALUES (:id, :name, '', 'ADOPTED', '', 0, 0, '', '', "
+                "VALUES (:id, :name, '', 'ADOPTED', '', 0, 0, '', '', '', "
                 "        :now, TRUE, :gid, NULL)"
             ),
             {"id": device_id, "name": "int-dev", "now": now, "gid": group_id},

--- a/tests/integration/test_multireplica_wps_smoke.py
+++ b/tests/integration/test_multireplica_wps_smoke.py
@@ -122,9 +122,9 @@ async def _seed_minimal_device(engine: AsyncEngine) -> str:
                 "INSERT INTO devices "
                 "(id, name, location, status, firmware_version, "
                 " storage_capacity_mb, storage_used_mb, device_type, "
-                " supported_codecs, registered_at, online, "
+                " supported_codecs, os_version, registered_at, online, "
                 " upgrade_started_at) "
-                "VALUES (:id, :name, '', 'ADOPTED', '', 0, 0, '', '', "
+                "VALUES (:id, :name, '', 'ADOPTED', '', 0, 0, '', '', '', "
                 "        :now, FALSE, NULL)"
             ),
             {"id": device_id, "name": "wps-int-dev", "now": now},

--- a/tests/test_device_register.py
+++ b/tests/test_device_register.py
@@ -44,6 +44,7 @@ def _make_device(
     status: DeviceStatus = DeviceStatus.ADOPTED,
     device_type: str = "",
     firmware_version: str = "1.0.0",
+    os_version: str = "",
     supported_codecs: str = "",
     storage_capacity_mb: int = 0,
     storage_used_mb: int = 0,
@@ -58,6 +59,7 @@ def _make_device(
     d.status = status
     d.device_type = device_type
     d.firmware_version = firmware_version
+    d.os_version = os_version
     d.supported_codecs = supported_codecs
     d.storage_capacity_mb = storage_capacity_mb
     d.storage_used_mb = storage_used_mb
@@ -175,6 +177,7 @@ class TestRegisterKnownDevice:
                 "device_id": "pi-1",
                 "auth_token": "t",
                 "firmware_version": "1.12.0",
+                "os_version": "0.0.16-test",
                 "device_type": "Raspberry Pi 5",
                 "supported_codecs": ["h264", "vp8"],
                 "storage_capacity_mb": 32768,
@@ -184,6 +187,7 @@ class TestRegisterKnownDevice:
         )
 
         assert device.firmware_version == "1.12.0"
+        assert device.os_version == "0.0.16-test"
         assert device.device_type == "Raspberry Pi 5"
         assert device.supported_codecs == "h264,vp8"
         assert device.storage_capacity_mb == 32768

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -11,7 +11,7 @@ from httpx import ASGITransport, AsyncClient
 
 @pytest.mark.asyncio
 class TestWebSocket:
-    async def test_register_new_device(self, app):
+    async def test_register_new_device(self, app, db_session):
         from starlette.testclient import TestClient
 
         with TestClient(app) as tc:
@@ -22,6 +22,7 @@ class TestWebSocket:
                     "device_id": "ws-test-001",
                     "auth_token": "",
                     "firmware_version": "1.0.0",
+                    "os_version": "0.0.16-test",
                     "storage_capacity_mb": 500,
                     "storage_used_mb": 100,
                 })
@@ -35,6 +36,15 @@ class TestWebSocket:
                 time.sleep(0.5)  # Allow server to finish before disconnect
 
                 ws.close()
+
+        # Verify os_version was persisted on the new device row.
+        from cms.models.device import Device
+        from sqlalchemy import select
+
+        row = await db_session.execute(select(Device).where(Device.id == "ws-test-001"))
+        dev = row.scalar_one()
+        assert dev.firmware_version == "1.0.0"
+        assert dev.os_version == "0.0.16-test"
 
     async def test_register_known_device_valid_token(self, app, db_session):
         from cms.models.device import Device, DeviceStatus


### PR DESCRIPTION
## What

CMS-side companion to the device-side M4 change (sslivins/agora PR #205, merged).

- New `os_version` column on `devices` (indexed, default `""`) — alembic `0024`.
- `cms/routers/ws.py`: new-device construction stores `os_version` from the register payload.
- `cms/services/device_register.py`: known-device refresh persists `os_version` on every register.
- `cms/schemas/device.py`: exposes `os_version` on `DeviceOut`.
- `cms/templates/_macros.html`: surfaces OS Version in the device-detail block.
- Tests assert persistence on both new-device + known-device paths.

## Why

Phase M5 (next) flips the `/upgrade` endpoint to send `OSUpdateDispatchMessage` and fixes the post-OTA claim-clear lockout. The lockout fix compares `(os_version, firmware_version)` tuples between register messages — so we need the column non-NULL on every device before M5 ships. Without M4-CMS landed first, every successful OS OTA would lock operators out for the full 15-min `UPGRADE_TTL`.

## Test results (local)

- `tests/test_device_register.py + tests/test_migration_policy.py`: 84/84 green.
- `tests/test_websocket.py` minus 2 known Windows-only flakes (`test_status_message_updates_device`, `test_reflashed_device_empty_token_gets_readopted`): 12/12 green.
- `tests/test_wps_webhook.py tests/test_devices.py tests/test_device_identity.py tests/test_device_manager.py tests/test_device_alerts.py`: 157/157 green.

## Migration policy

`0024_devices_os_version.py` upgrade adds the column + index. Downgrade raises `NotImplementedError` per project policy (validated by `test_migration_policy.py`).