### PR TITLE
deploy-goodwill: add version=auto + pre-flight GHCR manifest check

### DIFF
--- a/.github/workflows/deploy-goodwill.yml
+++ b/.github/workflows/deploy-goodwill.yml
@@ -29,9 +29,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "CMS image version to deploy (e.g. 1.12.34 — must already exist as a tag on ghcr.io/sslivins/agora-cms)"
+        description: "Image version to deploy (e.g. 1.12.34) — must already be tagged on all three GHCR repos (agora-cms, agora-cms-mcp, agora-worker). Leave as 'auto' to resolve the highest co-versioned tag automatically."
         required: true
         type: string
+        default: auto
       deployRoleAssignments:
         description: "Run role assignment module (only needed on first bootstrap or when adminPrincipalId changes)"
         required: false
@@ -54,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: seattle-goodwill
     outputs:
+      resolved_version: ${{ steps.resolve.outputs.resolved_version }}
       revision_suffix: ${{ steps.revisions.outputs.revision_suffix }}
       previous_cms_revision: ${{ steps.revisions.outputs.previous_cms_revision }}
       previous_mcp_revision: ${{ steps.revisions.outputs.previous_mcp_revision }}
@@ -61,6 +63,18 @@ jobs:
       new_mcp_revision: ${{ steps.revisions.outputs.new_mcp_revision }}
     steps:
       - uses: actions/checkout@v4
+
+      # Resolve "auto" -> latest co-versioned semver across all three GHCR
+      # repos (agora-cms, agora-cms-mcp, agora-worker), or accept a literal
+      # pin. Either way, HEAD every manifest before we touch Azure so a
+      # missing tag fails in ~5 seconds with a helpful hint instead of
+      # 4 minutes into Bicep with MANIFEST_UNKNOWN. Runs before azure/login
+      # because it only needs GHCR — no Azure credentials required.
+      - name: Resolve and verify image version
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: python3 scripts/resolve_deploy_version.py
 
       - name: Log in to Azure
         uses: azure/login@v2
@@ -105,7 +119,7 @@ jobs:
 
           # ACA revision suffixes must be lowercase alphanumeric with dashes,
           # max 64 chars. Versions look like "1.12.34" -> "v1-12-34".
-          SUFFIX="v$(echo '${{ inputs.version }}' | tr '.' '-')"
+          SUFFIX="v$(echo '${{ steps.resolve.outputs.resolved_version }}' | tr '.' '-')"
           echo "revision_suffix=${SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "  new revision suffix: ${SUFFIX}"
 
@@ -115,9 +129,10 @@ jobs:
 
       - name: Deploy infrastructure
         run: |
-          CMS_REF='ghcr.io/sslivins/agora-cms:${{ inputs.version }}'
-          MCP_REF='ghcr.io/sslivins/agora-cms-mcp:${{ inputs.version }}'
-          WORKER_REF='ghcr.io/sslivins/agora-worker:${{ inputs.version }}'
+          VERSION='${{ steps.resolve.outputs.resolved_version }}'
+          CMS_REF="ghcr.io/sslivins/agora-cms:${VERSION}"
+          MCP_REF="ghcr.io/sslivins/agora-cms-mcp:${VERSION}"
+          WORKER_REF="ghcr.io/sslivins/agora-worker:${VERSION}"
           echo "Deploying:"
           echo "  cms:    $CMS_REF"
           echo "  mcp:    $MCP_REF"
@@ -222,7 +237,7 @@ jobs:
       - name: Wait for new CMS revision to become healthy
         id: health
         run: |
-          EXPECTED="${{ inputs.version }}"
+          EXPECTED="${{ needs.deploy.outputs.resolved_version }}"
           FQDN='${{ steps.fqdn.outputs.cms_fqdn }}'
           URL="https://${FQDN}/healthz"
           echo "Polling $URL — expecting version $EXPECTED ..."

