### PR TITLE
feat(smtp): configurable From Name on outgoing email

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -35,6 +35,7 @@ SETTING_SMTP_PORT = "smtp_port"
 SETTING_SMTP_USERNAME = "smtp_username"
 SETTING_SMTP_PASSWORD = "smtp_password"
 SETTING_SMTP_FROM_EMAIL = "smtp_from_email"
+SETTING_SMTP_FROM_NAME = "smtp_from_name"
 SETTING_SETUP_COMPLETED = "setup_completed"
 
 # Paths reachable by an authenticated user who still has must_change_password=True.

--- a/cms/services/email_service.py
+++ b/cms/services/email_service.py
@@ -4,11 +4,13 @@ import logging
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formataddr
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.auth import (
     SETTING_SMTP_FROM_EMAIL,
+    SETTING_SMTP_FROM_NAME,
     SETTING_SMTP_HOST,
     SETTING_SMTP_PASSWORD,
     SETTING_SMTP_PORT,
@@ -28,6 +30,7 @@ async def get_smtp_settings(db: AsyncSession) -> dict:
         "username": await get_setting(db, SETTING_SMTP_USERNAME),
         "password": await get_setting(db, SETTING_SMTP_PASSWORD),
         "from_email": await get_setting(db, SETTING_SMTP_FROM_EMAIL),
+        "from_name": await get_setting(db, SETTING_SMTP_FROM_NAME),
         "use_tls": True,
     }
 
@@ -41,7 +44,19 @@ def _send_email(smtp_cfg: dict, to_email: str, subject: str, html_body: str, tex
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
-    msg["From"] = smtp_cfg["from_email"]
+    # Render the From header as `"Display Name" <addr@host>` when a from_name
+    # is configured, so mail clients show the friendly name instead of the
+    # bare address. The SMTP envelope-from (server.sendmail below) still uses
+    # the bare address, per RFC 5321 -- some relays reject angle-bracketed
+    # addresses there.
+    #
+    # Strip CR/LF from from_name before formatting: it ultimately ends up in a
+    # MIME header, and the default email.policy.compat32 does not detect CRLF
+    # header injection. Admin-only setting, but cheap defense in depth.
+    raw_name = smtp_cfg.get("from_name") or ""
+    from_name = raw_name.replace("\r", "").replace("\n", "").strip()
+    from_email = smtp_cfg["from_email"]
+    msg["From"] = formataddr((from_name, from_email)) if from_name else from_email
     msg["To"] = to_email
     msg.attach(MIMEText(text_body, "plain"))
     msg.attach(MIMEText(html_body, "html"))

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -143,6 +143,12 @@
         </div>
         <div class="form-row">
             <div class="form-group">
+                <label for="smtp-from-name">From Name <span class="text-muted" style="font-weight: normal; font-size: 0.8rem;">(optional)</span></label>
+                <input type="text" id="smtp-from-name" placeholder="e.g. Goodwill Digital Signage" value="{{ smtp_from_name or '' }}">
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
                 <label for="smtp-from-email">From Email</label>
                 <input type="email" id="smtp-from-email" placeholder="e.g. noreply@example.com" value="{{ smtp_from_email or '' }}">
             </div>
@@ -172,6 +178,7 @@ async function saveSmtpSettings() {
         host: document.getElementById("smtp-host").value.trim(),
         port: parseInt(document.getElementById("smtp-port").value) || 587,
         username: document.getElementById("smtp-username").value.trim(),
+        from_name: document.getElementById("smtp-from-name").value.trim(),
         from_email: document.getElementById("smtp-from-email").value.trim(),
 
     };

--- a/cms/templates/setup.html
+++ b/cms/templates/setup.html
@@ -82,6 +82,12 @@
             </div>
             <div class="form-row">
                 <div class="form-group">
+                    <label for="smtp-from-name">From Name <span class="text-muted" style="font-weight: normal; font-size: 0.8rem;">(optional)</span></label>
+                    <input type="text" id="smtp-from-name" placeholder="e.g. Goodwill Digital Signage">
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group">
                     <label for="smtp-from">From Email</label>
                     <input type="email" id="smtp-from" placeholder="e.g. noreply@example.com">
                 </div>
@@ -263,6 +269,7 @@
             port: parseInt(document.getElementById("smtp-port").value) || 587,
             username: document.getElementById("smtp-username").value.trim(),
             password: document.getElementById("smtp-password").value,
+            from_name: document.getElementById("smtp-from-name").value.trim(),
             from_email: document.getElementById("smtp-from").value.trim(),
         };
 
