### PR TITLE
fix(bundle_checker): move latest bundle to shared DB row to stop UI flicker (#578)

### DIFF
--- a/alembic/versions/0026_agora_os_latest_bundle.py
+++ b/alembic/versions/0026_agora_os_latest_bundle.py
@@ -1,0 +1,72 @@
+"""Add ``agora_os_latest_bundle`` single-row table for cross-replica
+bundle_checker state (issue agora-cms#578).
+
+Before this revision, ``cms/services/bundle_checker.py`` cached the
+"latest agora-os release" in three module-level globals
+(``_latest_bundle``, ``_last_success_at``, ``_last_error``).  In a
+multi-replica deploy each worker had its own copy, so a
+``POST /api/devices/check-updates`` only refreshed the cache of the
+one replica it happened to land on; the others kept their stale view
+until their own 30-min cron tick fired.  ``GET /api/devices/{id}``
+round-robins, so ``update_available`` (computed from
+``device.os_version != bundle_checker.latest.target_version``) flipped
+True/False from request to request.  Visible UX impact: the "Update"
+action in the kebab menu rendered and unrendered every few seconds,
+making it noticeably hard to click manually-triggered OTAs.
+
+Solution: persist the bundle in a shared single-row table.  All readers
+hit the DB (one PK lookup amortised across all devices in a list response);
+all writers UPSERT into the same row.  Multiple replicas writing the same
+content is fine — last-write-wins on identical payloads is idempotent.
+
+``_last_error`` deliberately does *not* move here — it's per-replica debug
+state that's more useful as-is (lets ops see whether one replica's network
+egress is partially broken vs. all of them are failing).  ``_last_success_at``
+*does* move because it's the cross-replica freshness signal.
+
+The row is enforced singleton by a ``CHECK (id = 1)`` constraint.  The
+column shape mirrors :class:`cms.services.bundle_checker.BundleInfo`.
+
+Revision ID: 0026
+Revises: 0025
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agora_os_latest_bundle",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("target_version", sa.Text(), nullable=False),
+        sa.Column("release_id", sa.Text(), nullable=False),
+        sa.Column("min_from_version", sa.Text(), nullable=False),
+        sa.Column("bundle_url", sa.Text(), nullable=False),
+        sa.Column("signature_url", sa.Text(), nullable=False),
+        sa.Column("sha256_url", sa.Text(), nullable=True),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "last_success_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.CheckConstraint("id = 1", name="ck_agora_os_latest_bundle_single_row"),
+    )
+
+
+def downgrade() -> None:
+    # Project policy (test_migration_policy.py): every downgrade must
+    # raise NotImplementedError. Forward-only migrations only.
+    raise NotImplementedError(
+        "Downgrade of 0026 is intentionally not implemented per project policy."
+    )

--- a/alembic/versions/0026_agora_os_latest_bundle.py
+++ b/alembic/versions/0026_agora_os_latest_bundle.py
@@ -53,8 +53,8 @@ def upgrade() -> None:
         sa.Column("bundle_url", sa.Text(), nullable=False),
         sa.Column("signature_url", sa.Text(), nullable=False),
         sa.Column("sha256_url", sa.Text(), nullable=True),
-        sa.Column("size_bytes", sa.BigInteger(), nullable=False, server_default="0"),
-        sa.Column("created_at", sa.Text(), nullable=False, server_default=""),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
         sa.Column(
             "last_success_at",
             sa.DateTime(timezone=True),

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import relationship
 from cms.models.api_key import APIKey  # noqa: F401
 from cms.models.asset import Asset, AssetType, AssetVariant, DeviceAsset, VariantStatus  # noqa: F401
 from cms.models.audit_log import AuditLog  # noqa: F401
+from cms.models.agora_os_latest_bundle import AgoraOsLatestBundle  # noqa: F401
 from cms.models.device import Device, DeviceGroup, DeviceStatus  # noqa: F401
 from cms.models.device_alert_state import DeviceAlertState  # noqa: F401
 from cms.models.device_event import DeviceEvent, DeviceEventType  # noqa: F401

--- a/cms/models/agora_os_latest_bundle.py
+++ b/cms/models/agora_os_latest_bundle.py
@@ -1,0 +1,52 @@
+"""Single-row table holding the latest agora-os bundle metadata.
+
+The row is the **shared source of truth** for "what is the newest non-draft
+agora-os release?" across all CMS replicas.  Replaces the per-process
+``bundle_checker._latest_bundle`` module global that caused issue #578:
+each replica had its own cache, so the UI's ``update_available`` badge
+flickered on/off depending on which replica answered each round-robin
+request.
+
+The poller in :mod:`cms.services.bundle_checker` UPSERTs into this row
+on every successful GitHub fetch (replicated across replicas — writes
+are idempotent on identical payloads).  All readers — the device-list
+endpoints, the upgrade endpoint, the UI templates — read this row,
+which means every replica returns the same view of "latest" at any
+given moment.
+
+There is exactly one row, enforced by a ``CHECK (id = 1)`` constraint
+in the alembic migration (0026).  The model itself uses ``id`` as the
+PK so SQLAlchemy is happy; the CHECK guards against accidentally
+INSERTing a second row from buggy code.
+
+Per-replica failure state (``_last_error``) is *not* persisted here —
+it lives in :mod:`cms.services.bundle_checker` as a module global on
+purpose.  When one replica's poll fails, the others' caches are still
+fresh; treating "last error" as per-replica state makes it more useful
+for diagnosing partial outages.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, DateTime, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cms.database import Base
+
+
+class AgoraOsLatestBundle(Base):
+    __tablename__ = "agora_os_latest_bundle"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    target_version: Mapped[str] = mapped_column(Text, nullable=False)
+    release_id: Mapped[str] = mapped_column(Text, nullable=False)
+    min_from_version: Mapped[str] = mapped_column(Text, nullable=False)
+    bundle_url: Mapped[str] = mapped_column(Text, nullable=False)
+    signature_url: Mapped[str] = mapped_column(Text, nullable=False)
+    sha256_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    last_success_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -35,7 +35,7 @@ from cms.services.transport import get_transport
 from cms.services.scheduler import push_sync_to_device
 from cms.services.audit_service import audit_log, compute_diff
 from cms.services.asset_readiness import require_asset_ready
-from cms.services.bundle_checker import check_now, get_latest_bundle
+from cms.services.bundle_checker import check_now, get_latest_bundle, get_latest_os_version, is_os_update_available
 
 router = APIRouter(prefix="/api/devices", dependencies=[Depends(require_auth)])
 
@@ -214,9 +214,9 @@ async def _push_default_asset(device_id: str, asset: Asset, base_url: str, db: A
 
 
 @router.post("/check-updates", dependencies=[Depends(require_permission(DEVICES_MANAGE))])
-async def check_for_updates():
+async def check_for_updates(db: AsyncSession = Depends(get_db)):
     """Trigger an immediate check for the latest device firmware version."""
-    latest_bundle = await check_now()
+    latest_bundle = await check_now(db)
     return {"latest_version": latest_bundle.target_version if latest_bundle else None}
 
 
@@ -273,6 +273,10 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
         return _url_display.get(raw, raw) if raw else raw
 
     from cms.services.bundle_checker import is_os_update_available
+    # Issue #578: read the shared latest-version once per request and thread
+    # it through the per-device update_available check, so every replica
+    # returns the same view of "update available" within a single response.
+    latest_version = await get_latest_os_version(db)
     return [
         DeviceOut(
             **_device_row_kwargs(d),
@@ -294,7 +298,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             local_api_enabled=live_states[d.id]["local_api_enabled"] if d.id in live_states else None,
             error=live_states[d.id]["error"] if d.id in live_states else None,
             uptime_seconds=live_states[d.id]["uptime_seconds"] if d.id in live_states else 0,
-            update_available=is_os_update_available(d.os_version),
+            update_available=is_os_update_available(d.os_version, latest_version),
             has_active_schedule=d.id in scheduled_device_ids,
             **_ota_fields_for_out(d, now=now),
         )
@@ -333,6 +337,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
             raw_asset = resolved
 
     from cms.services.bundle_checker import is_os_update_available
+    latest_version = await get_latest_os_version(db)  # issue #578: shared cross-replica view
     return DeviceOut(
         **_device_row_kwargs(device),
         group_name=device.group.name if device.group else None,
@@ -353,7 +358,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         local_api_enabled=live_states[device.id]["local_api_enabled"] if device.id in live_states else None,
         error=live_states[device.id]["error"] if device.id in live_states else None,
         uptime_seconds=live_states[device.id]["uptime_seconds"] if device.id in live_states else 0,
-        update_available=is_os_update_available(device.os_version),
+        update_available=is_os_update_available(device.os_version, latest_version),
         has_active_schedule=device.id in scheduled_device_ids,
         **_ota_fields_for_out(device, now=now),
     )
@@ -575,7 +580,7 @@ async def upgrade_device(
     # poller refreshes this every 30 min; on a cold CMS start it may
     # still be None for up to one poll interval. Surface that as a
     # retryable 503 rather than dispatching a malformed message.
-    latest_bundle = get_latest_bundle()
+    latest_bundle = await get_latest_bundle(db)
     if latest_bundle is None:
         await _release_claim()
         raise HTTPException(
@@ -1092,6 +1097,7 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     ) or 0
 
     from cms.services.bundle_checker import is_os_update_available
+    latest_version = await get_latest_os_version(db)  # issue #578: shared cross-replica view
     transport = get_transport()
     live_states = {s["device_id"]: s for s in await transport.get_all_states()}
     for d in group.devices:
@@ -1112,7 +1118,7 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
         d.playback_position_ms = state["playback_position_ms"] if state else None
         d.ssh_enabled = state["ssh_enabled"] if state else None
         d.local_api_enabled = state["local_api_enabled"] if state else None
-        d.update_available = is_os_update_available(d.os_version)
+        d.update_available = is_os_update_available(d.os_version, latest_version)
         d.is_upgrading = _is_upgrading(d)
         d.has_active_schedule = False  # poller will flip this via updateLiveFields
 
@@ -1150,13 +1156,13 @@ async def get_group_panel(group_id: uuid.UUID, request: Request, db: AsyncSessio
     # Phase C: rich device_row needs profiles, latest_version, timezones, and
     # per-device severity_tags + per-group rollup.
     from cms.models.device_profile import DeviceProfile
-    from cms.services.bundle_checker import get_latest_os_version
     from cms.services.device_alerts import device_severity_tags, fleet_counts
     from cms.ui import COMMON_TIMEZONES
 
     profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
     profiles = profiles_q.scalars().all()
-    latest_version = get_latest_os_version()
+    # Reuse the latest_version we read above for the per-device update_available
+    # decoration — this is the same shared cross-replica value.
     timezones = COMMON_TIMEZONES
 
     for d in group.devices:

--- a/cms/services/bundle_checker.py
+++ b/cms/services/bundle_checker.py
@@ -23,6 +23,28 @@ are made authenticated (5000 calls/hr instead of 60/hr). The CMS does
 not require auth at the current poll cadence — one cycle uses ~2 calls
 — but if the workspace is restart-y, auth keeps us comfortably under
 the limit.
+
+Shared state across replicas (issue agora-cms#578)
+----------------------------------------------------
+The "latest bundle" used to live in module-level globals
+(``_latest_bundle``, ``_last_success_at``).  In a multi-replica deploy
+each worker had its own copy, so a successful ``POST /api/devices/
+check-updates`` only refreshed the cache of the replica it happened to
+land on; the others kept their stale view until their own 30-min cron
+tick fired, and the UI's ``update_available`` badge flickered on/off
+as the load balancer round-robined requests.
+
+The bundle and the last-success timestamp now live in the
+``agora_os_latest_bundle`` single-row table (migration 0026).  All
+readers go through :func:`get_latest_bundle` / :func:`get_latest_os_version`,
+which read this row.  All writers go through :func:`set_latest_bundle`,
+which UPSERTs the row.  Multiple replicas writing the same content is
+fine — last-write-wins on identical payloads is idempotent.
+
+``_last_error`` deliberately stays as a module global — it's per-replica
+debug state and it's *more* useful that way (lets ops see whether one
+replica's network egress is partially broken vs. all of them failing).
+It's surfaced via :func:`get_status` for the debug endpoint.
 """
 
 from __future__ import annotations
@@ -36,6 +58,10 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.agora_os_latest_bundle import AgoraOsLatestBundle
 
 logger = logging.getLogger("agora.cms.bundle_checker")
 
@@ -72,33 +98,66 @@ class BundleInfo:
     created_at: str  # release.published_at, ISO-8601
 
 
-# ── Module-level cache ──────────────────────────────────────────────
-# Reset by check_now() and bundle_check_loop().  Tests poke these
-# directly to stand up a deterministic state for is_os_update_available
-# / get_latest_os_version assertions.
-_latest_bundle: Optional[BundleInfo] = None
-_last_success_at: Optional[datetime] = None
+# ── Module-level state ──────────────────────────────────────────────
+# ``_last_error`` is intentionally per-replica: it's debug state for
+# ``get_status()`` and exists so an operator can tell whether a single
+# replica's poll is failing or whether they all are.  The actual bundle
+# and last-success timestamp live in the shared ``agora_os_latest_bundle``
+# row instead (see :func:`get_latest_bundle`).
 _last_error: Optional[str] = None
 
 
-def get_latest_bundle() -> Optional[BundleInfo]:
-    """Return the cached BundleInfo for the newest agora-os release, or None."""
-    return _latest_bundle
+def _bundle_from_row(row: AgoraOsLatestBundle) -> BundleInfo:
+    return BundleInfo(
+        target_version=row.target_version,
+        release_id=row.release_id,
+        min_from_version=row.min_from_version,
+        bundle_url=row.bundle_url,
+        signature_url=row.signature_url,
+        sha256_url=row.sha256_url,
+        size_bytes=row.size_bytes,
+        created_at=row.created_at,
+    )
 
 
-def get_latest_os_version() -> Optional[str]:
-    """Return the cached newest agora-os version, or None if unknown.
+async def get_latest_bundle(db: AsyncSession) -> Optional[BundleInfo]:
+    """Return the latest known BundleInfo (shared across replicas), or None.
+
+    Reads from the ``agora_os_latest_bundle`` single-row table.  Returns
+    ``None`` only when no poll has ever succeeded for this CMS deployment
+    (cold start before the first ``bundle_check_loop`` iteration writes
+    the row).
+    """
+    row = await db.scalar(
+        select(AgoraOsLatestBundle).where(AgoraOsLatestBundle.id == 1)
+    )
+    if row is None:
+        return None
+    return _bundle_from_row(row)
+
+
+async def get_latest_os_version(db: AsyncSession) -> Optional[str]:
+    """Return the latest known agora-os version, or None if no successful poll yet.
 
     This is the v-stripped semver string (e.g. ``"0.0.17-test"``).
     """
-    return _latest_bundle.target_version if _latest_bundle else None
+    bundle = await get_latest_bundle(db)
+    return bundle.target_version if bundle else None
 
 
-def get_status() -> dict:
-    """Return checker health snapshot for debug endpoints (P1-4)."""
+async def get_status(db: AsyncSession) -> dict:
+    """Return checker health snapshot for debug endpoints (P1-4).
+
+    ``last_error`` is per-replica (this process's last failed poll, if
+    any).  ``latest_version`` and ``last_success_at`` are read from the
+    shared DB row so all replicas report the same value for these.
+    """
+    row = await db.scalar(
+        select(AgoraOsLatestBundle).where(AgoraOsLatestBundle.id == 1)
+    )
     return {
-        "latest_version": get_latest_os_version(),
-        "last_success_at": _last_success_at.isoformat() if _last_success_at else None,
+        "latest_version": row.target_version if row else None,
+        "last_success_at": row.last_success_at.isoformat() if row else None,
         "last_error": _last_error,
     }
 
@@ -131,24 +190,26 @@ def _parse_version(v: str) -> tuple:
     return tuple(out)
 
 
-def is_os_update_available(current_os_version: Optional[str], latest: Optional[str] = None) -> bool:
-    """Return True iff the device is running an older OS version than the latest.
+def is_os_update_available(
+    current_os_version: Optional[str],
+    latest: Optional[str],
+) -> bool:
+    """Return True iff the device is running an older OS version than ``latest``.
 
-    Mirrors ``version_checker.is_update_available`` semantics:
-    ``current_os_version`` and ``latest`` may be None (returns False),
-    and comparison falls back to the cached ``get_latest_os_version()``
-    when ``latest`` is omitted.
+    Pure function — does NOT consult any cache or DB.  Callers must pass
+    ``latest`` explicitly (typically obtained once per HTTP request via
+    ``await get_latest_os_version(db)``).  Issue #578: this is deliberate
+    — the old implicit-fallback behaviour was the source of the per-replica
+    cache drift.
 
-    As of M6, all callers pass ``device.os_version`` (populated by the
-    M4-device register message, sslivins/agora#205, first shipped in
-    agora.deb v1.11.61 and bundled into agora-os v0.0.18-test).  Devices
-    on older OS bundles still report a NULL ``os_version`` and will
-    short-circuit to False below — i.e. their Update button stays
-    dark, which is the correct behaviour (their firmware_version namespace
-    is no longer comparable to bundle target_version).
+    Either argument may be ``None`` (returns ``False``).  As of M6, all
+    callers pass ``device.os_version`` (populated by the M4-device register
+    message, sslivins/agora#205).  Devices on older OS bundles still report
+    a NULL ``os_version`` and short-circuit to ``False`` below — i.e. their
+    Update button stays dark, which is the correct behaviour (their
+    firmware_version namespace is no longer comparable to bundle
+    target_version).
     """
-    if latest is None:
-        latest = get_latest_os_version()
     if not latest or not current_os_version:
         return False
     return _parse_version(current_os_version) < _parse_version(latest)
@@ -174,8 +235,9 @@ async def _fetch_latest_bundle() -> Optional[BundleInfo]:
       2. Fetch that release's meta.json asset for min_from_version.
 
     Returns None on any failure (network, missing asset, malformed
-    meta.json).  Caller decides whether to keep the prior cache value
-    or treat as unknown.
+    meta.json).  Side-effects: updates the module-local ``_last_error``
+    (per-replica debug state surfaced via :func:`get_status`).  Caller
+    decides whether to keep the prior DB row or treat as unknown.
     """
     global _last_error
     try:
@@ -262,25 +324,79 @@ async def _fetch_latest_bundle() -> Optional[BundleInfo]:
         return None
 
 
-async def check_now() -> Optional[BundleInfo]:
-    """Trigger an immediate poll and update the cache.
+# ── DB persistence ──────────────────────────────────────────────────
 
-    Returns the new BundleInfo on success or the previously-cached
-    value on failure (so callers can rely on ``get_latest_bundle()``
+
+async def set_latest_bundle(db: AsyncSession, bundle: BundleInfo) -> None:
+    """UPSERT the shared single-row ``agora_os_latest_bundle`` table.
+
+    Caller is responsible for committing the session.  Stamps
+    ``last_success_at`` to ``datetime.now(UTC)``.  Public so tests
+    (which previously poked ``_latest_bundle`` directly) can seed
+    state in a multi-replica-correct way.
+    """
+    now = datetime.now(timezone.utc)
+    row = await db.scalar(
+        select(AgoraOsLatestBundle).where(AgoraOsLatestBundle.id == 1)
+    )
+    if row is None:
+        db.add(
+            AgoraOsLatestBundle(
+                id=1,
+                target_version=bundle.target_version,
+                release_id=bundle.release_id,
+                min_from_version=bundle.min_from_version,
+                bundle_url=bundle.bundle_url,
+                signature_url=bundle.signature_url,
+                sha256_url=bundle.sha256_url,
+                size_bytes=bundle.size_bytes,
+                created_at=bundle.created_at,
+                last_success_at=now,
+            )
+        )
+    else:
+        row.target_version = bundle.target_version
+        row.release_id = bundle.release_id
+        row.min_from_version = bundle.min_from_version
+        row.bundle_url = bundle.bundle_url
+        row.signature_url = bundle.signature_url
+        row.sha256_url = bundle.sha256_url
+        row.size_bytes = bundle.size_bytes
+        row.created_at = bundle.created_at
+        row.last_success_at = now
+
+
+async def check_now(db: AsyncSession) -> Optional[BundleInfo]:
+    """Trigger an immediate poll and update the shared DB row.
+
+    Returns the new BundleInfo on success or the previously-stored
+    value on failure (so callers can rely on a successful ``check_now``
     not abruptly going None during transient GitHub flakes).
     """
-    global _latest_bundle, _last_success_at, _last_error
+    global _last_error
     bundle = await _fetch_latest_bundle()
     if bundle is not None:
-        _latest_bundle = bundle
-        _last_success_at = datetime.now(timezone.utc)
+        await set_latest_bundle(db, bundle)
+        await db.commit()
         _last_error = None
-    return _latest_bundle
+        return bundle
+    # Fetch failed; surface whatever the DB has (may still be None on
+    # cold-start before any successful poll has ever landed).
+    return await get_latest_bundle(db)
 
 
 async def bundle_check_loop() -> None:
-    """Background loop that polls GitHub releases periodically."""
-    global _latest_bundle, _last_success_at, _last_error
+    """Background loop that polls GitHub releases periodically.
+
+    Runs replicated across all CMS replicas (writes are idempotent on
+    identical payloads, so concurrent writers converge to the same
+    row content).
+    """
+    global _last_error
+
+    # Lazy import — avoids a hard cms.database dep at module import time
+    # so the test layer can import the module before init_db() runs.
+    from cms.database import get_session_factory
 
     try:
         await asyncio.sleep(10)
@@ -293,17 +409,40 @@ async def bundle_check_loop() -> None:
         except asyncio.CancelledError:
             return
         if bundle is not None:
-            prev_version = _latest_bundle.target_version if _latest_bundle else None
-            if prev_version != bundle.target_version:
-                logger.info(
-                    "Latest agora-os release: %s (was %s)",
-                    bundle.target_version,
-                    prev_version,
-                )
-            _latest_bundle = bundle
-            _last_success_at = datetime.now(timezone.utc)
-            _last_error = None
+            sf = get_session_factory()
+            if sf is None:
+                # Session factory not initialised (very early startup or
+                # tests that import this module without init_db()).
+                # Best-effort: skip this iteration, retry next tick.
+                logger.debug("bundle_check_loop: session factory not ready; skipping write")
+            else:
+                try:
+                    async with sf() as db:
+                        prev = await db.scalar(
+                            select(AgoraOsLatestBundle.target_version).where(
+                                AgoraOsLatestBundle.id == 1
+                            )
+                        )
+                        if prev != bundle.target_version:
+                            logger.info(
+                                "Latest agora-os release: %s (was %s)",
+                                bundle.target_version,
+                                prev,
+                            )
+                        await set_latest_bundle(db, bundle)
+                        await db.commit()
+                    _last_error = None
+                except Exception:
+                    # Don't crash the loop on a transient DB error -- the
+                    # in-process _last_error is left alone so a stuck DB
+                    # surfaces on the debug endpoint as the GH-side error,
+                    # but we log it for completeness.
+                    logger.warning(
+                        "bundle_check_loop: failed to persist latest bundle",
+                        exc_info=True,
+                    )
         try:
             await asyncio.sleep(CHECK_INTERVAL)
         except asyncio.CancelledError:
             return
+

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -741,6 +741,9 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     # the alert taxonomy needs.
     from cms.services.device_alerts import fleet_counts as _fleet_counts
     from cms.services.bundle_checker import is_os_update_available as _is_update_available
+    # Issue #578: read shared latest OS version once for this request,
+    # so every replica produces a consistent badge state.
+    _latest_os_version = await get_latest_os_version(db)
     _triage_devices = list(all_devices) + list(orphaned_devices)
     for d in _triage_devices:
         try:
@@ -753,7 +756,7 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
         d.pipeline_state = state["pipeline_state"] if state else None
         d.display_connected = state["display_connected"] if state else None
         d.display_ports = state["display_ports"] if state else None
-        d.update_available = _is_update_available(d.os_version)
+        d.update_available = _is_update_available(d.os_version, _latest_os_version)
         d.is_upgrading = _devices_is_upgrading(d)
     fleet_counts_dashboard = _fleet_counts(_triage_devices, user_perms)
 
@@ -1051,6 +1054,10 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
     _connected_ids = set(await _transport.connected_ids())
     scheduled_device_ids = {np["device_id"] for np in await compute_now_playing(db, tz, now)}
 
+    # Issue #578: read the shared latest OS version once for this request,
+    # so every replica produces a consistent "Update available" view.
+    latest_os_version = await get_latest_os_version(db)
+
     # Build URL→display name map for resolving playback_asset on URL-based assets
     assets_early_q = await db.execute(
         select(Asset)
@@ -1092,7 +1099,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         d.playback_position_ms = state["playback_position_ms"] if state else None
         d.ssh_enabled = state["ssh_enabled"] if state else None
         d.local_api_enabled = state["local_api_enabled"] if state else None
-        d.update_available = is_os_update_available(d.os_version)
+        d.update_available = is_os_update_available(d.os_version, latest_os_version)
         d.is_upgrading = _devices_is_upgrading(d)
         d.has_active_schedule = d.id in scheduled_device_ids
 
@@ -1144,7 +1151,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
             d.playback_position_ms = state["playback_position_ms"] if state else None
             d.ssh_enabled = state["ssh_enabled"] if state else None
             d.local_api_enabled = state["local_api_enabled"] if state else None
-            d.update_available = is_os_update_available(d.os_version)
+            d.update_available = is_os_update_available(d.os_version, latest_os_version)
             d.is_upgrading = _devices_is_upgrading(d)
             d.has_active_schedule = d.id in scheduled_device_ids
 
@@ -1199,7 +1206,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         "assets": assets,
         "profiles": profiles,
         "timezones": COMMON_TIMEZONES,
-        "latest_version": get_latest_os_version(),
+        "latest_version": latest_os_version,
         "pending_ttl_hours": get_settings().pending_device_ttl_hours,
         "fleet_counts": counts,
         "active_alert": active_alert,

--- a/tests/test_bundle_checker.py
+++ b/tests/test_bundle_checker.py
@@ -3,7 +3,11 @@
 Mirrors the structure of the deleted tests/test_version_checker.py, but
 exercises the new agora-os GitHub-Releases-driven module that replaces
 the agora deb-polling version_checker as part of the CMS upgrade-path
-migration (M2).
+migration (M2).  Issue #578 moved the cached bundle out of a module
+global and into a shared single-row ``agora_os_latest_bundle`` table,
+so the seeding pattern is now ``await bundle_checker.set_latest_bundle(
+db_session, stub); await db_session.commit()`` instead of
+``bundle_checker._latest_bundle = stub``.
 """
 
 from __future__ import annotations
@@ -42,7 +46,7 @@ class TestParseVersion:
         assert _parse_version("v1.2.3") == (1, 2, 3)
 
     def test_test_suffix_equals_unsuffixed(self):
-        """``0.0.17-test`` and ``0.0.17`` should compare equal — we treat the
+        """``0.0.17-test`` and ``0.0.17`` should compare equal -- we treat the
         ``-test`` label as the same release."""
         from cms.services.bundle_checker import _parse_version
 
@@ -56,7 +60,7 @@ class TestParseVersion:
         assert _parse_version("1.0.0") > _parse_version("0.99.99")
 
     def test_garbage_returns_empty_tuple(self):
-        """Empty tuple compares less than any populated tuple — same
+        """Empty tuple compares less than any populated tuple -- same
         fall-back behaviour as the old version_checker._parse_version."""
         from cms.services.bundle_checker import _parse_version
 
@@ -70,134 +74,149 @@ class TestParseVersion:
 
 
 class TestIsOsUpdateAvailable:
-    def test_returns_false_when_no_cache(self):
+    """``latest`` is required positionally after #578 -- no implicit
+    fallback to a module-level cache (the fallback WAS the per-replica
+    drift bug).  Every test passes ``latest`` directly."""
+
+    def test_returns_false_when_latest_is_none(self):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = None
-        try:
-            assert bundle_checker.is_os_update_available("1.0.0") is False
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available("1.0.0", None) is False
 
     def test_returns_false_when_current_is_none(self):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("1.2.3")
-        try:
-            assert bundle_checker.is_os_update_available(None) is False
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available(None, "1.2.3") is False
 
     def test_returns_true_when_older(self):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("1.2.3")
-        try:
-            assert bundle_checker.is_os_update_available("1.2.2") is True
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available("1.2.2", "1.2.3") is True
 
     def test_returns_false_when_equal(self):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("1.2.3")
-        try:
-            assert bundle_checker.is_os_update_available("1.2.3") is False
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available("1.2.3", "1.2.3") is False
 
     def test_returns_false_when_newer(self):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("1.2.3")
-        try:
-            assert bundle_checker.is_os_update_available("1.3.0") is False
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available("1.3.0", "1.2.3") is False
 
     def test_test_suffix_does_not_count_as_update(self):
         """``0.0.17-test`` and ``0.0.17`` compare equal, so the badge must
-        stay dark when the cached latest matches the device label-stripped."""
+        stay dark when the latest matches the device label-stripped."""
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("0.0.17-test")
-        try:
-            assert bundle_checker.is_os_update_available("0.0.17") is False
-            assert bundle_checker.is_os_update_available("0.0.17-test") is False
-        finally:
-            bundle_checker._latest_bundle = original
-
-    def test_explicit_latest_overrides_cache(self):
-        from cms.services import bundle_checker
-
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("1.0.0")
-        try:
-            assert bundle_checker.is_os_update_available("1.0.0", latest="2.0.0") is True
-        finally:
-            bundle_checker._latest_bundle = original
+        assert bundle_checker.is_os_update_available("0.0.17", "0.0.17-test") is False
+        assert bundle_checker.is_os_update_available("0.0.17-test", "0.0.17-test") is False
 
 
 @pytest.mark.asyncio
 class TestCheckNow:
-    async def test_check_now_updates_cache_on_success(self):
+    async def test_check_now_persists_to_shared_row_on_success(self, db_session):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        try:
-            bundle_checker._latest_bundle = None
-            stub = _stub_bundle("1.2.3")
-            with patch.object(bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=stub):
-                result = await bundle_checker.check_now()
-            assert result is stub
-            assert bundle_checker._latest_bundle is stub
-        finally:
-            bundle_checker._latest_bundle = original
+        stub = _stub_bundle("1.2.3")
+        with patch.object(
+            bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=stub
+        ):
+            result = await bundle_checker.check_now(db_session)
+        assert result is not None
+        assert result.target_version == "1.2.3"
+        # And the row is visible to a follow-on read on the same session.
+        assert (await bundle_checker.get_latest_os_version(db_session)) == "1.2.3"
 
-    async def test_check_now_keeps_prior_cache_on_fetch_failure(self):
-        """If GitHub is flaky, callers should still see the last known
-        good value via get_latest_bundle() / get_latest_os_version()."""
+    async def test_check_now_keeps_prior_row_on_fetch_failure(self, db_session):
+        """If GitHub is flaky, callers should still see the last known good
+        value via get_latest_bundle() / get_latest_os_version()."""
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        try:
-            prior = _stub_bundle("0.5.0")
-            bundle_checker._latest_bundle = prior
-            with patch.object(bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=None):
-                result = await bundle_checker.check_now()
-            # check_now returns the cached value, not None.
-            assert result is prior
-            assert bundle_checker._latest_bundle is prior
-        finally:
-            bundle_checker._latest_bundle = original
+        prior = _stub_bundle("0.5.0")
+        await bundle_checker.set_latest_bundle(db_session, prior)
+        await db_session.commit()
+
+        with patch.object(
+            bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=None
+        ):
+            result = await bundle_checker.check_now(db_session)
+        # check_now returns the persisted value, not None.
+        assert result is not None
+        assert result.target_version == "0.5.0"
+        assert (await bundle_checker.get_latest_os_version(db_session)) == "0.5.0"
 
 
+@pytest.mark.asyncio
 class TestGetLatestOsVersion:
-    def test_returns_none_when_empty(self):
+    async def test_returns_none_when_row_absent(self, db_session):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = None
-        try:
-            assert bundle_checker.get_latest_os_version() is None
-        finally:
-            bundle_checker._latest_bundle = original
+        assert (await bundle_checker.get_latest_os_version(db_session)) is None
 
-    def test_returns_target_version(self):
+    async def test_returns_target_version(self, db_session):
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = _stub_bundle("0.0.17-test")
-        try:
-            assert bundle_checker.get_latest_os_version() == "0.0.17-test"
-        finally:
-            bundle_checker._latest_bundle = original
+        await bundle_checker.set_latest_bundle(db_session, _stub_bundle("0.0.17-test"))
+        await db_session.commit()
+        assert (await bundle_checker.get_latest_os_version(db_session)) == "0.0.17-test"
+
+
+@pytest.mark.asyncio
+class TestSetLatestBundleUpsert:
+    """The shared row is a singleton (PK=1, CHECK id=1).  A second
+    ``set_latest_bundle`` must overwrite the row in place, not insert
+    a duplicate (which would 23514 the CHECK constraint anyway)."""
+
+    async def test_upsert_overwrites_existing_row(self, db_session):
+        from cms.services import bundle_checker
+        from cms.models.agora_os_latest_bundle import AgoraOsLatestBundle
+        from sqlalchemy import func, select
+
+        await bundle_checker.set_latest_bundle(db_session, _stub_bundle("1.0.0"))
+        await db_session.commit()
+        await bundle_checker.set_latest_bundle(db_session, _stub_bundle("1.0.1"))
+        await db_session.commit()
+
+        count = await db_session.scalar(select(func.count()).select_from(AgoraOsLatestBundle))
+        assert count == 1
+        assert (await bundle_checker.get_latest_os_version(db_session)) == "1.0.1"
+
+    async def test_upsert_stamps_last_success_at(self, db_session):
+        from cms.services import bundle_checker
+
+        await bundle_checker.set_latest_bundle(db_session, _stub_bundle("1.0.0"))
+        await db_session.commit()
+        status = await bundle_checker.get_status(db_session)
+        assert status["last_success_at"] is not None
+
+
+@pytest.mark.asyncio
+class TestSharedStateAcrossSessions:
+    """Issue #578 invariant: a write through session A must be visible
+    to a read through a separate session B (same engine, different
+    SQLAlchemy session).  This is the multi-replica correctness
+    guarantee that justifies the migration off the module global --
+    every CMS replica has its own session pool, but they all share the
+    same Postgres row."""
+
+    async def test_write_visible_to_independent_session(self, db_engine):
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+        from cms.services import bundle_checker
+
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        # "Replica A" writes.
+        async with factory() as session_a:
+            await bundle_checker.set_latest_bundle(session_a, _stub_bundle("3.4.5"))
+            await session_a.commit()
+
+        # "Replica B" reads through a completely separate session.
+        async with factory() as session_b:
+            assert (await bundle_checker.get_latest_os_version(session_b)) == "3.4.5"
+            bundle = await bundle_checker.get_latest_bundle(session_b)
+            assert bundle is not None
+            assert bundle.target_version == "3.4.5"
+            assert bundle.release_id == "stub-id"
 
 
 @pytest.mark.asyncio
@@ -213,7 +232,6 @@ class TestFetchLatestBundleFollowsRedirects:
     """
 
     async def test_meta_json_302_is_followed(self):
-        import json
         import httpx
         from cms.services import bundle_checker
 

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -443,22 +443,25 @@ class TestFirmwareBadgePermission:
         from cms.models.device import Device, DeviceStatus
         from cms.services import bundle_checker
 
-        # Set a known latest version
-        bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-            target_version="99.0.0",
-            release_id="stub",
-            min_from_version="0.0.0",
-            bundle_url="https://example.com/x.tar.zst",
-            signature_url="https://example.com/x.tar.zst.minisig",
-            sha256_url=None,
-            size_bytes=0,
-            created_at="2026-05-15T00:00:00Z",
-        )
-
         factory = app.dependency_overrides[get_db]
         device_id = "firmware-test-001"
 
         async for db in factory():
+            # Issue #578: seed the shared DB row through the same factory
+            # the route handler uses so the latest_version is visible.
+            await bundle_checker.set_latest_bundle(
+                db,
+                bundle_checker.BundleInfo(
+                    target_version="99.0.0",
+                    release_id="stub",
+                    min_from_version="0.0.0",
+                    bundle_url="https://example.com/x.tar.zst",
+                    signature_url="https://example.com/x.tar.zst.minisig",
+                    sha256_url=None,
+                    size_bytes=0,
+                    created_at="2026-05-15T00:00:00Z",
+                ),
+            )
             device = Device(
                 id=device_id,
                 status=DeviceStatus.ADOPTED,
@@ -474,30 +477,29 @@ class TestFirmwareBadgePermission:
         assert resp.status_code == 200
         assert "99.0.0 available" in resp.text
 
-        # Cleanup
-        bundle_checker._latest_bundle = None
-
     async def test_operator_no_firmware_badge(self, operator_client, app):
         """Operator should NOT see firmware update badge."""
         from cms.database import get_db
         from cms.models.device import Device, DeviceStatus
         from cms.services import bundle_checker
 
-        bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-            target_version="99.0.0",
-            release_id="stub",
-            min_from_version="0.0.0",
-            bundle_url="https://example.com/x.tar.zst",
-            signature_url="https://example.com/x.tar.zst.minisig",
-            sha256_url=None,
-            size_bytes=0,
-            created_at="2026-05-15T00:00:00Z",
-        )
-
         factory = app.dependency_overrides[get_db]
         device_id = "firmware-test-002"
 
         async for db in factory():
+            await bundle_checker.set_latest_bundle(
+                db,
+                bundle_checker.BundleInfo(
+                    target_version="99.0.0",
+                    release_id="stub",
+                    min_from_version="0.0.0",
+                    bundle_url="https://example.com/x.tar.zst",
+                    signature_url="https://example.com/x.tar.zst.minisig",
+                    sha256_url=None,
+                    size_bytes=0,
+                    created_at="2026-05-15T00:00:00Z",
+                ),
+            )
             device = Device(
                 id=device_id,
                 status=DeviceStatus.ADOPTED,
@@ -512,8 +514,6 @@ class TestFirmwareBadgePermission:
         resp = await operator_client.get("/devices")
         assert resp.status_code == 200
         assert "99.0.0 available" not in resp.text
-
-        bundle_checker._latest_bundle = None
 
 
 @pytest.mark.asyncio

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -288,7 +288,6 @@ class TestCheckUpdates:
         from unittest.mock import AsyncMock, patch
         from cms.services import bundle_checker
 
-        original = bundle_checker._latest_bundle
         stub = bundle_checker.BundleInfo(
             target_version="9.9.9",
             release_id="stub",
@@ -299,13 +298,13 @@ class TestCheckUpdates:
             size_bytes=0,
             created_at="2026-05-15T00:00:00Z",
         )
-        try:
-            with patch.object(bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=stub):
-                resp = await client.post("/api/devices/check-updates")
-            assert resp.status_code == 200
-            assert resp.json()["latest_version"] == "9.9.9"
-        finally:
-            bundle_checker._latest_bundle = original
+        # Issue #578: check_now writes to the shared DB row -- the
+        # endpoint reads back via the same row so we don't need to
+        # pre-seed; patching _fetch_latest_bundle is enough.
+        with patch.object(bundle_checker, "_fetch_latest_bundle", new_callable=AsyncMock, return_value=stub):
+            resp = await client.post("/api/devices/check-updates")
+        assert resp.status_code == 200
+        assert resp.json()["latest_version"] == "9.9.9"
 
 
 @pytest.mark.asyncio
@@ -667,23 +666,25 @@ class TestUpgradeGuard:
         from cms.services import device_presence
         await device_presence.mark_online(db_session, "up-pi-002")
 
-        prior_bundle = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-            target_version="0.0.17-test",
-            release_id="rel-up-002",
-            min_from_version="0.0.0",
-            bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
-            signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
-            sha256_url=None,
-            size_bytes=1,
-            created_at="2026-05-15T00:00:00Z",
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-002",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
+                signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=1,
+                created_at="2026-05-15T00:00:00Z",
+            ),
         )
+        await db_session.commit()
         try:
             resp = await client.post("/api/devices/up-pi-002/upgrade")
             assert resp.status_code == 409
             assert "already in progress" in resp.json()["detail"]
         finally:
-            bundle_checker._latest_bundle = prior_bundle
             device_manager.disconnect("up-pi-002")
 
     async def test_upgrade_no_bundle_cached(self, client, db_session):
@@ -709,14 +710,13 @@ class TestUpgradeGuard:
         device_manager.register("up-pi-503", FakeWS())
         await device_presence.mark_online(db_session, "up-pi-503")
 
-        prior_bundle = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = None
+        # Issue #578: shared DB row stays empty in this test -- no
+        # set_latest_bundle() means the upgrade endpoint sees None.
         try:
             resp = await client.post("/api/devices/up-pi-503/upgrade")
             assert resp.status_code == 503
             assert resp.json()["detail"] == "bundle_not_yet_cached"
         finally:
-            bundle_checker._latest_bundle = prior_bundle
             device_manager.disconnect("up-pi-503")
 
     async def test_upgrade_already_on_target_version(self, client, db_session):
@@ -745,23 +745,25 @@ class TestUpgradeGuard:
         device_manager.register("up-pi-409a", FakeWS())
         await device_presence.mark_online(db_session, "up-pi-409a")
 
-        prior_bundle = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-            target_version="0.0.17-test",
-            release_id="rel-up-409a",
-            min_from_version="0.0.0",
-            bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
-            signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
-            sha256_url=None,
-            size_bytes=1,
-            created_at="2026-05-15T00:00:00Z",
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-409a",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
+                signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=1,
+                created_at="2026-05-15T00:00:00Z",
+            ),
         )
+        await db_session.commit()
         try:
             resp = await client.post("/api/devices/up-pi-409a/upgrade")
             assert resp.status_code == 409
             assert resp.json()["detail"] == "already_on_target_version"
         finally:
-            bundle_checker._latest_bundle = prior_bundle
             device_manager.disconnect("up-pi-409a")
 
     async def test_upgrade_sends_os_update_dispatch(self, client, db_session):
@@ -796,17 +798,20 @@ class TestUpgradeGuard:
                 sent_messages.append((device_id, msg))
                 return True
 
-        prior_bundle = bundle_checker._latest_bundle
-        bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-            target_version="0.0.17-test",
-            release_id="rel-up-ok",
-            min_from_version="0.0.0",
-            bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
-            signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
-            sha256_url=None,
-            size_bytes=12345,
-            created_at="2026-05-15T00:00:00Z",
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-ok",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst",
+                signature_url="https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=12345,
+                created_at="2026-05-15T00:00:00Z",
+            ),
         )
+        await db_session.commit()
 
         set_transport(CapturingTransport())
         try:
@@ -826,7 +831,6 @@ class TestUpgradeGuard:
                 "https://example.invalid/agora-bundle-0.0.17-test.tar.zst.minisig"
             )
         finally:
