### PR TITLE
fix(deploy): make Publish & Deploy idempotent on duplicate trigger

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -134,6 +134,7 @@ jobs:
       previous_mcp_revision: ${{ steps.revisions.outputs.previous_mcp_revision }}
       new_cms_revision: ${{ steps.revisions.outputs.new_cms_revision }}
       new_mcp_revision: ${{ steps.revisions.outputs.new_mcp_revision }}
+      skip_deploy: ${{ steps.preflight.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
 
@@ -206,7 +207,52 @@ jobs:
           echo "new_cms_revision=${CMS_APP}--${SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "new_mcp_revision=${MCP_APP}--${SUFFIX}" >> "$GITHUB_OUTPUT"
 
+      # Idempotency guard. When two PRs merge to main back-to-back, each
+      # one's Smoke Test fires a separate Publish & Deploy run via the
+      # `workflow_run` trigger. Both runs read `cms/__init__.py` from
+      # whatever main looks like at checkout time, so they compute the
+      # same revision suffix. The second one to start would otherwise
+      # crash the `Deploy infrastructure` step with
+      #   Field 'template.revisionsuffix' is invalid with details:
+      #   'Invalid value: "v1-37-XXX": revision with suffix v1-37-XXX
+      #   already exists.'
+      # which surfaces as a deploy failure even though the version is
+      # already in prod (see #604). Probe ACA for the target revisions:
+      # if both apps already have them, the prior run already shipped
+      # this version end-to-end — exit clean and skip verify/bump-main.
+      - name: Preflight - skip if revision already deployed
+        id: preflight
+        run: |
+          set -uo pipefail
+          CMS_APP="${{ vars.INFRA_PREFIX }}-cms"
+          MCP_APP="${{ vars.INFRA_PREFIX }}-mcp"
+          RG="${{ env.AZURE_RESOURCE_GROUP }}"
+          NEW_CMS='${{ steps.revisions.outputs.new_cms_revision }}'
+          NEW_MCP='${{ steps.revisions.outputs.new_mcp_revision }}'
+
+          CMS_EXISTS=0
+          MCP_EXISTS=0
+          if az containerapp revision show --name "$CMS_APP" --resource-group "$RG" --revision "$NEW_CMS" -o none 2>/dev/null; then
+            CMS_EXISTS=1
+          fi
+          if az containerapp revision show --name "$MCP_APP" --resource-group "$RG" --revision "$NEW_MCP" -o none 2>/dev/null; then
+            MCP_EXISTS=1
+          fi
+
+          # Only short-circuit if BOTH revisions exist. A half-deployed
+          # state (one revision present, the other missing) still needs
+          # bicep to run; the existing-revision side will fail loudly,
+          # which is the correct signal that something needs cleanup.
+          if [ "$CMS_EXISTS" = "1" ] && [ "$MCP_EXISTS" = "1" ]; then
+            echo "::notice::Revisions $NEW_CMS and $NEW_MCP already exist - assuming version ${{ needs.publish.outputs.version }} is already deployed. Skipping deploy + verify + bump-main."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "CMS_EXISTS=$CMS_EXISTS MCP_EXISTS=$MCP_EXISTS - proceeding with deploy."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy infrastructure
+        if: steps.preflight.outputs.skip != 'true'
         run: |
           CMS_REF='ghcr.io/sslivins/agora-cms@${{ needs.publish.outputs.cms_digest }}'
           MCP_REF='ghcr.io/sslivins/agora-cms-mcp@${{ needs.publish.outputs.mcp_digest }}'
@@ -237,7 +283,7 @@ jobs:
               cmsBaseUrlOverride='${{ vars.CMS_CUSTOM_DOMAIN != '' && format('https://{0}', vars.CMS_CUSTOM_DOMAIN) || '' }}'
 
       - name: Bind custom domains (if configured)
-        if: vars.CMS_CUSTOM_DOMAIN != '' || vars.MCP_CUSTOM_DOMAIN != ''
+        if: steps.preflight.outputs.skip != 'true' && (vars.CMS_CUSTOM_DOMAIN != '' || vars.MCP_CUSTOM_DOMAIN != '')
         run: |
           ENV_NAME="${{ vars.INFRA_PREFIX }}-env"
           RG="${{ env.AZURE_RESOURCE_GROUP }}"
@@ -276,6 +322,12 @@ jobs:
 
   verify:
     needs: [publish, deploy]
+    # If preflight detected the revisions already exist, the prior run
+    # already shipped this version (including the traffic flip). Skip
+    # verify entirely - re-running Flip traffic when previous_revision
+    # == new_revision would fail, and Deactivate stale revisions would
+    # kill the real previous revision (rollback target). See #604.
+    if: needs.deploy.outputs.skip_deploy != 'true'
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## What

Adds a preflight idempotency check to `Publish & Deploy` so a duplicate `workflow_run` trigger on the same source state cleanly no-ops instead of crashing the bicep step with a revision-suffix collision.

## Why

When two PRs merge to `main` back-to-back, each one's Smoke Test fires a separate Publish & Deploy via the `workflow_run` trigger. Both runs check out the current `main` and compute the same revision suffix. The second one then fails the `Deploy infrastructure` step with:

> Field `template.revisionsuffix` is invalid with details: `Invalid value: "v1-37-228": revision with suffix v1-37-228 already exists.`

…even though the version is already in prod. The watcher (and humans) see "Publish & Deploy: failure" and assume the worst.

This happened tonight on the PR #603 merge — see [the failure run](https://github.com/sslivins/agora-cms/actions/runs/26072325534) vs [the successful run](https://github.com/sslivins/agora-cms/actions/runs/26072158013) on the same SHA. Full diagnosis in #604.

## How

After `Capture pre-deploy revision state` (which computes the new revision names), probe ACA:

```yaml
- name: Preflight - skip if revision already deployed
  id: preflight
  run: |
    # az containerapp revision show ... for both CMS and MCP
    # If BOTH exist: skip=true
```

Gates added:

- **`Deploy infrastructure`** + **`Bind custom domains`** — step-level `if: steps.preflight.outputs.skip != 'true'`.
- **`verify`** job — job-level `if: needs.deploy.outputs.skip_deploy != 'true'`. Re-running `Flip traffic` when `previous_revision == new_revision` would fail, and `Deactivate stale revisions` would kill the real previous revision (rollback target).
- **`bump-main`** — auto-skips because `needs: verify` propagates.

When only **one** of the two revisions exists (half-deployed state from a prior aborted run), bicep is still attempted so the existing-revision side fails loudly. That's a signal something needs manual cleanup, not something to silently mask.

## What I considered and rejected

**`concurrency: { cancel-in-progress: true }`.** Cancels the OLDER run, not the newer one. If run A is mid-bicep when run B fires, A gets cancelled mid-deployment — potentially leaving ACA in a partial state. Strictly worse than today's cosmetic failure. Skipped.

**Pin checkout to `workflow_run.head_sha`.** Doesn't actually solve the duplicate-deploy problem (both events still target the same revision suffix), forces custom logic for bump-main, and complicates the workflow. Skipped.

## Testing

- `actionlint` clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` clean.
- Real-world test: open two no-op PRs that touch unrelated files and auto-merge both within ~2 min. Today: second deploy fails red. After this: second deploy exits clean (deploy + verify + bump-main all skipped with a `::notice::` in the log).

## Closes

#604
