### PR TITLE
fix(infra): use CMS_CUSTOM_DOMAIN for AGORA_CMS_BASE_URL so invite emails point at the custom domain

### DIFF
--- a/.github/workflows/deploy-goodwill.yml
+++ b/.github/workflows/deploy-goodwill.yml
@@ -155,7 +155,8 @@ jobs:
               previousCmsRevisionName='${{ steps.revisions.outputs.previous_cms_revision }}' \
               mcpRevisionSuffix='${{ steps.revisions.outputs.revision_suffix }}' \
               previousMcpRevisionName='${{ steps.revisions.outputs.previous_mcp_revision }}' \
-              alertEmail='${{ vars.ALERT_EMAIL }}'
+              alertEmail='${{ vars.ALERT_EMAIL }}' \
+              cmsBaseUrlOverride='${{ vars.CMS_CUSTOM_DOMAIN != '' && format('https://{0}', vars.CMS_CUSTOM_DOMAIN) || '' }}'
 
       - name: Bind custom domains (if configured)
         if: vars.CMS_CUSTOM_DOMAIN != '' || vars.MCP_CUSTOM_DOMAIN != ''

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -233,7 +233,8 @@ jobs:
               previousCmsRevisionName='${{ steps.revisions.outputs.previous_cms_revision }}' \
               mcpRevisionSuffix='${{ steps.revisions.outputs.revision_suffix }}' \
               previousMcpRevisionName='${{ steps.revisions.outputs.previous_mcp_revision }}' \
-              alertEmail='${{ vars.ALERT_EMAIL }}'
+              alertEmail='${{ vars.ALERT_EMAIL }}' \
+              cmsBaseUrlOverride='${{ vars.CMS_CUSTOM_DOMAIN != '' && format('https://{0}', vars.CMS_CUSTOM_DOMAIN) || '' }}'
 
       - name: Bind custom domains (if configured)
         if: vars.CMS_CUSTOM_DOMAIN != '' || vars.MCP_CUSTOM_DOMAIN != ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -46,6 +46,9 @@ param cmsAdminPassword string
 @secure()
 param githubIssuesToken string = ''
 
+@description('Public CMS URL override (e.g. https://agora.example.com, no trailing slash). When non-empty, used for AGORA_CMS_BASE_URL on the CMS container -- needed when a custom domain fronts the app so invite/setup-account email links and the wss://host/ws/device URL baked into provisioned Pis point at the real public hostname. When empty, bicep auto-derives the Azure default-domain URL.')
+param cmsBaseUrlOverride string = ''
+
 @description('Device transport mode: "wps" (multi-replica safe, routes via Azure Web PubSub — provisioned and wired by this template) or "local" (direct CMS→device websockets, single-replica only — skips the WPS resource entirely).')
 @allowed(['wps', 'local'])
 param deviceTransport string = 'wps'