-            bundle_checker._latest_bundle = prior_bundle
             reset_transport_to_local()
 
     async def test_upgrade_clears_flag_on_disconnect(self, client, db_session):

--- a/tests/test_devices_phase_d_coverage.py
+++ b/tests/test_devices_phase_d_coverage.py
@@ -111,21 +111,27 @@ async def grouped_update_device(app):
         device_id = device.id
         break
 
-    saved = bundle_checker._latest_bundle
-    bundle_checker._latest_bundle = bundle_checker.BundleInfo(
-        target_version="9.9.9",
-        release_id="stub",
-        min_from_version="0.0.0",
-        bundle_url="https://example.com/x.tar.zst",
-        signature_url="https://example.com/x.tar.zst.minisig",
-        sha256_url=None,
-        size_bytes=0,
-        created_at="2026-05-15T00:00:00Z",
-    )
-    try:
-        yield {"group_id": group_id, "device_id": device_id}
-    finally:
-        bundle_checker._latest_bundle = saved
+    # Issue #578: seed the shared agora_os_latest_bundle DB row instead of
+    # poking the (now-removed) module-level cache. Reuse the same factory
+    # so the write is visible to the route handler's session.
+    async for db in factory():
+        await bundle_checker.set_latest_bundle(
+            db,
+            bundle_checker.BundleInfo(
+                target_version="9.9.9",
+                release_id="stub",
+                min_from_version="0.0.0",
+                bundle_url="https://example.com/x.tar.zst",
+                signature_url="https://example.com/x.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=0,
+                created_at="2026-05-15T00:00:00Z",
+            ),
+        )
+        await db.commit()
+        break
+
+    yield {"group_id": group_id, "device_id": device_id}
 
 
 # ── /api/devices/groups/{id}/panel — permission gating ──────────────


