### PR TITLE
fix(assets): reset upload form after successful upload

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1692,15 +1692,20 @@ async function uploadAsset(form) {
                 statusEl.className = "form-status text-success";
                 let newId = null;
                 try { newId = JSON.parse(xhr.responseText)?.id || null; } catch (_) {}
-                // Reset the form so another upload can start immediately
+                // Reset the form so another upload can start immediately.
+                // form.reset() clears fileInput.files but does NOT fire the
+                // input's change event, so the drop-label and submit-disabled
+                // state must be reset manually to match the initial page load.
                 form.reset();
+                const dropLabel = document.getElementById("drop-label");
+                if (dropLabel) dropLabel.textContent = "Drag \u0026 drop a file here, or";
                 const badges = document.getElementById("upload-groups-badges");
                 if (badges) {
                     badges.querySelectorAll(".badge[data-group-id]").forEach(b => b.remove());
                 }
                 const popup = document.getElementById("upload-group-popup");
                 if (popup) popup.querySelectorAll("[data-group-id]").forEach(b => { b.style.display = ""; });
-                submitBtn.disabled = false;
+                submitBtn.disabled = true;
                 // Insert the new row (server-rendered, newest-first)
                 if (newId && window._insertAssetRow) {
                     window._insertAssetRow(newId).finally(() => {

--- a/tests_e2e/test_ui_upload_cancel.py
+++ b/tests_e2e/test_ui_upload_cancel.py
@@ -1,4 +1,9 @@
-"""E2E: cancelling the file picker after a drag-drop should reset the label."""
+"""E2E: cancelling the file picker after a drag-drop should reset the label.
+
+Also covers the post-successful-upload reset (issue #582): after a 201
+response the drop-label must revert to the default and the Upload
+button must be disabled, so the form looks fresh for the next upload.
+"""
 
 import pytest
 
@@ -46,3 +51,44 @@ def test_cancel_file_picker_resets_label_after_choose(page: "Page"):
     # Cancel
     file_input.set_input_files([])
     assert label.text_content() == DEFAULT_LABEL
+
+
+def test_form_resets_after_successful_upload(page: "Page"):
+    """Issue #582: after a 201 from /api/assets/upload, the drop-label
+    must revert to the default text and the Upload button must be
+    disabled — otherwise the form looks like it's still holding the
+    file the user just uploaded."""
+
+    page.goto("/assets")
+
+    label = page.locator("#drop-label")
+    submit = page.locator("#upload-submit")
+
+    # Sanity: initial state is the default label + disabled button.
+    assert label.text_content() == DEFAULT_LABEL
+    assert submit.is_disabled()
+
+    file_input = page.locator("#file-input")
+    file_input.set_input_files(
+        {"name": "reset-me.jpg", "mimeType": "image/jpeg", "buffer": b"\xFF\xD8" * 8}
+    )
+
+    # Pre-upload: label shows filename, button enabled.
+    assert label.text_content() == "reset-me.jpg"
+    assert submit.is_enabled()
+
+    # Fire the upload and wait for the 201.
+    with page.expect_response(
+        lambda r: "/api/assets/upload" in r.url and r.request.method == "POST",
+        timeout=30_000,
+    ) as rinfo:
+        submit.click()
+    resp = rinfo.value
+    assert resp.status == 201, f"upload failed: HTTP {resp.status} — {resp.text()[:300]}"
+
+    # Post-upload: label is reset, submit re-disabled.
+    # Use expect for both so we wait out the async XHR-load handler.
+    from playwright.sync_api import expect
+    expect(label).to_have_text(DEFAULT_LABEL, timeout=5_000)
+    expect(submit).to_be_disabled(timeout=5_000)
+


### PR DESCRIPTION
Closes #582

After a successful upload the drop-zone still showed the just-uploaded
filename and the Upload button was still enabled, so the form looked
like it was holding the file the user had already uploaded.

`form.reset()` clears `fileInput.files` but the file input's
`change` event does not fire, so the existing drop-label / submit-
disabled bookkeeping in `assets.html` never ran. Reset both pieces
explicitly to mirror the initial page-load state.

### Test

E2E test `test_form_resets_after_successful_upload` added to
`tests_e2e/test_ui_upload_cancel.py`: drops a file, submits the
form, waits for the 201, then asserts the drop-label is back to
`"Drag & drop a file here, or"` and the Upload button is disabled.
