### PR TITLE
fix(upgrade): cooldown gate on send failure to break retry race (#511)

### DIFF
--- a/alembic/versions/0027_devices_upgrade_cooldown_until.py
+++ b/alembic/versions/0027_devices_upgrade_cooldown_until.py
@@ -1,0 +1,63 @@
+"""Add ``devices.upgrade_cooldown_until`` column for the upgrade endpoint's
+send-failure cooldown (issue agora-cms#511).
+
+Before this revision, the upgrade endpoint's three failure paths all
+called ``_release_claim()`` to clear ``upgrade_started_at`` back to
+NULL.  That's correct for the 503 (bundle not cached) and 409 (already
+on target) fast-fail paths -- both return the same answer on an
+immediate retry, so a held claim only adds friction -- but it's wrong
+for the 502 (send-to-device failed) path: a user who double-clicks
+"Update" while the first send is in flight gets back-to-back 502s
+because both requests see ``upgrade_started_at IS NULL`` after each
+other's failure rolls back the claim.
+
+The simplest backdated-marker trick (write a stale ``upgrade_started_at``
+so it auto-expires in ~10s via the existing TTL) doesn't work because
+``_is_upgrading()`` reads the same column, so a backdated marker (which
+is 14m50s "in the past") still reads as within ``UPGRADE_TTL = 15m`` --
+the UI would show "Upgrading..." for 10s with no upgrade actually in
+flight, which is more confusing than the original race.
+
+Solution: a separate ``upgrade_cooldown_until`` timestamptz column.
+The CAS-claim SQL adds a clause requiring this column to be either
+NULL or in the past; ``_is_upgrading()`` does NOT inspect this column,
+so the "Upgrading..." badge correctly stays off during the cooldown
+window.  The send-failure rollback both clears ``upgrade_started_at``
+to NULL and sets ``upgrade_cooldown_until = now() + 10s`` in a single
+UPDATE.
+
+The column is nullable with no server-side default so the existing
+fleet rows pick up NULL on upgrade, exactly what we want (no
+back-pressure on any device that wasn't mid-failure at migration time).
+
+Revision ID: 0027
+Revises: 0026
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "devices",
+        sa.Column(
+            "upgrade_cooldown_until",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Downgrade of 0027 is intentionally not implemented per project policy."
+    )

--- a/cms/models/device.py
+++ b/cms/models/device.py
@@ -165,6 +165,24 @@ class Device(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # ---- Issue agora-cms#511: send-failure cooldown ----
+    # When the upgrade endpoint's send-to-device call fails (502), we
+    # don't immediately clear ``upgrade_started_at`` -- a double-click
+    # during a slow send would otherwise hit the second send before the
+    # first's failure had a chance to roll back the claim, returning a
+    # second 502 instead of "wait a moment".  Instead, the send-failure
+    # path clears ``upgrade_started_at`` to NULL and sets this column
+    # to ``now() + SEND_FAILURE_COOLDOWN`` in a single UPDATE; the CAS
+    # in the upgrade endpoint refuses to issue a new claim while this
+    # timestamp is in the future.  Kept separate from
+    # ``upgrade_started_at`` so ``_is_upgrading()`` stays correct -- a
+    # device that hit a 502 is NOT upgrading, and the UI badge should
+    # reflect that.  Nullable + no default so existing rows pick up
+    # NULL on migration, which matches "no cooldown active".
+    upgrade_cooldown_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # ---- OTA progress (issue agora-cms#574 / migration 0025) ----
     # Live progress for the in-flight OS OTA, written by the WPS lifecycle
     # event handler (`cms.services.ota_progress.handle_event`) and surfaced

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -54,6 +54,16 @@ device_originated_router = APIRouter(prefix="/api/devices", tags=["devices (devi
 # letting another upgrade request reclaim it (covers stuck reboots).
 UPGRADE_TTL = timedelta(minutes=15)
 
+# Issue agora-cms#511: when the send-to-device call fails (502), hold a
+# cooldown for this short window before allowing another claim. Without
+# it, a double-click while the first send is in flight returns back-to-
+# back 502s instead of "give the first one a moment". Stored in its own
+# ``upgrade_cooldown_until`` column rather than backdating
+# ``upgrade_started_at`` so ``_is_upgrading()`` stays semantically
+# correct -- a device that just hit a 502 is *not* upgrading, and the
+# UI badge must reflect that throughout the cooldown.
+SEND_FAILURE_COOLDOWN = timedelta(seconds=10)
+
 # Issue agora-cms#574 — how recent a device's last lifecycle event has
 # to be before we still trust ``devices.ota_*`` to reflect a live OTA.
 # Devices emit events on every FSM transition + every 2s during long
@@ -549,6 +559,16 @@ async def upgrade_device(
                 Device.upgrade_started_at < ttl_cutoff,
             )
         )
+        .where(
+            # Issue agora-cms#511: also gate on the send-failure cooldown.
+            # A row that just rolled back from a 502 will have this column
+            # set ~10s into the future; the CAS must reject the retry
+            # until the cooldown elapses.
+            or_(
+                Device.upgrade_cooldown_until.is_(None),
+                Device.upgrade_cooldown_until < claim_ts,
+            )
+        )
         .values(upgrade_started_at=claim_ts)
         .returning(Device.upgrade_started_at)
         .execution_options(synchronize_session=False)
@@ -556,7 +576,8 @@ async def upgrade_device(
     claimed = result.scalar_one_or_none()
     await db.commit()
     if claimed is None:
-        # Another request holds a live claim within TTL.
+        # Another request holds a live claim within TTL, or we're inside
+        # the post-502 send-failure cooldown window.
         raise HTTPException(
             status_code=409,
             detail="Upgrade already in progress for this device",
@@ -572,6 +593,29 @@ async def upgrade_device(
             .where(Device.id == device_id)
             .where(Device.upgrade_started_at == claimed)
             .values(upgrade_started_at=None)
+            .execution_options(synchronize_session=False)
+        )
+        await db.commit()
+
+    async def _release_with_cooldown() -> None:
+        """Release the claim AND arm the send-failure cooldown.
+
+        Used by the 502 (send-to-device failed) path only.  We clear
+        ``upgrade_started_at`` (so ``_is_upgrading()`` returns False
+        and the UI badge stops showing "Upgrading...") AND set
+        ``upgrade_cooldown_until = now + SEND_FAILURE_COOLDOWN`` in a
+        single UPDATE, guarded by the claim token so we don't disturb
+        a successor's claim if one snuck in past the cooldown clause.
+        """
+        cooldown_until = datetime.now(timezone.utc) + SEND_FAILURE_COOLDOWN
+        await db.execute(
+            update(Device)
+            .where(Device.id == device_id)
+            .where(Device.upgrade_started_at == claimed)
+            .values(
+                upgrade_started_at=None,
+                upgrade_cooldown_until=cooldown_until,
+            )
             .execution_options(synchronize_session=False)
         )
         await db.commit()
@@ -610,7 +654,10 @@ async def upgrade_device(
     )
     sent = await get_transport().send_to_device(device_id, upgrade_msg.model_dump(mode="json"))
     if not sent:
-        await _release_claim()
+        # Issue agora-cms#511: hold the claim slot for a short cooldown
+        # window before allowing another attempt. Without this, a
+        # double-click during a slow send returns back-to-back 502s.
+        await _release_with_cooldown()
         raise HTTPException(status_code=502, detail="Failed to send to device")
 
     await audit_log(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -856,6 +856,227 @@ class TestUpgradeGuard:
         )).scalar_one()
         assert row.upgrade_started_at is None
 
+    async def test_send_failure_holds_claim_for_cooldown(self, client, db_session):
+        """Issue #511: a 502 send-failure arms a short cooldown window
+        during which a retry returns 409, not another 502.
+
+        Without this, double-clicking Upgrade while the first send is
+        in flight reliably produces back-to-back 502s because each
+        request sees ``upgrade_started_at IS NULL`` after the other's
+        rollback. The cooldown column makes the CAS reject the retry
+        until the window elapses.
+        """
+        from datetime import datetime, timezone, timedelta
+        from sqlalchemy import select, update
+        from cms.models.device import Device, DeviceStatus
+        from cms.services import bundle_checker, device_presence
+        from cms.services.transport import set_transport, reset_transport_to_local
+
+        device = Device(
+            id="up-pi-511a",
+            name="up-pi-511a",
+            status=DeviceStatus.ADOPTED,
+            os_version="0.0.16-test",
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await device_presence.mark_online(db_session, "up-pi-511a")
+
+        class AlwaysFailTransport:
+            async def is_connected(self, device_id): return True
+            async def send_to_device(self, device_id, msg): return False
+
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-511a",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/x.tar.zst",
+                signature_url="https://example.invalid/x.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=1,
+                created_at="2026-05-15T00:00:00Z",
+            ),
+        )
+        await db_session.commit()
+
+        set_transport(AlwaysFailTransport())
+        try:
+            # First attempt -- send fails, claim rolls back, cooldown is armed.
+            resp1 = await client.post("/api/devices/up-pi-511a/upgrade")
+            assert resp1.status_code == 502
+            assert resp1.json()["detail"] == "Failed to send to device"
+
+            # Immediate retry -- still inside cooldown window, must 409.
+            resp2 = await client.post("/api/devices/up-pi-511a/upgrade")
+            assert resp2.status_code == 409, (
+                f"expected 409 during cooldown, got {resp2.status_code}: {resp2.text}"
+            )
+            assert "already in progress" in resp2.json()["detail"]
+
+            # Verify the database state: upgrade_started_at cleared,
+            # cooldown set in the future.
+            db_session.expire_all()
+            row = (await db_session.execute(
+                select(Device).where(Device.id == "up-pi-511a")
+            )).scalar_one()
+            assert row.upgrade_started_at is None
+            assert row.upgrade_cooldown_until is not None
+            cooldown_until = row.upgrade_cooldown_until
+            if cooldown_until.tzinfo is None:
+                cooldown_until = cooldown_until.replace(tzinfo=timezone.utc)
+            assert cooldown_until > datetime.now(timezone.utc)
+
+            # Fast-forward past the cooldown by rewriting the column,
+            # then assert the CAS succeeds again (proves the cooldown
+            # was the only thing blocking the retry, not some leftover
+            # claim).
+            await db_session.execute(
+                update(Device)
+                .where(Device.id == "up-pi-511a")
+                .values(upgrade_cooldown_until=datetime.now(timezone.utc) - timedelta(seconds=1))
+            )
+            await db_session.commit()
+            resp3 = await client.post("/api/devices/up-pi-511a/upgrade")
+            assert resp3.status_code == 502  # still fails (transport still mocked to fail) but now reaches send
+        finally:
+            reset_transport_to_local()
+
+    async def test_send_failure_cooldown_does_not_render_is_upgrading(
+        self, client, db_session
+    ):
+        """Issue #511: during the post-502 cooldown window, the device
+        must NOT show ``is_upgrading=True`` -- no upgrade is in flight.
+
+        This is the test that would have caught the earlier backdated-
+        timestamp design: writing a stale ``upgrade_started_at`` would
+        make ``_is_upgrading()`` return True for the entire cooldown
+        window, displaying "Upgrading..." in the UI when nothing was
+        actually happening.
+        """
+        from cms.models.device import Device, DeviceStatus
+        from cms.services import bundle_checker, device_presence
+        from cms.services.transport import set_transport, reset_transport_to_local
+
+        device = Device(
+            id="up-pi-511b",
+            name="up-pi-511b",
+            status=DeviceStatus.ADOPTED,
+            os_version="0.0.16-test",
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await device_presence.mark_online(db_session, "up-pi-511b")
+
+        class AlwaysFailTransport:
+            async def is_connected(self, device_id): return True
+            async def send_to_device(self, device_id, msg): return False
+
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-511b",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/x.tar.zst",
+                signature_url="https://example.invalid/x.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=1,
+                created_at="2026-05-15T00:00:00Z",
+            ),
+        )
+        await db_session.commit()
+
+        set_transport(AlwaysFailTransport())
+        try:
+            resp_fail = await client.post("/api/devices/up-pi-511b/upgrade")
+            assert resp_fail.status_code == 502
+        finally:
+            reset_transport_to_local()
+
+        # GET /api/devices uses get_all_states() which AlwaysFailTransport
+        # doesn't stub; reset to the local transport first so the device
+        # list response is well-formed and we can assert on is_upgrading.
+        resp_list = await client.get("/api/devices")
+        assert resp_list.status_code == 200
+        target = next((d for d in resp_list.json() if d["id"] == "up-pi-511b"), None)
+        assert target is not None, "device not in /api/devices response"
+        assert target["is_upgrading"] is False, (
+            "is_upgrading must be False during send-failure cooldown -- "
+            "the UI must not lie about the device's upgrade state"
+        )
+
+    async def test_send_failure_cooldown_does_not_extend_ttl_recovery(
+        self, client, db_session
+    ):
+        """Issue #511: a stale ``upgrade_started_at`` claim (operator
+        clicked Upgrade, device dropped before any failure rollback)
+        still auto-expires via the existing ``UPGRADE_TTL`` regardless
+        of whether ``upgrade_cooldown_until`` is also set in the past.
+
+        Guards against an accidental implementation that ANDs the
+        cooldown clause into the TTL check itself, which would block
+        recovery from a stuck upgrade for any device that had ever hit
+        a 502 in the past (since cooldown_until is set permanently as
+        a timestamp, never NULLed out).
+        """
+        from datetime import datetime, timezone, timedelta
+        from cms.models.device import Device, DeviceStatus
+        from cms.services import bundle_checker, device_presence
+        from cms.services.transport import set_transport, reset_transport_to_local
+
+        # Seed a device with a STALE upgrade_started_at (older than
+        # UPGRADE_TTL) AND a long-past cooldown_until -- the legitimate
+        # state of a device that hit a 502 some time ago, then had an
+        # operator click Upgrade and lose connectivity. The new attempt
+        # below must succeed because the original claim is past TTL.
+        long_ago = datetime.now(timezone.utc) - timedelta(minutes=30)
+        device = Device(
+            id="up-pi-511c",
+            name="up-pi-511c",
+            status=DeviceStatus.ADOPTED,
+            os_version="0.0.16-test",
+            upgrade_started_at=long_ago,
+            upgrade_cooldown_until=long_ago,
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await device_presence.mark_online(db_session, "up-pi-511c")
+
+        sent_messages: list = []
+
+        class CapturingTransport:
+            async def is_connected(self, device_id): return True
+            async def send_to_device(self, device_id, msg):
+                sent_messages.append((device_id, msg))
+                return True
+
+        await bundle_checker.set_latest_bundle(
+            db_session,
+            bundle_checker.BundleInfo(
+                target_version="0.0.17-test",
+                release_id="rel-up-511c",
+                min_from_version="0.0.0",
+                bundle_url="https://example.invalid/x.tar.zst",
+                signature_url="https://example.invalid/x.tar.zst.minisig",
+                sha256_url=None,
+                size_bytes=1,
+                created_at="2026-05-15T00:00:00Z",
+            ),
+        )
+        await db_session.commit()
+
+        set_transport(CapturingTransport())
+        try:
+            resp = await client.post("/api/devices/up-pi-511c/upgrade")
+            assert resp.status_code == 200, (
+                f"stale TTL claim should release; got {resp.status_code}: {resp.text}"
+            )
+            assert len(sent_messages) == 1
+        finally:
+            reset_transport_to_local()
+
 
 @pytest.mark.asyncio
 class TestDeviceGroups:


### PR DESCRIPTION
Closes #511.

## What this fixes

When the upgrade-endpoint POST succeeded at the CAS but the directive send
to the device failed (transport 502), the previous code released the
claim by clearing `upgrade_started_at` back to NULL. A racing client retry
that landed in the same tick could win the next CAS immediately, re-emit
the directive, and (if the transport was still degraded) produce a thrash
of 502s with no breathing room for the underlying transport to recover.

This change introduces a per-device cooldown column,
`upgrade_cooldown_until`, that gates the CAS for `SEND_FAILURE_COOLDOWN`
(10s) after a 502 send-failure release. During the window:

- the CAS rejects new claim attempts (returns 409), and
- `_is_upgrading()` correctly reports `False` because it only consults
  `upgrade_started_at` — the badge does **not** light up as "Upgrading…"
  during a cooldown when no upgrade is in flight.

## Why a separate column

The obvious shorter approach would be to backdate `upgrade_started_at`
into the past (CAS already rejects rows whose timestamp is within
`UPGRADE_TTL`). But `_is_upgrading()` (`devices.py` L82-87) reads
`upgrade_started_at` against the same 15-minute TTL. A backdated marker
that's still within TTL would render the device as "Upgrading…" for the
entire cooldown window even though no upgrade is actually in flight.
That UX is worse than the original retry race — operators would think
the upgrade succeeded when it didn't. **Duck flagged this**; the column
approach keeps the two concerns decoupled.

## Implementation

- **`alembic/versions/0027_devices_upgrade_cooldown_until.py`** — add
  nullable timestamptz `upgrade_cooldown_until` on `devices`. No
  `server_default`, no backfill — column is NULL until a send-failure
  path writes to it. Downgrade raises `NotImplementedError` per project
  policy.
- **`cms/models/device.py`** — matching `Mapped[datetime | None]`
  declaration immediately after `upgrade_started_at`, with a block
  comment explaining why this isn't combined with the existing column.
- **`cms/routers/devices.py`**:
  - `SEND_FAILURE_COOLDOWN = timedelta(seconds=10)` constant alongside
    `UPGRADE_TTL`.
  - Extend the CAS with a second `or_()` `.where()` clause that lets a
    claim through only when the cooldown is `NULL` or in the past.
  - `_release_with_cooldown()` helper: clears `upgrade_started_at` AND
    stamps `upgrade_cooldown_until` in a single `UPDATE`, guarded by the
    claim token so it can't disturb a successor's claim.
  - Wire the 502 send-failure path to use it; 503 (no bundle) and 409
    (already-on-target) keep using `_release_claim` because retrying
    those returns the same answer immediately.

## Tests (all green locally — 102 passed across `test_devices.py` + `test_device_live_updates.py`)

- **`test_send_failure_holds_claim_for_cooldown`** — 502, then immediate
  POST returns 409; fast-forward `cooldown_until` into the past and the
  next CAS succeeds.
- **`test_send_failure_cooldown_does_not_render_is_upgrading`** — GET
  `/api/devices` reports `is_upgrading=False` during the cooldown
  window. (Would fail under the backdating approach.)
- **`test_send_failure_cooldown_does_not_extend_ttl_recovery`** — a
  stuck stale-TTL claim still auto-recovers regardless of
  `cooldown_until`.

## Risk + rollback

Additive: one new column, one new constant, one new helper. Worst-case
behavior change is that a Pi whose first upgrade attempt fails has to
wait 10 seconds before the next attempt instead of being able to retry
immediately. Revert by reverting the merge commit; the column stays
nullable so existing rows are unaffected.
