### PR TITLE
bundle_checker: follow redirects on meta.json fetch + populate _last_error

### DIFF
--- a/cms/services/bundle_checker.py
+++ b/cms/services/bundle_checker.py
@@ -177,21 +177,32 @@ async def _fetch_latest_bundle() -> Optional[BundleInfo]:
     meta.json).  Caller decides whether to keep the prior cache value
     or treat as unknown.
     """
+    global _last_error
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
+        # follow_redirects=True is REQUIRED: GitHub release-asset
+        # browser_download_url endpoints always 302 to the actual blob
+        # storage URL on objects.githubusercontent.com.  Without this
+        # flag every meta.json fetch returns HTTP 302 and check_now()
+        # silently returns None -- the UI then shows "latest version:
+        # unknown" with no clue why.
+        async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
             resp = await client.get(
                 AGORA_OS_RELEASES_URL,
                 params={"per_page": 10},
                 headers=_gh_headers(),
             )
             if resp.status_code != 200:
-                logger.warning("GitHub API /releases returned %d", resp.status_code)
+                msg = f"GitHub API /releases returned {resp.status_code}"
+                logger.warning(msg)
+                _last_error = msg
                 return None
             releases = resp.json()
 
             non_draft = [r for r in releases if not r.get("draft")]
             if not non_draft:
-                logger.debug("No non-draft agora-os releases found")
+                msg = "No non-draft agora-os releases found"
+                logger.debug(msg)
+                _last_error = msg
                 return None
             non_draft.sort(key=lambda r: r.get("published_at") or "", reverse=True)
             release = non_draft[0]
@@ -203,33 +214,35 @@ async def _fetch_latest_bundle() -> Optional[BundleInfo]:
             meta_asset = next((a for a in assets if _BUNDLE_META_RE.match(a["name"])), None)
 
             if not bundle_asset or not sig_asset or not meta_asset:
-                logger.warning(
-                    "Release %s missing required assets (bundle=%s sig=%s meta=%s)",
-                    release.get("tag_name"),
-                    bool(bundle_asset),
-                    bool(sig_asset),
-                    bool(meta_asset),
+                msg = (
+                    f"Release {release.get('tag_name')!r} missing required assets "
+                    f"(bundle={bool(bundle_asset)} sig={bool(sig_asset)} meta={bool(meta_asset)})"
                 )
+                logger.warning(msg)
+                _last_error = msg
                 return None
 
             meta_resp = await client.get(meta_asset["browser_download_url"], headers=_gh_headers())
             if meta_resp.status_code != 200:
-                logger.warning(
-                    "Failed to fetch meta.json for %s: HTTP %d",
-                    release.get("tag_name"),
-                    meta_resp.status_code,
+                msg = (
+                    f"Failed to fetch meta.json for {release.get('tag_name')!r}: "
+                    f"HTTP {meta_resp.status_code}"
                 )
+                logger.warning(msg)
+                _last_error = msg
                 return None
             meta = meta_resp.json()
 
             target_version = meta.get("version") or (release.get("tag_name") or "").lstrip("v")
             min_from_version = meta.get("min_from_version")
             if not target_version or not min_from_version:
-                logger.warning(
-                    "Release %s meta.json missing version/min_from_version: %r",
-                    release.get("tag_name"),
-                    {k: meta.get(k) for k in ("version", "min_from_version")},
+                meta_subset = {k: meta.get(k) for k in ("version", "min_from_version")}
+                msg = (
+                    f"Release {release.get('tag_name')!r} meta.json missing version/"
+                    f"min_from_version: {meta_subset!r}"
                 )
+                logger.warning(msg)
+                _last_error = msg
                 return None
 
             return BundleInfo(
@@ -245,7 +258,6 @@ async def _fetch_latest_bundle() -> Optional[BundleInfo]:
     except Exception as exc:
         logger.debug("Failed to fetch latest agora-os bundle", exc_info=True)
         # Preserve last_error so the debug endpoint surfaces stale polls.
-        global _last_error
         _last_error = f"{type(exc).__name__}: {exc}"
         return None
 

--- a/tests/test_bundle_checker.py
+++ b/tests/test_bundle_checker.py
@@ -198,3 +198,152 @@ class TestGetLatestOsVersion:
             assert bundle_checker.get_latest_os_version() == "0.0.17-test"
         finally:
             bundle_checker._latest_bundle = original
+
+
+@pytest.mark.asyncio
+class TestFetchLatestBundleFollowsRedirects:
+    """Regression tests for the GitHub-asset 302 redirect bug.
+
+    GitHub's release-asset ``browser_download_url`` endpoints always
+    302 to a one-time-signed URL on ``objects.githubusercontent.com``.
+    httpx defaults to **not** following redirects (unlike ``requests``),
+    so without ``follow_redirects=True`` every meta.json fetch silently
+    failed and the UI's "Check for updates" toast read
+    ``"Latest version: unknown"`` with no diagnostic.
+    """
+
+    async def test_meta_json_302_is_followed(self):
+        import json
+        import httpx
+        from cms.services import bundle_checker
+
+        releases_url = bundle_checker.AGORA_OS_RELEASES_URL
+        meta_redirect_url = "https://github.com/sslivins/agora-os/releases/download/v0.0.21-test/meta.json"
+        meta_blob_url = "https://objects.githubusercontent.com/blob/meta.json?token=stub"
+
+        meta_body = {
+            "version": "0.0.21-test",
+            "min_from_version": "0.0.0",
+            "sha256": "deadbeef",
+            "size_bytes": 12345,
+        }
+        release_body = [
+            {
+                "id": 999,
+                "tag_name": "v0.0.21-test",
+                "draft": False,
+                "prerelease": True,
+                "published_at": "2026-05-15T12:00:00Z",
+                "assets": [
+                    {
+                        "name": "agora-bundle-0.0.21-test.tar.zst",
+                        "browser_download_url": "https://github.com/sslivins/agora-os/releases/download/v0.0.21-test/agora-bundle-0.0.21-test.tar.zst",
+                        "size": 12345,
+                    },
+                    {
+                        "name": "agora-bundle-0.0.21-test.tar.zst.minisig",
+                        "browser_download_url": "https://github.com/sslivins/agora-os/releases/download/v0.0.21-test/agora-bundle-0.0.21-test.tar.zst.minisig",
+                        "size": 100,
+                    },
+                    {
+                        "name": "agora-bundle-0.0.21-test.tar.zst.sha256",
+                        "browser_download_url": "https://github.com/sslivins/agora-os/releases/download/v0.0.21-test/agora-bundle-0.0.21-test.tar.zst.sha256",
+                        "size": 80,
+                    },
+                    {
+                        "name": "agora-bundle-0.0.21-test.meta.json",
+                        "browser_download_url": meta_redirect_url,
+                        "size": 200,
+                    },
+                ],
+            }
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url).startswith(releases_url):
+                return httpx.Response(200, json=release_body)
+            if str(request.url) == meta_redirect_url:
+                # Simulate GitHub's behaviour: 302 to a signed blob URL.
+                return httpx.Response(302, headers={"location": meta_blob_url})
+            if str(request.url) == meta_blob_url:
+                return httpx.Response(200, json=meta_body)
+            return httpx.Response(404, text=f"unexpected URL {request.url}")
+
+        transport = httpx.MockTransport(handler)
+
+        # Monkey-patch httpx.AsyncClient so the production code path uses
+        # the mock transport, but otherwise runs unmodified -- crucially
+        # this exercises the real ``follow_redirects`` argument.
+        real_async_client = httpx.AsyncClient
+
+        def factory(*args, **kwargs):
+            kwargs["transport"] = transport
+            return real_async_client(*args, **kwargs)
+
+        # Reset module state so we can assert _last_error.
+        original_last_error = bundle_checker._last_error
+        bundle_checker._last_error = None
+        try:
+            with patch.object(bundle_checker.httpx, "AsyncClient", side_effect=factory):
+                result = await bundle_checker._fetch_latest_bundle()
+            assert result is not None, (
+                f"expected fetcher to follow the meta.json 302; got None. "
+                f"_last_error={bundle_checker._last_error!r}"
+            )
+            assert result.target_version == "0.0.21-test"
+            assert result.min_from_version == "0.0.0"
+            assert bundle_checker._last_error is None
+        finally:
+            bundle_checker._last_error = original_last_error
+
+    async def test_meta_json_non_200_sets_last_error(self):
+        """Defensive: when meta.json returns a real non-200 (after any
+        redirects), _last_error must be populated so get_status() can
+        surface it via the debug endpoint. Previously this path only
+        emitted a logger.warning and left _last_error=None, which made
+        the failure invisible to operators."""
+        import httpx
+        from cms.services import bundle_checker
+
+        releases_url = bundle_checker.AGORA_OS_RELEASES_URL
+        meta_url = "https://github.com/sslivins/agora-os/releases/download/v0.0.21-test/meta.json"
+
+        release_body = [
+            {
+                "id": 999,
+                "tag_name": "v0.0.21-test",
+                "draft": False,
+                "prerelease": True,
+                "published_at": "2026-05-15T12:00:00Z",
+                "assets": [
+                    {"name": "agora-bundle-0.0.21-test.tar.zst", "browser_download_url": "https://x/a.tar.zst", "size": 1},
+                    {"name": "agora-bundle-0.0.21-test.tar.zst.minisig", "browser_download_url": "https://x/a.minisig", "size": 1},
+                    {"name": "agora-bundle-0.0.21-test.meta.json", "browser_download_url": meta_url, "size": 1},
+                ],
+            }
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url).startswith(releases_url):
+                return httpx.Response(200, json=release_body)
+            if str(request.url) == meta_url:
+                return httpx.Response(500, text="boom")
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
+
+        def factory(*args, **kwargs):
+            kwargs["transport"] = transport
+            return real_async_client(*args, **kwargs)
+
+        original_last_error = bundle_checker._last_error
+        bundle_checker._last_error = None
+        try:
+            with patch.object(bundle_checker.httpx, "AsyncClient", side_effect=factory):
+                result = await bundle_checker._fetch_latest_bundle()
+            assert result is None
+            assert bundle_checker._last_error is not None
+            assert "500" in bundle_checker._last_error
+        finally:
+            bundle_checker._last_error = original_last_error


### PR DESCRIPTION
## What

`bundle_checker._fetch_latest_bundle()` now:

1. Creates its `httpx.AsyncClient` with `follow_redirects=True`.
2. Sets `_last_error` in every failure path (5 sites), not only the catch-all `except`.

Adds 2 regression tests using `httpx.MockTransport` that exercise the real
production code path (no `_fetch_latest_bundle` mock — that's why this
bug shipped).

## Why

Clicking "Check for updates" in the CMS UI on Pi100 showed
`Latest version: unknown` with no diagnostic. Live probe of the
`agoragw-cms` Container Apps revision via `az containerapp exec` got:

```
Failed to fetch meta.json for v0.0.21-test: HTTP 302
```

Root cause: `httpx` (unlike `requests`) does **not** follow redirects by
default. Every GitHub release-asset `browser_download_url` ALWAYS 302s
to a one-time-signed URL on `objects.githubusercontent.com`. Without
`follow_redirects=True`, every `meta.json` fetch hit a 302 → tripped the
`if status_code != 200` guard → returned `None` → CMS never cached a
latest version.

A separate observability gap made the failure invisible: the 4 non-200
/missing-asset / bad-meta paths only emitted `logger.warning(...)` and
returned. `_last_error` was set only in the catch-all `except Exception`,
so the first `get_status()` probe came back with `last_error=null` and
hid the real problem behind apparent silence. All 4 paths now write
`_last_error` so the `/api/debug/bundle-checker` endpoint surfaces the
actual reason on subsequent probes.

## Test coverage

`tests/test_bundle_checker.py` had 17 tests, all of which mocked
`_fetch_latest_bundle` directly — exercising none of the httpx code path
where the bug lived. The 2 new tests in `TestFetchLatestBundleFollowsRedirects`
use `httpx.MockTransport` injected via a factory wrapper around
`httpx.AsyncClient`, so the production code's `follow_redirects=True`
argument is what's actually under test.

Verified the 302 test fails against the pre-fix code (temporarily
reverted `follow_redirects=True` locally — test goes red, restore →
green).

Broader regression: `pytest tests/test_bundle_checker.py
tests/test_devices.py tests/test_devices_phase_d_coverage.py
tests/test_device_live_updates.py` = **121 passed**.

## Risks

Low. Following redirects on `httpx.AsyncClient` is the same default
behavior as `requests`, the rest of the CMS already assumes works (e.g.
the imager catalog download). Adding `_last_error` writes to existing
warning paths doesn't change observable behavior — it makes operators
able to see what's wrong.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
