### PR TITLE
ota_progress: align extract_progress sub-phase to device wire

### DIFF
--- a/cms/services/ota_progress.py
+++ b/cms/services/ota_progress.py
@@ -110,9 +110,12 @@ _STAGE_SUBPHASE_LABELS: dict[str, str] = {
 # extract_progress sub-phase → label.  This event fires *during* either
 # the extracting_boot or extracting_rootfs stage_progress windows, and
 # carries bytes_done / bytes_total of the underlying zstd stream.
+# Sub-phase strings match the corresponding stage_progress sub-phases
+# (see ``_STAGE_SUBPHASE_LABELS`` above) so the on-device emitter can
+# pass the same token through both event_types unchanged.
 _EXTRACT_SUBPHASE_LABELS: dict[str, str] = {
-    "boot":   "Extracting boot",
-    "rootfs": "Extracting rootfs",
+    "extracting_boot":   "Extracting boot",
+    "extracting_rootfs": "Extracting rootfs",
 }
 
 
@@ -126,7 +129,7 @@ def _derive(event_type: str, payload: dict) -> tuple[
 
       - download_progress: ``{bytes_done, bytes_total}``
       - stage_progress:    ``{phase: <one of 8 sub-phases>}``
-      - extract_progress:  ``{phase: "boot"|"rootfs", bytes_done, bytes_total}``
+      - extract_progress:  ``{phase: "extracting_boot"|"extracting_rootfs", bytes_done, bytes_total}``
       - all others:        no body fields used here
     """
     phase = event_type

--- a/tests/test_ota_progress.py
+++ b/tests/test_ota_progress.py
@@ -108,7 +108,7 @@ def test_stage_progress_unknown_sub_phase_falls_back_to_generic_label():
 def test_extract_progress_computes_pct_with_sub_phase_label():
     d = _DeviceStub()
     ota_progress.handle_event(d, "ota_extract_progress",
-                              {"phase": "rootfs",
+                              {"phase": "extracting_rootfs",
                                "bytes_done": 500_000_000,
                                "bytes_total": 1_000_000_000})
     assert d.ota_phase == "ota_extract_progress"


### PR DESCRIPTION
Follow-up to #575. The device-side emitter shipped in
[agora#216](https://github.com/sslivins/agora/pull/216) uses
`extracting_boot` / `extracting_rootfs` as the `phase` token for
**both** `stage_progress` and `extract_progress` events -- they
share a vocabulary so the on-device emitter can pass the same
sub-phase string through both event types unchanged. CMS was keyed
on the shorter `boot` / `rootfs` for `extract_progress` only, which
would have caused the label fallback to kick in on every real
extract_progress event from the field (the bytes/pct math still
works because that branch unconditionally reads `bytes_done` /
`bytes_total`, but the badge label would have been the generic
"Extracting bundle" instead of "Extracting boot" / "Extracting
rootfs").

Catches this before any device starts emitting the new event types.
