### PR TITLE
imager: add "Copy download link" kebab action on Built Images

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -26,6 +26,10 @@ pipeline shipped in PRs 1–3:
   ``IMAGE_PROVISION`` lands.
 * :http:get:`/api/imager/download/{job_id}` — 302 to a fresh SAS
   URL for the provisioned image.  Audited.
+* :http:get:`/api/imager/download-url/{job_id}` — return that same
+  fresh SAS URL as JSON ``{"url": ...}`` so the UI's "Copy
+  download link" action can hand the raw URL to ``wget`` / ``curl``
+  without going through a browser redirect.  Audited.
 
 Identity model is **Model B only**: the image carries fleet
 credentials, not per-device credentials.  Each Pi flashed with the
@@ -1115,20 +1119,32 @@ async def get_job_status(
     return out
 
 
-@router.get("/download/{job_id}")
-async def download_provisioned(
-    job_id: uuid.UUID,
-    request: Request,
-    user: User = Depends(require_permission(IMAGER_BUILD)),
-    db: AsyncSession = Depends(get_db),
-    settings: Settings = Depends(get_settings),
-) -> RedirectResponse:
-    """Return a 302 to a fresh SAS URL for the provisioned image.
+class DownloadUrlOut(BaseModel):
+    """Response body for :http:get:`/api/imager/download-url/{job_id}`."""
 
-    Audited.  404s when the job is unknown, not an ``IMAGE_PROVISION``,
-    not yet succeeded, or whose row is no longer ``READY`` (e.g. the
-    24 h Azure lifecycle policy has expired the blob and the row is
-    now ``EXPIRED``).
+    url: str
+
+
+async def _resolve_provisioned_sas(
+    job_id: uuid.UUID,
+    db: AsyncSession,
+    settings: Settings,
+) -> tuple[Job, ProvisionedImage, str]:
+    """Validate an ``IMAGE_PROVISION`` job and mint a fresh SAS URL for it.
+
+    Shared between :func:`download_provisioned` (302 redirect) and
+    :func:`download_url_provisioned` (JSON for the "Copy download link"
+    kebab action) so both code paths apply identical validation +
+    blob-presence + SAS-minting rules.  Each caller is responsible
+    for its own ``audit_log`` entry and ``db.commit``.
+
+    Raises the same ``HTTPException``s the original endpoint did:
+
+    * 404 — job is unknown / not ``IMAGE_PROVISION`` / no longer
+      ``READY`` (e.g. the 24 h Azure lifecycle policy already
+      expired the blob and the row is now ``EXPIRED``) / the blob is
+      missing from storage.
+    * 409 — job is known but has not reached ``DONE`` yet.
     """
     job = await db.get(Job, job_id)
     if job is None or job.type != JobType.IMAGE_PROVISION:
@@ -1155,24 +1171,80 @@ async def download_provisioned(
         pi.blob_path,
         settings.imager_sas_ttl_hours,
     )
+    return job, pi, url
+
+
+def _provisioned_audit_details(job: Job, pi: ProvisionedImage) -> dict[str, Any]:
+    """Identity fields stamped into download/copy-link audit rows."""
+    return {
+        "job_id": str(job.id),
+        # base_image_id may be NULL if the cached base was deleted
+        # after this build was produced (audit FK is SET NULL).
+        # base_variant / base_version snapshot columns preserve
+        # identity in that case.
+        "base_image_id": str(pi.base_image_id) if pi.base_image_id else None,
+        "base_variant": pi.base_variant,
+        "base_version": pi.base_version,
+        "fleet_id": pi.fleet_id,
+        "output_name": pi.output_name,
+    }
+
+
+@router.get("/download/{job_id}")
+async def download_provisioned(
+    job_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_BUILD)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> RedirectResponse:
+    """Return a 302 to a fresh SAS URL for the provisioned image.
+
+    Audited.  404s when the job is unknown, not an ``IMAGE_PROVISION``,
+    not yet succeeded, or whose row is no longer ``READY`` (e.g. the
+    24 h Azure lifecycle policy has expired the blob and the row is
+    now ``EXPIRED``).
+    """
+    job, pi, url = await _resolve_provisioned_sas(job_id, db, settings)
 
     await audit_log(
         db, user=user, action="imager.download",
         resource_type="provisioned_image", resource_id=str(pi.id),
-        details={
-            "job_id": str(job.id),
-            # base_image_id may be NULL if the cached base was
-            # deleted after this build was produced (audit FK is
-            # SET NULL).  base_variant / base_version snapshot
-            # columns preserve identity in that case.
-            "base_image_id": str(pi.base_image_id) if pi.base_image_id else None,
-            "base_variant": pi.base_variant,
-            "base_version": pi.base_version,
-            "fleet_id": pi.fleet_id,
-            "output_name": pi.output_name,
-        },
+        details=_provisioned_audit_details(job, pi),
         request=request,
     )
     await db.commit()
 
     return RedirectResponse(url=url, status_code=302)
+
+
+@router.get("/download-url/{job_id}", response_model=DownloadUrlOut)
+async def download_url_provisioned(
+    job_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_BUILD)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> DownloadUrlOut:
+    """Return a fresh SAS download URL for the provisioned image as JSON.
+
+    Backs the built-images table's "Copy download link" kebab action
+    so an operator can paste the URL into ``wget`` / ``curl`` from a
+    Linux shell without going through the browser's redirect chain.
+
+    Applies the same validation, blob-existence check, and SAS TTL
+    as :func:`download_provisioned`.  Audited as ``imager.copy_link``
+    so this is distinguishable from a normal browser download in the
+    audit trail.
+    """
+    job, pi, url = await _resolve_provisioned_sas(job_id, db, settings)
+
+    await audit_log(
+        db, user=user, action="imager.copy_link",
+        resource_type="provisioned_image", resource_id=str(pi.id),
+        details=_provisioned_audit_details(job, pi),
+        request=request,
+    )
+    await db.commit()
+
+    return DownloadUrlOut(url=url)

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -512,19 +512,36 @@
                     ? '<a class="btn btn-primary btn-sm" href="/api/imager/download/' +
                       encodeURIComponent(r.download_job_id) + '" download>Download</a>'
                     : '<span class="text-muted" style="font-size:0.8rem;">unavailable</span>';
-                // Kebab (Delete only for now) -- matches the shared
-                // pattern from _macros.html / .btn-kebab CSS / the
-                // global popover positioning in app.js.
+                // Kebab (Copy download link + Delete) -- matches the
+                // shared pattern from _macros.html / .btn-kebab CSS /
+                // the global popover positioning in app.js.  We show
+                // the kebab whenever it would have at least one item:
+                // Copy-Link follows whoever can use the Download
+                // button (imager:build), and Delete is admin-only
+                // (canManage).  Non-manager users with a READY image
+                // therefore see a kebab containing only Copy-Link.
                 var actions = dlBtn;
+                var menuItems = '';
+                if (dlEnabled) {
+                    menuItems +=
+                        '<button type="button" role="menuitem" ' +
+                            'data-built-copy-link="' + escHtml(r.download_job_id) +
+                            '" data-built-name="' + escHtml(r.output_name) + '">' +
+                            'Copy download link</button>';
+                }
                 if (canManage) {
+                    menuItems +=
+                        '<button type="button" role="menuitem" class="kebab-item-danger" ' +
+                            'data-built-delete="' + escHtml(r.id) +
+                            '" data-built-name="' + escHtml(r.output_name) + '">Delete</button>';
+                }
+                if (menuItems) {
                     var kid = 'kebab-built-' + Math.floor(Math.random() * 1e12);
                     actions += ' ' +
                         '<button type="button" class="btn-kebab" popovertarget="' + kid +
                             '" aria-haspopup="menu" aria-label="Actions">\u22ee</button>' +
                         '<div id="' + kid + '" popover class="kebab-menu" role="menu">' +
-                            '<button type="button" role="menuitem" class="kebab-item-danger" ' +
-                                'data-built-delete="' + escHtml(r.id) +
-                                '" data-built-name="' + escHtml(r.output_name) + '">Delete</button>' +
+                            menuItems +
                         '</div>';
                 }
                 var base = (r.base_variant || r.base_version)
@@ -566,6 +583,17 @@
                     deleteBuiltImage(btn.dataset.builtDelete, btn.dataset.builtName);
                 });
             });
+            // Wire up "Copy download link" buttons (anyone who can
+            // see Download).  Fetches a fresh SAS URL on click so the
+            // copied link reflects the current TTL, and pastes
+            // straight into the OS clipboard via the shared
+            // ``copyToClipboard`` helper (which also fires its own
+            // "Copied to clipboard" toast).
+            tbody.querySelectorAll('button[data-built-copy-link]').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    copyBuiltImageLink(btn.dataset.builtCopyLink, btn.dataset.builtName);
+                });
+            });
         } catch (e) {
             if (myReq !== loadBuiltImagesReq) return;
             lastBuiltSig = '';
@@ -600,6 +628,31 @@
             loadBuiltImages();
         } catch (e) {
             toast('Delete failed: ' + (e.message || e), 'error');
+        }
+    }
+
+    async function copyBuiltImageLink(jobId, name) {
+        // Close the open kebab popover first so the "Copied to
+        // clipboard" toast isn't visually layered behind the menu.
+        var openPop = document.querySelector('.kebab-menu:popover-open');
+        if (openPop) { try { openPop.hidePopover(); } catch (e) { /* unsupported */ } }
+        try {
+            var resp = await jsonFetch('/api/imager/download-url/' + encodeURIComponent(jobId));
+            if (!resp || !resp.url) {
+                toast('Failed to mint download link for ' + name, 'error');
+                return;
+            }
+            // ``copyToClipboard`` shows its own "Copied to clipboard"
+            // toast on success and a fallback-failure toast on error,
+            // so we don't double-up here.
+            if (typeof copyToClipboard === 'function') {
+                copyToClipboard(resp.url);
+            } else {
+                // Defensive fallback: app.js missing for some reason.
+                toast(resp.url, 'success');
+            }
+        } catch (e) {
+            toast('Copy link failed: ' + (e.message || e), 'error');
         }
     }
 

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -176,6 +176,7 @@ async def test_endpoints_require_auth(unauthed_client):
         ("DELETE", f"/api/imager/provisioned-images/{uuid.uuid4()}"),
         ("GET", f"/api/imager/jobs/{uuid.uuid4()}"),
         ("GET", f"/api/imager/download/{uuid.uuid4()}"),
+        ("GET", f"/api/imager/download-url/{uuid.uuid4()}"),
     ]
     for method, path in paths:
         kwargs = {"json": {}} if method == "POST" else {}
@@ -1004,6 +1005,86 @@ async def test_download_redirects_when_ready(
     resp = await client.get(f"/api/imager/download/{job.id}", follow_redirects=False)
     assert resp.status_code == 302, resp.text
     assert resp.headers.get("location", "").startswith("https://example.com/sas/")
+
+
+@pytest.mark.asyncio
+async def test_download_url_returns_sas_as_json(
+    client, db_session, imager_settings, monkeypatch,
+):
+    """``/download-url/{job_id}`` hands back the SAS as JSON for wget-style copy."""
+    from cms.models.audit_log import AuditLog
+    from shared.services import storage as storage_mod
+
+    async def _blob_exists(self, container: str, blob_name: str) -> bool:
+        return True
+
+    def _sas(self, container: str, blob_name: str, ttl_hours: int) -> str:
+        return f"https://example.com/sas/{container}/{blob_name}?sig=stub"
+
+    monkeypatch.setattr(
+        storage_mod.LocalStorageBackend, "blob_exists", _blob_exists,
+    )
+    monkeypatch.setattr(
+        storage_mod.LocalStorageBackend, "generate_blob_sas_url", _sas,
+    )
+
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"x\n",
+        status=ProvisionedImageStatus.READY.value,
+        blob_path="abc/x.img.xz",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+    )
+    db_session.add(pi)
+    await db_session.flush()
+    job = Job(
+        type=JobType.IMAGE_PROVISION, target_id=pi.id,
+        status=JobStatus.DONE,
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/download-url/{job.id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["url"].startswith("https://example.com/sas/")
+    assert "?sig=" in body["url"]
+
+    # Audit row is logged under a distinct action so the audit trail
+    # can distinguish "copied the link" from "actually downloaded".
+    rows = (await db_session.execute(
+        select(AuditLog).where(AuditLog.action == "imager.copy_link")
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].resource_id == str(pi.id)
+
+
+@pytest.mark.asyncio
+async def test_download_url_404_when_not_ready(
+    client, db_session, imager_settings,
+):
+    """Same not-ready guards as ``/download/{job_id}`` (job pending → 409)."""
+    bi = BaseImage(variant="pi5", version="v1", status=BaseImageStatus.READY.value)
+    db_session.add(bi)
+    await db_session.flush()
+    pi = ProvisionedImage(
+        base_image_id=bi.id,
+        output_name="x.img.xz",
+        fleet_env_payload=b"x\n",
+        status=ProvisionedImageStatus.PROVISIONING.value,
+    )
+    db_session.add(pi)
+    await db_session.flush()
+    job = Job(type=JobType.IMAGE_PROVISION, target_id=pi.id, status=JobStatus.PENDING)
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.get(f"/api/imager/download-url/{job.id}")
+    assert resp.status_code == 409
 
 
 # ── Audit ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds a **"Copy download link"** action to the kebab on each row in the **Built Images** panel of the Imager tab. Clicking it copies a fresh SAS URL to the clipboard so an operator can paste it straight into `wget` / `curl` from a Linux shell, instead of going through the browser's 302-redirect chain on the Download button.

## Why

Today, the only way to grab a built `.img.xz` is to click **Download** in the browser, which mints a SAS and 302s to it. That round-trip is awkward when the operator is on a Linux box (e.g. SSHed into a Pi or workstation) and just wants `wget <url>` — they have to download in the browser and then move the file.

## How

### Server (`cms/routers/imager.py`)

- Refactored the validation + SAS-minting logic out of `GET /api/imager/download/{job_id}` into a shared `_resolve_provisioned_sas` helper so both endpoints apply identical job-state, blob-existence, and TTL rules. **No code duplication.**
- New endpoint `GET /api/imager/download-url/{job_id}` returns `{"url": "<fresh SAS URL>"}` as JSON.
  - Same `IMAGER_BUILD` permission as the existing redirect endpoint.
  - Same 404 / 409 rules.
  - Audited as `imager.copy_link` so the audit trail can distinguish "copied the link" from "downloaded via browser".

### UI (`cms/templates/imager.html`)

- Built-images kebab now contains a **"Copy download link"** item whenever the Download button is enabled (`READY` + `download_job_id`).
- The kebab itself now renders whenever it has at least one item, so non-manager operators with `imager:build` finally get a kebab containing just Copy-Link. **Delete** remains admin-only (`canManage`).
- Click handler closes the popover, fetches a fresh SAS via the new endpoint, and hands it to the existing `copyToClipboard()` helper in `app.js` (which already shows the "Copied to clipboard" toast and has a non-HTTPS fallback).

## Tests

- `test_endpoints_require_auth` extended to cover the new path.
- New `test_download_url_returns_sas_as_json` — happy path; asserts the JSON shape **and** the `imager.copy_link` audit row.
- New `test_download_url_404_when_not_ready` — same 409 guard as the redirect endpoint.

86 imager tests pass locally (`pytest tests/test_imager_api.py tests/test_imager_ui.py tests/test_imager.py`).

## Security notes

The SAS URL is the same one the existing Download button already redirects to — TTL is unchanged (`imager_sas_ttl_hours`). This PR doesn't expand the SAS exposure surface, it just lets operators capture the URL their browser would have followed anyway.
