### PR TITLE
Defer setup_token burn, close /api/users auth gap, fix HTTPException header drop

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -37,6 +37,16 @@ SETTING_SMTP_PASSWORD = "smtp_password"
 SETTING_SMTP_FROM_EMAIL = "smtp_from_email"
 SETTING_SETUP_COMPLETED = "setup_completed"
 
+# Paths reachable by an authenticated user who still has must_change_password=True.
+# Anything not in this set returns 307 -> /force-password-change. Keep this set
+# as small as possible -- each entry widens the surface a half-setup user can
+# reach with only the session cookie minted by /setup-account.
+_PASSWORD_CHANGE_EXEMPT_PATHS = frozenset({
+    "/force-password-change",     # the HTML form itself
+    "/api/users/me/password",     # the JSON API that backs the same operation
+    "/logout",                    # let them bail out without being trapped
+})
+
 
 @lru_cache
 def get_settings() -> Settings:
@@ -223,8 +233,11 @@ async def require_auth(
     user = await get_current_user(request, settings, db)
     request.state.user = user
 
-    # Force password change redirect for web UI requests
-    if user.must_change_password and request.url.path != "/force-password-change":
+    # Force password change redirect for users that haven't completed setup.
+    # The exempt set is the minimum surface a half-setup user must reach to
+    # finish: the HTML form, the JSON API that backs the same operation,
+    # and logout (so they can bail out without being trapped).
+    if user.must_change_password and request.url.path not in _PASSWORD_CHANGE_EXEMPT_PATHS:
         from fastapi.responses import RedirectResponse
         raise HTTPException(
             status_code=status.HTTP_307_TEMPORARY_REDIRECT,

--- a/cms/main.py
+++ b/cms/main.py
@@ -790,7 +790,15 @@ async def setup_redirect_middleware(request: Request, call_next):
 
 @app.exception_handler(HTTPException)
 async def unauthorized_redirect(request: Request, exc: HTTPException):
-    """Redirect browser requests to /login on 401, return JSON for API calls."""
+    """Redirect browser requests to /login on 401, return JSON for API calls.
+
+    Always preserves ``exc.headers`` so things like 307 redirects raised by
+    ``require_auth`` (Location -> /force-password-change) survive the handler.
+    Before this was added, ``HTTPException(307, headers={'Location': ...})``
+    came out the other side as a 307 with no Location at all -- browsers just
+    showed an error page. Only ``require_auth`` actually uses ``headers``,
+    so honoring them is a safe no-op for every other raise site.
+    """
     if exc.status_code == status.HTTP_401_UNAUTHORIZED:
         accept = request.headers.get("accept", "")
         if "text/html" in accept:
@@ -799,6 +807,7 @@ async def unauthorized_redirect(request: Request, exc: HTTPException):
     return JSONResponse(
         status_code=exc.status_code,
         content={"detail": exc.detail},
+        headers=getattr(exc, "headers", None),
     )
 
 # Static files

--- a/cms/routers/users.py
+++ b/cms/routers/users.py
@@ -8,14 +8,28 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from cms.auth import get_current_user, get_settings, hash_password, require_permission, verify_password
+from cms.auth import (
+    get_current_user,
+    get_settings,
+    hash_password,
+    require_auth,
+    require_permission,
+    verify_password,
+)
 from cms.database import get_db
 from cms.models.user import Role, User, UserGroup
 from cms.permissions import USERS_READ, USERS_WRITE
 from cms.schemas.user import PasswordChange, UserCreate, UserMe, UserRead, UserUpdate
 from cms.services.audit_service import audit_log
 
-router = APIRouter(prefix="/api/users")
+# require_auth at the router level enforces both authentication and the
+# must_change_password gate (see cms/auth.py::require_auth). Without this,
+# /api/users/me and /api/users/me/password were reachable by half-setup
+# users -- a real exploit window after we stopped burning setup_token on
+# the GET /setup-account prefetch. /api/users/me/password is exempted from
+# the must_change_password redirect inside require_auth so users can still
+# complete setup.
+router = APIRouter(prefix="/api/users", dependencies=[Depends(require_auth)])
 
 
 def _user_to_read(user: User, group_ids: list[uuid.UUID] | None = None) -> UserRead:
@@ -70,6 +84,10 @@ async def change_my_password(
         raise HTTPException(status_code=400, detail="Current password is incorrect")
     current_user.password_hash = hash_password(data.new_password)
     current_user.must_change_password = False
+    # Burn the setup token now -- successful password set is the only signal
+    # that the human actually completed setup. See cms/ui.py::setup_account
+    # for why we defer this from the GET handler.
+    current_user.setup_token = None
     await db.commit()
     return {"status": "ok"}
 

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -189,7 +189,17 @@ async def setup_account(
     settings: Settings = Depends(get_settings),
     db: AsyncSession = Depends(get_db),
 ):
-    """One-time magic link from welcome email — logs user in and redirects to password change."""
+    """Magic link from welcome email -- logs user in and redirects to password change.
+
+    The setup token is intentionally NOT consumed here. Many email-security
+    products (Microsoft Defender for Office 365 Safe Links, Proofpoint URL
+    Defense, Mimecast, etc.) detonate links in outbound mail to evaluate
+    reputation before delivery; that detonation is a real GET against this
+    handler. If we nulled the token on GET, the detonator would burn it
+    before the human ever clicked. The token is instead burned on successful
+    completion of /force-password-change (or POST /api/users/me/password),
+    so this endpoint is idempotent and replay-safe up until setup completes.
+    """
     result = await db.execute(
         select(User).where(User.setup_token == token, User.is_active.is_(True))
     )
@@ -201,8 +211,6 @@ async def setup_account(
             status_code=400,
         )
 
-    # Invalidate the token (single-use)
-    user.setup_token = None
     from datetime import datetime, timezone
     user.last_login_at = datetime.now(timezone.utc)
     await db.commit()
@@ -348,6 +356,10 @@ async def force_password_change_submit(
 
     user.password_hash = hash_password(new_password)
     user.must_change_password = False
+    # Burn the setup token now -- successful password set is the only signal
+    # that the human actually completed setup. See setup_account() for why
+    # we defer this from the GET handler.
+    user.setup_token = None
     await db.commit()
 
     return RedirectResponse(url="/", status_code=303)

--- a/tests/nightly/test_06_rbac.py
+++ b/tests/nightly/test_06_rbac.py
@@ -11,9 +11,13 @@ compose stack:
 3. For each new user we walk the real welcome-email flow:
      a. Mailpit receives the welcome email.
      b. Follow ``/setup-account?token=...`` in a fresh browser context
-        (invalidates the token, sets a session cookie, redirects to
-        ``/force-password-change``).
-     c. Submit the new password via the force-password-change form.
+        (sets a session cookie, redirects to ``/force-password-change``).
+        The token is intentionally NOT consumed at this step -- it lives
+        until the user successfully sets a new password, so email-security
+        URL detonators (Defender for Office 365 Safe Links, etc.) can't
+        burn it before the human ever clicks.
+     c. Submit the new password via the force-password-change form. This
+        is what actually nulls ``setup_token`` in the DB.
      d. Log in via ``/login`` with the new creds.
 4. Assert the permission matrix:
      - Operator A can CRUD resources in Group A.

--- a/tests/test_setup_token_defer.py
+++ b/tests/test_setup_token_defer.py
@@ -1,0 +1,299 @@
+"""Regression tests for deferring setup_token nullification.
+
+The bug fixed alongside these tests: ``GET /setup-account?token=...`` used
+to null ``setup_token`` on first hit, making the URL strictly single-use.
+Outbound mail leaving an M365 tenant goes through Defender for Office 365
+Safe Links, which DETONATES URLs in transit to evaluate reputation; that
+detonation is a real HEAD then GET against the URL. Result: the token was
+burned ~3 seconds after user creation, before the human ever saw the email.
+External recipients (i.e. anyone outside the sending tenant) could never
+complete setup.
+
+Fix: defer the token-burn to the moment the user actually completes setup
+(successful POST to ``/force-password-change`` or ``/api/users/me/password``).
+The GET is now idempotent and replay-safe.
+
+Closing the latent gap that the deferral surfaced: ``/api/users`` was the
+only API router without ``require_auth`` at the router level, so a half-set
+user (one who'd hit the GET but not yet set a password) could call
+``/api/users/me`` and ``/api/users/me/password`` directly. With the longer
+window the new behaviour creates, that's a real exploit -- so this PR also
+gates ``/api/users`` on ``require_auth`` and exempts the password-change
+endpoint specifically from the ``must_change_password`` redirect.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import hash_password
+from cms.models.user import Role, User
+
+
+async def _get_role_id(db: AsyncSession, name: str) -> uuid.UUID:
+    result = await db.execute(select(Role).where(Role.name == name))
+    return result.scalar_one().id
+
+
+async def _create_pending_user(
+    db: AsyncSession,
+    *,
+    email: str = "pending@test.com",
+    setup_token: str = "test-setup-token-abc123",
+    temp_password: str = "temp-password-1",
+) -> User:
+    role_id = await _get_role_id(db, "Viewer")
+    user = User(
+        username=email.split("@")[0],
+        email=email,
+        display_name=email.split("@")[0],
+        password_hash=hash_password(temp_password),
+        role_id=role_id,
+        is_active=True,
+        must_change_password=True,
+        setup_token=setup_token,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _reload_setup_token(db: AsyncSession, user_id: uuid.UUID) -> str | None:
+    """Read setup_token straight from the DB, bypassing any session cache.
+
+    Tests that mutate state through the HTTP client see those mutations via
+    a different DB session; our local db_session may have a stale view of
+    the row. ``db.execute(select(...))`` always issues a fresh query, so we
+    just need to make sure the user_id we filter on is a plain UUID (not a
+    ``user.id`` ORM attribute that would trigger lazy reload).
+    """
+    result = await db.execute(select(User.setup_token).where(User.id == user_id))
+    return result.scalar_one()
+
+
+async def _reload_must_change(db: AsyncSession, user_id: uuid.UUID) -> bool:
+    result = await db.execute(
+        select(User.must_change_password).where(User.id == user_id)
+    )
+    return result.scalar_one()
+
+
+# -- token deferral on GET ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_does_not_burn_token(
+    app, unauthed_client, db_session
+):
+    """GET /setup-account?token=X must NOT null setup_token; the prefetch
+    fix depends on this so an outbound URL-detonator can't kill the link."""
+    user = await _create_pending_user(
+        db_session, email="defer1@test.com", setup_token="tok-defer-1"
+    )
+    user_id = user.id
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-defer-1", follow_redirects=False
+    )
+
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "/force-password-change"
+
+    still_set = await _reload_setup_token(db_session, user_id)
+    assert still_set == "tok-defer-1", (
+        f"setup_token must survive GET; got {still_set!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_is_idempotent(app, unauthed_client, db_session):
+    """A second GET with the same token must also succeed -- defeats every
+    URL prefetcher that does HEAD+GET (Safe Links, Proofpoint, etc.) and
+    also any legit retry from the user (back button, refresh)."""
+    await _create_pending_user(
+        db_session, email="defer2@test.com", setup_token="tok-defer-2"
+    )
+
+    first = await unauthed_client.get(
+        "/setup-account?token=tok-defer-2", follow_redirects=False
+    )
+    assert first.status_code == 303, first.text
+
+    # Drop the cookie the first GET set so the second GET looks like a
+    # fresh prefetch from a different client (i.e. the Defender detonator
+    # followed by the human user from their email).
+    unauthed_client.cookies.clear()
+
+    second = await unauthed_client.get(
+        "/setup-account?token=tok-defer-2", follow_redirects=False
+    )
+    assert second.status_code == 303, second.text
+    assert second.headers["location"] == "/force-password-change"
+
+
+# -- token burned on actual setup completion -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_password_change_burns_setup_token(
+    app, unauthed_client, db_session
+):
+    """POST /force-password-change with a valid password must null setup_token.
+    This is the only moment we know the human actually completed setup."""
+    user = await _create_pending_user(
+        db_session, email="burn1@test.com", setup_token="tok-burn-1"
+    )
+    user_id = user.id
+
+    # Click the magic link to get a session cookie.
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-burn-1", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    # Submit a new password via the form.
+    resp = await unauthed_client.post(
+        "/force-password-change",
+        data={"new_password": "new-password-456", "confirm_password": "new-password-456"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+
+    assert await _reload_setup_token(db_session, user_id) is None
+    assert await _reload_must_change(db_session, user_id) is False
+
+
+@pytest.mark.asyncio
+async def test_api_change_password_burns_setup_token(
+    app, unauthed_client, db_session
+):
+    """POST /api/users/me/password with the temp password must null setup_token."""
+    user = await _create_pending_user(
+        db_session,
+        email="burn2@test.com",
+        setup_token="tok-burn-2",
+        temp_password="initial-temp-1",
+    )
+    user_id = user.id
+
+    # Get a cookie via the magic link.
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-burn-2", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    # Change password through the JSON API the way a JS client would.
+    resp = await unauthed_client.post(
+        "/api/users/me/password",
+        json={"current_password": "initial-temp-1", "new_password": "new-password-789"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert await _reload_setup_token(db_session, user_id) is None
+    assert await _reload_must_change(db_session, user_id) is False
+
+
+# -- /api/users hardening: must_change_password gate -----------------------
+
+
+@pytest.mark.asyncio
+async def test_must_change_password_user_blocked_from_get_me(
+    app, unauthed_client, db_session
+):
+    """A half-set user (must_change_password=True) with a session cookie
+    must NOT be able to read /api/users/me; require_auth's exempt-set
+    intentionally does not include it. Pre-fix this leaked profile data
+    (email, role, group_ids, permissions) to anyone holding the URL."""
+    await _create_pending_user(
+        db_session, email="gate1@test.com", setup_token="tok-gate-1"
+    )
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-gate-1", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.get("/api/users/me", follow_redirects=False)
+    assert resp.status_code == 307, resp.text
+    assert resp.headers["location"] == "/force-password-change"
+
+
+@pytest.mark.asyncio
+async def test_must_change_password_user_blocked_from_users_list(
+    app, unauthed_client, db_session
+):
+    """Same gate must cover every other /api/users route -- they all gain
+    the must_change_password check via the router-level dependency."""
+    await _create_pending_user(
+        db_session, email="gate2@test.com", setup_token="tok-gate-2"
+    )
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-gate-2", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.get("/api/users", follow_redirects=False)
+    assert resp.status_code == 307, resp.text
+
+
+@pytest.mark.asyncio
+async def test_must_change_password_user_can_hit_password_endpoint(
+    app, unauthed_client, db_session
+):
+    """The password-change endpoint MUST stay reachable mid-setup -- it's
+    the whole point of the flow. If require_auth's exempt-set drops it,
+    users get trapped in a redirect loop and can never finish setup."""
+    user = await _create_pending_user(
+        db_session,
+        email="gate3@test.com",
+        setup_token="tok-gate-3",
+        temp_password="initial-temp-3",
+    )
+    user_id = user.id
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-gate-3", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.post(
+        "/api/users/me/password",
+        json={"current_password": "initial-temp-3", "new_password": "fresh-password-3"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert await _reload_must_change(db_session, user_id) is False
+
+
+@pytest.mark.asyncio
+async def test_password_change_with_wrong_current_password_does_not_burn_token(
+    app, unauthed_client, db_session
+):
+    """If the password-change call fails (wrong current_password), the
+    setup_token must NOT be nulled -- otherwise an attacker with the URL
+    could brick the link by submitting bogus password attempts."""
+    user = await _create_pending_user(
+        db_session,
+        email="burn3@test.com",
+        setup_token="tok-burn-3",
+        temp_password="initial-temp-3b",
+    )
+    user_id = user.id
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-burn-3", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.post(
+        "/api/users/me/password",
+        json={"current_password": "wrong-password", "new_password": "anything-456"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400, resp.text
+
+    assert await _reload_setup_token(db_session, user_id) == "tok-burn-3"
+    assert await _reload_must_change(db_session, user_id) is True


### PR DESCRIPTION
## Why

A Goodwill CMS invite to `sslivins@gmail.com` came back as "This setup link is invalid or has already been used." App Insights traces showed a `HEAD` + `GET` against the URL **three seconds before the recipient ever clicked**:

```
22:04:48  user row created (setup_token = j3sprywp...)
22:04:51  HEAD /setup-account?token=j3sprywp...  -> 405   (Defender prober)
22:04:51  GET  /setup-account?token=j3sprywp...  -> 303   (Defender consumed the token)
22:04:59  GET  /setup-account?token=j3sprywp...  -> 400   (user's actual click, too late)
```

Goodwill sends invites via `smtp.office365.com`. Microsoft Defender for Office 365 **Safe Links** rewrites + detonates external URLs at send time to evaluate reputation. The detonation is a real GET — and since the old GET handler nulled `setup_token` on first hit, the recipient's click always lost the race. Internal `@seattlegoodwill.org` invites worked because intra-tenant mail bypasses Safe Links.

While putting this fix together a [code-review subagent](#) flagged that the previous design plus the deferred token-burn would open an account-takeover window. Closing that too in this PR — see Fix 2 below.

## What changed

### Fix 1 — Defer the token burn (the original bug)
`GET /setup-account?token=...` now verifies the token, mints the session cookie, sets `must_change_password`, and 303s to `/force-password-change`, but **leaves `setup_token` on the row**. It's nulled only when the user actually submits a new password:

- `POST /force-password-change` (`cms/ui.py`)
- `POST /api/users/me/password` (`cms/routers/users.py`)

Immunizes against every URL prefetcher, not just Defender.

### Fix 2 — Lock down `/api/users`
`/api/users` was the only API router without router-level `require_auth`. Per-route `Depends(get_current_user)` and `Depends(require_permission(...))` do **not** enforce `must_change_password` — only `require_auth` does. With the deferred token burn, a half-set user with the session cookie could:
- call `GET /api/users/me` (info leak), and
- `POST /api/users/me/password` with the temp password from the email (full account takeover).

Closed by adding `dependencies=[Depends(require_auth)]` at the router and a `_PASSWORD_CHANGE_EXEMPT_PATHS` allow-list in `cms/auth.py` so the must-change redirect doesn't trap the user out of `/api/users/me/password` itself.

### Fix 3 — Stop dropping `HTTPException` headers
The global `HTTPException` handler at `cms/main.py:791` was rebuilding the response from `(status_code, detail)` only, silently discarding `exc.headers`. The only raise site that uses headers is `require_auth`'s 307 → `/force-password-change` redirect, so production has been emitting a `307` with **no `Location` header** all along. Browsers ignore that. Handler now forwards `getattr(exc, "headers", None)`. Safe no-op for every existing 401/403/422 raise; surfaced by the new tests.

## Tests

New `tests/test_setup_token_defer.py` (8 tests, all green locally):
- `GET /setup-account` does not burn the token
- `GET /setup-account` is idempotent (Safe Links + user both click)
- `POST /force-password-change` burns the token
- `POST /api/users/me/password` burns the token
- `must_change_password` user is 307-redirected from `/api/users/me`
- `must_change_password` user is 307-redirected from `/api/users/`
- `must_change_password` user **can** reach `/api/users/me/password`
- wrong current-password doesn't burn the token

Updated `tests/nightly/test_06_rbac.py` docstring to reflect the deferred burn (the smoke test still validates idempotency).

Also re-ran 528 adjacent tests locally green (`test_auth.py`, `test_setup_wizard.py`, `test_mcp_auth.py`, `test_download_auth.py`, `test_notifications.py`, `test_invite_url_base_url.py`, `test_rbac.py`, `test_rbac_api_keys.py`, `test_rbac_matrix.py`).

## Related

- #598 — invite-URL custom-domain fix (separate root cause, same email flow).
