### PR TITLE
fix(ui): don't dismiss the prompt modal on backdrop click

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -98,8 +98,13 @@ function showPrompt(message, defaultValue = "", isPassword = false) {
         const close = (val) => { overlay.remove(); resolve(val); };
         cancelBtn.onclick = () => close(null);
         okBtn.onclick = () => close(input.value);
-        input.addEventListener("keydown", (e) => { if (e.key === "Enter") close(input.value); });
-        overlay.addEventListener("click", (e) => { if (e.target === overlay) close(null); });
+        input.addEventListener("keydown", (e) => {
+            if (e.key === "Enter") close(input.value);
+            else if (e.key === "Escape") close(null);
+        });
+        // Intentionally NOT closing on backdrop click -- the prompt has a
+        // text input and it's too easy to lose typed content with a stray
+        // click outside the dialog. Users dismiss via Cancel/Esc.
     });
 }
 


### PR DESCRIPTION
## What

Stop the custom prompt modal (`showPrompt()` in `cms/static/app.js`) from dismissing when the user clicks the dark backdrop outside the dialog box. The most user-visible instance is the **Edit URL** modal on a webpage asset, but the same helper is also used for the device web-UI password prompt -- both are text inputs where a stray click can silently lose what you've typed.

## Change

- Remove the backdrop `click` handler that was resolving to `null`.
- Add `Escape` as an explicit dismiss key so keyboard users still have a one-key way out.
- `Enter` to confirm and the Cancel button are unchanged.

## Scope

Only `showPrompt()`. `showConfirm()` is intentionally left alone -- its backdrop dismiss resolves to `false`, which is the safe default for a confirmation dialog and worth keeping as a quick-out for the user.

## Tests

No existing test relied on backdrop click-to-dismiss (grep'd `modal-overlay` / `e.target === overlay` -- only nightly tests that explicitly click OK/Cancel buttons).