### PR TITLE
fix(templates): escape user-typed strings in inline onclick handlers (sweep)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Notes for AI coding agents working in this repo
+
+Short, agent-facing guidance. Human-facing dev docs live in `CONTRIBUTING.md`
+and `README.md`.
+
+## Testing
+
+- **Do not run the full pytest suite locally.** It's ~3000 tests and
+  takes ~8 min on a fast box and >10 min on slower Windows machines.
+  Let GitHub CI cover the full sweep.
+- **Run targeted test files** for whatever you changed (the test files
+  that exercise the modified modules, plus any obvious neighbours).
+  Open the PR and watch CI for the broad regression.
+- On Windows, always pass `-p no:timeout` — pytest-timeout uses
+  `signal.SIGALRM`, which is POSIX-only.
+- Known flake: `tests/test_websocket.py::TestWebSocket::test_reflashed_device_empty_token_gets_readopted`
+  sometimes hits a 60-second setup timeout. If it's the only failure on
+  a PR, rerun the failed job (`gh run rerun <run-id> --failed`) rather
+  than investigating a real regression.
+
+## Templates: HTML-attribute escaping for inline JS
+
+If you find yourself writing an `onclick="fn('{{ x }}')"` in a Jinja
+template where `x` is **user-typed text** (a name, filename, email,
+URL, etc.), use this pattern instead:
+
+```jinja
+onclick="fn('{{ x.id }}', {{ x.name | tojson | forceescape }})"
+```
+
+`tojson | forceescape` is the safe shape — JSON-quoted (`"`), then
+HTML-encoded (`&#34;`) so it survives both layers of decoding intact.
+A bare `'{{ x.name }}'` inside a double-quoted attribute breaks for
+any name containing a literal `'` (Jinja autoescapes to `&#39;`, the
+browser HTML-decodes back to `'`, JS parser bails with
+`SyntaxError: missing ) after argument list` at element insertion
+time, the onclick is never wired up, and the button silently does
+nothing). UUIDs / hex IDs are safe to leave as `'{{ x.id }}'`.
+
+Real bugs that have shipped from this pattern:
+
+- PR #589 — webpage asset "Edit URL" kebab inert on any URL with a `'`
+- PR #590 — devices kebab Update / Reboot / etc. inert for `Mia's pi5`
+- PR #591 — sweep fix across assets / users / slideshow builder / asset row
+
+## PR workflow
+
+- Auto-merge is enabled on this repo — push, open the PR, and
+  `gh pr merge <N> --squash --auto --delete-branch`. CI gates the merge.
+- After opening any auto-merge PR, start a watcher script that exits on
+  merge or check failure so you receive a completion notification
+  (see the user's "PR Watcher Pattern" in their global instructions).
+- **Watcher gotcha on this repo:** after every merge to `main`, a
+  `github-actions[bot]` immediately pushes a `chore: bump version
+  [skip ci]` commit. The `Publish & Deploy` workflow is triggered via
+  `workflow_run` after `Smoke Test` succeeds, and GitHub Actions
+  records its `headSha` as the latest `main` commit at trigger time —
+  which is the bump commit, NOT your merge commit. A SHA-filter-only
+  watcher (like the default `watch-pr-to-prod` template) will never see
+  the deploy run and time out at exit code 5 even though prod deployed
+  fine. Workaround: match `Publish & Deploy` runs that have `headSha`
+  *equal to* or *one commit ahead of* the merge SHA (the bump is always
+  a single commit on top).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Real bugs that have shipped from this pattern:
 
 - PR #589 — webpage asset "Edit URL" kebab inert on any URL with a `'`
 - PR #590 — devices kebab Update / Reboot / etc. inert for `Mia's pi5`
-- PR #591 — sweep fix across assets / users / slideshow builder / asset row
+- PR #594 — sweep fix across assets / users / slideshow builder / asset row
 
 ## PR workflow
 

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -229,16 +229,16 @@
                         <a role="menuitem" href="/assets/{{ a.id }}/slideshow">View slides</a>
                         {% endif %}
                     {% else %}
-                        <button type="button" role="menuitem" onclick="previewAsset('{{ a.id }}', '{{ a.filename }}', '{{ a.asset_type.value }}')">Preview</button>
+                        <button type="button" role="menuitem" onclick="previewAsset('{{ a.id }}', {{ a.filename | tojson | forceescape }}, '{{ a.asset_type.value }}')">Preview</button>
                     {% endif %}
                     {% if 'assets:write' in user_perms and a.asset_type.value == 'saved_stream' and is_owner %}
-                        <button type="button" role="menuitem" onclick="recaptureStream('{{ a.id }}', '{{ a.display_name or a.original_filename or a.filename }}')" title="Re-run the stream capture">Re-capture</button>
+                        <button type="button" role="menuitem" onclick="recaptureStream('{{ a.id }}', {{ (a.display_name or a.original_filename or a.filename) | tojson | forceescape }})" title="Re-run the stream capture">Re-capture</button>
                     {% endif %}
                     {% if 'assets:write' in user_perms and is_owner %}
                         {% if a.schedule_count > 0 %}
                         <button type="button" role="menuitem" class="kebab-item-danger" disabled title="Used by {{ a.schedule_count }} schedule{{ 's' if a.schedule_count != 1 }}. Remove from all schedules before deleting.">Delete</button>
                         {% else %}
-                        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset('{{ a.id }}', '{{ a.filename }}')">Delete</button>
+                        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset('{{ a.id }}', {{ a.filename | tojson | forceescape }})">Delete</button>
                         {% endif %}
                     {% endif %}
                     {% endcall %}
@@ -357,7 +357,7 @@
                                     <div id="group-popup-{{ a.id }}" popover class="group-popup">
                                         {% for g in unassigned %}
                                         <button type="button" class="group-popup-item" data-group-id="{{ g.id }}"
-                                                onclick="event.stopPropagation(); pickAssetGroup('{{ a.id }}', '{{ g.id }}', '{{ g.name }}', this)">{{ g.name }}</button>
+                                                onclick="event.stopPropagation(); pickAssetGroup('{{ a.id }}', '{{ g.id }}', {{ g.name | tojson | forceescape }}, this)">{{ g.name }}</button>
                                         {% endfor %}
                                     </div>
                                 </span>
@@ -424,7 +424,7 @@
                                     </td>
                                     <td>
                                         {% if v.status.value == 'ready' %}
-                                        <button class="btn btn-secondary btn-sm" onclick="event.stopPropagation(); previewVariant('{{ v.id }}', '{{ a.filename }}', '{{ a.asset_type.value }}', '{{ v.profile.name if v.profile else '' }}')">Preview</button>
+                                        <button class="btn btn-secondary btn-sm" onclick="event.stopPropagation(); previewVariant('{{ v.id }}', {{ a.filename | tojson | forceescape }}, '{{ a.asset_type.value }}', {{ (v.profile.name if v.profile else '') | tojson | forceescape }})">Preview</button>
                                         {% else %}—{% endif %}
                                     </td>
                                 </tr>

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -36,7 +36,7 @@
                     <div id="upload-group-popup" popover class="group-popup">
                         {% for g in user_groups %}
                         <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
-                                onclick="event.stopPropagation(); pickUploadGroup('{{ g.id }}', '{{ g.name }}')">{{ g.name }}</button>
+                                onclick="event.stopPropagation(); pickUploadGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
                         {% endfor %}
                     </div>
                 </span>
@@ -76,7 +76,7 @@
                     <div id="webpage-group-popup" popover class="group-popup">
                         {% for g in user_groups %}
                         <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
-                                onclick="event.stopPropagation(); pickWebpageGroup('{{ g.id }}', '{{ g.name }}')">{{ g.name }}</button>
+                                onclick="event.stopPropagation(); pickWebpageGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
                         {% endfor %}
                     </div>
                 </span>
@@ -145,7 +145,7 @@
                     <div id="stream-group-popup" popover class="group-popup">
                         {% for g in user_groups %}
                         <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
-                                onclick="event.stopPropagation(); pickStreamGroup('{{ g.id }}', '{{ g.name }}')">{{ g.name }}</button>
+                                onclick="event.stopPropagation(); pickStreamGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
                         {% endfor %}
                     </div>
                 </span>

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -424,7 +424,7 @@
                         <div id="ss-group-popup" popover class="group-popup">
                             {% for g in user_groups %}
                             <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
-                                    onclick="event.stopPropagation(); pickSsGroup('{{ g.id }}', '{{ g.name | replace("'", "\\'") }}')">{{ g.name }}</button>
+                                    onclick="event.stopPropagation(); pickSsGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
                             {% endfor %}
                         </div>
                     </span>

--- a/cms/templates/users.html
+++ b/cms/templates/users.html
@@ -102,7 +102,7 @@
                     {% call macros.kebab_menu() %}
                         <button type="button" role="menuitem" onclick="openEditUser('{{ u.id }}')">Edit</button>
                         {% if u.must_change_password %}
-                        <button type="button" role="menuitem" onclick="resendInvite('{{ u.id }}', '{{ u.email }}')">Resend Invite</button>
+                        <button type="button" role="menuitem" onclick="resendInvite('{{ u.id }}', {{ u.email | tojson | forceescape }})">Resend Invite</button>
                         {% endif %}
                         {% if u.id | string != current_user_id %}
                             {% if u.is_active %}
@@ -110,7 +110,7 @@
                             {% else %}
                             <button type="button" role="menuitem" onclick="toggleUserActive('{{ u.id }}', true)">Enable</button>
                             {% endif %}
-                            <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteUser('{{ u.id }}', '{{ u.email }}')">Delete</button>
+                            <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteUser('{{ u.id }}', {{ u.email | tojson | forceescape }})">Delete</button>
                         {% endif %}
                     {% endcall %}
                 </td>
@@ -191,7 +191,7 @@
             <div class="role-actions">
                 {% call macros.kebab_menu() %}
                     <button type="button" role="menuitem" onclick="openEditRole('{{ role.id }}')">Edit</button>
-                    <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteRole('{{ role.id }}', '{{ role.name }}')">Delete</button>
+                    <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteRole('{{ role.id }}', {{ role.name | tojson | forceescape }})">Delete</button>
                 {% endcall %}
             </div>
             {% endif %}

--- a/tests/test_onclick_html_escape_sweep.py
+++ b/tests/test_onclick_html_escape_sweep.py
@@ -1,0 +1,280 @@
+"""Regression sweep for the ``onclick="fn('{{ x }}')"`` HTML-escaping
+bug pattern across all CMS templates.
+
+The bug class
+=============
+
+Whenever a Jinja template renders an inline JS call inside a
+double-quoted HTML attribute with user-typed text wrapped in single
+quotes, like::
+
+    onclick="handler('{{ user_typed_name }}')"
+
+Jinja's autoescape rewrites a literal ``'`` in the value to ``&#39;``
+inside the HTML attribute. The browser's HTML parser **decodes**
+``&#39;`` back to ``'`` before handing the value to the JavaScript
+engine. So a value like ``Mia's pi5`` ends up as the JS source::
+
+    handler('Mia's pi5')
+
+which is a syntax error — the handler is silently never registered
+and clicking the button does nothing.
+
+The fix is to filter both args through ``tojson | forceescape``
+(matching the pattern used by ``editWebpageUrl`` from PR #589 and the
+device-row kebab from PR #590). ``tojson`` produces a JSON string
+literal quoted with ``"``; ``forceescape`` HTML-encodes those to
+``&#34;``; the browser decodes ``&#34;`` to ``"`` inside the
+attribute; the JS engine sees a valid double-quoted string. JSON's
+``\u0027`` carries the apostrophe through cleanly.
+
+What this file covers
+=====================
+
+Every template that had at least one offending onclick before this PR:
+
+* ``_macros.html`` asset row — ``previewAsset``, ``recaptureStream``,
+  ``deleteAsset``, ``pickAssetGroup``, ``previewVariant``
+* ``assets.html`` upload/webpage/stream group dropdowns —
+  ``pickUploadGroup``, ``pickWebpageGroup``, ``pickStreamGroup``
+* ``slideshow_builder.html`` group dropdown — ``pickSsGroup``
+* ``users.html`` row + role row — ``resendInvite``, ``deleteUser``,
+  ``deleteRole``
+
+The shape of each test is the same: seed an entity whose user-typed
+field contains an apostrophe (``Mia's …``), hit the page or fragment
+endpoint that renders it, and assert no onclick contains the broken
+``'X&#39;Y'`` form. The negative assertion is page-wide because the
+broken pattern is unambiguous — any single-quote-then-``&#39;``
+sequence inside any onclick is a bug.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import pytest_asyncio
+
+
+# Find every onclick="..." attribute value and check each in isolation
+# for the broken pattern: a single-quoted JS string literal whose
+# contents include the HTML entity ``&#39;``.
+_ONCLICK_RE = re.compile(r'onclick="([^"]*)"')
+_BROKEN_QUOTED_LITERAL = re.compile(r"'[^']*&#39;[^']*'")
+
+
+def assert_no_broken_onclicks(body: str, context: str) -> None:
+    bad = []
+    for onclick_val in _ONCLICK_RE.findall(body):
+        if _BROKEN_QUOTED_LITERAL.search(onclick_val):
+            bad.append(onclick_val)
+    assert not bad, (
+        f"Found {len(bad)} broken onclick(s) in {context}: a single-quoted "
+        f"JS string literal contains &#39; which the browser will HTML-decode "
+        f"to a stray ' and crash JS parsing. Use `{{{{ ... | tojson | "
+        f"forceescape }}}}` instead.\nFirst match: {bad[0]!r}"
+    )
+
+
+# ── Asset row fragment endpoint ────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def asset_with_apostrophe_and_group(client, app):
+    """Seed: a group named ``Mia's group`` + a video asset whose filename
+    contains an apostrophe (seeded directly via DB to bypass the upload
+    endpoint's filename validation — the test is about HTML rendering,
+    not the upload path). Returns the asset id + group id.
+    """
+    import uuid as _uuid
+
+    from cms.database import get_db
+    from cms.models.asset import Asset, AssetType
+    from cms.models.device import DeviceGroup
+    from cms.models.user import User
+    from sqlalchemy import select
+
+    factory = app.dependency_overrides[get_db]
+    asset_id = group_id = None
+    async for db in factory():
+        group = DeviceGroup(name="Mia's group", description="")
+        db.add(group)
+        await db.flush()
+        group_id = str(group.id)
+
+        admin = (
+            await db.execute(select(User).where(User.username == "admin"))
+        ).scalar_one()
+
+        asset = Asset(
+            id=_uuid.uuid4(),
+            filename="Mia's clip.mp4",
+            original_filename="Mia's clip.mp4",
+            display_name="Mia's clip",
+            asset_type=AssetType.VIDEO,
+            size_bytes=11,
+            checksum="0" * 64,
+            uploaded_by_user_id=admin.id,
+        )
+        db.add(asset)
+        await db.commit()
+        asset_id = str(asset.id)
+        break
+
+    return {"asset_id": asset_id, "group_id": group_id}
+
+
+@pytest.mark.asyncio
+class TestAssetRowOnclickEscaping:
+    async def test_asset_row_onclicks_are_html_safe(
+        self, client, asset_with_apostrophe_and_group
+    ):
+        asset_id = asset_with_apostrophe_and_group["asset_id"]
+
+        resp = await client.get(f"/api/assets/{asset_id}/row")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+
+        # The two onclicks gated on a regular video asset + admin owner +
+        # 0 schedules: previewAsset and deleteAsset. Both should now use
+        # the safe form.
+        assert "previewAsset(" in body
+        assert "deleteAsset(" in body
+        # Group dropdown for pickAssetGroup renders the seeded group too.
+        assert "pickAssetGroup(" in body
+
+        assert_no_broken_onclicks(body, f"/api/assets/{asset_id}/row")
+
+        # Positive: the safe HTML-encoded JSON quote should appear in
+        # at least one of the patched onclicks (the filename arg).
+        assert "&#34;Mia" in body, (
+            "Expected the filename to render with HTML-encoded JSON quotes "
+            "after applying `| tojson | forceescape`."
+        )
+
+
+# ── /assets full page ──────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def group_with_apostrophe(app):
+    """Seed a single group named ``Mia's group`` visible to admin."""
+    from cms.database import get_db
+    from cms.models.device import DeviceGroup
+
+    factory = app.dependency_overrides[get_db]
+    group_id = None
+    async for db in factory():
+        group = DeviceGroup(name="Mia's group", description="")
+        db.add(group)
+        await db.flush()
+        group_id = str(group.id)
+        await db.commit()
+        break
+
+    return {"group_id": group_id}
+
+
+@pytest.mark.asyncio
+class TestAssetsPageOnclickEscaping:
+    async def test_assets_page_group_dropdowns_are_html_safe(
+        self, client, group_with_apostrophe
+    ):
+        resp = await client.get("/assets")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+
+        # All three pick*Group handlers should be present on /assets.
+        # (They live in the upload-form / webpage-form / stream-form
+        # dropdown popups respectively.)
+        for handler in ("pickUploadGroup", "pickWebpageGroup", "pickStreamGroup"):
+            assert handler + "(" in body, (
+                f"{handler} missing from /assets page output -- did the "
+                f"upload form structure change?"
+            )
+
+        assert_no_broken_onclicks(body, "/assets")
+
+
+# ── /assets/new/slideshow ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestSlideshowBuilderOnclickEscaping:
+    async def test_slideshow_builder_group_picker_is_html_safe(
+        self, client, group_with_apostrophe
+    ):
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+
+        assert "pickSsGroup(" in body, (
+            "pickSsGroup missing from slideshow builder output -- did the "
+            "group picker structure change?"
+        )
+
+        assert_no_broken_onclicks(body, "/assets/new/slideshow")
+
+
+# ── /users full page ───────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def user_and_role_with_apostrophes(app):
+    """Seed an extra user whose email contains an apostrophe and a role
+    whose name contains an apostrophe. The default admin already exists
+    so the /users page will have at least two user rows.
+    """
+    from sqlalchemy import select
+
+    from cms.auth import hash_password
+    from cms.database import get_db
+    from cms.models.user import Role, User
+
+    factory = app.dependency_overrides[get_db]
+    user_id = role_id = None
+    async for db in factory():
+        # Custom role -- name with apostrophe.
+        role = Role(name="Mia's role", description="apostrophe role")
+        db.add(role)
+        await db.flush()
+        role_id = str(role.id)
+
+        # User with apostrophe in the email local-part. RFC 5321 allows
+        # quoted local-parts that can contain ', so this is valid input.
+        user = User(
+            username="mia_apos",
+            email="mia'apos@example.com",
+            display_name="Mia Apostrophe",
+            password_hash=hash_password("p"),
+            role_id=role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(user)
+        await db.commit()
+        user_id = str(user.id)
+        break
+
+    return {"user_id": user_id, "role_id": role_id}
+
+
+@pytest.mark.asyncio
+class TestUsersPageOnclickEscaping:
+    async def test_users_page_onclicks_are_html_safe(
+        self, client, user_and_role_with_apostrophes
+    ):
+        resp = await client.get("/users")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+
+        # All three patched handlers should still render somewhere on
+        # the page (admin sees them on the seeded user + role).
+        for handler in ("resendInvite", "deleteUser", "deleteRole"):
+            assert handler + "(" in body, (
+                f"{handler} missing from /users output -- did the kebab "
+                f"structure change?"
+            )
+
+        assert_no_broken_onclicks(body, "/users")


### PR DESCRIPTION
### What

Follow-up sweep to PRs #589 (asset Edit URL) and #590 (devices kebab) — fixes every remaining `onclick="fn('{{ x }}')"` in the templates where `x` is user-typed text.

### Why

`'{{ user_typed }}'` inside a double-quoted HTML attribute is broken for any value containing a literal `'`. Jinja autoescape rewrites `'` → `&#39;`, the browser HTML-decodes `&#39;` back to `'` before handing the value to the JS engine, the JS engine bails with `SyntaxError: missing ) after argument list` at element insertion time, and the click handler is silently never wired up — the button looks normal but does nothing.

### Handlers fixed

| Template | Handler | Arg fixed |
|---|---|---|
| `_macros.html` (asset row) | `previewAsset` | filename |
| `_macros.html` (asset row) | `recaptureStream` | display_name / original_filename / filename |
| `_macros.html` (asset row) | `deleteAsset` | filename |
| `_macros.html` (asset row) | `pickAssetGroup` | group name |
| `_macros.html` (asset row) | `previewVariant` | filename, profile name |
| `assets.html` | `pickUploadGroup` | group name |
| `assets.html` | `pickWebpageGroup` | group name |
| `assets.html` | `pickStreamGroup` | group name |
| `slideshow_builder.html` | `pickSsGroup` | group name (replaces a hand-rolled `replace("'", "\\'")` that worked by accident) |
| `users.html` | `resendInvite` | email |
| `users.html` | `deleteUser` | email |
| `users.html` | `deleteRole` | role name |

Each fix is the same one-token pattern PR #589 and PR #590 established:

```jinja
- onclick="fn('{{ x.id }}', '{{ x.name }}')"
+ onclick="fn('{{ x.id }}', {{ x.name | tojson | forceescape }})"
```

UUID/hex IDs are left as `'{{ x.id }}'` — they can't contain a `'`, and `tojson` isn't UUID-aware so converting would need an extra `| string` on every line.

### Tests

`tests/test_onclick_html_escape_sweep.py` — for each affected template, seed an entity whose user-typed field contains an apostrophe (group `Mia's group`, role `Mia's role`, email `mia'apos@example.com`, filename `Mia's clip.mp4`), hit the page/fragment endpoint, parse every `onclick="…"` attribute and assert none contains the broken `'X&#39;Y'` quoted-string form. Verified failing without the macro changes, green with them.

Local sanity sweep (53 tests across `test_assets.py`, `test_asset_row_endpoint.py`, `test_device_kebab_html_escaping.py`, `test_devices_phase_d_coverage.py`, `test_group_panel_endpoint.py`, `test_slideshow_builder_ui.py`, the new sweep file): all green.

### Bonus

Adds an `AGENTS.md` section "Templates: HTML-attribute escaping for inline JS" documenting the bug class and the canonical fix pattern so future agents notice the smell before it ships.
