### PR TITLE
Wire up profile enable/disable UI and gate device assignment (#583)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -476,8 +476,11 @@ async def upload_asset(
 
     # Queue transcoding for all profiles (video and image assets)
     if asset_type in (AssetType.VIDEO, AssetType.IMAGE):
-        variant_ids = await _enqueue_transcoding(asset, db)
-        from cms.services.transcoder import enqueue_variants
+        from cms.services.transcoder import (
+            _enqueue_transcoding_for_asset,
+            enqueue_variants,
+        )
+        variant_ids = await _enqueue_transcoding_for_asset(asset, db)
         await enqueue_variants(db, variant_ids)
 
     await audit_log(
@@ -1394,36 +1397,6 @@ async def recapture_stream(
     await db.commit()
 
     return {"recaptured": True, "asset_id": str(asset_id)}
-
-
-async def _enqueue_transcoding(asset: Asset, db: AsyncSession) -> list[uuid.UUID]:
-    """Create pending AssetVariant rows for all device profiles.
-
-    Returns the list of newly-created variant ids so the caller can pass
-    them to ``enqueue_variants`` for fan-out.
-    """
-    result = await db.execute(select(DeviceProfile))
-    profiles = result.scalars().all()
-    new_ids: list[uuid.UUID] = []
-    for profile in profiles:
-        variant_id = uuid.uuid4()
-        if asset.asset_type == AssetType.IMAGE:
-            from cms.services.transcoder import _image_variant_ext
-            ext = _image_variant_ext(asset)
-        elif profile.audio_codec == "libopus":
-            ext = ".mkv"
-        else:
-            ext = ".mp4"
-        variant = AssetVariant(
-            id=variant_id,
-            source_asset_id=asset.id,
-            profile_id=profile.id,
-            filename=f"{variant_id}{ext}",
-        )
-        db.add(variant)
-        new_ids.append(variant_id)
-    await db.commit()
-    return new_ids
 
 
 @router.get("/{asset_id}/row", dependencies=[Depends(require_permission(ASSETS_READ))])

--- a/cms/routers/bootstrap.py
+++ b/cms/routers/bootstrap.py
@@ -359,6 +359,8 @@ async def adopt(
         msg = str(e)
         if msg in ("group_not_found", "profile_not_found"):
             raise HTTPException(status_code=404, detail=msg) from e
+        if msg == "profile_disabled":
+            raise HTTPException(status_code=422, detail=msg) from e
         raise HTTPException(status_code=400, detail=msg) from e
     except HTTPException:
         await db.rollback()
@@ -503,6 +505,8 @@ async def adopt_pending(
         msg = str(e)
         if msg in ("group_not_found", "profile_not_found"):
             raise HTTPException(status_code=404, detail=msg) from e
+        if msg == "profile_disabled":
+            raise HTTPException(status_code=422, detail=msg) from e
         raise HTTPException(status_code=400, detail=msg) from e
     except HTTPException:
         await db.rollback()

--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -421,6 +421,16 @@ async def update_device(
                     ),
                 )
 
+    # Reject assignment to a missing or disabled profile (issue #583).
+    # Missing is 404 (a separate pre-existing gap, fixed here because we
+    # need the fetch anyway); disabled is 422.
+    if updates.get("profile_id"):
+        target_profile = await db.get(DeviceProfile, updates["profile_id"])
+        if target_profile is None:
+            raise HTTPException(status_code=404, detail="Profile not found")
+        if not target_profile.enabled:
+            raise HTTPException(status_code=422, detail="Profile is disabled")
+
     # Snapshot before mutation so we can build a true diff for the audit log
     changes = compute_diff(device, updates)
 
@@ -808,10 +818,13 @@ async def adopt_device(device_id: str, body: AdoptRequest, request: Request, db:
             raise HTTPException(status_code=404, detail="Group not found")
         device.group_id = body.group_id
 
-    # Verify and assign the encoder profile (required)
-    prof = await db.execute(select(DeviceProfile).where(DeviceProfile.id == body.profile_id))
-    if not prof.scalar_one_or_none():
+    # Verify and assign the encoder profile (required).
+    # Reject if missing (404) or disabled (422) — issue #583.
+    target_profile = await db.get(DeviceProfile, body.profile_id)
+    if target_profile is None:
         raise HTTPException(status_code=404, detail="Profile not found")
+    if not target_profile.enabled:
+        raise HTTPException(status_code=422, detail="Profile is disabled")
     device.profile_id = body.profile_id
 
     await db.commit()

--- a/cms/services/device_bootstrap.py
+++ b/cms/services/device_bootstrap.py
@@ -484,6 +484,8 @@ async def _perform_adoption(
     ).scalar_one_or_none()
     if prof is None:
         raise ValueError("profile_not_found")
+    if not prof.enabled:
+        raise ValueError("profile_disabled")
 
     # Create the devices row.  ID is a fresh UUID — the device doesn't
     # pick its own id in the new flow; it learns it from the outbox

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -35,10 +35,11 @@
   /remove it.
 #}
 {% macro profile_row(p, user_perms) -%}
-<tr data-profile-id="{{ p.id }}">
+<tr data-profile-id="{{ p.id }}"{% if not p.enabled %} class="row-inactive"{% endif %}>
     <td>
         {{ p.name }}
         {% if p.builtin %}<span class="badge badge-builtin">built-in</span>{% endif %}
+        {% if not p.enabled %}<span class="badge badge-muted">disabled</span>{% endif %}
     </td>
     <td>{% if p.video_codec == 'h264' %}H.264{% elif p.video_codec == 'h265' %}HEVC{% elif p.video_codec == 'av1' %}AV1{% else %}{{ p.video_codec }}{% endif %} / {{ p.video_profile | capitalize }}</td>
     <td>{{ p.max_width }}×{{ p.max_height }}</td>
@@ -64,6 +65,11 @@
         {% if 'profiles:write' in user_perms %}
         {% call kebab_menu() %}
             <button type="button" role="menuitem" onclick="editProfile('{{ p.id }}')">Edit</button>
+            {% if p.enabled %}
+            <button type="button" role="menuitem" onclick="disableProfile('{{ p.id }}', {{ p.name | tojson | forceescape }}, {{ p.total_variants }})">Disable</button>
+            {% else %}
+            <button type="button" role="menuitem" onclick="enableProfile('{{ p.id }}', {{ p.name | tojson | forceescape }})">Enable</button>
+            {% endif %}
             <button type="button" role="menuitem" onclick="copyProfile('{{ p.id }}', {{ p.name | tojson | forceescape }})">Copy</button>
             {% if p.builtin %}
                 {% if p.matches_defaults %}
@@ -643,8 +649,13 @@
     <td>
         <select class="inline-edit" onclick="event.stopPropagation()" onchange="setProfile('{{ d.id }}', this.value)">
             <option value="">None</option>
+            {# Skip disabled profiles, but always include the currently-assigned
+               one so its <option> can render selected — admins can switch off
+               a disabled profile but can't re-pick it without re-enabling. #}
             {% for p in profiles %}
-            <option value="{{ p.id }}" {% if d.profile_id == p.id %}selected{% endif %}>{{ p.name }}</option>
+            {% if p.enabled or d.profile_id == p.id %}
+            <option value="{{ p.id }}" {% if d.profile_id == p.id %}selected{% endif %}>{{ p.name }}{% if not p.enabled %} (disabled){% endif %}</option>
+            {% endif %}
             {% endfor %}
         </select>
     </td>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -450,7 +450,7 @@ window._adoptionGroups = [
     {% endfor %}
 ];
 window._adoptionProfiles = [
-    {% for p in profiles %}
+    {% for p in adoption_profiles %}
     { id: {{ p.id | string | tojson }}, name: {{ p.name | tojson }} }{% if not loop.last %},{% endif %}
     {% endfor %}
 ];

--- a/cms/templates/profiles.html
+++ b/cms/templates/profiles.html
@@ -452,6 +452,41 @@ async function resetProfile(profileId, name) {
     }
 }
 
+async function disableProfile(profileId, name, totalVariants) {
+    let msg = `Disable profile "${name}"?\n\nNew variants will not be generated for this profile until it is re-enabled.`;
+    if (totalVariants > 0) {
+        msg += `\n\nExisting variants (${totalVariants}) are preserved. Any ongoing transcodes for this profile will be stopped.`;
+    }
+    if (!await showConfirm(msg)) return;
+    const resp = await apiCall("POST", `/api/profiles/${profileId}/disable`);
+    if (resp && resp.ok) {
+        const updated = await resp.json().catch(() => null);
+        showToast(`Profile "${name}" disabled`);
+        if (updated && updated.id) {
+            window._rememberProfile && window._rememberProfile(updated.id, updated);
+        }
+        await window._replaceProfileRow(profileId);
+    } else if (resp) {
+        const err = await resp.json().catch(() => null);
+        showToast(err?.detail || "Disable failed", true);
+    }
+}
+
+async function enableProfile(profileId, name) {
+    const resp = await apiCall("POST", `/api/profiles/${profileId}/enable`);
+    if (resp && resp.ok) {
+        const updated = await resp.json().catch(() => null);
+        showToast(`Profile "${name}" enabled`);
+        if (updated && updated.id) {
+            window._rememberProfile && window._rememberProfile(updated.id, updated);
+        }
+        await window._replaceProfileRow(profileId);
+    } else if (resp) {
+        const err = await resp.json().catch(() => null);
+        showToast(err?.detail || "Enable failed", true);
+    }
+}
+
 // ── Row fragment helpers + cross-session poller ──
 (function() {
     const tbody = document.getElementById('profiles-body');

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -824,7 +824,9 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     adoption_groups_q = await db.execute(adoption_groups_query)
     adoption_groups = adoption_groups_q.scalars().all()
 
-    adoption_profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
+    adoption_profiles_q = await db.execute(
+        select(DeviceProfile).where(DeviceProfile.enabled == True).order_by(DeviceProfile.name)  # noqa: E712
+    )
     adoption_profiles = adoption_profiles_q.scalars().all()
 
     return templates.TemplateResponse(request, "dashboard.html", {
@@ -1162,6 +1164,11 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
 
     profiles_q = await db.execute(select(DeviceProfile).order_by(DeviceProfile.name))
     profiles = profiles_q.scalars().all()
+    # Adoption modal must only offer enabled profiles — disabled ones
+    # mustn't be assignable. The full `profiles` list is still passed
+    # to `device_row` so the per-device dropdown can keep showing a
+    # device's currently-assigned profile even if it was later disabled.
+    adoption_profiles = [p for p in profiles if p.enabled]
 
     from cms.services.device_alerts import (
         device_severity_tags,
@@ -1205,6 +1212,7 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
         "ungrouped": ungrouped,
         "assets": assets,
         "profiles": profiles,
+        "adoption_profiles": adoption_profiles,
         "timezones": COMMON_TIMEZONES,
         "latest_version": latest_os_version,
         "pending_ttl_hours": get_settings().pending_device_ttl_hours,

--- a/tests/test_bootstrap_endpoints.py
+++ b/tests/test_bootstrap_endpoints.py
@@ -719,6 +719,29 @@ class TestAdopt:
         assert listed.status_code == 200
         assert listed.json() == {"items": []}
 
+    async def test_disabled_profile_returns_422(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        # Issue #583: disabled profiles must not be assignable via /adopt
+        # either. Distinct from missing-profile (404) — 422 unprocessable.
+        _, pairing_secret, _, _ = await _register_one(
+            unauthed_client, device_id="pi-adopt-disabled",
+        )
+        from cms.models.device_profile import DeviceProfile
+        prof = DeviceProfile(name="adopt-disabled", enabled=False)
+        db_session.add(prof)
+        await db_session.commit()
+        r = await client.post(
+            "/api/devices/adopt",
+            json={
+                "pairing_secret": pairing_secret,
+                "profile_id": str(prof.id),
+            },
+        )
+        assert r.status_code == 422
+        assert r.json()["detail"] == "profile_disabled"
+
 
 # ---------------------------------------------------------------------
 # /pending + /adopt-pending + DELETE /pending/{id}
@@ -938,6 +961,27 @@ class TestAdoptPending:
         )
         assert r.status_code == 404
         assert r.json()["detail"] == "profile_not_found"
+
+    async def test_disabled_profile_returns_422(
+        self, client, unauthed_client, fleet_secret_enabled,
+        stub_wps_transport, db_session,
+    ):
+        # Issue #583: disabled profiles must not be assignable via
+        # /adopt-pending. Distinct from missing (404) — 422 unprocessable.
+        await _register_one(unauthed_client, device_id="pi-disprof")
+        listing = await client.get("/api/devices/pending")
+        pending_id = listing.json()["items"][0]["id"]
+        from cms.models.device_profile import DeviceProfile
+        prof = DeviceProfile(name="bootstrap-disabled-byid", enabled=False)
+        db_session.add(prof)
+        await db_session.commit()
+        r = await client.post(
+            "/api/devices/adopt-pending",
+            json={"pending_id": pending_id,
+                  "profile_id": str(prof.id)},
+        )
+        assert r.status_code == 422
+        assert r.json()["detail"] == "profile_disabled"
 
 
 class TestRejectPending:

--- a/tests/test_device_dropdown_filter.py
+++ b/tests/test_device_dropdown_filter.py
@@ -1,0 +1,158 @@
+"""Issue #583: disabled profiles must not be selectable for devices.
+
+Surfaces tested:
+  * Per-device profile dropdown in the ``device_row`` macro (devices page) —
+    must exclude disabled profiles UNLESS one is currently assigned to that
+    device (in which case it renders selected with a "(disabled)" suffix so
+    the operator can see WHY the device is in a weird state and pick an
+    enabled profile to replace it).
+  * Adoption modals — the ``window._adoptionProfiles`` JS array on both
+    ``/devices`` and ``/dashboard`` only contains enabled profiles.
+"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestDeviceDropdownFilter:
+    async def _make_profile(self, db_session, name, *, enabled=True):
+        from cms.models.device_profile import DeviceProfile
+        p = DeviceProfile(name=name, video_codec="h264", enabled=enabled)
+        db_session.add(p)
+        await db_session.flush()
+        return p
+
+    async def _make_device(self, db_session, name, *, profile_id=None):
+        from cms.models.device import Device, DeviceStatus
+        d = Device(
+            id=f"{name}-{uuid.uuid4().hex[:6]}",
+            name=name,
+            status=DeviceStatus.ADOPTED,
+            profile_id=profile_id,
+        )
+        db_session.add(d)
+        await db_session.flush()
+        return d
+
+    def _option_for(self, html: str, profile_id) -> str | None:
+        """Return the substring of html containing the <option> for the
+        given profile_id, or None if no such option exists."""
+        marker = f'value="{profile_id}"'
+        idx = html.find(marker)
+        if idx == -1:
+            return None
+        start = html.rfind("<option", 0, idx)
+        end = html.find("</option>", idx)
+        return html[start:end + len("</option>")]
+
+    async def test_dropdown_excludes_disabled_profile(self, client, db_session):
+        """When no device is assigned to it, a disabled profile must not
+        appear as an <option> in any per-device dropdown."""
+        on = await self._make_profile(db_session, "ddf-on")
+        off = await self._make_profile(db_session, "ddf-off", enabled=False)
+        # Make a device assigned to the ENABLED profile so the page has a row.
+        await self._make_device(db_session, "ddf-dev", profile_id=on.id)
+        await db_session.commit()
+
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        body = resp.text
+        assert self._option_for(body, on.id) is not None
+        assert self._option_for(body, off.id) is None, (
+            "disabled profile (with no device assigned to it) must not appear "
+            "in any per-device profile dropdown"
+        )
+
+    async def test_dropdown_keeps_currently_assigned_disabled_profile(
+        self, client, db_session,
+    ):
+        """A device assigned to profile P keeps showing P in its dropdown
+        (with a "(disabled)" suffix and selected) even after P is disabled —
+        otherwise the dropdown would render no selected option at all."""
+        p = await self._make_profile(db_session, "ddf-keep")
+        d = await self._make_device(db_session, "ddf-keep-dev", profile_id=p.id)
+        await db_session.commit()
+        pid = p.id
+        did = d.id
+
+        # Disable the profile through the API (simulates the real flow).
+        r = await client.post(f"/api/profiles/{pid}/disable")
+        assert r.status_code == 200
+
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        body = resp.text
+        opt = self._option_for(body, pid)
+        assert opt is not None, (
+            f"profile {pid} currently assigned to device {did} must still appear "
+            "in that device's dropdown even when disabled"
+        )
+        assert "selected" in opt
+        assert "(disabled)" in opt
+
+    async def test_dropdown_no_profile_assigned_shows_only_enabled(
+        self, client, db_session,
+    ):
+        """NULL-safety: when ``device.profile_id`` is None the Jinja
+        ``p.enabled or d.profile_id == p.id`` guard must still exclude
+        disabled profiles (the second clause is False for every profile)."""
+        on = await self._make_profile(db_session, "ddf-null-on")
+        off = await self._make_profile(db_session, "ddf-null-off", enabled=False)
+        await self._make_device(db_session, "ddf-null-dev", profile_id=None)
+        await db_session.commit()
+
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        body = resp.text
+        assert self._option_for(body, on.id) is not None
+        assert self._option_for(body, off.id) is None
+
+    async def test_devices_page_adoption_array_excludes_disabled(
+        self, client, db_session,
+    ):
+        """``window._adoptionProfiles`` on /devices is the JS source the
+        adoption modal reads — disabled profiles must not appear."""
+        on = await self._make_profile(db_session, "ddf-mod-on")
+        off = await self._make_profile(db_session, "ddf-mod-off", enabled=False)
+        await db_session.commit()
+
+        resp = await client.get("/devices")
+        assert resp.status_code == 200
+        # Extract the _adoptionProfiles literal.
+        body = resp.text
+        marker = "window._adoptionProfiles ="
+        idx = body.find(marker)
+        assert idx != -1, "expected window._adoptionProfiles in /devices HTML"
+        end = body.find("];", idx)
+        assert end != -1
+        snippet = body[idx:end]
+        assert "ddf-mod-on" in snippet
+        assert "ddf-mod-off" not in snippet, (
+            "disabled profile must not appear in the adoption modal's source array"
+        )
+        # Sanity: the disabled profile's id must not appear either.
+        assert str(off.id) not in snippet
+
+    async def test_dashboard_adoption_array_excludes_disabled(
+        self, client, db_session,
+    ):
+        """Same check for the dashboard's adoption modal (separate query
+        in cms/ui.py). Dashboard is served at '/'."""
+        on = await self._make_profile(db_session, "ddf-dash-on")
+        off = await self._make_profile(db_session, "ddf-dash-off", enabled=False)
+        await db_session.commit()
+
+        resp = await client.get("/")
+        assert resp.status_code == 200
+        body = resp.text
+        marker = "window._adoptionProfiles ="
+        idx = body.find(marker)
+        assert idx != -1, "expected window._adoptionProfiles in dashboard HTML"
+        end = body.find("];", idx)
+        assert end != -1
+        snippet = body[idx:end]
+        assert "ddf-dash-on" in snippet
+        assert "ddf-dash-off" not in snippet
+        assert str(off.id) not in snippet

--- a/tests/test_image_variants.py
+++ b/tests/test_image_variants.py
@@ -53,8 +53,8 @@ class TestEnqueueVariantExtension:
         db_session.add(asset)
         await db_session.commit()
 
-        from cms.routers.assets import _enqueue_transcoding
-        await _enqueue_transcoding(asset, db_session)
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         variants = (await db_session.execute(
             __import__("sqlalchemy").select(AssetVariant)
@@ -71,8 +71,8 @@ class TestEnqueueVariantExtension:
         db_session.add(asset)
         await db_session.commit()
 
-        from cms.routers.assets import _enqueue_transcoding
-        await _enqueue_transcoding(asset, db_session)
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         variants = (await db_session.execute(
             __import__("sqlalchemy").select(AssetVariant)
@@ -91,8 +91,8 @@ class TestEnqueueVariantExtension:
         db_session.add(asset)
         await db_session.commit()
 
-        from cms.routers.assets import _enqueue_transcoding
-        await _enqueue_transcoding(asset, db_session)
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         variants = (await db_session.execute(
             __import__("sqlalchemy").select(AssetVariant)
@@ -109,8 +109,8 @@ class TestEnqueueVariantExtension:
         db_session.add(asset)
         await db_session.commit()
 
-        from cms.routers.assets import _enqueue_transcoding
-        await _enqueue_transcoding(asset, db_session)
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         variants = (await db_session.execute(
             __import__("sqlalchemy").select(AssetVariant)

--- a/tests/test_profile_enable_disable.py
+++ b/tests/test_profile_enable_disable.py
@@ -201,3 +201,243 @@ class TestDisabledProfileSkipsTranscode:
         assert len(variants) == 1, (
             f"re-enable should enqueue a variant for the missed asset, got {variants}"
         )
+
+    async def test_upload_route_skips_disabled_profile(self, client, db_session):
+        """Regression for #583: the HTTP upload route used to call a
+        local `_enqueue_transcoding` that did NOT filter `enabled`, so
+        disabling a profile didn't actually stop new uploads from getting
+        variants for it. After consolidation onto
+        `_enqueue_transcoding_for_asset` the upload path now skips
+        disabled profiles like the rest of the fan-out."""
+        import io
+        from cms.models.asset import AssetVariant
+        from cms.models.device_profile import DeviceProfile
+
+        on_profile = DeviceProfile(
+            name="upload-route-on", video_codec="h264", enabled=True,
+        )
+        off_profile = DeviceProfile(
+            name="upload-route-off", video_codec="h264", enabled=False,
+        )
+        db_session.add_all([on_profile, off_profile])
+        await db_session.commit()
+        on_id, off_id = on_profile.id, off_profile.id
+
+        files = {
+            "file": (
+                f"route-{uuid.uuid4().hex[:6]}.mp4",
+                io.BytesIO(b"fakecontent"),
+                "application/octet-stream",
+            ),
+        }
+        resp = await client.post("/api/assets/upload", files=files)
+        assert resp.status_code == 201, resp.text
+        asset_id = uuid.UUID(resp.json()["id"])
+
+        on_variants = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset_id,
+                AssetVariant.profile_id == on_id,
+            )
+        )).scalars().all()
+        off_variants = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset_id,
+                AssetVariant.profile_id == off_id,
+            )
+        )).scalars().all()
+        assert len(on_variants) == 1, "enabled profile should get a variant"
+        assert off_variants == [], (
+            "disabled profile must not get a variant from HTTP upload"
+        )
+
+
+@pytest.mark.asyncio
+class TestProfileEnableDisableAuditLog:
+    """Backend audit-log entries land for enable + disable actions."""
+
+    async def test_disable_writes_audit_log(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+        from cms.models.audit_log import AuditLog
+
+        profile = DeviceProfile(name="audit-dis", video_codec="h264")
+        db_session.add(profile)
+        await db_session.commit()
+        pid = profile.id
+
+        r = await client.post(f"/api/profiles/{pid}/disable")
+        assert r.status_code == 200
+
+        rows = (await db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.action == "profile.disable")
+            .where(AuditLog.resource_id == str(pid))
+        )).scalars().all()
+        assert len(rows) == 1
+
+    async def test_enable_writes_audit_log(self, client, db_session):
+        from cms.models.device_profile import DeviceProfile
+        from cms.models.audit_log import AuditLog
+
+        profile = DeviceProfile(name="audit-en", video_codec="h264", enabled=False)
+        db_session.add(profile)
+        await db_session.commit()
+        pid = profile.id
+
+        r = await client.post(f"/api/profiles/{pid}/enable")
+        assert r.status_code == 200
+
+        rows = (await db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.action == "profile.enable")
+            .where(AuditLog.resource_id == str(pid))
+        )).scalars().all()
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+class TestDisabledProfileDeviceAssignment:
+    """Issue #583: device-assignment paths must reject disabled profiles.
+
+    Surface inventory (see plan):
+      * `PATCH /api/devices/{id}` -> 422 (and 404 for missing — pre-existing gap)
+      * `POST /api/devices/{id}/adopt` -> 422
+      * `device_bootstrap.adopt_pending_by_id` service -> ValueError("profile_disabled")
+        (the bootstrap router exception mapping is covered in
+        test_bootstrap_endpoints.py)
+      * existing device keeps its assignment when the profile is later disabled
+        (no cascade-clear).
+    """
+
+    async def _make_device(self, db_session, name="dev-assign", status=None):
+        from cms.models.device import Device, DeviceStatus
+        d = Device(
+            id=f"{name}-{uuid.uuid4().hex[:6]}",
+            name=name,
+            status=status or DeviceStatus.ADOPTED,
+        )
+        db_session.add(d)
+        await db_session.flush()
+        return d
+
+    async def _make_profile(self, db_session, name, *, enabled=True):
+        from cms.models.device_profile import DeviceProfile
+        p = DeviceProfile(name=name, video_codec="h264", enabled=enabled)
+        db_session.add(p)
+        await db_session.flush()
+        return p
+
+    async def test_patch_device_profile_rejects_disabled(self, client, db_session):
+        device = await self._make_device(db_session, name="patch-dis")
+        prof = await self._make_profile(db_session, "patch-disabled-prof", enabled=False)
+        await db_session.commit()
+
+        r = await client.patch(
+            f"/api/devices/{device.id}",
+            json={"profile_id": str(prof.id)},
+        )
+        assert r.status_code == 422
+        assert "disabled" in r.json()["detail"].lower()
+
+    async def test_patch_device_profile_404_when_missing(self, client, db_session):
+        # Pre-existing gap folded in: PATCH used to silently accept a
+        # nonexistent profile id (setattr with no validation). Now 404s.
+        device = await self._make_device(db_session, name="patch-404")
+        await db_session.commit()
+        r = await client.patch(
+            f"/api/devices/{device.id}",
+            json={"profile_id": str(uuid.uuid4())},
+        )
+        assert r.status_code == 404
+
+    async def test_patch_device_profile_accepts_enabled(self, client, db_session):
+        # Sanity: the new validation must NOT break the happy path.
+        device = await self._make_device(db_session, name="patch-ok")
+        prof = await self._make_profile(db_session, "patch-enabled-prof")
+        await db_session.commit()
+
+        r = await client.patch(
+            f"/api/devices/{device.id}",
+            json={"profile_id": str(prof.id)},
+        )
+        assert r.status_code == 200
+        await db_session.refresh(device)
+        assert device.profile_id == prof.id
+
+    async def test_adopt_existing_rejects_disabled(self, client, db_session):
+        from cms.models.device import DeviceStatus
+        device = await self._make_device(
+            db_session, name="adopt-dis", status=DeviceStatus.PENDING,
+        )
+        prof = await self._make_profile(db_session, "adopt-disabled-prof", enabled=False)
+        await db_session.commit()
+
+        r = await client.post(
+            f"/api/devices/{device.id}/adopt",
+            json={"profile_id": str(prof.id)},
+        )
+        assert r.status_code == 422
+        assert "disabled" in r.json()["detail"].lower()
+
+    async def test_bootstrap_service_rejects_disabled(self, db_session):
+        """`device_bootstrap.adopt_pending_by_id` raises
+        ``ValueError("profile_disabled")`` when the requested profile is
+        disabled. The bootstrap routers translate that into 422 — covered
+        by tests in test_bootstrap_endpoints.py. This test guards the
+        service contract directly so any future router change still has
+        the disabled-profile check at the service boundary."""
+        from cms.models.pending_registration import PendingRegistration
+        from cms.services import device_bootstrap
+
+        # Minimal pending row — only enough fields to reach the
+        # profile-validation block at L486.
+        pending = PendingRegistration(
+            device_id=f"pi-svc-{uuid.uuid4().hex[:6]}",
+            pubkey="dummy-pubkey",
+            pairing_secret_hash="dummy-hash",
+        )
+        db_session.add(pending)
+        prof = await self._make_profile(
+            db_session, "svc-disabled-prof", enabled=False,
+        )
+        await db_session.commit()
+
+        async def _mint(_device_row_id):  # pragma: no cover (not reached)
+            return {}
+
+        with pytest.raises(ValueError) as excinfo:
+            await device_bootstrap.adopt_pending_by_id(
+                db=db_session,
+                pending_id=pending.id,
+                profile_id=str(prof.id),
+                name=None,
+                location=None,
+                group_id=None,
+                mint_wps_jwt=_mint,
+                settings=None,
+            )
+        assert str(excinfo.value) == "profile_disabled"
+
+    async def test_existing_device_keeps_disabled_profile_assignment(
+        self, client, db_session,
+    ):
+        """No cascade-clear: disabling a profile leaves already-assigned
+        devices pointing at it. Only the FK column matters — there's no
+        denormalized profile_name cache."""
+        prof = await self._make_profile(db_session, "keepme-prof")
+        device = await self._make_device(db_session, name="keep-assn")
+        device.profile_id = prof.id
+        await db_session.commit()
+        pid = prof.id
+        did = device.id
+
+        r = await client.post(f"/api/profiles/{pid}/disable")
+        assert r.status_code == 200
+
+        db_session.expire_all()
+        from cms.models.device import Device
+        fresh = await db_session.get(Device, did)
+        assert fresh.profile_id == pid, (
+            "device.profile_id must remain pointing at the now-disabled profile"
+        )
+

--- a/tests/test_profile_row_endpoint.py
+++ b/tests/test_profile_row_endpoint.py
@@ -3,13 +3,52 @@ used by the profiles page's per-row poller to swap a single <tr> without
 a full page reload (issue #87)."""
 
 import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
 
 from cms.models.device_profile import DeviceProfile
 
 
+@pytest_asyncio.fixture
+async def viewer_client(app):
+    """Authenticated HTTP client logged in as a viewer (read-only) user."""
+    from sqlalchemy import select
+    from cms.database import get_db
+    from cms.models.user import Role, User
+    from cms.auth import hash_password
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        result = await db.execute(select(Role).where(Role.name == "Viewer"))
+        viewer_role = result.scalar_one()
+        viewer_user = User(
+            username="viewer_profile_row_test",
+            email="viewer_profile_row@test.com",
+            display_name="Viewer Profile Row",
+            password_hash=hash_password("viewerpass"),
+            role_id=viewer_role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(viewer_user)
+        await db.commit()
+        break
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/login",
+            data={"username": "viewer_profile_row_test", "password": "viewerpass"},
+            follow_redirects=False,
+        )
+        yield ac
+
+
 @pytest.mark.asyncio
 class TestProfileRowEndpoint:
-    async def _make_profile(self, db_session, name="row-test") -> DeviceProfile:
+    async def _make_profile(
+        self, db_session, name="row-test", *, builtin=False, enabled=True
+    ) -> DeviceProfile:
         profile = DeviceProfile(
             name=name,
             description="row endpoint test",
@@ -24,7 +63,8 @@ class TestProfileRowEndpoint:
             color_space="auto",
             audio_codec="aac",
             audio_bitrate="128k",
-            builtin=False,
+            builtin=builtin,
+            enabled=enabled,
         )
         db_session.add(profile)
         await db_session.commit()
@@ -42,3 +82,57 @@ class TestProfileRowEndpoint:
     async def test_row_unknown_id_404(self, client):
         resp = await client.get("/api/profiles/00000000-0000-0000-0000-000000000000/row")
         assert resp.status_code == 404
+
+    # ── Issue #583 row rendering ──
+
+    async def test_enabled_profile_row_shows_disable_item(self, client, db_session):
+        profile = await self._make_profile(db_session, name="enabled-row")
+        resp = await client.get(f"/api/profiles/{profile.id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        # Enabled profiles render the Disable kebab item, NOT Enable.
+        assert "disableProfile(" in body
+        assert "enableProfile(" not in body
+        # No inactive styling or "disabled" badge for an enabled profile.
+        assert "row-inactive" not in body
+        assert ">disabled<" not in body
+
+    async def test_disabled_profile_row_shows_enable_item(self, client, db_session):
+        profile = await self._make_profile(db_session, name="disabled-row", enabled=False)
+        resp = await client.get(f"/api/profiles/{profile.id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "enableProfile(" in body
+        assert "disableProfile(" not in body
+        assert "row-inactive" in body
+        # Disabled badge in the name cell.
+        assert ">disabled<" in body
+
+    async def test_builtin_enabled_row_shows_disable_item(self, client, db_session):
+        # Built-ins must be disable-able (issue #583's headline ask).
+        profile = await self._make_profile(db_session, name="builtin-enabled", builtin=True)
+        resp = await client.get(f"/api/profiles/{profile.id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "disableProfile(" in body
+
+    async def test_builtin_disabled_row_shows_enable_item(self, client, db_session):
+        profile = await self._make_profile(
+            db_session, name="builtin-disabled", builtin=True, enabled=False
+        )
+        resp = await client.get(f"/api/profiles/{profile.id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "enableProfile(" in body
+        assert "row-inactive" in body
+
+    async def test_row_readonly_user_has_no_kebab(self, viewer_client, db_session):
+        profile = await self._make_profile(db_session, name="viewer-row")
+        resp = await viewer_client.get(f"/api/profiles/{profile.id}/row")
+        assert resp.status_code == 200
+        body = resp.text
+        # Read-only users see no kebab menu and therefore no enable/disable items.
+        assert "kebab-menu" not in body
+        assert "disableProfile(" not in body
+        assert "enableProfile(" not in body
+

--- a/tests/test_variant_uuid_filenames.py
+++ b/tests/test_variant_uuid_filenames.py
@@ -20,7 +20,7 @@ class TestVariantUUIDFilenames:
         """_enqueue_transcoding should create variants with UUID filenames."""
         from cms.models.asset import Asset, AssetType, AssetVariant
         from cms.models.device_profile import DeviceProfile
-        from cms.routers.assets import _enqueue_transcoding
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
 
         profile = DeviceProfile(name="pi-zero-2w", video_codec="h264")
         db_session.add(profile)
@@ -33,7 +33,7 @@ class TestVariantUUIDFilenames:
         db_session.add(asset)
         await db_session.flush()
 
-        await _enqueue_transcoding(asset, db_session)
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         from sqlalchemy import select
         result = await db_session.execute(select(AssetVariant))
@@ -74,7 +74,7 @@ class TestVariantUUIDFilenames:
         """Variant filename must NOT contain the profile name."""
         from cms.models.asset import Asset, AssetType, AssetVariant
         from cms.models.device_profile import DeviceProfile
-        from cms.routers.assets import _enqueue_transcoding
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
 
         profile = DeviceProfile(name="my-special-profile", video_codec="h264")
         db_session.add(profile)
@@ -87,7 +87,7 @@ class TestVariantUUIDFilenames:
         db_session.add(asset)
         await db_session.flush()
 
-        await _enqueue_transcoding(asset, db_session)
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         from sqlalchemy import select
         v = (await db_session.execute(select(AssetVariant))).scalar_one()
@@ -98,7 +98,7 @@ class TestVariantUUIDFilenames:
         """_enqueue_transcoding should create .jpg variants for IMAGE assets."""
         from cms.models.asset import Asset, AssetType, AssetVariant
         from cms.models.device_profile import DeviceProfile
-        from cms.routers.assets import _enqueue_transcoding
+        from cms.services.transcoder import _enqueue_transcoding_for_asset
 
         profile = DeviceProfile(name="pi-img-test", video_codec="h264")
         db_session.add(profile)
@@ -111,7 +111,7 @@ class TestVariantUUIDFilenames:
         db_session.add(asset)
         await db_session.flush()
 
-        await _enqueue_transcoding(asset, db_session)
+        await _enqueue_transcoding_for_asset(asset, db_session)
 
         from sqlalchemy import select
         result = await db_session.execute(select(AssetVariant))


### PR DESCRIPTION
## Summary

Wires up the UI for the existing profile enable/disable backend (#237) and closes the gaps that let disabled profiles still leak into transcode fan-outs and device assignments.

Closes #583.

## What's in here

### UI
- **Profiles page row** (`_macros.html` `profile_row`): row-inactive styling + "disabled" badge for disabled profiles; **Disable / Enable** kebab item between Edit and Copy. **Built-ins are NOT gated** — disable applies to built-ins too (the explicit ask in #583).
- **Profiles page JS** (`profiles.html`): `disableProfile(id, name, totalVariants)` and `enableProfile(id, name)` next to `resetProfile`. Disable prompts when there are existing variants ("transcodes will be stopped"); enable is one click.
- **Per-device dropdown** (`device_row`): hide disabled profiles UNLESS the device is currently assigned to one — in which case keep it selected with a "(disabled)" suffix so the operator can see the state. NULL `device.profile_id` is handled correctly.
- **Adoption modals** (devices.html + dashboard.html via `cms/ui.py`): both use a new `adoption_profiles` context var (enabled-only). The unfiltered `profiles` list is still passed to `device_row` for the "show currently-assigned even if disabled" logic.

### Backend
- **Consolidate two duplicate `_enqueue_transcoding` implementations.** The HTTP upload path in `routers/assets.py` had a local copy that did NOT filter `DeviceProfile.enabled`. So before this PR, disabling a profile didn't actually stop new uploads from creating variants for it. Deleted the duplicate; upload path now uses `services/transcoder.py:_enqueue_transcoding_for_asset` (single source of truth).
- **`PATCH /api/devices/{id}`** rejects assignment to a disabled profile (422) or a missing one (404 — a pre-existing gap that the same validation block closes).
- **`POST /api/devices/{id}/adopt`** (legacy adopt) rejects disabled (422).
- **`device_bootstrap.adopt_pending_by_id`** raises `ValueError("profile_disabled")`; both `/adopt` and `/adopt-pending` exception handlers map it to 422.

### Tests
- `test_profile_row_endpoint.py`: 5 new rendering cases (enabled / disabled / builtin-enabled / builtin-disabled / read-only-user-no-kebab).
- `test_profile_enable_disable.py`: HTTP upload regression for the fan-out consolidation, audit log coverage for both actions, and `TestDisabledProfileDeviceAssignment` (PATCH reject + 404 + happy path, legacy adopt reject, bootstrap service reject, no-cascade-clear guarantee).
- `test_device_dropdown_filter.py` (new): 5 tests for the per-device dropdown filter incl. NULL `profile_id` safety and the adoption-modal source array on both `/devices` and `/`.
- `test_bootstrap_endpoints.py`: 2 tests asserting `/adopt` and `/adopt-pending` map `profile_disabled` → 422.
- `test_image_variants.py` + `test_variant_uuid_filenames.py`: mechanical update of 7 imports from the deleted `cms.routers.assets._enqueue_transcoding` to `cms.services.transcoder._enqueue_transcoding_for_asset`.

## Out of scope
- "Currently-assigned device pointing at a deleted profile" — pre-existing, separate concern.
- Reset behavior intentionally unchanged: Reset only touches encoder fields. If a built-in is disabled, Reset leaves it disabled.

## Verification

Targeted local pytest (224 tests across the impacted modules) all pass:
- `test_profile_enable_disable.py`, `test_profile_row_endpoint.py`, `test_device_dropdown_filter.py`
- `test_bootstrap_endpoints.py`, `test_devices.py`, `test_adoption_flow.py`
- `test_assets.py`, `test_image_variants.py`, `test_variant_uuid_filenames.py`, `test_asset_row_endpoint.py`

Full sweep left to CI per local-runtime guidance.