@@ -290,6 +297,7 @@
             port: parseInt(document.getElementById("smtp-port").value) || 587,
             username: document.getElementById("smtp-username").value.trim(),
             password: document.getElementById("smtp-password").value,
+            from_name: document.getElementById("smtp-from-name").value.trim(),
             from_email: document.getElementById("smtp-from").value.trim(),
         };
         try {

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -17,6 +17,7 @@ from cms.auth import (
     SETTING_PASSWORD_HASH,
     SETTING_SETUP_COMPLETED,
     SETTING_SMTP_FROM_EMAIL,
+    SETTING_SMTP_FROM_NAME,
     SETTING_SMTP_HOST,
     SETTING_SMTP_PASSWORD,
     SETTING_SMTP_PORT,
@@ -465,6 +466,7 @@ async def setup_smtp(
     if data.get("password"):
         await set_setting(db, SETTING_SMTP_PASSWORD, data["password"])
     await set_setting(db, SETTING_SMTP_FROM_EMAIL, data.get("from_email", ""))
+    await set_setting(db, SETTING_SMTP_FROM_NAME, data.get("from_name", ""))
     await audit_log(
         db, user=user, action="settings.smtp.update", resource_type="settings",
         description=f"Setup wizard: updated SMTP settings (host={data.get('host', '')})",
@@ -473,6 +475,7 @@ async def setup_smtp(
             "port": data.get("port"),
             "username": data.get("username", ""),
             "from_email": data.get("from_email", ""),
+            "from_name": data.get("from_name", ""),
             "password_changed": bool(data.get("password")),
         },
         request=request,
@@ -1862,6 +1865,7 @@ async def settings_page(
     smtp_username = await get_setting(db, SETTING_SMTP_USERNAME) or ""
     smtp_password = await get_setting(db, SETTING_SMTP_PASSWORD) or ""
     smtp_from_email = await get_setting(db, SETTING_SMTP_FROM_EMAIL) or ""
+    smtp_from_name = await get_setting(db, SETTING_SMTP_FROM_NAME) or ""
 
     # Timezone
     current_timezone = await get_setting(db, SETTING_TIMEZONE) or "UTC"
@@ -1893,6 +1897,7 @@ async def settings_page(
         "smtp_username": smtp_username,
         "smtp_password": smtp_password,
         "smtp_from_email": smtp_from_email,
+        "smtp_from_name": smtp_from_name,
         "current_timezone": current_timezone,
         "timezone_saved": timezone_saved,
         "timezones": tz_options,
@@ -2041,6 +2046,7 @@ async def save_smtp_settings(
     if "password" in data and data["password"]:
         await set_setting(db, SETTING_SMTP_PASSWORD, data["password"])
     await set_setting(db, SETTING_SMTP_FROM_EMAIL, data.get("from_email", ""))
+    await set_setting(db, SETTING_SMTP_FROM_NAME, data.get("from_name", ""))
     await audit_log(
         db, user=_user, action="settings.smtp.update", resource_type="settings",
         description=f"Updated SMTP settings (host={data.get('host', '')})",
@@ -2049,6 +2055,7 @@ async def save_smtp_settings(
             "port": data.get("port"),
             "username": data.get("username", ""),
             "from_email": data.get("from_email", ""),
+            "from_name": data.get("from_name", ""),
             "password_changed": bool(data.get("password")),
         },
         request=request,
@@ -2198,6 +2205,7 @@ async def change_timezone(
     smtp_username = await get_setting(db, SETTING_SMTP_USERNAME) or ""
     smtp_password = await get_setting(db, SETTING_SMTP_PASSWORD) or ""
     smtp_from_email = await get_setting(db, SETTING_SMTP_FROM_EMAIL) or ""
+    smtp_from_name = await get_setting(db, SETTING_SMTP_FROM_NAME) or ""
 
     base_ctx = {
         "active_tab": "settings",
@@ -2207,6 +2215,7 @@ async def change_timezone(
         "smtp_username": smtp_username,
         "smtp_password": smtp_password,
         "smtp_from_email": smtp_from_email,
+        "smtp_from_name": smtp_from_name,
         "timezones": tz_options,
         "devices": device_list,
     }

--- a/tests/test_smtp_from_name.py
+++ b/tests/test_smtp_from_name.py
@@ -1,0 +1,126 @@
+"""Regression test for SMTP From-header rendering with a configurable display
+name.
+
+The bug fixed alongside this test: ``cms/services/email_service.py``
+hardcoded ``msg["From"] = smtp_cfg["from_email"]``, so the welcome email
+shipped with just the bare address as the sender. We now read a separate
+``from_name`` setting and emit ``"Display Name" <addr@host>`` when it's set.
+
+What this test guards:
+
+1. ``from_name`` set       -> header is ``"Pretty Name" <bare@addr>``.
+2. ``from_name`` missing   -> header is the bare email (back-compat).
+3. ``from_name`` only-whitespace -> treated as missing.
+4. ``from_name`` with CR/LF -> CR/LF stripped before formatting (defense
+   in depth against header injection -- ``email.policy.compat32`` does not
+   detect CRLF, and even though the setting is admin-only, scrubbing it is
+   one line of code).
+5. SMTP envelope-from (the first arg to ``server.sendmail``) is always the
+   bare email -- some relays reject angle-bracketed forms in MAIL FROM.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from cms.services.email_service import _send_email
+
+
+def _base_cfg(**overrides):
+    cfg = {
+        "host": "smtp.example.com",
+        "port": 587,
+        "username": "user",
+        "password": "pass",
+        "from_email": "noreply@example.com",
+        "from_name": None,
+        "use_tls": True,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _send_and_capture(cfg):
+    """Invoke _send_email with a mocked smtplib server; return the (server,
+    sent_message) pair so the caller can assert on either side."""
+    with patch("cms.services.email_service.smtplib.SMTP") as smtp_cls:
+        server = MagicMock()
+        smtp_cls.return_value = server
+        ok, err = _send_email(cfg, "to@example.com", "subj", "<p>html</p>", "text")
+    assert ok, f"_send_email failed: {err!r}"
+    # server.sendmail(envelope_from, [to], rfc822_string)
+    assert server.sendmail.called, "sendmail was never called"
+    envelope_from, _recipients, rfc822 = server.sendmail.call_args.args
+    return envelope_from, rfc822
+
+
+def _from_header(rfc822: str) -> str:
+    """Extract the From: header value from a serialized MIME message."""
+    for line in rfc822.splitlines():
+        if line.lower().startswith("from:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"no From header in message:\n{rfc822}")
+
+
+def test_from_header_uses_name_when_configured():
+    envelope_from, rfc822 = _send_and_capture(
+        _base_cfg(from_name="Goodwill Digital Signage")
+    )
+    assert _from_header(rfc822) == 'Goodwill Digital Signage <noreply@example.com>'
+    # Envelope must stay bare per RFC 5321.
+    assert envelope_from == "noreply@example.com"
+
+
+def test_from_header_is_bare_when_name_missing():
+    envelope_from, rfc822 = _send_and_capture(_base_cfg(from_name=None))
+    assert _from_header(rfc822) == "noreply@example.com"
+    assert envelope_from == "noreply@example.com"
+
+
+def test_from_header_is_bare_when_name_is_empty_string():
+    envelope_from, rfc822 = _send_and_capture(_base_cfg(from_name=""))
+    assert _from_header(rfc822) == "noreply@example.com"
+    assert envelope_from == "noreply@example.com"
+
+
+def test_from_header_is_bare_when_name_is_whitespace_only():
+    envelope_from, rfc822 = _send_and_capture(_base_cfg(from_name="   "))
+    assert _from_header(rfc822) == "noreply@example.com"
+    assert envelope_from == "noreply@example.com"
+
+
+def test_from_name_strips_crlf_to_prevent_header_injection():
+    # Classic CRLF injection attempt: try to smuggle a Bcc into the message.
+    # With CR/LF scrubbed, the whole malicious string becomes a single quoted
+    # display name -- never breaks out into its own header.
+    import email as email_pkg
+    envelope_from, rfc822 = _send_and_capture(
+        _base_cfg(from_name="Evil\r\nBcc: attacker@example.com")
+    )
+    parsed = email_pkg.message_from_string(rfc822)
+    # No injected header reached the parsed message:
+    assert parsed.get("Bcc") is None, f"Bcc header was injected: {parsed.get_all('Bcc')!r}"
+    assert parsed.get_all("To") == ["to@example.com"], (
+        f"unexpected To headers: {parsed.get_all('To')!r}"
+    )
+    # The From header itself must be a single logical line -- the parser
+    # normalises folding, so getting one string back means no CRLF leak.
+    from_hdr = parsed.get("From") or ""
+    assert "\r" not in from_hdr and "\n" not in from_hdr, (
+        f"raw CRLF leaked into From header: {from_hdr!r}"
+    )
+    # And the address part must still parse correctly.
+    from email.utils import parseaddr
+    _name, addr = parseaddr(from_hdr)
+    assert addr == "noreply@example.com", f"address corrupted: {from_hdr!r}"
+    assert envelope_from == "noreply@example.com"
+
+
+def test_from_name_with_special_chars_is_quoted_correctly():
+    # formataddr should quote a name containing commas or quotes per RFC 5322.
+    _envelope, rfc822 = _send_and_capture(
+        _base_cfg(from_name='Smith, John "JS"')
+    )
+    header = _from_header(rfc822)
+    assert header.endswith("<noreply@example.com>")
+    # The address part must still be parseable -- the display name is what
+    # gets quoted; the bracketed address must be intact.
+    assert "<noreply@example.com>" in header


### PR DESCRIPTION
## What

Adds a configurable **From Name** to outgoing SMTP email so the welcome email shows e.g. `"Goodwill Digital Signage" <noreply@goodwill.org>` instead of a bare address.

## Why

Today `_send_email` hardcodes `msg["From"] = smtp_cfg["from_email"]`. There's no way to set a friendly sender name short of jamming RFC 5322 syntax into the From Email field, which is fragile (the same string gets handed to `server.sendmail` as the SMTP envelope-from, where some relays reject angle-bracketed forms).

## How

* New `smtp_from_name` setting (key-value, no schema change).
* When set, `msg["From"]` is built via `email.utils.formataddr((name, email))`; otherwise it's the bare email (back-compat).
* SMTP envelope-from passed to `server.sendmail` is always the bare email per RFC 5321.
* CR/LF are stripped from `from_name` before formatting -- `email.policy.compat32` doesn't detect CRLF header injection, so this is defense in depth even though the setting is admin-only.
* New field on **Settings -> SMTP** card and in the **setup wizard**'s SMTP step. Both persist via the existing endpoints; both add the value to the audit log details.

## Tests

New `tests/test_smtp_from_name.py`:
* From: rendered as `"Pretty Name" <bare@addr>` when name configured.
* From: bare email when name missing / empty / whitespace-only.
* CR/LF in the name doesn't produce a real injected header (parsed message has no Bcc, From has no newlines).
* Names with commas/quotes are quoted correctly per RFC 5322.
* Envelope-from is always the bare email regardless.

Verified adjacent SMTP-touching tests still pass: `test_invite_url_base_url.py`, `test_notifications.py`, `test_rbac.py`, `test_smtp_from_name.py` -> 143 passed locally.

## Migration

None. `smtp_from_name` is a new row in the existing `settings` key-value table. Until an admin types a name, behaviour is unchanged.