### PR TITLE
Fix grouped-device-row tint not covering chevron column

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1043,11 +1043,21 @@ tr.highlight-new td {
     z-index: 1;
 }
 .group-panel .device-row td.expand-toggle + td { padding-left: 2.5rem; }
-/* Tint applies only to in-flow tds; the absolute chevron td must stay
-   transparent or its background stacks over the in-flow row and produces a
-   darker stripe in the first 2.5rem (#569 follow-up). */
-.group-panel .device-row td:not(.expand-toggle) { background: rgba(255,255,255,0.05); }
-.group-panel .device-row:hover td:not(.expand-toggle) { background: rgba(255,255,255,0.09); }
+/* Row tint must cover the entire row including the chevron's 2.5rem
+   slot. Painting it on the <tr> (with the cells left transparent) means
+   one background layer covers the whole row -- including under the
+   absolutely-positioned chevron td, whose containing block is this
+   relatively-positioned <tr>. Avoids the "darker stripe in the first
+   2.5rem" double-tint that happens if both the chevron td and the
+   adjacent in-flow td paint their own backgrounds at the same alpha. */
+.group-panel .device-row { background: rgba(255,255,255,0.05); }
+.group-panel .device-row:hover { background: rgba(255,255,255,0.09); }
+/* Neutralize the global `.device-row:hover td` rule (line ~895) inside
+   group panels. Without this, in-flow tds would stack their own 0.04
+   tint on top of the row's hover tint, producing a darker band on every
+   cell except the absolutely-positioned chevron td (which isn't covered
+   by the global rule). Row-level hover is sufficient here. */
+.group-panel .device-row:hover td { background: transparent; }
 .group-header .badge-count { font-size: 0.75rem; background: var(--primary); color: var(--text); padding: 0.15rem 0.5rem; border-radius: 10px; }
 .group-actions { margin-left: auto; display: flex; align-items: center; gap: 0.5rem; }
 .group-actions .btn-sm { font-size: 0.9rem; }


### PR DESCRIPTION
## Problem

Inside a device-group panel on /devices, the row tint applied to grouped devices stopped at the chevron column, leaving an un-tinted strip in the first 2.5rem of each row. On hover the same area showed a *darker* band between the chevron and the device-name cell.

## Root cause

The #569 follow-up tint was applied per-cell with `:not(.expand-toggle)` because the chevron td is `position: absolute` — tinting it explicitly stacked over the adjacent in-flow td's tint and produced a darker stripe in the first 2.5rem (the original bug that #569 was avoiding).

The hover band was a separate symptom: the global `.device-row:hover td { background: rgba(255,255,255,0.04); }` rule painted every in-flow td on hover; combined with the per-cell hover tint inside group panels, the in-flow area got two layers of tint while the absolutely-positioned chevron td only got one — producing a visible darker stripe between them.

## Fix

Move both the static tint and the hover tint up to the `<tr>` level, and explicitly neutralize the global per-cell hover rule inside group panels:

- The `<tr>`'s single background layer paints uniformly across the whole row.
- The chevron td is `position:absolute` and transparent — its containing block is the relatively-positioned `<tr>`, whose background shows through.
- The in-flow tds are also transparent, so the row's background shows through there too. No double-stacking, no stripe.

## Verification

- Brought up a local docker-compose stack with `cms/static` bind-mounted, seeded a device group with 3 fake devices, and confirmed both states visually:
  - Resting state: tint covers the entire row including the chevron area.
  - Hover state: tint deepens uniformly across the entire row, no darker band anywhere.
- Diff is CSS-only, scoped to `.group-panel .device-row` — ungrouped Devices and other tables are unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>