### PR TITLE
Stop URL prefetchers from stamping last_login_at on invitees

### DIFF
--- a/cms/routers/users.py
+++ b/cms/routers/users.py
@@ -82,12 +82,21 @@ async def change_my_password(
     """Change the current user's own password."""
     if not verify_password(data.current_password, current_user.password_hash):
         raise HTTPException(status_code=400, detail="Current password is incorrect")
+    was_setup_completion = current_user.must_change_password
     current_user.password_hash = hash_password(data.new_password)
     current_user.must_change_password = False
     # Burn the setup token now -- successful password set is the only signal
     # that the human actually completed setup. See cms/ui.py::setup_account
     # for why we defer this from the GET handler.
     current_user.setup_token = None
+    if was_setup_completion:
+        # This call was the user finishing first-time setup, so it doubles
+        # as their first real authentication. Stamp last_login_at to match
+        # what POST /force-password-change does. Skipped for plain password
+        # changes from already-set-up users -- those would clobber a real
+        # last_login_at written by POST /login.
+        from datetime import datetime, timezone
+        current_user.last_login_at = datetime.now(timezone.utc)
     await db.commit()
     return {"status": "ok"}
 

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -212,9 +212,12 @@ async def setup_account(
             status_code=400,
         )
 
-    from datetime import datetime, timezone
-    user.last_login_at = datetime.now(timezone.utc)
-    await db.commit()
+    # NOTE: do NOT touch user.last_login_at here. This endpoint is hit by
+    # email URL prefetchers (Defender Safe Links, Proofpoint, etc.) before
+    # the user ever sees the message, so writing a timestamp on every GET
+    # produces phantom "last login" values for invitees who haven't clicked.
+    # last_login_at is set on real authentications: POST /login and the
+    # successful first POST /force-password-change (see below).
 
     # Create session and redirect to force-password-change
     serializer = URLSafeTimedSerializer(settings.secret_key)
@@ -367,6 +370,11 @@ async def force_password_change_submit(
     # that the human actually completed setup. See setup_account() for why
     # we defer this from the GET handler.
     user.setup_token = None
+    # First real authentication moment: stamp last_login_at here (was
+    # previously stamped on every GET /setup-account, but that fires for
+    # URL prefetchers before the user even clicks -- see setup_account()).
+    from datetime import datetime, timezone
+    user.last_login_at = datetime.now(timezone.utc)
     await db.commit()
 
     return RedirectResponse(url="/", status_code=303)

--- a/tests/test_setup_token_defer.py
+++ b/tests/test_setup_token_defer.py
@@ -82,6 +82,14 @@ async def _reload_must_change(db: AsyncSession, user_id: uuid.UUID) -> bool:
     return result.scalar_one()
 
 
+async def _reload_last_login(db: AsyncSession, user_id: uuid.UUID):
+    """Read last_login_at straight from the DB, bypassing any session cache."""
+    result = await db.execute(
+        select(User.last_login_at).where(User.id == user_id)
+    )
+    return result.scalar_one()
+
+
 # -- token deferral on GET ------------------------------------------------
 
 
@@ -106,6 +114,33 @@ async def test_setup_account_get_does_not_burn_token(
     still_set = await _reload_setup_token(db_session, user_id)
     assert still_set == "tok-defer-1", (
         f"setup_token must survive GET; got {still_set!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_does_not_set_last_login(
+    app, unauthed_client, db_session
+):
+    """GET /setup-account must NOT stamp last_login_at; URL prefetchers
+    (Defender Safe Links, Proofpoint, etc.) fire that GET before the user
+    ever clicks, which previously produced phantom 'last login' timestamps
+    on invitees who never actually completed setup."""
+    user = await _create_pending_user(
+        db_session, email="lastlogin1@test.com", setup_token="tok-ll-1"
+    )
+    user_id = user.id
+
+    # Sanity: user has never logged in
+    assert await _reload_last_login(db_session, user_id) is None
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-ll-1", follow_redirects=False
+    )
+    assert resp.status_code == 303, resp.text
+
+    still_none = await _reload_last_login(db_session, user_id)
+    assert still_none is None, (
+        f"last_login_at must remain NULL after a prefetcher-style GET; got {still_none!r}"
     )
 
 
@@ -168,6 +203,36 @@ async def test_force_password_change_burns_setup_token(
 
 
 @pytest.mark.asyncio
+async def test_force_password_change_sets_last_login(
+    app, unauthed_client, db_session
+):
+    """Successfully completing /force-password-change is the first real
+    authentication moment; last_login_at must be stamped here so the user
+    actually shows up as 'has logged in' on the users page."""
+    user = await _create_pending_user(
+        db_session, email="ll-force@test.com", setup_token="tok-ll-force"
+    )
+    user_id = user.id
+
+    assert await _reload_last_login(db_session, user_id) is None
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-ll-force", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.post(
+        "/force-password-change",
+        data={"new_password": "set-via-form-1", "confirm_password": "set-via-form-1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+
+    stamp = await _reload_last_login(db_session, user_id)
+    assert stamp is not None, "last_login_at must be set after first successful setup"
+
+
+@pytest.mark.asyncio
 async def test_api_change_password_burns_setup_token(
     app, unauthed_client, db_session
 ):
@@ -196,6 +261,92 @@ async def test_api_change_password_burns_setup_token(
 
     assert await _reload_setup_token(db_session, user_id) is None
     assert await _reload_must_change(db_session, user_id) is False
+
+
+@pytest.mark.asyncio
+async def test_api_change_password_sets_last_login_on_setup_completion(
+    app, unauthed_client, db_session
+):
+    """When a freshly-invited user finishes setup via the JSON API, the
+    call doubles as their first authentication so last_login_at must be
+    stamped (mirrors the form path)."""
+    user = await _create_pending_user(
+        db_session,
+        email="ll-api@test.com",
+        setup_token="tok-ll-api",
+        temp_password="initial-temp-api",
+    )
+    user_id = user.id
+
+    assert await _reload_last_login(db_session, user_id) is None
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-ll-api", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.post(
+        "/api/users/me/password",
+        json={"current_password": "initial-temp-api", "new_password": "post-setup-1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200, resp.text
+
+    stamp = await _reload_last_login(db_session, user_id)
+    assert stamp is not None, "last_login_at must be set after first setup completion via API"
+
+
+@pytest.mark.asyncio
+async def test_api_change_password_preserves_last_login_for_normal_change(
+    app, unauthed_client, db_session
+):
+    """A normal password change by an already-set-up user must NOT clobber
+    last_login_at -- that field reflects the last real login, not the last
+    password change. Without the must_change_password gate, this endpoint
+    would overwrite a meaningful timestamp with a meaningless one."""
+    from datetime import datetime, timezone, timedelta
+
+    role_id = await _get_role_id(db_session, "Viewer")
+    pinned = datetime.now(timezone.utc) - timedelta(days=7)
+    user = User(
+        username="settled",
+        email="settled@test.com",
+        display_name="Settled User",
+        password_hash=hash_password("current-pwd-1"),
+        role_id=role_id,
+        is_active=True,
+        must_change_password=False,
+        setup_token=None,
+        last_login_at=pinned,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    user_id = user.id
+
+    # Log in to mint a session cookie (last_login_at will be refreshed by /login;
+    # we capture the new value as the baseline we expect to be preserved).
+    resp = await unauthed_client.post(
+        "/login",
+        data={"email": "settled@test.com", "password": "current-pwd-1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+    baseline = await _reload_last_login(db_session, user_id)
+    assert baseline is not None
+
+    # Now change password via the API. last_login_at must NOT move.
+    resp = await unauthed_client.post(
+        "/api/users/me/password",
+        json={"current_password": "current-pwd-1", "new_password": "next-pwd-2"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200, resp.text
+
+    after = await _reload_last_login(db_session, user_id)
+    assert after == baseline, (
+        f"plain password change must not move last_login_at; baseline={baseline!r} after={after!r}"
+    )
 
 
 # -- /api/users hardening: must_change_password gate -----------------------


### PR DESCRIPTION
## Problem

The users page shows a `Last Login` for users who have been invited but have never clicked the email link or set a password. This is misleading -- those invitees haven't actually logged in.

## Root cause

`GET /setup-account?token=...` sets `user.last_login_at = datetime.now()` on every hit. Outbound email-security products (Microsoft Defender for Office 365 Safe Links, Proofpoint URL Defense, Mimecast, etc.) fire silent GETs against URLs in transit before the message is delivered, so `last_login_at` gets stamped seconds after the invite is sent -- long before the human ever sees the email.

This is the same class of bug as the deferred setup_token burn we already shipped in PR #600. Writing user state on a prefetcher GET is wrong on principle.

It's also wrong conceptually: a magic-link click proves the user has the token, not that they know any credentials -- so the GET isn't a 'login' event in any meaningful sense.

## Fix

- **`GET /setup-account`**: remove the `last_login_at` assignment (and the now-empty commit). This endpoint is now state-free -- exactly what we want for something a prefetcher will hit.
- **`POST /force-password-change`**: stamp `last_login_at` on successful submit. That's the first moment we know the user actually received the email, chose a password, and authenticated.
- **`POST /api/users/me/password`**: only stamp `last_login_at` when the user was still in `must_change_password` state at entry (i.e. this call **is** the setup-completion). For an already-set-up user changing their password normally, leave it alone -- otherwise we'd clobber the real `/login` timestamp with a password-change timestamp.

## Tests (regression, in `tests/test_setup_token_defer.py`)

- `test_setup_account_get_does_not_set_last_login` -- prefetcher GET keeps `last_login_at` NULL.
- `test_force_password_change_sets_last_login` -- form-path setup completion stamps it.
- `test_api_change_password_sets_last_login_on_setup_completion` -- API setup completion stamps it (mirrors form path).
- `test_api_change_password_preserves_last_login_for_normal_change` -- a settled user's plain password change does **not** move `last_login_at`.

All 12 tests in `test_setup_token_defer.py` green locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>