### PR TITLE
fix(assets): escape webpage URL in Edit URL kebab onclick

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -218,7 +218,7 @@
                     {% if a.asset_type.value == 'webpage' %}
                         <a role="menuitem" href="{{ a.url }}" target="_blank" rel="noopener">Open URL</a>
                         {% if 'assets:write' in user_perms and is_owner %}
-                        <button type="button" role="menuitem" onclick="editWebpageUrl('{{ a.id }}', {{ (a.url or '') | tojson }})">Edit URL</button>
+                        <button type="button" role="menuitem" onclick="editWebpageUrl('{{ a.id }}', {{ (a.url or '') | tojson | forceescape }})">Edit URL</button>
                         {% endif %}
                     {% elif a.asset_type.value == 'stream' %}
                         <a role="menuitem" href="{{ a.url }}" target="_blank" rel="noopener">Open Stream</a>

--- a/tests/test_asset_row_endpoint.py
+++ b/tests/test_asset_row_endpoint.py
@@ -28,3 +28,54 @@ class TestAssetRowEndpoint:
     async def test_row_unknown_id_404(self, client):
         resp = await client.get("/api/assets/00000000-0000-0000-0000-000000000000/row")
         assert resp.status_code == 404
+
+    async def test_webpage_row_edit_url_onclick_is_html_safe(self, client):
+        """Regression: the 'Edit URL' kebab item rendered for webpage assets
+        must HTML-escape the embedded URL so the browser's HTML parser doesn't
+        terminate the onclick="..." attribute at the URL's opening "
+        character.
+
+        Before the fix, the macro emitted::
+
+            onclick="editWebpageUrl('<id>', "https://example.com/x")"
+
+        which the browser parses as ``onclick="editWebpageUrl('<id>', "``
+        followed by stray attributes — so the menu item's click handler is
+        effectively empty and "Edit URL" does nothing (issue from the
+        agora-cms assets page).
+
+        The fix is to filter ``tojson`` through ``forceescape`` so the
+        double-quotes become ``&#34;`` inside the attribute.
+        """
+        url = "https://example.com/some/path?a=1&b=2"
+        resp = await client.post("/api/assets/webpage", json={"url": url, "name": "kebab-test"})
+        assert resp.status_code == 201, resp.text
+        asset_id = resp.json()["id"]
+
+        row = await client.get(f"/api/assets/{asset_id}/row")
+        assert row.status_code == 200
+        body = row.text
+
+        # The kebab Edit URL handler must be present.
+        assert f"editWebpageUrl('{asset_id}'" in body, (
+            "Edit URL kebab item missing from the rendered row -- "
+            "did the macro's webpage branch or assets:write/is_owner gate change?"
+        )
+
+        # The URL must be HTML-encoded inside the onclick attribute. If the
+        # raw " from tojson survives into the rendered HTML, the browser will
+        # terminate the onclick attribute prematurely and the click handler
+        # silently does nothing.
+        bad = f'editWebpageUrl(\'{asset_id}\', "https://'
+        assert bad not in body, (
+            "Raw double-quote leaked into onclick attribute -- the Edit URL "
+            "kebab item is inert. Use `| tojson | forceescape` so the quotes "
+            "become &#34; in the attribute."
+        )
+        # Positive: the safe-escaped form should be there instead.
+        assert f"editWebpageUrl('{asset_id}', &#34;https://" in body, (
+            "Expected the URL inside onclick to be HTML-escaped via "
+            "tojson | forceescape so the browser hands a valid JS expression "
+            "to the click handler."
+        )
+


### PR DESCRIPTION
On the CMS assets page, clicking the kebab → "Edit URL" on a freshly-
created webpage asset did nothing -- no prompt modal, no PATCH, no
toast.

### Root cause

The asset_row macro rendered:

    <button onclick="editWebpageUrl('<id>', {{ (a.url or '') | tojson }})">

`tojson` emits the JSON string with literal ASCII `"..."` quotes.
Because the surrounding `onclick="..."` attribute is also double-
quoted, the browser's HTML parser terminated the attribute at the
first character of the URL:

    onclick="editWebpageUrl('<id>', "https://example.com/x")"
                                     ^ HTML parser stops here

The click handler was effectively empty, so the kebab item was inert.

### Fix

Pipe `tojson` through `forceescape` (the same pattern used by the
other `onclick` handlers in this macro -- `deleteProfile`,
`copyProfile`, etc.). The double-quotes become `&#34;` inside the
attribute, the HTML parser keeps the full expression, and the click
handler receives a valid JS string.

### Test

New unit test `test_webpage_row_edit_url_onclick_is_html_safe` in
`tests/test_asset_row_endpoint.py`:

- creates a webpage asset via `POST /api/assets/webpage`
- fetches the row fragment from `/api/assets/{id}/row`
- asserts the rendered onclick uses the HTML-encoded `&#34;`
- asserts the raw, attribute-terminating `", "https://` form is
  absent

Fails on `main`; passes after the fix.
