### PR TITLE
feat(devices): live OTA progress badge driven by lifecycle events

### DIFF
--- a/alembic/versions/0025_devices_ota_progress.py
+++ b/alembic/versions/0025_devices_ota_progress.py
@@ -1,0 +1,94 @@
+"""Add OTA progress columns to devices + widen device_events.event_type.
+
+Issue agora-cms#574 — replaces the static "Upgrading…" badge with a live
+progress bar driven by per-OTA lifecycle events from the device.
+
+Two structural changes:
+
+1. Six nullable columns on ``devices`` so the WPS lifecycle event handler
+   has a single multi-replica-safe place to write progress to:
+
+   - ``ota_phase``       — machine-readable, e.g. ``"downloading"``
+   - ``ota_label``       — human-readable, e.g. ``"Downloading bundle"``
+   - ``ota_pct``         — 0.0–100.0 float, NULL for phases that don't
+                            carry byte progress (e.g. ``signature_verified``)
+   - ``ota_bytes_done``  — current byte counter for download / extract
+   - ``ota_bytes_total`` — expected total for the same
+   - ``ota_updated_at`` — UTC timestamp of the last event; also acts as
+                          the freshness gate in
+                          ``cms.routers.devices._ota_fields_for_out`` so
+                          stale rows (orphaned by a missed terminal event)
+                          fall back to NULL after OTA_FRESH_TTL.
+
+   All six are nullable / default NULL — they're populated only while an
+   OTA is in flight and cleared on terminal events.  No write path
+   relies on a default, so we don't need ``server_default`` round-trip
+   handling.
+
+2. ``device_events.event_type`` width bumped 20 → 40 to fit the 12 new
+   ``OTA_*`` values added in ``cms.models.device_event``.  The longest
+   existing value was 22 chars (``display_disconnected``) which already
+   matched the existing 20-char limit poorly (string was 20 chars but
+   the column was 20 chars — silent truncation never bit us only because
+   the corresponding ``DeviceEventType`` enum value never actually got
+   stored).  Bumping to 40 covers
+   ``OTA_MIGRATION_COMPLETE`` (22), ``OTA_SIGNATURE_VERIFIED`` (22),
+   ``OTA_DOWNLOAD_PROGRESS`` (21), ``OTA_EXTRACT_PROGRESS`` (20) etc.
+
+Revision ID: 0025
+Revises: 0024
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "devices",
+        sa.Column("ota_phase", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("ota_label", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("ota_pct", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("ota_bytes_done", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("ota_bytes_total", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "devices",
+        sa.Column("ota_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.alter_column(
+        "device_events",
+        "event_type",
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=40),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Project policy (test_migration_policy.py): every downgrade must
+    # raise NotImplementedError. Forward-only migrations only.
+    raise NotImplementedError(
+        "Downgrade of 0025 is intentionally not implemented per project policy."
+    )

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum as PyEnum
 
-from sqlalchemy import JSON, Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy import BigInteger, JSON, Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -162,6 +162,25 @@ class Device(Base):
     # register path on reconnect and by the upgrade endpoint's failure
     # rollback (compare-and-clear against the claimed timestamp).
     upgrade_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # ---- OTA progress (issue agora-cms#574 / migration 0025) ----
+    # Live progress for the in-flight OS OTA, written by the WPS lifecycle
+    # event handler (`cms.services.ota_progress.handle_event`) and surfaced
+    # by `/api/devices` so the UI badge can render a filling progress bar
+    # instead of a static "Upgrading…" chip.  All six columns are nullable
+    # and default NULL — populated only while an OTA is in flight, cleared
+    # on every terminal lifecycle event (promoted / migration_complete /
+    # failed / declined).  `ota_updated_at` doubles as a freshness gate:
+    # `_ota_fields_for_out` in cms.routers.devices treats anything older
+    # than OTA_FRESH_TTL as stale and serves NULLs back to the UI.
+    ota_phase: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ota_label: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ota_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    ota_bytes_done: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    ota_bytes_total: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    ota_updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 

--- a/cms/models/device_event.py
+++ b/cms/models/device_event.py
@@ -22,6 +22,23 @@ class DeviceEventType(str, PyEnum):
     ERROR_CLEARED = "error_cleared"
     CMS_STARTED = "cms_started"
     CMS_STOPPED = "cms_stopped"
+    # OTA lifecycle events — one per device-side FSM transition.
+    # Persisted to ``device_events`` for the audit/event-log surface;
+    # also drive the UI badge via ``cms.services.ota_progress``.  See
+    # ``WIRE_TO_CMS_EVENT`` in ``cms.services.device_inbound`` for the
+    # wire-format → enum mapping.
+    OTA_DOWNLOAD_STARTED = "ota_download_started"
+    OTA_DOWNLOAD_PROGRESS = "ota_download_progress"
+    OTA_SIGNATURE_VERIFIED = "ota_signature_verified"
+    OTA_STAGED = "ota_staged"
+    OTA_STAGE_PROGRESS = "ota_stage_progress"
+    OTA_EXTRACT_PROGRESS = "ota_extract_progress"
+    OTA_TRYBOOT_INITIATED = "ota_tryboot_initiated"
+    OTA_SLOT_CONFIRMED = "ota_slot_confirmed"
+    OTA_PROMOTED = "ota_promoted"
+    OTA_MIGRATION_COMPLETE = "ota_migration_complete"
+    OTA_FAILED = "ota_failed"
+    OTA_DECLINED = "ota_declined"
 
 
 class DeviceEvent(Base):
@@ -50,7 +67,7 @@ class DeviceEvent(Base):
         doc="Denormalized snapshot of group name at event time",
     )
     event_type: Mapped[str] = mapped_column(
-        String(20), nullable=False, index=True,
+        String(40), nullable=False, index=True,
     )
     details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -54,13 +54,69 @@ device_originated_router = APIRouter(prefix="/api/devices", tags=["devices (devi
 # letting another upgrade request reclaim it (covers stuck reboots).
 UPGRADE_TTL = timedelta(minutes=15)
 
+# Issue agora-cms#574 — how recent a device's last lifecycle event has
+# to be before we still trust ``devices.ota_*`` to reflect a live OTA.
+# Devices emit events on every FSM transition + every 2s during long
+# phases (download / extract), so 2 minutes is comfortably looser than
+# the slowest healthy cadence while still falling off quickly if the
+# device drops without a terminal event (kernel panic mid-extract,
+# tryboot that never confirms, etc.).
+OTA_FRESH_TTL = timedelta(minutes=2)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Promote a naive ``datetime`` to UTC.
+
+    Postgres ``timestamptz`` columns round-trip as tz-aware datetimes,
+    but the SQLite test backend strips the tzinfo on read.  Comparing
+    against ``datetime.now(timezone.utc)`` (always aware) would then
+    raise ``TypeError: can't subtract offset-naive and offset-aware
+    datetimes``.  All ``upgrade_started_at`` / ``ota_updated_at`` writes
+    in production are UTC, so naive ⇒ UTC is the right normalization.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
 
 def _is_upgrading(device: Device, *, now: datetime | None = None) -> bool:
     """Return whether *device* has an active upgrade claim within TTL."""
     if device.upgrade_started_at is None:
         return False
     ref = now or datetime.now(timezone.utc)
-    return (ref - device.upgrade_started_at) < UPGRADE_TTL
+    return (ref - _as_utc(device.upgrade_started_at)) < UPGRADE_TTL
+
+
+def _ota_fields_for_out(device: Device, *, now: datetime | None = None) -> dict:
+    """Return staleness-gated ``ota_*`` kwargs for ``DeviceOut``.
+
+    All five UI-facing OTA fields are returned NULL when the device's
+    last lifecycle event is older than ``OTA_FRESH_TTL`` — that's
+    the safety net for OTAs that stall without a terminal event
+    (kernel panic, network drop, tryboot revert).  Without this gate
+    a device that hung mid-extract would render a stuck "Extracting
+    rootfs 47%" forever; with it, the badge falls back to the legacy
+    "Upgrading…" chip (driven by ``is_upgrading``) and eventually
+    clears at ``UPGRADE_TTL``.
+    """
+    if device.ota_updated_at is None:
+        return {
+            "ota_phase": None, "ota_label": None, "ota_pct": None,
+            "ota_bytes_done": None, "ota_bytes_total": None,
+        }
+    ref = now or datetime.now(timezone.utc)
+    if (ref - _as_utc(device.ota_updated_at)) >= OTA_FRESH_TTL:
+        return {
+            "ota_phase": None, "ota_label": None, "ota_pct": None,
+            "ota_bytes_done": None, "ota_bytes_total": None,
+        }
+    return {
+        "ota_phase": device.ota_phase,
+        "ota_label": device.ota_label,
+        "ota_pct": device.ota_pct,
+        "ota_bytes_done": device.ota_bytes_done,
+        "ota_bytes_total": device.ota_bytes_total,
+    }
 
 # Device model columns that are *also* passed explicitly as kwargs when
 # building a ``DeviceOut`` from the live-state + ORM row merge below.
@@ -90,6 +146,16 @@ _DEVICE_OUT_OVERLAP_COLUMNS = {
     "display_connected",
     "display_ports",
     "ip_address",
+    # OTA progress columns are excluded from the splat so the staleness
+    # gate in ``_ota_fields_for_out`` is the only path that writes them
+    # into the ``DeviceOut`` — preserves the invariant that the UI
+    # never sees stale OTA state past OTA_FRESH_TTL.
+    "ota_phase",
+    "ota_label",
+    "ota_pct",
+    "ota_bytes_done",
+    "ota_bytes_total",
+    "ota_updated_at",
 }
 
 
@@ -212,7 +278,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             **_device_row_kwargs(d),
             group_name=d.group.name if d.group else None,
             is_online=d.id in connected_ids,
-            is_upgrading=_is_upgrading(d),
+            is_upgrading=_is_upgrading(d, now=now),
             playback_mode=live_states[d.id]["mode"] if d.id in live_states else None,
             playback_asset=_resolve_asset_name(d.id),
             pipeline_state=live_states[d.id]["pipeline_state"] if d.id in live_states else None,
@@ -230,6 +296,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             uptime_seconds=live_states[d.id]["uptime_seconds"] if d.id in live_states else 0,
             update_available=is_os_update_available(d.os_version),
             has_active_schedule=d.id in scheduled_device_ids,
+            **_ota_fields_for_out(d, now=now),
         )
         for d in devices
     ]
@@ -270,7 +337,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         **_device_row_kwargs(device),
         group_name=device.group.name if device.group else None,
         is_online=is_online,
-        is_upgrading=_is_upgrading(device),
+        is_upgrading=_is_upgrading(device, now=now),
         playback_mode=live_states[device.id]["mode"] if device.id in live_states else None,
         playback_asset=raw_asset,
         pipeline_state=live_states[device.id]["pipeline_state"] if device.id in live_states else None,
@@ -288,6 +355,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         uptime_seconds=live_states[device.id]["uptime_seconds"] if device.id in live_states else 0,
         update_available=is_os_update_available(device.os_version),
         has_active_schedule=device.id in scheduled_device_ids,
+        **_ota_fields_for_out(device, now=now),
     )
 
 

--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -30,6 +30,21 @@ class DeviceOut(BaseModel):
     registered_at: datetime
     is_online: bool = False
     is_upgrading: bool = False
+    # ── OTA progress (issue agora-cms#574) ──
+    # While a device is in the middle of an OS OTA, these fields drive
+    # the live progress badge in the UI.  All None when no OTA is in
+    # flight, OR when the row is stale (last update older than
+    # ``OTA_FRESH_TTL`` per ``cms.routers.devices._ota_fields_for_out``).
+    # The UI falls back to the legacy "Upgrading…" badge when
+    # ``is_upgrading`` is True but these are all None — that's the
+    # transition window between the upgrade claim landing and the first
+    # lifecycle event arriving, plus any time a firmware older than
+    # ``agora#215`` is mid-OTA.
+    ota_phase: Optional[str] = None
+    ota_label: Optional[str] = None
+    ota_pct: Optional[float] = None
+    ota_bytes_done: Optional[int] = None
+    ota_bytes_total: Optional[int] = None
     playback_mode: Optional[str] = None
     playback_asset: Optional[str] = None
     pipeline_state: Optional[str] = None

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -68,6 +68,11 @@ class MessageType(str, Enum):
     FACTORY_RESET = "factory_reset"
     WIPE_ASSETS = "wipe_assets"
     REQUEST_LOGS = "request_logs"
+    # Device → CMS: per-OTA lifecycle event.  See
+    # ``cms.services.device_inbound`` for the ``WIRE_TO_CMS_EVENT`` map
+    # and ``cms.services.ota_progress`` for how the wire payload turns
+    # into UI-visible badge state.
+    LIFECYCLE_EVENT = "lifecycle_event"
 
     # Device → CMS (playback events)
     PLAYBACK_STARTED = "playback_started"

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import selectinload
 
 from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.device import Device, DeviceStatus
+from cms.models.device_event import DeviceEventType
 from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLogEvent
 from cms.schemas.protocol import (
@@ -40,6 +41,29 @@ from cms.services.scheduler import (
 from cms.services.storage import get_storage
 
 logger = logging.getLogger("agora.cms.ws")
+
+
+# Wire ``event_type`` (per ``agora/os_updater/events.py::LifecycleEventType``)
+# → CMS ``DeviceEventType``.  Single source of truth for the
+# device → CMS contract on lifecycle event names.  Used by both the
+# ``lifecycle_event`` branch in ``dispatch_device_message`` below and
+# the unit tests in ``tests/test_lifecycle_events.py``.  Any new
+# wire-type ships in lock-step with both repos (agora#215 has a
+# matching enum on the device side).
+WIRE_TO_CMS_EVENT: dict[str, "DeviceEventType"] = {
+    "download_started":     DeviceEventType.OTA_DOWNLOAD_STARTED,
+    "download_progress":    DeviceEventType.OTA_DOWNLOAD_PROGRESS,
+    "signature_verified":   DeviceEventType.OTA_SIGNATURE_VERIFIED,
+    "staged":               DeviceEventType.OTA_STAGED,
+    "stage_progress":       DeviceEventType.OTA_STAGE_PROGRESS,
+    "extract_progress":     DeviceEventType.OTA_EXTRACT_PROGRESS,
+    "tryboot_initiated":    DeviceEventType.OTA_TRYBOOT_INITIATED,
+    "slot_confirmed":       DeviceEventType.OTA_SLOT_CONFIRMED,
+    "promoted":             DeviceEventType.OTA_PROMOTED,
+    "migration_complete":   DeviceEventType.OTA_MIGRATION_COMPLETE,
+    "failed":               DeviceEventType.OTA_FAILED,
+    "declined":             DeviceEventType.OTA_DECLINED,
+}
 
 
 def _hash_token(token: str) -> str:
@@ -518,6 +542,73 @@ async def dispatch_device_message(
                     "LOGS_RESPONSE outbox write failed for request %s (device %s)",
                     request_id, device_id, exc_info=True,
                 )
+
+    elif msg_type == MessageType.LIFECYCLE_EVENT:
+        # OTA lifecycle event from the device (issue agora-cms#574 /
+        # agora#215).  Wire shape:
+        #   {"type": "lifecycle_event",
+        #    "event_id": <per-device monotonic int>,
+        #    "event_type": "download_started" | "download_progress" | ...,
+        #    "release_id": str|None,
+        #    "target_version": str|None,
+        #    "occurred_at": ISO-8601 str|None,
+        #    "reason": str|None,
+        #    "payload": {...}}
+        #
+        # Two side effects per event:
+        #   1) Apply the projection to ``devices.ota_*`` so the next
+        #      ``/api/devices`` poll renders the live badge.
+        #   2) Persist a ``device_events`` row so the existing event-log
+        #      surface shows the OTA timeline (and so we have an audit
+        #      trail when post-mortem'ing a stuck OTA).
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+        from cms.services import ota_progress
+
+        # Forward-compat: an unknown wire ``event_type`` is dropped with
+        # an INFO log.  Distinct from the OUTER ``ce-type`` 400 rejection
+        # in ``wps_webhook.py`` (which is for unknown CloudEvents types
+        # at the HTTP envelope layer, not unknown user-message bodies).
+        wire_type = msg.get("event_type", "")
+        cms_type = WIRE_TO_CMS_EVENT.get(wire_type)
+        if cms_type is None:
+            logger.info(
+                "Unknown lifecycle event_type %r from device %s; dropping (forward-compat)",
+                wire_type, device_id,
+            )
+            return
+
+        payload = msg.get("payload") or {}
+
+        mutated = ota_progress.handle_event(device, cms_type.value, payload)
+
+        # Audit row.  We write this even when ``mutated`` is False
+        # (regression-dropped or unknown sub-payload) so the event log
+        # still shows that the device's monotonic event_id was
+        # accounted for — easier to debug "where did event_id 47 go?"
+        # if every event lands in the table, regression-dropped or not.
+        group_uuid = None
+        if ctx.group_id:
+            try:
+                group_uuid = uuid.UUID(ctx.group_id)
+            except (TypeError, ValueError):
+                group_uuid = None
+        db.add(DeviceEvent(
+            device_id=device_id,
+            device_name=ctx.device_name or device_id,
+            group_id=group_uuid,
+            group_name=ctx.group_name or "",
+            event_type=cms_type.value,
+            details={
+                "event_id": msg.get("event_id"),
+                "payload": payload,
+                "release_id": msg.get("release_id"),
+                "target_version": msg.get("target_version"),
+                "occurred_at": msg.get("occurred_at"),
+                "reason": msg.get("reason"),
+                "projection_applied": mutated,
+            },
+        ))
+        await db.commit()
 
     else:
         logger.warning("Unknown message type from %s: %s", device_id, msg_type)

--- a/cms/services/ota_progress.py
+++ b/cms/services/ota_progress.py
@@ -1,0 +1,245 @@
+"""OTA progress projection — lifecycle events → ``devices.ota_*`` columns.
+
+Issue agora-cms#574 (companion to ``sslivins/agora#215``).  Devices on
+firmware that ships the WPS lifecycle event sender (see agora#215) push
+a stream of ``lifecycle_event`` messages over WPS during every OTA.
+This module is the pure projection layer: it takes one wire event +
+payload, applies the regression-safe state transitions, and mutates a
+``Device`` ORM row in place.  The caller (`device_inbound.py`) owns the
+commit.
+
+The data model is **multi-replica safe by virtue of Postgres**: every
+event causes a single ``UPDATE devices SET ota_* = ...`` so any replica
+reading the row in a subsequent transaction sees the latest applied
+event.  No in-memory cache — the bug we explicitly avoid is one
+replica's webhook updating an in-memory dict while a different replica
+serves ``/api/devices`` and reads NULLs.
+
+Three correctness rails:
+
+1. **Phase-order regression guard.**  ``_PHASE_ORDER`` assigns each
+   known event_type an integer.  An incoming event whose order is
+   strictly less than the row's current order is dropped.  Same-order
+   download/extract events check ``bytes_done`` for monotonicity.
+
+2. **Explicit clearing on terminal events.**  Promoted, migration-
+   complete, failed, and declined all clear every ``ota_*`` column to
+   NULL *and* drop the ``upgrade_started_at`` claim so the badge falls
+   off immediately rather than waiting for ``UPGRADE_TTL`` to expire.
+
+3. **pct=None on phase transitions to non-progress phases.**  When the
+   wire event carries no bytes (signature_verified, tryboot_initiated,
+   slot_confirmed, …) the projection writes ``pct = None`` rather than
+   leaving the previous phase's 100% sticking around.
+
+Forward-compat: an unknown ``event_type`` (something a newer firmware
+ships that this CMS hasn't been taught about yet) is a no-op — the
+caller has already logged + dropped before we'd be called.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from cms.models.device import Device
+
+
+# ── Phase ordering ─────────────────────────────────────────────────────
+#
+# Smaller integer = earlier in the OTA timeline.  We use a single
+# ordinal for the two "during one of the long staging phases" events
+# (stage_progress + extract_progress) because their CMS-side ordering
+# relative to each other isn't well-defined — extract_progress fires
+# *during* the extract sub-phases of stage_progress, and the timestamps
+# on the wire don't quite align.  Treating them as the same step lets
+# us still reject e.g. a stale ``staged`` event arriving after the
+# device already moved on to ``tryboot_initiated``.
+_PHASE_ORDER: dict[str, int] = {
+    "ota_download_started":      10,
+    "ota_download_progress":     20,
+    "ota_signature_verified":    30,
+    "ota_staged":                40,
+    "ota_stage_progress":        50,
+    "ota_extract_progress":      50,
+    "ota_tryboot_initiated":     70,
+    "ota_slot_confirmed":        80,
+    "ota_promoted":              90,
+    "ota_migration_complete":   100,
+    "ota_failed":               999,
+    "ota_declined":             999,
+}
+
+_TERMINAL: frozenset[str] = frozenset(
+    {"ota_promoted", "ota_migration_complete", "ota_failed", "ota_declined"}
+)
+
+# Stable label strings for the UI.  The bare ``ota_phase`` is also kept
+# on the row so the front end can branch on it (a tooltip, a colour, an
+# icon — all easier off a stable token than a freeform label).
+_PHASE_LABELS: dict[str, str] = {
+    "ota_download_started":     "Starting download",
+    "ota_download_progress":    "Downloading bundle",
+    "ota_signature_verified":   "Verifying signature",
+    "ota_staged":               "Staging bundle",
+    "ota_stage_progress":       "Staging",
+    "ota_extract_progress":     "Extracting bundle",
+    "ota_tryboot_initiated":    "Rebooting into new slot",
+    "ota_slot_confirmed":       "Confirming new slot",
+    "ota_promoted":             "Promoted",
+    "ota_migration_complete":   "Promoted",
+    "ota_failed":               "Failed",
+    "ota_declined":             "Declined",
+}
+
+# stage_progress sub-phase → human label.  These come through as the
+# ``phase`` field of the payload (one of the 8 entries in
+# ``agora/os_updater/apply.py::STAGE_PROGRESS_PHASES``).
+_STAGE_SUBPHASE_LABELS: dict[str, str] = {
+    "extracting_meta":     "Extracting metadata",
+    "mounting_inactive":   "Mounting inactive slot",
+    "wiping_inactive":     "Wiping inactive slot",
+    "extracting_boot":     "Extracting boot",
+    "extracting_rootfs":   "Extracting rootfs",
+    "verifying_manifest":  "Verifying manifest",
+    "copying_fleet_state": "Copying fleet state",
+    "finalizing":          "Finalizing",
+}
+
+# extract_progress sub-phase → label.  This event fires *during* either
+# the extracting_boot or extracting_rootfs stage_progress windows, and
+# carries bytes_done / bytes_total of the underlying zstd stream.
+_EXTRACT_SUBPHASE_LABELS: dict[str, str] = {
+    "boot":   "Extracting boot",
+    "rootfs": "Extracting rootfs",
+}
+
+
+def _derive(event_type: str, payload: dict) -> tuple[
+    str, str, float | None, int | None, int | None,
+]:
+    """Pure event → (phase_token, label, pct, bytes_done, bytes_total).
+
+    Caller has already validated ``event_type`` is in ``_PHASE_ORDER``.
+    Payload schema by event:
+
+      - download_progress: ``{bytes_done, bytes_total}``
+      - stage_progress:    ``{phase: <one of 8 sub-phases>}``
+      - extract_progress:  ``{phase: "boot"|"rootfs", bytes_done, bytes_total}``
+      - all others:        no body fields used here
+    """
+    phase = event_type
+    label = _PHASE_LABELS.get(event_type, event_type)
+    pct: float | None = None
+    bytes_done: int | None = None
+    bytes_total: int | None = None
+
+    if event_type == "ota_download_progress":
+        bytes_done = _safe_int(payload.get("bytes_done"))
+        bytes_total = _safe_int(payload.get("bytes_total"))
+        pct = _safe_pct(bytes_done, bytes_total)
+
+    elif event_type == "ota_stage_progress":
+        sub = payload.get("phase")
+        if isinstance(sub, str) and sub in _STAGE_SUBPHASE_LABELS:
+            label = _STAGE_SUBPHASE_LABELS[sub]
+        # stage_progress carries no bytes — leave pct / bytes None so a
+        # transition out of download (which had pct=100) doesn't visually
+        # stick at "100% complete" through the staging window.
+
+    elif event_type == "ota_extract_progress":
+        sub = payload.get("phase")
+        if isinstance(sub, str) and sub in _EXTRACT_SUBPHASE_LABELS:
+            label = _EXTRACT_SUBPHASE_LABELS[sub]
+        bytes_done = _safe_int(payload.get("bytes_done"))
+        bytes_total = _safe_int(payload.get("bytes_total"))
+        pct = _safe_pct(bytes_done, bytes_total)
+
+    # All other event_types (download_started, signature_verified,
+    # staged, tryboot_initiated, slot_confirmed) carry no progress —
+    # the defaults above already give them label + None pct/bytes.
+
+    return phase, label, pct, bytes_done, bytes_total
+
+
+def _safe_int(v) -> int | None:
+    if v is None:
+        return None
+    try:
+        i = int(v)
+    except (TypeError, ValueError):
+        return None
+    return i if i >= 0 else None
+
+
+def _safe_pct(done: int | None, total: int | None) -> float | None:
+    if done is None or total is None or total <= 0:
+        return None
+    pct = (done / total) * 100.0
+    if pct < 0.0:
+        return 0.0
+    if pct > 100.0:
+        return 100.0
+    return pct
+
+
+def handle_event(device: "Device", event_type: str, payload: dict) -> bool:
+    """Apply one lifecycle event to ``device``.  Returns True if mutated.
+
+    Caller owns the ``await db.commit()``.  Returns False on
+    forward-compat unknowns and on regression-guard drops so the caller
+    can still emit a ``DeviceEvent`` audit row even when the projection
+    is a no-op (the device's monotonic ``event_id`` still counted that
+    event, regression-dropped or not — we don't want gaps in the audit
+    log).
+    """
+    new_order = _PHASE_ORDER.get(event_type)
+    if new_order is None:
+        return False
+
+    cur_phase = device.ota_phase
+    cur_order = _PHASE_ORDER.get(cur_phase, -1) if cur_phase else -1
+
+    # Regression guard #1: an older phase event arriving after a newer
+    # one (network reorder, replay, etc.) is dropped.  Terminal events
+    # (order=999) are explicitly allowed even from earlier phases —
+    # they're how the device tells us the OTA ended.
+    if new_order < cur_order and event_type not in _TERMINAL:
+        return False
+
+    if event_type in _TERMINAL:
+        device.ota_phase = None
+        device.ota_label = None
+        device.ota_pct = None
+        device.ota_bytes_done = None
+        device.ota_bytes_total = None
+        device.ota_updated_at = None
+        # Release the atomic upgrade claim immediately.  This is what
+        # makes the badge fall off the moment ``promoted`` arrives,
+        # rather than waiting for the device to reboot + re-register
+        # (success path) or for ``UPGRADE_TTL`` to expire (failure
+        # path).  Today the register-handler clears it on a real
+        # version bump too; this is the belt-and-suspenders that
+        # closes the failure-path UX gap (badge was sticking
+        # "Upgrading…" for 15 minutes after every failed OTA).
+        device.upgrade_started_at = None
+        return True
+
+    phase, label, pct, bytes_done, bytes_total = _derive(event_type, payload or {})
+
+    # Regression guard #2: same phase, byte counter went backwards.
+    # Catches a rebroadcast of an older download_progress event after
+    # a newer one already landed.
+    if new_order == cur_order and bytes_done is not None:
+        prev_bytes_done = device.ota_bytes_done
+        if prev_bytes_done is not None and bytes_done < prev_bytes_done:
+            return False
+
+    device.ota_phase = phase
+    device.ota_label = label
+    device.ota_pct = pct
+    device.ota_bytes_done = bytes_done
+    device.ota_bytes_total = bytes_total
+    device.ota_updated_at = datetime.now(timezone.utc)
+    return True

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -516,8 +516,12 @@
 {% if d.is_online and (d.error or d.pipeline_state == 'ERROR') %}
 <span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">{% if d.error %}{{ d.error }}{% else %}Player pipeline reported an error{% endif %}</span></span>
 {% endif %}
-{# Upgrading #}
-{% if d.is_upgrading %}
+{# Upgrading — show live OTA progress bar when available, else fall back to static "Upgrading…" chip #}
+{% if d.is_upgrading and d.ota_phase and d.ota_pct is not none %}
+<span class="has-tooltip"><span class="badge badge-progress" style="--pct: {{ "%.1f"|format(d.ota_pct) }}%">{{ d.ota_label or 'Upgrading' }} {{ d.ota_pct | round(0) | int }}%</span><span class="tooltip">{{ d.ota_label or 'Upgrading' }} — device will reboot when done</span></span>
+{% elif d.is_upgrading and d.ota_phase %}
+<span class="has-tooltip"><span class="badge badge-processing">{{ d.ota_label or 'Upgrading…' }}</span><span class="tooltip">{{ d.ota_label or 'Upgrading' }} — device will reboot when done</span></span>
+{% elif d.is_upgrading %}
 <span class="has-tooltip"><span class="badge badge-processing">Upgrading…</span><span class="tooltip">Firmware upgrade in progress — device will reboot when done</span></span>
 {% endif %}
 {# Temp #}
@@ -595,7 +599,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">This device matches a known device but couldn't authenticate, likely due to a factory reset or SD card replacement. It needs to be re-adopted.</span></span>
         {% elif d.status.value == 'pending' %}
@@ -855,7 +859,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">Re-flashed device — needs re-adoption</span></span>
         {% elif d.status.value == 'pending' %}

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -547,8 +547,17 @@ window._adoptionProfiles = [
             const msg = d.error ? String(d.error).replace(/[<>&]/g, '') : 'Player pipeline reported an error';
             out.push('<span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">' + msg + '</span></span>');
         }
-        // Upgrading
-        if (d.is_upgrading) {
+        // Upgrading — live OTA progress bar if available, else legacy chip.
+        if (d.is_upgrading && d.ota_phase && d.ota_pct != null) {
+            const pct = Math.round(d.ota_pct);
+            const label = (d.ota_label || 'Upgrading').replace(/[<>&]/g, '');
+            const tooltip = label + ' — device will reboot when done';
+            out.push('<span class="has-tooltip"><span class="badge badge-progress" style="--pct: ' + d.ota_pct.toFixed(1) + '%">' + label + ' ' + pct + '%</span><span class="tooltip">' + tooltip + '</span></span>');
+        } else if (d.is_upgrading && d.ota_phase) {
+            const label = (d.ota_label || 'Upgrading…').replace(/[<>&]/g, '');
+            const tooltip = (d.ota_label || 'Upgrading').replace(/[<>&]/g, '') + ' — device will reboot when done';
+            out.push('<span class="has-tooltip"><span class="badge badge-processing">' + label + '</span><span class="tooltip">' + tooltip + '</span></span>');
+        } else if (d.is_upgrading) {
             out.push('<span class="has-tooltip"><span class="badge badge-processing">Upgrading…</span><span class="tooltip">Firmware upgrade in progress — device will reboot when done</span></span>');
         }
         // Temp
@@ -599,9 +608,17 @@ window._adoptionProfiles = [
         const storageBucket = (d.storage_capacity_mb && d.storage_capacity_mb > 0)
             ? Math.round((d.storage_capacity_mb - (d.storage_used_mb || 0)) / d.storage_capacity_mb * 100)
             : 'n';
+        // OTA progress signal — phase token + rounded pct bucket.  Both
+        // tokens must match the Jinja side at _macros.html (see the
+        // ``data-alerts-sig`` attribute on the live-status <td>) so the
+        // very first poll after page load doesn't trigger a redundant
+        // re-render when the OTA badge is unchanged.
+        const otaPhase = d.ota_phase || 'n';
+        const otaPctBucket = d.ota_pct != null ? Math.round(d.ota_pct) : 'n';
         return [
             d.status, d.is_online ? 1 : 0, d.is_upgrading ? 1 : 0,
-            d.update_available ? 1 : 0, errFlag, tempBucket, displayOff, storageBucket
+            d.update_available ? 1 : 0, errFlag, tempBucket, displayOff, storageBucket,
+            otaPhase, otaPctBucket
         ].join('|');
     }
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -516,6 +516,110 @@ class TestGetSingleDevice:
 
 
 @pytest.mark.asyncio
+class TestOtaProgressFields:
+    """OTA progress columns are surfaced through ``DeviceOut`` only when
+    the device's last lifecycle event was within ``OTA_FRESH_TTL``.
+
+    Staleness gate (``cms/routers/devices.py::_ota_fields_for_out``)
+    exists so an OTA that hangs without a terminal event doesn't leave
+    the UI stuck on "Extracting rootfs 47%" forever — the badge falls
+    back to the legacy ``Upgrading…`` chip after the freshness window
+    and eventually clears at ``UPGRADE_TTL``.
+    """
+
+    async def test_ota_fields_fresh_show_through(self, client, db_session):
+        from datetime import datetime, timezone
+
+        from cms.models.device import Device, DeviceStatus
+
+        d = Device(
+            id="ota-fresh", name="ota-fresh", status=DeviceStatus.ADOPTED,
+            ota_phase="ota_download_progress",
+            ota_label="Downloading bundle",
+            ota_pct=42.5,
+            ota_bytes_done=425,
+            ota_bytes_total=1000,
+            ota_updated_at=datetime.now(timezone.utc),
+        )
+        db_session.add(d)
+        await db_session.commit()
+
+        # List endpoint surface.
+        resp = await client.get("/api/devices")
+        assert resp.status_code == 200
+        row = next(r for r in resp.json() if r["id"] == "ota-fresh")
+        assert row["ota_phase"] == "ota_download_progress"
+        assert row["ota_label"] == "Downloading bundle"
+        assert row["ota_pct"] == pytest.approx(42.5)
+        assert row["ota_bytes_done"] == 425
+        assert row["ota_bytes_total"] == 1000
+
+        # Detail endpoint surface — same staleness gate, same result.
+        resp = await client.get("/api/devices/ota-fresh")
+        assert resp.status_code == 200
+        detail = resp.json()
+        assert detail["ota_phase"] == "ota_download_progress"
+        assert detail["ota_pct"] == pytest.approx(42.5)
+
+    async def test_ota_fields_stale_are_null(self, client, db_session):
+        from datetime import datetime, timedelta, timezone
+
+        from cms.models.device import Device, DeviceStatus
+        from cms.routers.devices import OTA_FRESH_TTL
+
+        # ota_updated_at older than OTA_FRESH_TTL (default 2 min).
+        stale_at = datetime.now(timezone.utc) - OTA_FRESH_TTL - timedelta(seconds=1)
+        d = Device(
+            id="ota-stale", name="ota-stale", status=DeviceStatus.ADOPTED,
+            ota_phase="ota_extract_progress",
+            ota_label="Extracting rootfs",
+            ota_pct=47.0,
+            ota_bytes_done=470_000_000,
+            ota_bytes_total=1_000_000_000,
+            ota_updated_at=stale_at,
+        )
+        db_session.add(d)
+        await db_session.commit()
+
+        # List endpoint surface — all OTA fields NULL despite the row
+        # still carrying values; gate fires here.
+        resp = await client.get("/api/devices")
+        assert resp.status_code == 200
+        row = next(r for r in resp.json() if r["id"] == "ota-stale")
+        assert row["ota_phase"] is None
+        assert row["ota_label"] is None
+        assert row["ota_pct"] is None
+        assert row["ota_bytes_done"] is None
+        assert row["ota_bytes_total"] is None
+
+        # Detail endpoint surface — same.
+        resp = await client.get("/api/devices/ota-stale")
+        assert resp.status_code == 200
+        detail = resp.json()
+        assert detail["ota_phase"] is None
+        assert detail["ota_pct"] is None
+
+    async def test_ota_fields_never_set_are_null(self, client, db_session):
+        # A device that has never taken an OTA (ota_updated_at IS NULL)
+        # must surface NULL across all five OTA fields — no false-positive
+        # "Upgrading 0%" badge on a brand-new device.
+        from cms.models.device import Device, DeviceStatus
+
+        d = Device(id="ota-virgin", name="ota-virgin", status=DeviceStatus.ADOPTED)
+        db_session.add(d)
+        await db_session.commit()
+
+        resp = await client.get("/api/devices")
+        assert resp.status_code == 200
+        row = next(r for r in resp.json() if r["id"] == "ota-virgin")
+        assert row["ota_phase"] is None
+        assert row["ota_label"] is None
+        assert row["ota_pct"] is None
+        assert row["ota_bytes_done"] is None
+        assert row["ota_bytes_total"] is None
+
+
+@pytest.mark.asyncio
 class TestUpgradeGuard:
     async def test_upgrade_not_connected(self, client, db_session):
         """Upgrading an offline device returns 409."""

--- a/tests/test_lifecycle_events.py
+++ b/tests/test_lifecycle_events.py
@@ -1,0 +1,226 @@
+"""Integration tests for the OTA ``lifecycle_event`` branch in
+``cms.services.device_inbound.dispatch_device_message`` (issue
+agora-cms#574 / agora#215).
+
+Pattern mirrors ``tests/test_logs_response_shim.py``: drive the
+dispatcher directly with a synthetic message, then re-open the
+session to verify the row + audit event landed.
+
+Covers:
+  - happy path: a known event_type updates ``devices.ota_*`` AND
+    writes a ``device_events`` audit row.
+  - unknown wire event_type: dropped with INFO log, no audit row,
+    no Device mutation, no commit.
+  - terminal event clears ``upgrade_started_at`` end-to-end through
+    the dispatch path (this is the failure-path UX fix — without it
+    a failed OTA would leave the "Upgrading…" badge stuck for the
+    full ``UPGRADE_TTL=15min``).
+  - regression-dropped event STILL writes an audit row with
+    ``projection_applied: false`` so the device's monotonic event_id
+    is accounted for in the event log.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.database import get_session_factory
+from cms.models.device import Device, DeviceStatus
+from cms.models.device_event import DeviceEvent, DeviceEventType
+from cms.schemas.protocol import MessageType
+from cms.services.device_inbound import InboundContext, dispatch_device_message
+
+
+async def _noop_send(msg: dict) -> None:
+    return None
+
+
+@pytest_asyncio.fixture
+async def _device(app):
+    factory = get_session_factory()
+    async with factory() as db:
+        dev = Device(
+            id="dev-ota-1", name="OTA",
+            status=DeviceStatus.ADOPTED,
+            upgrade_started_at=datetime.now(timezone.utc),
+        )
+        db.add(dev)
+        await db.commit()
+    return "dev-ota-1"
+
+
+async def _dispatch(_device, msg, app):
+    """Helper — open a session, build context, dispatch one message."""
+    from cms.auth import get_settings
+    settings = app.dependency_overrides[get_settings]()
+    factory = get_session_factory()
+    async with factory() as db:
+        device = await db.get(Device, _device)
+        ctx = InboundContext(
+            device_id=_device, device=device,
+            device_name=device.name,
+            base_url="http://test", settings=settings,
+            group_id=None, group_name=None,
+            device_status=device.status,
+        )
+        await dispatch_device_message(msg=msg, ctx=ctx, db=db, send=_noop_send)
+
+
+async def _read_device(_device):
+    factory = get_session_factory()
+    async with factory() as db:
+        return await db.get(Device, _device)
+
+
+async def _read_events(_device, event_type=None):
+    factory = get_session_factory()
+    async with factory() as db:
+        q = select(DeviceEvent).where(DeviceEvent.device_id == _device)
+        if event_type is not None:
+            q = q.where(DeviceEvent.event_type == event_type)
+        result = await db.execute(q)
+        return result.scalars().all()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_download_progress_updates_device_and_writes_audit(
+    app, _device,
+):
+    msg = {
+        "type": MessageType.LIFECYCLE_EVENT.value,
+        "event_id": 42,
+        "event_type": "download_progress",
+        "release_id": "rel-v0.0.30-test",
+        "target_version": "0.0.30-test",
+        "occurred_at": "2026-05-16T07:30:00Z",
+        "payload": {"bytes_done": 250, "bytes_total": 1000},
+    }
+    await _dispatch(_device, msg, app)
+
+    dev = await _read_device(_device)
+    assert dev.ota_phase == DeviceEventType.OTA_DOWNLOAD_PROGRESS.value
+    assert dev.ota_pct == pytest.approx(25.0)
+    assert dev.ota_bytes_done == 250
+    assert dev.ota_bytes_total == 1000
+    assert dev.ota_updated_at is not None
+    # The atomic upgrade claim is NOT cleared (still in flight).
+    assert dev.upgrade_started_at is not None
+
+    events = await _read_events(_device,
+                                DeviceEventType.OTA_DOWNLOAD_PROGRESS.value)
+    assert len(events) == 1
+    detail = events[0].details
+    assert detail["event_id"] == 42
+    assert detail["payload"]["bytes_done"] == 250
+    assert detail["release_id"] == "rel-v0.0.30-test"
+    assert detail["target_version"] == "0.0.30-test"
+    assert detail["projection_applied"] is True
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_unknown_event_type_is_silently_dropped(app, _device):
+    # An event_type the CMS doesn't know about (added later in agora
+    # but not yet in this CMS deploy) must be a no-op — no audit row,
+    # no Device mutation, no exception.  Forward-compat is mandatory
+    # because agora ships independently of agora-cms.
+    msg = {
+        "type": MessageType.LIFECYCLE_EVENT.value,
+        "event_id": 99,
+        "event_type": "brand_new_event_invented_in_v2",
+        "payload": {"shiny": True},
+    }
+    await _dispatch(_device, msg, app)
+
+    dev = await _read_device(_device)
+    assert dev.ota_phase is None
+    assert dev.ota_label is None
+    # upgrade_started_at left as fixture put it (still set).
+    assert dev.upgrade_started_at is not None
+
+    events = await _read_events(_device)
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_terminal_event_clears_upgrade_claim(app, _device):
+    # Pre-condition: device is mid-OTA so ota_* columns are set AND
+    # upgrade_started_at is set (fixture sets the latter).
+    setup_msg = {
+        "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 1,
+        "event_type": "stage_progress",
+        "payload": {"phase": "extracting_meta"},
+    }
+    await _dispatch(_device, setup_msg, app)
+
+    # Sanity check that we set up a "mid-OTA" state.
+    mid = await _read_device(_device)
+    assert mid.ota_phase == DeviceEventType.OTA_STAGE_PROGRESS.value
+    assert mid.upgrade_started_at is not None
+
+    # Now a terminal failure event arrives.
+    fail_msg = {
+        "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 2,
+        "event_type": "failed",
+        "reason": "signature_mismatch",
+        "payload": {},
+    }
+    await _dispatch(_device, fail_msg, app)
+
+    dev = await _read_device(_device)
+    # All ota_* fields cleared.
+    assert dev.ota_phase is None
+    assert dev.ota_label is None
+    assert dev.ota_pct is None
+    assert dev.ota_bytes_done is None
+    assert dev.ota_bytes_total is None
+    # The atomic upgrade claim is ALSO cleared so the badge falls off
+    # immediately on failure rather than hanging for UPGRADE_TTL.
+    assert dev.upgrade_started_at is None
+
+    # Audit row carries the reason for postmortem use.
+    events = await _read_events(_device, DeviceEventType.OTA_FAILED.value)
+    assert len(events) == 1
+    assert events[0].details["reason"] == "signature_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_regression_dropped_event_still_audits(app, _device):
+    # First event lands.
+    forward = {
+        "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 10,
+        "event_type": "slot_confirmed", "payload": {},
+    }
+    await _dispatch(_device, forward, app)
+
+    dev_after_forward = await _read_device(_device)
+    assert dev_after_forward.ota_phase == DeviceEventType.OTA_SLOT_CONFIRMED.value
+
+    # A regression event arrives (download_progress, ordinal much
+    # lower than slot_confirmed).  Projection refuses the regression
+    # but we MUST still write an audit row so the device's monotonic
+    # event_id is accounted for in the event log.
+    regression = {
+        "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 11,
+        "event_type": "download_progress",
+        "payload": {"bytes_done": 50, "bytes_total": 1000},
+    }
+    await _dispatch(_device, regression, app)
+
+    dev_after = await _read_device(_device)
+    # Device state unchanged — slot_confirmed still wins.
+    assert dev_after.ota_phase == DeviceEventType.OTA_SLOT_CONFIRMED.value
+    assert dev_after.ota_bytes_done is None  # never set by slot_confirmed
+
+    # But the audit row landed with projection_applied=False so the
+    # event-log surface can still display the dropped event for
+    # debugging.
+    regr_events = await _read_events(
+        _device, DeviceEventType.OTA_DOWNLOAD_PROGRESS.value,
+    )
+    assert len(regr_events) == 1
+    assert regr_events[0].details["event_id"] == 11
+    assert regr_events[0].details["projection_applied"] is False

--- a/tests/test_ota_progress.py
+++ b/tests/test_ota_progress.py
@@ -1,0 +1,263 @@
+"""Unit tests for ``cms.services.ota_progress``.
+
+Pure projection tests — no DB. The handler mutates a ``Device`` row
+in place; we use a lightweight stand-in with the same attribute
+surface so we can exercise every transition without spinning Postgres.
+
+Coverage targets (per ota-progress-badge plan v2):
+
+  - happy path: each event_type produces the right phase/label/pct
+  - download_progress bytes calculation
+  - extract_progress bytes calculation
+  - stage_progress label resolution from sub-phase
+  - regression guard: older phase event after newer one is dropped
+  - regression guard: same-phase bytes_done going backwards is dropped
+  - terminal events clear every ota_* column AND upgrade_started_at
+  - terminal events can land even from an earlier ordinal (they're
+    always allowed)
+  - pct=None on phase transitions to non-progress phases (the bug the
+    rubber-duck caught — pct=100 from download must not visually carry
+    into the verifying-signature window)
+  - unknown event_type is a no-op (forward-compat)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cms.services import ota_progress
+
+
+class _DeviceStub:
+    """Minimal in-memory stand-in for the ``Device`` SQLAlchemy row.
+
+    The projection only reads/writes the six ``ota_*`` columns and
+    ``upgrade_started_at``; everything else is irrelevant.
+    """
+
+    def __init__(self, **overrides):
+        self.ota_phase = None
+        self.ota_label = None
+        self.ota_pct = None
+        self.ota_bytes_done = None
+        self.ota_bytes_total = None
+        self.ota_updated_at = None
+        self.upgrade_started_at = datetime.now(timezone.utc)
+        for k, v in overrides.items():
+            setattr(self, k, v)
+
+
+# ── happy-path projection ──────────────────────────────────────────────
+
+
+def test_download_started_sets_phase_no_pct():
+    d = _DeviceStub()
+    assert ota_progress.handle_event(d, "ota_download_started", {}) is True
+    assert d.ota_phase == "ota_download_started"
+    assert d.ota_label == "Starting download"
+    assert d.ota_pct is None
+    assert d.ota_bytes_done is None
+    assert d.ota_bytes_total is None
+    assert d.ota_updated_at is not None
+
+
+def test_download_progress_computes_pct_from_bytes():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_download_progress",
+                              {"bytes_done": 300, "bytes_total": 1000})
+    assert d.ota_phase == "ota_download_progress"
+    assert d.ota_label == "Downloading bundle"
+    assert d.ota_pct == pytest.approx(30.0)
+    assert d.ota_bytes_done == 300
+    assert d.ota_bytes_total == 1000
+
+
+def test_signature_verified_resets_pct_to_none():
+    # The bug the rubber-duck caught: a download finishing at pct=100
+    # transitions to signature_verified (no bytes); pct must clear so
+    # the badge doesn't visually stick at 100% during the verify window.
+    d = _DeviceStub(ota_phase="ota_download_progress", ota_pct=100.0,
+                    ota_bytes_done=1000, ota_bytes_total=1000)
+    ota_progress.handle_event(d, "ota_signature_verified", {})
+    assert d.ota_phase == "ota_signature_verified"
+    assert d.ota_label == "Verifying signature"
+    assert d.ota_pct is None
+    assert d.ota_bytes_done is None
+    assert d.ota_bytes_total is None
+
+
+def test_stage_progress_resolves_sub_phase_label():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_stage_progress",
+                              {"phase": "wiping_inactive"})
+    assert d.ota_phase == "ota_stage_progress"
+    assert d.ota_label == "Wiping inactive slot"
+    assert d.ota_pct is None
+
+
+def test_stage_progress_unknown_sub_phase_falls_back_to_generic_label():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_stage_progress",
+                              {"phase": "never_heard_of_it"})
+    assert d.ota_phase == "ota_stage_progress"
+    assert d.ota_label == "Staging"  # _PHASE_LABELS default
+
+
+def test_extract_progress_computes_pct_with_sub_phase_label():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_extract_progress",
+                              {"phase": "rootfs",
+                               "bytes_done": 500_000_000,
+                               "bytes_total": 1_000_000_000})
+    assert d.ota_phase == "ota_extract_progress"
+    assert d.ota_label == "Extracting rootfs"
+    assert d.ota_pct == pytest.approx(50.0)
+
+
+# ── regression guards ─────────────────────────────────────────────────
+
+
+def test_older_phase_event_after_newer_is_dropped():
+    d = _DeviceStub(ota_phase="ota_slot_confirmed", ota_label="Confirming")
+    # An out-of-order download_started arriving after slot_confirmed
+    # must NOT rewind the row.
+    assert ota_progress.handle_event(d, "ota_download_started", {}) is False
+    assert d.ota_phase == "ota_slot_confirmed"
+    assert d.ota_label == "Confirming"
+
+
+def test_same_phase_bytes_done_regression_is_dropped():
+    d = _DeviceStub(ota_phase="ota_download_progress", ota_pct=80.0,
+                    ota_bytes_done=800, ota_bytes_total=1000)
+    # A rebroadcast of an older download_progress event (bytes_done=300)
+    # arriving after a newer one (bytes_done=800) must be dropped.
+    assert ota_progress.handle_event(
+        d, "ota_download_progress",
+        {"bytes_done": 300, "bytes_total": 1000},
+    ) is False
+    assert d.ota_bytes_done == 800  # unchanged
+    assert d.ota_pct == pytest.approx(80.0)
+
+
+def test_same_phase_bytes_done_advance_is_accepted():
+    d = _DeviceStub(ota_phase="ota_download_progress", ota_pct=30.0,
+                    ota_bytes_done=300, ota_bytes_total=1000)
+    assert ota_progress.handle_event(
+        d, "ota_download_progress",
+        {"bytes_done": 600, "bytes_total": 1000},
+    ) is True
+    assert d.ota_bytes_done == 600
+    assert d.ota_pct == pytest.approx(60.0)
+
+
+def test_advance_to_higher_phase_resets_byte_history():
+    # Going from download_progress → stage_progress should NOT trip the
+    # same-phase regression guard even though stage carries no bytes.
+    d = _DeviceStub(ota_phase="ota_download_progress", ota_pct=100.0,
+                    ota_bytes_done=1000, ota_bytes_total=1000)
+    assert ota_progress.handle_event(
+        d, "ota_stage_progress", {"phase": "extracting_meta"},
+    ) is True
+    assert d.ota_phase == "ota_stage_progress"
+    assert d.ota_bytes_done is None
+    assert d.ota_bytes_total is None
+    assert d.ota_pct is None
+
+
+# ── terminal events ───────────────────────────────────────────────────
+
+
+def _terminal_test_helper(event_type: str):
+    """Common assertions for any of the four terminal event types."""
+    started_at = datetime.now(timezone.utc) - timedelta(minutes=3)
+    d = _DeviceStub(
+        ota_phase="ota_extract_progress", ota_pct=47.0,
+        ota_bytes_done=470, ota_bytes_total=1000,
+        upgrade_started_at=started_at,
+    )
+    assert ota_progress.handle_event(d, event_type, {}) is True
+    assert d.ota_phase is None
+    assert d.ota_label is None
+    assert d.ota_pct is None
+    assert d.ota_bytes_done is None
+    assert d.ota_bytes_total is None
+    assert d.ota_updated_at is None
+    # Terminal events also clear the atomic upgrade claim so the badge
+    # falls off immediately instead of hanging for UPGRADE_TTL (this is
+    # the failure-path UX fix from the rubber-duck review).
+    assert d.upgrade_started_at is None
+
+
+def test_promoted_clears_everything():
+    _terminal_test_helper("ota_promoted")
+
+
+def test_migration_complete_clears_everything():
+    _terminal_test_helper("ota_migration_complete")
+
+
+def test_failed_clears_everything():
+    _terminal_test_helper("ota_failed")
+
+
+def test_declined_clears_everything():
+    _terminal_test_helper("ota_declined")
+
+
+def test_terminal_event_always_lands_even_from_earlier_ordinal():
+    # A device that's mid-extract (order=50) and then immediately gets a
+    # failed event must NOT have the failed dropped as "regression" —
+    # terminal events bypass the order guard.
+    d = _DeviceStub(ota_phase="ota_slot_confirmed",  # order=80
+                    upgrade_started_at=datetime.now(timezone.utc))
+    # ota_failed has order=999 so it's allowed anyway, but verify that
+    # an explicit terminal with an _earlier_ order also lands.  (For
+    # the current schema all terminals are at 999; this test pins the
+    # contract for future changes.)
+    assert ota_progress.handle_event(d, "ota_failed", {}) is True
+    assert d.upgrade_started_at is None
+
+
+# ── forward-compat ────────────────────────────────────────────────────
+
+
+def test_unknown_event_type_is_noop():
+    d = _DeviceStub(ota_phase="ota_download_progress", ota_pct=42.0)
+    assert ota_progress.handle_event(d, "ota_brand_new_event_type", {}) is False
+    # State unchanged.
+    assert d.ota_phase == "ota_download_progress"
+    assert d.ota_pct == pytest.approx(42.0)
+
+
+# ── edge cases in payload parsing ─────────────────────────────────────
+
+
+def test_download_progress_with_zero_total_yields_no_pct():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_download_progress",
+                              {"bytes_done": 0, "bytes_total": 0})
+    assert d.ota_bytes_done == 0
+    assert d.ota_bytes_total == 0
+    assert d.ota_pct is None
+
+
+def test_download_progress_with_malformed_payload_doesnt_crash():
+    d = _DeviceStub()
+    # Strings instead of ints
+    assert ota_progress.handle_event(
+        d, "ota_download_progress",
+        {"bytes_done": "not-a-number", "bytes_total": "also-not"},
+    ) is True
+    assert d.ota_bytes_done is None
+    assert d.ota_bytes_total is None
+    assert d.ota_pct is None
+
+
+def test_download_progress_with_done_over_total_caps_at_100():
+    d = _DeviceStub()
+    ota_progress.handle_event(d, "ota_download_progress",
+                              {"bytes_done": 1500, "bytes_total": 1000})
+    # Tolerates server-side rounding errors / off-by-one chunks.
+    assert d.ota_pct == pytest.approx(100.0)

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -718,7 +718,7 @@ class TestUserEvents:
         # Confirm an UPDATE statement was issued targeting upgrade_started_at.
         update_stmts = [
             str(s) for s in session.executed
-            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+            if str(s).strip().upper().startswith("UPDATE ") and "upgrade_started_at" in str(s)
         ]
         assert update_stmts, (
             f"Expected CAS UPDATE clearing upgrade_started_at, "
@@ -781,7 +781,7 @@ class TestUserEvents:
         assert r.status_code == 204
         update_stmts = [
             str(s) for s in session.executed
-            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+            if str(s).strip().upper().startswith("UPDATE ") and "upgrade_started_at" in str(s)
         ]
         assert update_stmts, (
             f"Expected CAS UPDATE clearing upgrade_started_at on os_version "
@@ -843,7 +843,7 @@ class TestUserEvents:
         assert r.status_code == 204
         update_stmts = [
             str(s) for s in session.executed
-            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+            if str(s).strip().upper().startswith("UPDATE ") and "upgrade_started_at" in str(s)
         ]
         assert not update_stmts, (
             f"Did not expect upgrade_started_at UPDATE for same-fw register, "
@@ -904,7 +904,7 @@ class TestUserEvents:
         assert r.status_code == 204
         update_stmts = [
             str(s) for s in session.executed
-            if "UPDATE" in str(s).upper() and "upgrade_started_at" in str(s)
+            if str(s).strip().upper().startswith("UPDATE ") and "upgrade_started_at" in str(s)
         ]
         assert not update_stmts, (
             f"Did not expect upgrade_started_at UPDATE when register "


### PR DESCRIPTION
Replaces the static Upgrading...' chip on the devices page with a live progress bar mirroring the imager `badge-progress` pattern (linear gradient driven by `--pct` CSS var). Progress updates come from `lifecycle_event` messages emitted by `agora-os-updater` on the device side (see sslivins/agora#215 for the companion firmware work).

Closes #574.

## What you'll see

| Before | After |
|---|---|
| Static `Upgrading...` blue chip for the full upgrade duration | Live progress bar with sub-phase label (`Downloading bundle 42%`, `Verifying signature`, `Extracting rootfs 73%`, `Confirming slot`, ...) updating in real time |

## Safety properties

- **Multi-replica safe.** All state lives in Postgres on the `devices` table (no in-memory cache). Verified there's no Redis in the repo; `upgrade_started_at` precedent in this codebase already documents the multi-replica invariant.
- **Staleness gate (`OTA_FRESH_TTL=2min`).** If a device stops emitting lifecycle events without a terminal event (kernel panic mid-extract, tryboot revert), the UI falls back to the legacy `Upgrading...` chip instead of hanging on a stuck percentage.
- **Failure-path UX fix.** Terminal events (`failed`/`declined` as well as the happy-path `promoted`/`migration_complete`) now clear `upgrade_started_at` explicitly, so the badge drops immediately on failure instead of hanging for the full `UPGRADE_TTL=15min`. This is a pre-existing bug the rubber-duck review surfaced that this PR fixes.
- **Phase regression guard.** Out-of-order events (e.g. a delayed `download_progress` arriving after `slot_confirmed`) are dropped by the projection so the bar can't visually rewind.
- **Bytes monotonicity guard.** Same-phase events with `bytes_done` going backwards are dropped.
- **Forward-compat.** Unknown wire `event_type` values are dropped with an INFO log (no HTTP 400) — future `agora` firmware can ship new event types without lock-step CMS coordination.

## Files

| File | Purpose |
|---|---|
| `alembic/versions/0025_devices_ota_progress.py` | 6 nullable OTA columns on `devices`; widens `device_events.event_type` 20->40 |
| `cms/models/device.py` | ORM columns |
| `cms/models/device_event.py` | 12 new `OTA_*` enum values |
| `cms/schemas/device.py` | `DeviceOut` exposes 5 OTA fields |
| `cms/schemas/protocol.py` | `MessageType.LIFECYCLE_EVENT` |
| `cms/services/ota_progress.py` (new) | Pure projection module |
| `cms/services/device_inbound.py` | `lifecycle_event` dispatch branch + `WIRE_TO_CMS_EVENT` map |
| `cms/routers/devices.py` | `_ota_fields_for_out` staleness gate, wired into both `/api/devices` and `/api/devices/{id}` |
| `cms/templates/_macros.html` + `devices.html` | 3-way badge branch (progress / label-only / legacy chip) + `data-alerts-sig` / `alertsSig()` extension |

## Tests

- `tests/test_ota_progress.py` — **19 unit tests** for the projection covering happy paths, regression guards, terminal clearing, edge cases.
- `tests/test_lifecycle_events.py` — **4 integration tests** via `dispatch_device_message` (real DB) — happy path with audit row, unknown event drop, terminal clears claim end-to-end, regression-dropped events still audit.
- `tests/test_devices.py` — **3 new staleness-gate tests** (fresh, stale, never-set).
- `tests/test_wps_webhook.py` — fixed a pre-existing brittle `"UPDATE" in str(s).upper()` filter that started false-positive-matching on the new `ota_updated_at` column name.

Full suite: **2623 passed, 0 failed** (3 pre-existing tz failures in `test_device_event_transitions.py` and Playwright e2e errors are unrelated and present on `main`).

## Out of scope (filed as follow-ups)

PR 2 is the agora-side companion that actually emits `download_progress` and `extract_progress` events with bytes counters — without it this PR only renders progress for the 8 events `agora` already emits (which is still a strict upgrade over the static chip).