@@ -236,6 +239,9 @@ module containerApps 'modules/containerApps.bicep' = {
 
     // Report-issue feature (GitHub)
     githubIssuesToken: githubIssuesToken
+
+    // Public CMS URL override (custom domain). Propagated to AGORA_CMS_BASE_URL.
+    cmsBaseUrlOverride: cmsBaseUrlOverride
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -59,6 +59,9 @@ param deviceTransport string = 'wps'
 @secure()
 param githubIssuesToken string = ''
 
+@description('Public CMS URL override (e.g. https://agora.example.com, no trailing slash). When non-empty, takes precedence over the auto-derived "https://<cmsAppName>.<defaultDomain>" for AGORA_CMS_BASE_URL -- needed when a custom domain fronts the app so invite/setup-account links, imager URLs, and the wss://host/ws/device baked into Pi fleet env all point at the real public hostname.')
+param cmsBaseUrlOverride string = ''
+
 // ── Blue/green deploy controls (Multiple revision mode) ──
 @description('Revision suffix for the CMS Container App. Each deploy MUST pass a unique value (e.g. "v1-12-34") so a brand-new revision is created at 0% traffic. The workflow flips traffic to it after smoke probes pass.')
 param cmsRevisionSuffix string = ''
@@ -287,14 +290,15 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               secretRef: 'github-issues-token'
             }
             {
-              // Public URL of the CMS — derived from the container app name +
-              // the managed environment's default domain so we have a single
-              // source of truth. The imager router and fleet env payload read
-              // this to build wss://host/ws/device for provisioned Pis. If you
-              // ever front the app with a custom domain (e.g. agora.example.com)
-              // this is the one place to override it.
+              // Public URL of the CMS -- the value used for invite-email
+              // setup-account links, the imager router's wss://host/ws/device
+              // URL baked into provisioned Pis, and any other place that
+              // needs an absolute URL. When cmsBaseUrlOverride is set (e.g.
+              // 'https://agora.example.com' for a custom-domain deploy) it
+              // wins; otherwise we auto-derive the Azure default-domain URL
+              // from the container app name + the managed environment.
               name: 'AGORA_CMS_BASE_URL'
-              value: 'https://${cmsAppName}.${containerAppsEnv.properties.defaultDomain}'
+              value: empty(cmsBaseUrlOverride) ? 'https://${cmsAppName}.${containerAppsEnv.properties.defaultDomain}' : cmsBaseUrlOverride
             }
             {
               // Picked up by azure-monitor-opentelemetry's

--- a/tests/test_invite_url_base_url.py
+++ b/tests/test_invite_url_base_url.py
@@ -1,0 +1,216 @@
+"""Regression test for the welcome-email setup URL.
+
+The bug fixed alongside this test: the URL emitted in invite emails was the
+Azure Container App default-domain FQDN instead of the bound custom domain
+(``agora.egnw.org`` on Goodwill, ``agora.mennlabs.com`` on prod). The
+router already had the right logic --
+
+    base = (get_settings().base_url or request.base_url._url).rstrip("/")
+    setup_url = f"{base}/setup-account?token={token}"
+
+-- but ``AGORA_CMS_BASE_URL`` was hardcoded by bicep to the Azure default
+domain, so ``get_settings().base_url`` always won and always pointed at the
+wrong host. The bicep fix exposes a ``cmsBaseUrlOverride`` knob set from the
+``CMS_CUSTOM_DOMAIN`` GitHub Actions variable per environment; this test
+guards the router contract so a future regression that flips back to
+``request.base_url`` (or drops the env var) is caught immediately.
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms import auth as auth_module
+from cms.auth import hash_password, set_setting
+from cms.models.user import Role, User
+from cms.services import email_service as email_service_module
+
+
+# ── Helpers (mirroring tests/test_notifications.py) ──
+
+
+async def _get_role_id(db: AsyncSession, name: str) -> uuid.UUID:
+    from sqlalchemy import select
+    result = await db.execute(select(Role).where(Role.name == name))
+    return result.scalar_one().id
+
+
+async def _setup_smtp(db: AsyncSession) -> None:
+    await set_setting(db, "smtp_host", "smtp.example.com")
+    await set_setting(db, "smtp_from_email", "noreply@example.com")
+    await db.commit()
+
+
+async def _create_pending_user(
+    db: AsyncSession, *, email: str = "pending@test.com"
+) -> User:
+    role_id = await _get_role_id(db, "Viewer")
+    user = User(
+        username=email.split("@")[0],
+        email=email,
+        display_name=email.split("@")[0],
+        password_hash=hash_password("temp-password"),
+        role_id=role_id,
+        is_active=True,
+        must_change_password=True,
+        setup_token="initial-token",
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@asynccontextmanager
+async def _capture_welcome_setup_url(monkeypatch: pytest.MonkeyPatch):
+    """Patch send_welcome_email_background to capture the setup_url it gets."""
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        email_service_module, "send_welcome_email_background", _capture
+    )
+    yield captured
+
+
+def _set_base_url_env(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    """Set/clear AGORA_CMS_BASE_URL and bust the Settings lru_cache so the
+    router picks up the new value on its next get_settings() call."""
+    if value is None:
+        monkeypatch.delenv("AGORA_CMS_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("AGORA_CMS_BASE_URL", value)
+    auth_module.get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _restore_settings_cache():
+    """Ensure other tests aren't poisoned by a cached Settings carrying our
+    monkeypatched env var."""
+    yield
+    auth_module.get_settings.cache_clear()
+
+
+# ── create user ──
+
+
+@pytest.mark.asyncio
+async def test_create_user_setup_url_uses_base_url_override(
+    app, client, db_session, monkeypatch
+):
+    """When AGORA_CMS_BASE_URL is set, the invite link uses it -- not the
+    request host."""
+    await _setup_smtp(db_session)
+    role_id = await _get_role_id(db_session, "Viewer")
+
+    _set_base_url_env(monkeypatch, "https://agora.egnw.org")
+
+    async with _capture_welcome_setup_url(monkeypatch) as captured:
+        resp = await client.post(
+            "/api/users",
+            json={
+                "email": "newcomer@test.com",
+                "display_name": "Newcomer",
+                "role_id": str(role_id),
+                "group_ids": [],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    setup_url = captured.get("setup_url")
+    assert setup_url, f"send_welcome_email_background was never called; captured={captured!r}"
+    assert setup_url.startswith("https://agora.egnw.org/setup-account?token="), (
+        f"expected custom-domain prefix, got {setup_url!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_user_setup_url_falls_back_to_request_host_when_unset(
+    app, client, db_session, monkeypatch
+):
+    """When AGORA_CMS_BASE_URL is unset, the link falls back to the request
+    host so local dev / non-customised deploys still work."""
+    await _setup_smtp(db_session)
+    role_id = await _get_role_id(db_session, "Viewer")
+
+    _set_base_url_env(monkeypatch, None)
+
+    async with _capture_welcome_setup_url(monkeypatch) as captured:
+        resp = await client.post(
+            "/api/users",
+            json={
+                "email": "fallback@test.com",
+                "display_name": "Fallback",
+                "role_id": str(role_id),
+                "group_ids": [],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    setup_url = captured.get("setup_url")
+    assert setup_url, "send_welcome_email_background was never called"
+    assert setup_url.startswith("http://test/setup-account?token="), (
+        f"expected fallback to test client host, got {setup_url!r}"
+    )
+
+
+# ── resend invite ──
+
+
+@pytest.mark.asyncio
+async def test_resend_invite_setup_url_uses_base_url_override(
+    app, client, db_session, monkeypatch
+):
+    """The resend-invite endpoint must honour the same base-URL override."""
+    await _setup_smtp(db_session)
+    user = await _create_pending_user(db_session, email="pending2@test.com")
+
+    _set_base_url_env(monkeypatch, "https://agora.egnw.org")
+
+    async with _capture_welcome_setup_url(monkeypatch) as captured:
+        resp = await client.post(f"/api/users/{user.id}/resend-invite")
+        assert resp.status_code == 200, resp.text
+
+    setup_url = captured.get("setup_url")
+    assert setup_url, "send_welcome_email_background was never called"
+    assert setup_url.startswith("https://agora.egnw.org/setup-account?token="), (
+        f"expected custom-domain prefix, got {setup_url!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_url_override_with_trailing_slash_is_normalised(
+    app, client, db_session, monkeypatch
+):
+    """A trailing slash on AGORA_CMS_BASE_URL must not produce '//setup-account'."""
+    await _setup_smtp(db_session)
+    role_id = await _get_role_id(db_session, "Viewer")
+
+    _set_base_url_env(monkeypatch, "https://agora.egnw.org/")
+
+    async with _capture_welcome_setup_url(monkeypatch) as captured:
+        resp = await client.post(
+            "/api/users",
+            json={
+                "email": "slashy@test.com",
+                "display_name": "Slashy",
+                "role_id": str(role_id),
+                "group_ids": [],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    setup_url = captured.get("setup_url")
+    assert setup_url, "send_welcome_email_background was never called"
+    assert "//setup-account" not in setup_url, (
+        f"trailing slash on base_url leaked into the URL: {setup_url!r}"
+    )
+    assert setup_url.startswith("https://agora.egnw.org/setup-account?token="), (
+        f"expected custom-domain prefix, got {setup_url!r}"
+    )


### PR DESCRIPTION
### What

Invite / "resend invite" emails were emitting setup-account links with the **Azure default-domain FQDN** instead of the bound custom domain (`agora.egnw.org` on Goodwill, `agora.mennlabs.com` on personal prod). Browsing to either custom domain has been working since each deploy already binds it via `az containerapp hostname add ... --validation-method CNAME` — only the URLs we *generated* were wrong.

### Why

The router was already correct:

```python
base = (get_settings().base_url or request.base_url._url).rstrip("/")
setup_url = f"{base}/setup-account?token={setup_token}"
```

But `infra/modules/containerApps.bicep` hardcoded the env var the router reads:

```bicep
name: 'AGORA_CMS_BASE_URL'
value: 'https://${cmsAppName}.${containerAppsEnv.properties.defaultDomain}'
```

So `get_settings().base_url` always won — and always pointed at the wrong host.

### Fix

Add a `cmsBaseUrlOverride` knob plumbed through bicep:

| File | Change |
|---|---|
| `infra/modules/containerApps.bicep` | New `cmsBaseUrlOverride string = ''` param; env value becomes `empty(cmsBaseUrlOverride) ? '<default>' : cmsBaseUrlOverride`. |
| `infra/main.bicep` | New top-level `cmsBaseUrlOverride string = ''` param threaded into the `containerApps` module. |
| `.github/workflows/publish-image.yml` | New `--parameters` line: `cmsBaseUrlOverride='${{ vars.CMS_CUSTOM_DOMAIN != '' && format('https://{0}', vars.CMS_CUSTOM_DOMAIN) || '' }}'`. |
| `.github/workflows/deploy-goodwill.yml` | Same line. |

The deploy workflows already source `CMS_CUSTOM_DOMAIN` per environment:

- `production` env → `agora.mennlabs.com`
- `seattle-goodwill` env → `agora.egnw.org`

so no new repo variable is needed — the existing one drives both the hostname binding *and* the env var on the next deploy.

### Tests

New `tests/test_invite_url_base_url.py` (4 tests, all green locally):

1. `POST /api/users` with `AGORA_CMS_BASE_URL=https://agora.egnw.org` produces a setup URL prefixed with `https://agora.egnw.org/setup-account?token=`.
2. Same endpoint with no override falls back to the request host (`http://test/`).
3. `POST /api/users/{id}/resend-invite` honours the override (this path builds the URL independently — separate guard).
4. A trailing slash on `AGORA_CMS_BASE_URL` never produces `//setup-account` (the router already does `.rstrip("/")`; this just locks the behaviour in).

Local sweep of neighbour tests: `test_notifications.py` (resend-invite happy/sad paths), `test_auth.py`, `test_deploy_config.py` — 56/56 green.

### Knock-on improvement

`AGORA_CMS_BASE_URL` is also baked into provisioned Pi images by the imager router (it becomes `wss://<host>/ws/device` in `agora-fleet.env`). After this lands, **newly-flashed Goodwill Pis will dial `wss://agora.egnw.org/ws/device` instead of the Azure default-domain URL.** Already-flashed Pis keep whatever was baked in at flash time, so no fleet impact until a Pi is re-flashed.

### Out of scope

- MCP doesn't have an analogous env var (the `MCP_CUSTOM_DOMAIN` variable is hostname-binding only). No `mcpBaseUrlOverride` added.
- No retroactive update to already-sent invite emails (those tokens are still valid; users will just see the old hostname).
