### PR TITLE
ui(devices): live-update supported codecs, device type, and storage capacity

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -705,11 +705,11 @@
             </div>
             <div class="detail-item">
                 <span class="detail-label">Device Type</span>
-                <span class="detail-value">{{ d.device_type or '—' }}</span>
+                <span class="detail-value" data-live-device-type="{{ d.id }}">{{ d.device_type or '—' }}</span>
             </div>
             <div class="detail-item">
                 <span class="detail-label">Supported Codecs</span>
-                <span class="detail-value">{{ d.supported_codecs.replace(',', ', ') if d.supported_codecs else '—' }}</span>
+                <span class="detail-value" data-live-supported-codecs="{{ d.id }}">{{ d.supported_codecs.replace(',', ', ') if d.supported_codecs else '—' }}</span>
             </div>
             <div class="detail-item">
                 <span class="detail-label">IP Address</span>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -644,12 +644,20 @@ window._adoptionProfiles = [
             });
 
             // ── Collapsed row: storage percentage ──
+            // Re-sync BOTH capacity and used from the API payload, not just
+            // used. The capacity bytes also change in practice (storage swap,
+            // re-flash with a different SD card) and reading capacity only
+            // from the initial server-rendered dataset is a stale-data bug.
             const storagePctEl = document.querySelector(`[data-live-storage-pct="${d.id}"]`);
             if (storagePctEl) {
-                const cap = parseInt(storagePctEl.dataset.storageMb) || 0;
+                const cap = (d.storage_capacity_mb != null)
+                    ? d.storage_capacity_mb
+                    : (parseInt(storagePctEl.dataset.storageMb) || 0);
                 if (cap > 0) {
                     const used = d.storage_used_mb != null ? d.storage_used_mb : parseInt(storagePctEl.dataset.usedMb) || 0;
                     storagePctEl.textContent = Math.round((cap - used) / cap * 100) + '% free';
+                    storagePctEl.dataset.storageMb = cap;
+                    storagePctEl.dataset.usedMb = used;
                 }
             }
 
@@ -722,12 +730,32 @@ window._adoptionProfiles = [
             if (badgeEl) badgeEl.style.display = d.update_available ? '' : 'none';
 
             // ── Detail panel: storage detail ──
+            // Same stale-capacity fix as the collapsed-row percentage above:
+            // pull capacity from the API payload, not the initial dataset.
             const storageEl = document.querySelector(`[data-live-storage="${d.id}"]`);
             if (storageEl) {
-                const cap = parseInt(storageEl.dataset.storageMb) || 0;
+                const cap = (d.storage_capacity_mb != null)
+                    ? d.storage_capacity_mb
+                    : (parseInt(storageEl.dataset.storageMb) || 0);
                 const used = d.storage_used_mb != null ? d.storage_used_mb : parseInt(storageEl.dataset.usedMb) || 0;
                 storageEl.textContent = fmtStorage(used) + ' / ' + fmtStorage(cap);
+                storageEl.dataset.storageMb = cap;
                 storageEl.dataset.usedMb = used;
+            }
+
+            // ── Detail panel: device type + supported codecs ──
+            // Both fields are written from the device's registration payload
+            // (services/device_register.py). Re-registration can change them,
+            // and after #573 we already repaint os/firmware version live in
+            // the same detail panel -- these two were the remaining stale
+            // values an operator could see without F5.
+            const deviceTypeEl = document.querySelector(`[data-live-device-type="${d.id}"]`);
+            if (deviceTypeEl) deviceTypeEl.textContent = d.device_type || '—';
+            const codecsEl = document.querySelector(`[data-live-supported-codecs="${d.id}"]`);
+            if (codecsEl) {
+                codecsEl.textContent = d.supported_codecs
+                    ? d.supported_codecs.replace(/,/g, ', ')
+                    : '—';
             }
 
             // ── Detail panel: last seen ──

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -395,6 +395,37 @@ class TestDevicesUILiveUpdates:
         assert f'data-live-firmware-version="{device_with_live_state}"' in resp.text
         assert f'data-live-os-version="{device_with_live_state}"' in resp.text
 
+    async def test_data_live_supported_codecs_attr_in_html(self, client, device_with_live_state):
+        """Sibling fix to #573: supported codecs span should have a
+        data-live-* attribute so re-registration (or any other update of the
+        device's reported codec list) repaints without a full page refresh."""
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        assert f'data-live-supported-codecs="{device_with_live_state}"' in resp.text
+
+    async def test_data_live_device_type_attr_in_html(self, client, device_with_live_state):
+        """Sibling fix to #573: device type span should have a data-live-*
+        attribute so a re-registration with a changed device_type repaints
+        without a full page refresh."""
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        assert f'data-live-device-type="{device_with_live_state}"' in resp.text
+
+    async def test_storage_handler_resyncs_capacity_from_api(self, client, device_with_live_state):
+        """The storage live-update JS must read storage_capacity_mb from the
+        API payload, not just storage_used_mb from the initial dataset.
+        Regression: prior to this fix the capacity was only read from the
+        server-rendered dataset, so a capacity change (storage swap / re-flash
+        with a different SD card) never appeared until a full page refresh."""
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        # Both the collapsed-row % handler and the detail-panel handler must
+        # write d.storage_capacity_mb back to dataset.storageMb (not just used).
+        assert "storagePctEl.dataset.storageMb = cap" in resp.text
+        assert "storageEl.dataset.storageMb = cap" in resp.text
+        # And both must source capacity from d.storage_capacity_mb first.
+        assert "d.storage_capacity_mb != null" in resp.text
+
     async def test_data_live_update_badge_always_rendered_for_admin(self, client, app):
         """#573: badge wrapper must always be emitted (hidden via display:none
         when no update available) so updateLiveFields() can flip its visibility


### PR DESCRIPTION
## Summary

Follow-up to #573. The device-detail panel rendered three other fields once at page load and never repainted them:

- **Supported Codecs** -- no `data-live-*` marker; only refreshed on F5 after a device re-registered with a different codec list.
- **Device Type** -- same gap.
- **Storage capacity** -- the `data-live-storage` and `data-live-storage-pct` JS handlers re-synced `storage_used_mb` from the API but pulled the **capacity** from the initial server-rendered dataset attributes, so a capacity change (SD card swap, re-flash with different media) was silently stale until a refresh.

## Changes

**`cms/templates/_macros.html`**
- Wrap Supported Codecs span with `data-live-supported-codecs`.
- Wrap Device Type span with `data-live-device-type`.

**`cms/templates/devices.html` (`updateLiveFields`)**
- New handler for `data-live-supported-codecs` -- matches the Jinja-side `", "`-separated render.
- New handler for `data-live-device-type`.
- Storage handlers now source capacity from `d.storage_capacity_mb` first and write it back to `dataset.storageMb` on every poll (both the collapsed-row `%` and the detail-panel `used / cap`).

## Tests (`tests/test_device_live_updates.py`)

- `test_data_live_supported_codecs_attr_in_html`
- `test_data_live_device_type_attr_in_html`
- `test_storage_handler_resyncs_capacity_from_api` -- JS-shape regression for the previously-silent capacity-from-dataset bug.

All 44 tests in `test_device_live_updates.py` pass locally.

## Not changed (intentionally)

- `Device ID` -- immutable.
- `Location` / `Timezone` -- already user-editable through inline-edit handlers; not poll-driven by design.
