### PR TITLE
docs(agents): document duplicate Publish & Deploy watcher gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,16 @@ Real bugs that have shipped from this pattern:
   fine. Workaround: match `Publish & Deploy` runs that have `headSha`
   *equal to* or *one commit ahead of* the merge SHA (the bump is always
   a single commit on top).
+- **Watcher gotcha #2 — duplicate Publish & Deploy runs for the same
+  SHA.** A merge can produce *multiple* `Publish & Deploy` runs for the
+  same `headSha` (workflow_run fires once for the merge-commit Smoke
+  Test, then again for an unrelated trigger or a Smoke Test rerun). The
+  first run claims the bicep `revisionsuffix` (e.g. `v1-37-220`); any
+  later run fails with `revision with suffix v1-37-220 already exists`.
+  The default watch-pr-to-prod template picks the *latest* deploy run
+  by `createdAt DESC` and reports that failure as "did not ship" — but
+  prod is actually fine, the earlier success run shipped it. Workaround:
+  if the latest deploy is `failure` AND its log contains
+  `revision with suffix ... already exists`, find the earlier
+  `success` deploy run for the same SHA before declaring a failure.
+  Seen on PR #594 (this commit's PR).


### PR DESCRIPTION
Tiny doc-only follow-up to PR #594.

Documents a second `watch-pr-to-prod` gotcha I hit on PR #594: when multiple `Publish & Deploy` runs fire for the same merge SHA (workflow_run can re-trigger for a Smoke Test rerun or an unrelated workflow), the first claims the bicep `revisionsuffix` (e.g. `v1-37-220`) and any later run fails with `revision with suffix ... already exists`. The default watcher picks `createdAt DESC | First 1` and treats the duplicate failure as "did not ship," but prod is actually fine.

On #594 this looked like a deploy failure, but run `26007144142` succeeded ~4 minutes before the failure run and shipped v1.37.220 to prod cleanly. AGENTS.md now flags the heuristic for spotting this so future agents don't double-deploy or panic.