--- a/scripts/resolve_deploy_version.py
+++ b/scripts/resolve_deploy_version.py
@@ -1,0 +1,178 @@
+"""Resolve and pre-flight a Goodwill deploy version.
+
+Reads the requested version from the environment variable INPUT_VERSION:
+
+* If INPUT_VERSION is empty or ``auto`` (case-insensitive), discover the
+  highest semver tag that exists in **all** of the three GHCR repos
+  agora-cms, agora-cms-mcp, and agora-worker, and use that.
+* Otherwise, use INPUT_VERSION verbatim.
+
+In either case, HEAD the manifest for each of the three image refs in
+GHCR. If any are missing, fail with the most recent co-versioned tags
+as a hint, so the operator (human or agent) sees the right answer next
+to the error message.
+
+The resolved version is written to ``$GITHUB_OUTPUT`` as
+``resolved_version=<x.y.z>`` so downstream steps can consume it
+without re-running this script. Designed to fail fast in CI well
+before Bicep gets handed bad image refs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Iterable
+
+ORG = "sslivins"
+REPOS = ("agora-cms", "agora-cms-mcp", "agora-worker")
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+# Accept common manifest media types so GHCR returns 200 on HEAD instead of
+# a 415 when negotiating content type for OCI vs. Docker manifests.
+MANIFEST_ACCEPT = ", ".join(
+    [
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    ]
+)
+
+_TOKENS: dict[str, str] = {}
+
+
+def _token(repo: str) -> str:
+    if repo not in _TOKENS:
+        url = f"https://ghcr.io/token?scope=repository:{ORG}/{repo}:pull"
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            _TOKENS[repo] = json.loads(resp.read())["token"]
+    return _TOKENS[repo]
+
+
+def fetch_tags(repo: str) -> list[str]:
+    """Return every tag in ``repo``, following GHCR's Link-header pagination.
+
+    The default tags/list response is alphabetical-ish and capped at 100
+    entries — both of those bit me when I tried to eyeball "the latest
+    tag" from a single page. Always paginate, then semver-sort
+    afterward.
+    """
+
+    tok = _token(repo)
+    tags: list[str] = []
+    url: str | None = f"https://ghcr.io/v2/{ORG}/{repo}/tags/list?n=1000"
+    while url:
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {tok}"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read())
+            tags.extend(body.get("tags") or [])
+            link = resp.headers.get("Link", "") or ""
+        m = re.search(r'<([^>]+)>;\s*rel="next"', link)
+        url = f"https://ghcr.io{m.group(1)}" if m else None
+    return tags
+
+
+def semver_only(tags: Iterable[str]) -> list[tuple[int, int, int, str]]:
+    """Filter ``tags`` down to ``X.Y.Z`` semver and return (major, minor, patch, tag)."""
+
+    out: list[tuple[int, int, int, str]] = []
+    for t in tags:
+        m = SEMVER_RE.match(t)
+        if m:
+            out.append((int(m.group(1)), int(m.group(2)), int(m.group(3)), t))
+    return out
+
+
+def manifest_exists(repo: str, version: str) -> bool:
+    tok = _token(repo)
+    url = f"https://ghcr.io/v2/{ORG}/{repo}/manifests/{version}"
+    req = urllib.request.Request(
+        url,
+        method="HEAD",
+        headers={"Authorization": f"Bearer {tok}", "Accept": MANIFEST_ACCEPT},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403, 404):
+            return False
+        raise
+
+
+def co_versioned_tags() -> list[tuple[int, int, int, str]]:
+    """Return semver tags present in **all** three repos, ascending."""
+
+    per_repo = {repo: {t for *_, t in semver_only(fetch_tags(repo))} for repo in REPOS}
+    common = set.intersection(*per_repo.values()) if per_repo else set()
+    return sorted(semver_only(common))
+
+
+def _emit_output(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        # Not running under GH Actions — print so a human invoker can see it.
+        print(f"{name}={value}")
+        return
+    with open(out, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    requested = (os.environ.get("INPUT_VERSION") or "").strip()
+    auto = requested.lower() in ("", "auto")
+
+    if auto:
+        print(f"::group::Resolving latest co-versioned tag across {', '.join(REPOS)}")
+        common = co_versioned_tags()
+        if not common:
+            print("::error::No co-versioned semver tag found across all three repos")
+            return 1
+        resolved = common[-1][3]
+        print(f"  Intersection size: {len(common)} co-versioned semver tags")
+        print(f"  Resolved version : {resolved}")
+        print("::endgroup::")
+    else:
+        resolved = requested
+        print(f"Using pinned version: {resolved}")
+
+    print("::group::Verifying GHCR manifests for resolved version")
+    missing: list[str] = []
+    for repo in REPOS:
+        ref = f"ghcr.io/{ORG}/{repo}:{resolved}"
+        if manifest_exists(repo, resolved):
+            print(f"  OK   {ref}")
+        else:
+            print(f"  MISS {ref}")
+            missing.append(repo)
+    print("::endgroup::")
+
+    if missing:
+        print(
+            "::error::version "
+            f"{resolved} is missing from: {', '.join(missing)}. "
+            "All three images must be present at the same tag — "
+            "check the most recent successful 'Publish & Deploy' run on main, "
+            "or rerun this workflow with version=auto."
+        )
+        print("::group::Most recent 10 co-versioned tags (any of these would deploy)")
+        try:
+            for *_, t in reversed(co_versioned_tags()[-10:]):
+                print(f"  {t}")
+        except Exception as e:  # pragma: no cover - best-effort hint
+            print(f"  (failed to compute hint: {e})")
+        print("::endgroup::")
+        return 1
+
+    _emit_output("resolved_version", resolved)
+    print(f"resolved_version={resolved}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Workflow_dispatch previously took a free-form `version` string with no validation that the tag actually existed on **all three** paired GHCR repos (`agora-cms`, `agora-cms-mcp`, `agora-worker`). Earlier today a deploy attempt with `version=1.25.0` failed 4 minutes into Bicep with `MANIFEST_UNKNOWN` because `agora-worker:1.25.0` doesn't exist — the tag was picked off the first page of agora-cms's GHCR tags list, which is sorted roughly alphabetically (1.4 sorts after 1.37) and paginated.

## Two paired changes

1. **`version: auto` (now the default)** resolves to the highest semver tag present in **all three** GHCR repos. Paginates `/v2/<repo>/tags/list` properly (Link headers, `?n=1000`) and semver-sorts before picking the max. Verified locally: 213 co-versioned tags across the three repos, resolved value is `1.37.202`.

2. **Pre-flight HEAD on every image manifest**, before Azure login, before Bicep. A missing tag now fails in ~5 seconds with the top 10 co-versioned tags listed in the error so the operator/agent sees the right answer next to the error. Verified locally with `INPUT_VERSION=1.25.0`: catches the missing `agora-worker:1.25.0` immediately, exits 1 with a hint list ending in `1.37.202`.

## Verify-job wiring

The verify job's `/healthz` version assertion now reads `needs.deploy.outputs.resolved_version` instead of `inputs.version`, so `auto` still produces a concrete value to assert against — no mutable `:latest` semantics introduced.

## Implementation notes

- Resolver is a 178-line Python stdlib script (`scripts/resolve_deploy_version.py`) — no external deps, no pyyaml, just `urllib` + `re` + `json`. Lives next to the other CI helpers.
- Step runs **before** `azure/login` so a bad version doesn't burn an Azure token before failing.
- Existing pinned-version flow still works: type `1.37.202` (or any other valid tag), the pre-flight verifies it, the deploy proceeds.

## Local smoke-test transcript

```
INPUT_VERSION=auto     -> resolved 1.37.202 (intersection of 213 tags), all 3 manifests OK, exit 0
INPUT_VERSION=1.25.0   -> resolved 1.25.0, MISS agora-worker:1.25.0, exit 1 with hint
INPUT_VERSION=1.37.202 -> resolved 1.37.202, all 3 manifests OK, exit 0
```