### PR TITLE
feat(schedules): add `Set to now` chip on edit-modal Start Time

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1540,3 +1540,40 @@ textarea:not(:-webkit-autofill) {
 .kebab-menu > .kebab-item-danger:hover:not(:disabled) {
     background: rgba(231, 76, 60, 0.12);
 }
+
+/* "Now" chip for time inputs -- a small floating pill that appears
+   just above the input while it (or the chip itself) has focus.  Lets
+   the operator set the field to the current wall-clock time without
+   replacing the native time picker. */
+.time-now-wrap {
+    position: relative;
+}
+.time-now-chip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 0;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem 0.25rem 0.6rem;
+    font-size: 0.78rem;
+    line-height: 1.2;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    gap: 0.3rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    white-space: nowrap;
+    z-index: 5;
+}
+.time-now-chip:hover { background: var(--accent-hover); }
+.time-now-wrap.focused .time-now-chip { display: inline-flex; }
+.time-now-chip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 14px;
+    border: 5px solid transparent;
+    border-top-color: var(--accent);
+}

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -797,7 +797,10 @@ function editSchedule(s) {
         <div class="form-row">
             <div class="form-group">
                 <label>Start Time</label>
-                <input type="time" id="edit-start-time" value="${s.start_time}">
+                <div class="time-now-wrap" id="edit-start-time-wrap">
+                    <button type="button" class="time-now-chip" id="edit-start-time-now" tabindex="-1">⏱ Set to now</button>
+                    <input type="time" id="edit-start-time" value="${s.start_time}">
+                </div>
             </div>
             <div class="form-group">
                 <label>End Time</label>
@@ -899,6 +902,57 @@ function editSchedule(s) {
         computeLoopEndTime(box);
         updateEditSummary();
     });
+
+    // "Now" chip for Start Time -- appears while the input is focused,
+    // sets the field to the current wall-clock time in the schedule's
+    // currently-selected timezone, and fires a synthetic ``change``
+    // event so the existing end-time recompute / summary update /
+    // dirty-tracking logic all run as if the user had typed it.
+    const startWrap = box.querySelector("#edit-start-time-wrap");
+    const startNowChip = box.querySelector("#edit-start-time-now");
+    const editTzSel = box.querySelector("#edit-timezone");
+    function _currentTimeInTz(tz) {
+        try {
+            return new Intl.DateTimeFormat('en-GB', {
+                hour: '2-digit', minute: '2-digit', hour12: false,
+                timeZone: tz || undefined,
+            }).format(new Date());
+        } catch (e) {
+            // Bad/unknown IANA name -- fall back to browser local time.
+            const now = new Date();
+            return String(now.getHours()).padStart(2, '0') + ':' +
+                   String(now.getMinutes()).padStart(2, '0');
+        }
+    }
+    function _updateStartNowChipLabel() {
+        startNowChip.textContent = '\u23f1 Set to now (' + _currentTimeInTz(editTzSel.value) + ')';
+    }
+    _updateStartNowChipLabel();
+    editStartTimeEl.addEventListener('focus', function() {
+        _updateStartNowChipLabel();
+        startWrap.classList.add('focused');
+    });
+    editStartTimeEl.addEventListener('blur', function() {
+        // Delay so a click on the chip still registers before we hide
+        // it -- if the user is mid-click on the chip, focus has briefly
+        // left the input but ``document.activeElement`` will be the
+        // chip button by the time this fires.
+        setTimeout(function() {
+            if (document.activeElement !== startNowChip) {
+                startWrap.classList.remove('focused');
+            }
+        }, 120);
+    });
+    // Prevent the chip's mousedown from blurring the input mid-click.
+    startNowChip.addEventListener('mousedown', function(e) { e.preventDefault(); });
+    startNowChip.addEventListener('click', function() {
+        editStartTimeEl.value = _currentTimeInTz(editTzSel.value);
+        editStartTimeEl.dispatchEvent(new Event('change', { bubbles: true }));
+        editStartTimeEl.focus();
+    });
+    // Keep the chip label honest if the user changes the timezone
+    // dropdown while the modal is open.
+    editTzSel.addEventListener('change', _updateStartNowChipLabel);
 
     // Auto-advance end date in edit modal
     const editStartDateEl = box.querySelector("#edit-start-date");


### PR DESCRIPTION
## What

Adds a focus-revealed **Set to now** chip above the Start Time input in the edit-schedule modal.

## Why

When editing an active or expired schedule it's common to need to shift the start time to right now (e.g. flipping a one-shot piece of content live). Doing this by hand requires guessing what minute it actually is in the schedule's configured timezone.

## How

- `cms/templates/schedules.html`: wraps the Start Time `<input type=time>` in a `.time-now-wrap` div and adds a `.time-now-chip` button above it. JS in `editSchedule()` shows the chip on focus, hides it on blur (with a 120 ms grace so the chip click registers), and on click fills the input with the current wall-clock time in the schedule's currently-selected timezone, dispatches `change` so existing end-time recompute / summary / dirty-tracking fire, then re-focuses the input.
- The chip label shows the time it will set (e.g. `Set to now (16:21)`) and updates when the field is focused or the timezone dropdown changes.
- `cms/static/style.css`: small block of styling for the wrap and the accent-pink pill, including a triangle pointer aimed at the input.

Native `<input type=time>` picker is untouched -- the chip floats above the input, since the browser-rendered popup is not customizable.

## Scope

Edit modal only. Create form Start Time is unchanged (can be a follow-up if useful).

## Tests

`test_schedules.py`, `test_page_smoke.py` and `test_expired_schedules.py` all pass locally (54 tests).