### PR DESCRIPTION
Fixes #578.

## Problem

Each CMS replica had its own in-memory cache of "latest agora-os release". The bundle_checker poll on one replica would refresh its cache, the others stayed stale until their own 30-min poll fired. Requests round-robined across replicas, so the "Update available" badge (and the Upgrade button driven by it) flickered on and off.

## Fix

Move the cached bundle into a new singleton-row Postgres table (\gora_os_latest_bundle\,  + "CHECK (id = 1)" + ) so every replica reads from the same source of truth. The poll loop on any replica writes there; every read path takes a db session.

### API change

 + "is_os_update_available(current, latest)" +  -- the  + "latest" +  arg is now **required**. The old implicit-fallback-to-module-cache was the bug we're fixing; every call site now pre-fetches latest_version once per request and threads it through.

### Per-replica vs shared

-  + "_last_success_at" +  -> moved into the shared DB row (cross-replica freshness signal).
-  + "_last_error" +  -> stays module-global (per-replica debug state, more useful for diagnosing partial outages).

## Changes

- New:  + "cms/models/agora_os_latest_bundle.py" +  (singleton model),  + "lembic/versions/0026_agora_os_latest_bundle.py" +  (migration).
-  + "cms/services/bundle_checker.py" +  rewritten: async  + "get_latest_bundle/get_latest_os_version/get_status/check_now/set_latest_bundle" + ; poll loop uses lazy session factory + defensive try/except so a transient DB error doesn't kill the loop.
-  + "cms/routers/devices.py" +  (5 call sites) +  + "cms/ui.py" +  (3 call sites) updated to the new shape.
-  + "	ests/test_bundle_checker.py" +  rewritten (21 tests). New  + "TestSharedStateAcrossSessions" +  proves a write on session A is visible to session B on the same engine.
-  + "	ests/test_devices.py/	ests/test_devices_phase_d_coverage.py/	ests/test_device_live_updates.py" +  migrated from  + "undle_checker._latest_bundle = stub" +  to  + "wait set_latest_bundle(db, stub); await db.commit()" + .

## Test plan

Targeted suites green locally:
-  + "	ests/test_bundle_checker.py" +  -- 21/21
-  + "	ests/test_devices.py + test_devices_phase_d_coverage.py + test_device_live_updates.py" +  -- 105/105

Full suite: relying on CI.
