### PR TITLE
refactor(ui): shared createModal() helper + opinionated dismissal defaults

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -34,14 +34,65 @@ function _closeOpenPopovers() {
     });
 }
 
+// ── Modal factory ─────────────────────────────────────────────────────
+// Builds the standard `modal-overlay` > `modal-box` shell, wires up the
+// close lifecycle, and exposes the helpers that nearly every modal needs.
+//
+// Opinionated defaults:
+//   - closeOnBackdrop: false — clicking the dark area outside the box does
+//     NOT dismiss the modal. Most modals contain form input where a stray
+//     click would silently lose state. Confirm dialogs and image-preview
+//     lightboxes opt in via {closeOnBackdrop: true}.
+//   - closeOnEsc: true — Esc always provides a one-key dismiss path.
+//
+// Returns {overlay, box, close}. Callers append their own content to
+// `box`, wire up their buttons to call `close(value)`, and pass an
+// `onClose` callback to receive the value (e.g. resolve a Promise).
+// `close()` is idempotent; safe to call from multiple paths.
+function createModal({ closeOnBackdrop = false, closeOnEsc = true, onClose } = {}) {
+    _closeOpenPopovers();
+    const overlay = document.createElement("div");
+    overlay.className = "modal-overlay";
+    const box = document.createElement("div");
+    box.className = "modal-box";
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    let closed = false;
+    function _onKey(e) {
+        if (e.key !== "Escape") return;
+        // Only respond if we're the topmost modal -- otherwise a nested
+        // confirm/prompt opened on top of us would inadvertently dismiss
+        // us when the user hits Esc to close the inner one.
+        const overlays = document.querySelectorAll(".modal-overlay");
+        if (overlays[overlays.length - 1] !== overlay) return;
+        close(undefined);
+    }
+    function close(value) {
+        if (closed) return;
+        closed = true;
+        document.removeEventListener("keydown", _onKey);
+        overlay.remove();
+        if (typeof onClose === "function") onClose(value);
+    }
+    if (closeOnEsc) document.addEventListener("keydown", _onKey);
+    if (closeOnBackdrop) {
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay) close(undefined);
+        });
+    }
+    return { overlay, box, close };
+}
+
 // ── Modal confirm (replaces native confirm()) ──
 function showConfirm(message) {
-    _closeOpenPopovers();
     return new Promise((resolve) => {
-        const overlay = document.createElement("div");
-        overlay.className = "modal-overlay";
-        const box = document.createElement("div");
-        box.className = "modal-box";
+        // Backdrop click is safe for confirms -- resolves to false (cancel).
+        const { box, close } = createModal({
+            closeOnBackdrop: true,
+            closeOnEsc: true,
+            onClose: (v) => resolve(v === undefined ? false : v),
+        });
         const msg = document.createElement("p");
         msg.textContent = message;
         const actions = document.createElement("div");
@@ -56,23 +107,19 @@ function showConfirm(message) {
         actions.appendChild(okBtn);
         box.appendChild(msg);
         box.appendChild(actions);
-        overlay.appendChild(box);
-        document.body.appendChild(overlay);
-        const close = (result) => { overlay.remove(); resolve(result); };
         cancelBtn.onclick = () => close(false);
         okBtn.onclick = () => close(true);
-        overlay.addEventListener("click", (e) => { if (e.target === overlay) close(false); });
     });
 }
 
 // ── Prompt modal (replaces native prompt()) ──
 function showPrompt(message, defaultValue = "", isPassword = false) {
-    _closeOpenPopovers();
     return new Promise((resolve) => {
-        const overlay = document.createElement("div");
-        overlay.className = "modal-overlay";
-        const box = document.createElement("div");
-        box.className = "modal-box";
+        // Defaults: no backdrop dismiss (text input -- don't lose typing),
+        // Esc cancels. Resolves null on cancel/Esc, string on submit.
+        const { box, close } = createModal({
+            onClose: (v) => resolve(v === undefined ? null : v),
+        });
         const msg = document.createElement("p");
         msg.textContent = message;
         const input = document.createElement("input");
@@ -92,14 +139,12 @@ function showPrompt(message, defaultValue = "", isPassword = false) {
         box.appendChild(msg);
         box.appendChild(input);
         box.appendChild(actions);
-        overlay.appendChild(box);
-        document.body.appendChild(overlay);
         input.focus();
-        const close = (val) => { overlay.remove(); resolve(val); };
         cancelBtn.onclick = () => close(null);
         okBtn.onclick = () => close(input.value);
-        input.addEventListener("keydown", (e) => { if (e.key === "Enter") close(input.value); });
-        overlay.addEventListener("click", (e) => { if (e.target === overlay) close(null); });
+        input.addEventListener("keydown", (e) => {
+            if (e.key === "Enter") close(input.value);
+        });
     });
 }
 
@@ -1199,12 +1244,11 @@ window.rejectPendingDevice = rejectPendingDevice;
 
 
 function showAdoptModal(defaultName, groups, profiles) {
-    _closeOpenPopovers();
     return new Promise((resolve) => {
-        const overlay = document.createElement("div");
-        overlay.className = "modal-overlay";
-        const box = document.createElement("div");
-        box.className = "modal-box";
+        // Defaults: no backdrop dismiss (form input), Esc cancels.
+        const { box, close } = createModal({
+            onClose: (v) => resolve(v === undefined ? null : v),
+        });
 
         const title = document.createElement("h3");
         title.textContent = "Adopt Device";
@@ -1302,12 +1346,9 @@ function showAdoptModal(defaultName, groups, profiles) {
         box.appendChild(groupLabel);
         box.appendChild(groupSelect);
         box.appendChild(actions);
-        overlay.appendChild(box);
-        document.body.appendChild(overlay);
         nameInput.focus();
         nameInput.select();
 
-        const close = (val) => { overlay.remove(); resolve(val); };
         cancelBtn.onclick = () => close(null);
         adoptBtn.onclick = () => {
             if (!nameInput.value.trim() || !profileSelect.value) return;
@@ -1470,11 +1511,12 @@ async function deleteGroup(groupId) {
 
 // ── Asset actions ──
 function previewAsset(assetId, filename, assetType) {
-    _closeOpenPopovers();
-    const overlay = document.createElement("div");
-    overlay.className = "modal-overlay";
-    const box = document.createElement("div");
-    box.className = "modal-box preview-box";
+    // Lightbox: backdrop dismiss is the expected pattern.
+    const { box, close } = createModal({
+        closeOnBackdrop: true,
+        closeOnEsc: true,
+    });
+    box.classList.add("preview-box");
     const header = document.createElement("div");
     header.className = "preview-header";
     const title = document.createElement("span");
@@ -1482,7 +1524,7 @@ function previewAsset(assetId, filename, assetType) {
     const closeBtn = document.createElement("button");
     closeBtn.className = "btn btn-secondary btn-sm";
     closeBtn.textContent = "Close";
-    closeBtn.onclick = () => overlay.remove();
+    closeBtn.onclick = () => close();
     header.appendChild(title);
     header.appendChild(closeBtn);
     box.appendChild(header);
@@ -1501,19 +1543,15 @@ function previewAsset(assetId, filename, assetType) {
         img.className = "preview-media";
         box.appendChild(img);
     }
-
-    overlay.appendChild(box);
-    document.body.appendChild(overlay);
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
-    document.addEventListener("keydown", function esc(e) { if (e.key === "Escape") { overlay.remove(); document.removeEventListener("keydown", esc); } });
 }
 
 function previewVariant(variantId, filename, assetType, profileName) {
-    _closeOpenPopovers();
-    const overlay = document.createElement("div");
-    overlay.className = "modal-overlay";
-    const box = document.createElement("div");
-    box.className = "modal-box preview-box";
+    // Lightbox: backdrop dismiss is the expected pattern.
+    const { box, close } = createModal({
+        closeOnBackdrop: true,
+        closeOnEsc: true,
+    });
+    box.classList.add("preview-box");
     const header = document.createElement("div");
     header.className = "preview-header";
     const title = document.createElement("span");
@@ -1521,7 +1559,7 @@ function previewVariant(variantId, filename, assetType, profileName) {
     const closeBtn = document.createElement("button");
     closeBtn.className = "btn btn-secondary btn-sm";
     closeBtn.textContent = "Close";
-    closeBtn.onclick = () => overlay.remove();
+    closeBtn.onclick = () => close();
     header.appendChild(title);
     header.appendChild(closeBtn);
     box.appendChild(header);
@@ -1540,11 +1578,6 @@ function previewVariant(variantId, filename, assetType, profileName) {
         img.className = "preview-media";
         box.appendChild(img);
     }
-
-    overlay.appendChild(box);
-    document.body.appendChild(overlay);
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
-    document.addEventListener("keydown", function esc(e) { if (e.key === "Escape") { overlay.remove(); document.removeEventListener("keydown", esc); } });
 }
 
 async function editAssetName(el) {

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -271,42 +271,35 @@
 
     /* ── Report an issue modal ── */
     function openReportIssueModal() {
-        if (typeof _closeOpenPopovers === 'function') _closeOpenPopovers();
-        const overlay = document.createElement('div');
-        overlay.className = 'modal-overlay';
-        overlay.innerHTML = `
-            <div class="modal-box" style="max-width:560px;width:100%;">
-                <h3 style="margin-top:0;">Report an issue</h3>
-                <p class="text-muted" style="margin-top:0;font-size:.9em;">
-                    Filed as a GitHub issue. Page URL, browser, app version, and your account
-                    info are included automatically.
-                </p>
-                <label style="display:block;margin-top:.75rem;font-weight:600;">Title</label>
-                <input type="text" id="report-issue-title" class="modal-input" maxlength="200"
-                       placeholder="Brief summary" style="width:100%;">
-                <label style="display:block;margin-top:.75rem;font-weight:600;">Description</label>
-                <textarea id="report-issue-body" class="modal-input" rows="6" maxlength="8000"
-                          placeholder="What happened? Steps to reproduce, what you expected, what you saw."
-                          style="width:100%;resize:vertical;font-family:inherit;"></textarea>
-                <div id="report-issue-error" style="display:none;color:var(--color-danger,#c22);margin-top:.5rem;font-size:.9em;"></div>
-                <div class="modal-actions">
-                    <button type="button" class="btn btn-secondary" id="report-issue-cancel">Cancel</button>
-                    <button type="button" class="btn btn-primary" id="report-issue-submit">Submit</button>
-                </div>
+        // No backdrop dismiss -- contains form input (title + textarea).
+        const { box, close } = createModal();
+        box.style.maxWidth = '560px';
+        box.style.width = '100%';
+        box.innerHTML = `
+            <h3 style="margin-top:0;">Report an issue</h3>
+            <p class="text-muted" style="margin-top:0;font-size:.9em;">
+                Filed as a GitHub issue. Page URL, browser, app version, and your account
+                info are included automatically.
+            </p>
+            <label style="display:block;margin-top:.75rem;font-weight:600;">Title</label>
+            <input type="text" id="report-issue-title" class="modal-input" maxlength="200"
+                   placeholder="Brief summary" style="width:100%;">
+            <label style="display:block;margin-top:.75rem;font-weight:600;">Description</label>
+            <textarea id="report-issue-body" class="modal-input" rows="6" maxlength="8000"
+                      placeholder="What happened? Steps to reproduce, what you expected, what you saw."
+                      style="width:100%;resize:vertical;font-family:inherit;"></textarea>
+            <div id="report-issue-error" style="display:none;color:var(--color-danger,#c22);margin-top:.5rem;font-size:.9em;"></div>
+            <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" id="report-issue-cancel">Cancel</button>
+                <button type="button" class="btn btn-primary" id="report-issue-submit">Submit</button>
             </div>
         `;
-        document.body.appendChild(overlay);
-        const titleEl = overlay.querySelector('#report-issue-title');
-        const bodyEl = overlay.querySelector('#report-issue-body');
-        const errEl = overlay.querySelector('#report-issue-error');
-        const cancelBtn = overlay.querySelector('#report-issue-cancel');
-        const submitBtn = overlay.querySelector('#report-issue-submit');
-        const close = () => overlay.remove();
-        cancelBtn.onclick = close;
-        overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-        document.addEventListener('keydown', function onKey(e) {
-            if (e.key === 'Escape') { document.removeEventListener('keydown', onKey); close(); }
-        });
+        const titleEl = box.querySelector('#report-issue-title');
+        const bodyEl = box.querySelector('#report-issue-body');
+        const errEl = box.querySelector('#report-issue-error');
+        const cancelBtn = box.querySelector('#report-issue-cancel');
+        const submitBtn = box.querySelector('#report-issue-submit');
+        cancelBtn.onclick = () => close();
         titleEl.focus();
 
         submitBtn.onclick = async () => {

--- a/cms/templates/profile.html
+++ b/cms/templates/profile.html
@@ -178,10 +178,9 @@
     }
 
     function showKeyModal(key, title) {
-        const overlay = document.createElement("div");
-        overlay.className = "modal-overlay";
-        const box = document.createElement("div");
-        box.className = "modal-box";
+        // No backdrop dismiss -- the key is shown once and only once.
+        // A stray click that closes this would lose the key forever.
+        const { box, close } = createModal();
         box.innerHTML = `
             <p style="margin-bottom:0.5rem;"><strong>${title}</strong></p>
             <p style="margin-bottom:0.75rem; font-size:0.85rem;" class="text-muted">Store it securely — it won't be shown again.</p>
@@ -191,13 +190,10 @@
                 <button class="btn btn-primary" id="key-ok-btn">OK</button>
             </div>
         `;
-        document.body.appendChild(overlay);
-        overlay.appendChild(box);
         const keyInput = box.querySelector("input");
         keyInput.select();
         box.querySelector("#key-copy-btn").onclick = () => { copyToClipboard(key); };
-        box.querySelector("#key-ok-btn").onclick = () => { overlay.remove(); };
-        overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+        box.querySelector("#key-ok-btn").onclick = () => close();
     }
 
     createBtn.addEventListener("click", async function() {

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -846,10 +846,22 @@ function editSchedule(s) {
             const ok = await showConfirm("\u26a0\ufe0f You have unsaved changes to this schedule. Discard them and close?");
             if (!ok) return;
         }
+        document.removeEventListener("keydown", _onEditEsc);
         _editModalDirtyTracker = null;
         overlay.remove();
     };
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) _closeEditModal(false); });
+    // Esc closes the modal (with the dirty-check guard). We intentionally
+    // do NOT close on backdrop click -- the modal has a large form and
+    // a stray click outside it shouldn't dump the user's unsaved edits.
+    // Only respond if we're the topmost modal so a nested showConfirm
+    // (e.g. the discard-changes prompt) doesn't dismiss us by mistake.
+    const _onEditEsc = (e) => {
+        if (e.key !== "Escape") return;
+        const overlays = document.querySelectorAll(".modal-overlay");
+        if (overlays[overlays.length - 1] !== overlay) return;
+        _closeEditModal(false);
+    };
+    document.addEventListener("keydown", _onEditEsc);
     box.querySelector("#edit-cancel").onclick = () => _closeEditModal(false);
 
     // Edit modal summary helper
@@ -1013,6 +1025,7 @@ function editSchedule(s) {
         body.loop_count = hasLoopCount ? parseInt(editLoopCount) : null;
         const resp = await apiCall("PATCH", `/api/schedules/${s.id}`, body);
         if (resp && resp.ok) {
+            document.removeEventListener("keydown", _onEditEsc);
             _editModalDirtyTracker = null;
             overlay.remove();
             // #546: if the edit changed which panel the row belongs in

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -989,13 +989,13 @@ function clearDirty() {
 
 // Custom 3-button modal for unsaved-changes navigation: Save / Discard /
 // Cancel. Visually matches showConfirm in app.js by reusing the same
-// modal-overlay / modal-box / modal-actions classes.
+// modal-overlay / modal-box / modal-actions classes via createModal().
 function showUnsavedChangesModal(targetHref) {
-    if (typeof _closeOpenPopovers === 'function') _closeOpenPopovers();
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    const box = document.createElement('div');
-    box.className = 'modal-box';
+    // Backdrop click is the same as Cancel here, so allow it.
+    const { box, close } = createModal({
+        closeOnBackdrop: true,
+        closeOnEsc: true,
+    });
     const msg = document.createElement('p');
     msg.textContent = 'You have unsaved changes. Save them before leaving?';
     const actions = document.createElement('div');
@@ -1014,9 +1014,6 @@ function showUnsavedChangesModal(targetHref) {
     actions.appendChild(saveBtn);
     box.appendChild(msg);
     box.appendChild(actions);
-    overlay.appendChild(box);
-    document.body.appendChild(overlay);
-    const close = () => overlay.remove();
     cancelBtn.onclick = () => close();
     discardBtn.onclick = () => {
         clearDirty();
@@ -1030,7 +1027,6 @@ function showUnsavedChangesModal(targetHref) {
         close();
         saveSlideshow({redirectTo: targetHref});
     };
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
 }
 
 function initDirtyTracking() {

--- a/cms/templates/users.html
+++ b/cms/templates/users.html
@@ -441,11 +441,8 @@ const rolesData = {
             const data = await resp.json();
             await loadAllKeys();
             copyToClipboard(data.key);
-            // Show key modal
-            const overlay = document.createElement("div");
-            overlay.className = "modal-overlay";
-            const box = document.createElement("div");
-            box.className = "modal-box";
+            // Show key modal. No backdrop dismiss -- key is shown once only.
+            const { box, close } = createModal();
             box.innerHTML = `
                 <p style="margin-bottom:0.5rem;"><strong>Key regenerated!</strong></p>
                 <p style="margin-bottom:0.75rem; font-size:0.85rem;" class="text-muted">Store it securely — it won't be shown again.</p>
@@ -455,12 +452,9 @@ const rolesData = {
                     <button class="btn btn-primary" id="admin-key-ok-btn">OK</button>
                 </div>
             `;
-            document.body.appendChild(overlay);
-            overlay.appendChild(box);
             box.querySelector("input").select();
             box.querySelector("#admin-key-copy-btn").onclick = () => { copyToClipboard(data.key); };
-            box.querySelector("#admin-key-ok-btn").onclick = () => { overlay.remove(); };
-            overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+            box.querySelector("#admin-key-ok-btn").onclick = () => close();
         } catch {
             showToast("Failed to regenerate key", true);
         }


### PR DESCRIPTION
## What

Adds a shared `createModal({closeOnBackdrop, closeOnEsc, onClose})` helper in `cms/static/app.js` and migrates the CMS's dynamically-created modals onto it with opinionated dismissal defaults. **This supersedes #592** -- the showPrompt fix from that PR is included here as part of the migration.

## Why

Every dynamic modal in the CMS was rolling its own `modal-overlay` + `modal-box` shell, its own backdrop-click handler, and (sometimes) its own Esc handler. The defaults were inconsistent and a few were actively bad:

- **Edit Schedule** -- clicking outside silently dropped your unsaved edits.
- **Edit URL** (showPrompt) -- one stray click and the URL you were typing was gone.
- **Report an issue** -- ditto for your typed bug report.
- **API key reveal** / **admin regenerated key** -- one stray click and the once-only display of the secret was gone forever.

## How

New factory with the opinionated defaults that match modern UX consensus (Material Design, Apple HIG):

- `closeOnBackdrop: false` -- clicking the dark area outside the box does **not** dismiss. Most modals contain form input or one-time secrets.
- `closeOnEsc: true` -- Esc is a one-key dismiss. Topmost-only so a nested confirm/prompt doesn't bubble Esc up to the parent modal.
- Idempotent `close()`, `onClose(value)` callback for Promise-returning modals, always calls `_closeOpenPopovers()` first.

### Migrations

| Modal | `closeOnBackdrop` | Note |
|---|---|---|
| `showConfirm` | true | backdrop = `false` = safe cancel |
| `showPrompt` | false | subsumes #592 |
| `previewAsset` / `previewVariant` | true | lightbox pattern |
| `showAdoptModal` | false | also adds Esc (it lacked one) |
| `showKeyModal` (profile.html) | false | one-time key |
| Admin regenerated-key (users.html) | false | one-time key |
| `openReportIssueModal` (base.html) | false | textarea content |
| `showUnsavedChangesModal` (slideshow_builder.html) | true | backdrop = cancel safe |

### Surgical fix (not migrated)

`editSchedule` in `schedules.html` is huge (~250 lines) and tightly coupled to the dirty-tracker. Migrating it to the factory wasn't worth the risk. Instead: removed the backdrop-dismiss handler and added an Esc handler with the same topmost-only guard, both routing through the existing `_closeEditModal(false)` so the dirty-changes prompt still appears.

### Intentionally left as-is

- `showBootstrapAdoptModal` already does the right thing (no backdrop, has Esc) and has a complex QR-scanner / camera lifecycle that isn't worth churning right now.
- Static-rendered modals in HTML (`imagerCatalogModal`, `edit-user-modal`, etc.) never had backdrop dismiss to begin with.

## Tests

	est_no_native_modals, 	est_schedules, 	est_page_smoke, 	est_expired_schedules -- 55 tests pass locally. The `.modal-overlay` / `.modal-box` / `.modal-input` class shape is preserved, so the nightly Playwright tests that select on those classes are unaffected.

## Follow-ups

Future modals should default to `createModal()`. The factory is the new convention; if a modal really needs backdrop dismiss (lightbox, confirm-style) it opts in explicitly.