### PR TITLE
imager: add Provision Softplayer endpoint + UI

### DIFF
--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -1086,7 +1086,12 @@ async def build_softplayer_credentials(
     )
     await db.commit()
 
-    filename = f"softplayer-{body.fleet_id}.env"
+    # Always emit the canonical name the loader looks for in its default
+    # search paths (%LOCALAPPDATA%\agora-softplayer\softplayer.env, next to
+    # the .exe, or cwd). Operators can rename to disambiguate across
+    # multiple fleets if they really need to, but the common path is
+    # "drop the download where it belongs and start the player".
+    filename = "softplayer.env"
     return Response(
         content=payload,
         media_type="text/plain; charset=utf-8",

--- a/cms/routers/imager.py
+++ b/cms/routers/imager.py
@@ -50,7 +50,7 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -212,6 +212,17 @@ class BuildBody(BaseModel):
                 "wifi_ssid and wifi_psk must be provided together or both omitted"
             )
         return self
+
+
+class SoftplayerCredentialsBody(BaseModel):
+    """Request body for ``POST /api/imager/softplayer-credentials``.
+
+    Just a fleet id -- the softplayer is the .env-file analogue of the Pi
+    .img.xz build, so there's no base image, output filename, or wifi to
+    plumb through.
+    """
+
+    fleet_id: str = Field(..., min_length=1, max_length=64)
 
 
 class ImagerSettingsOut(BaseModel):
@@ -967,6 +978,123 @@ async def build_provisioned_image(
         progress_stage=job.progress_stage or "",
         progress_pct=job.progress_pct,
         output_name=pi.output_name,
+    )
+
+
+@router.post("/softplayer-credentials")
+async def build_softplayer_credentials(
+    body: SoftplayerCredentialsBody,
+    request: Request,
+    user: User = Depends(require_permission(IMAGER_BUILD)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    """Render and return the ``softplayer.env`` body for a given fleet.
+
+    The Windows-native ``agora-softplayer`` is bootstrap-v2-only: it
+    authenticates to the CMS via the same fleet-HMAC pairing flow Pis
+    use in production. Operators provision a softplayer by downloading
+    this env file from the Imager tab and dropping it next to the .exe
+    (or under ``%LOCALAPPDATA%\\agora-softplayer\\``).
+
+    The output mirrors :func:`_fleet_env_payload`'s ``agora-fleet.env``
+    body baked into Pi images -- same keys, same ``AGORA_FLEET_SECRET_HEX``
+    encoding -- just delivered as a downloadable text file instead of
+    inside an ``.img.xz``. The softplayer CLI consumes the same
+    ``KEY=VALUE`` format.
+
+    Validates that:
+
+    * ``fleet_id`` matches ``_FLEET_ID_RE`` and is configured on this CMS
+      (resolves to a secret).
+    * ``settings.device_transport`` is ``local`` or ``wps``.
+    * ``settings.base_url`` is set (the firmware needs an absolute URL).
+
+    Audited via ``imager.softplayer_credentials.download``. No
+    ``ProvisionedImage`` row is written -- the env file is ephemeral and
+    regeneratable from the fleet at any time; revoking access means
+    deleting the fleet (which invalidates the HMAC for every previously
+    downloaded file).
+    """
+    if not _FLEET_ID_RE.match(body.fleet_id):
+        raise HTTPException(status_code=422, detail="invalid fleet_id")
+
+    # FOR SHARE lock -- same locking contract as the Pi /build endpoint.
+    # Serialises against a concurrent ``DELETE /api/imager/fleets/{id}``.
+    fleet = await fleet_registry.get_fleet_for_build(db, body.fleet_id)
+    if fleet is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"fleet_id {body.fleet_id!r} is not configured on this CMS",
+        )
+    try:
+        secret = base64.b64decode(fleet.secret_b64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"fleet {body.fleet_id!r} has a misconfigured secret",
+        ) from exc
+
+    if settings.device_transport not in ("local", "wps"):
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"Softplayer credentials require AGORA_CMS_DEVICE_TRANSPORT to be "
+                f"'local' or 'wps'; this CMS is configured for "
+                f"{settings.device_transport!r}."
+            ),
+        )
+
+    cms_base = (settings.base_url or "").rstrip("/")
+    if not cms_base:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "AGORA_CMS_BASE_URL is not configured. Set it to the public URL "
+                "of this CMS (e.g. https://agora.example.com) -- softplayer "
+                "credentials embed it so the device can reach /ws/device and "
+                "/api/devices/register."
+            ),
+        )
+    try:
+        cms_url = _derive_device_ws_url(cms_base)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"AGORA_CMS_BASE_URL is invalid ({exc}); expected an absolute URL "
+                "like https://agora.example.com"
+            ),
+        ) from exc
+
+    payload = _fleet_env_payload(
+        cms_url,
+        body.fleet_id,
+        secret,
+        settings.device_transport,
+    )
+
+    await audit_log(
+        db,
+        user=user,
+        action="imager.softplayer_credentials.download",
+        resource_type="fleet",
+        resource_id=str(fleet.id),
+        # NEVER include the secret here. fleet_id alone is enough trace.
+        details={"fleet_id": body.fleet_id},
+        request=request,
+    )
+    await db.commit()
+
+    filename = f"softplayer-{body.fleet_id}.env"
+    return Response(
+        content=payload,
+        media_type="text/plain; charset=utf-8",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            # Caching makes no sense for a secret-bearing download.
+            "Cache-Control": "no-store",
+        },
     )
 
 

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -2,8 +2,8 @@
 {% block title %}Imager — Agora CMS{% endblock %}
 {% block content %}
 <div class="page-header">
-    <h2>Pi Image Provisioning</h2>
-    <span class="text-muted">Build pre-provisioned Raspberry Pi <code>.img.xz</code> files for fleet enrollment.</span>
+    <h2>Imager</h2>
+    <span class="text-muted">Provision new devices: build Raspberry Pi <code>.img.xz</code> images or generate Softplayer <code>.env</code> credentials.</span>
 </div>
 
 {% if not imager_can_build and not imager_can_manage %}
@@ -14,15 +14,33 @@
 </div>
 {% endif %}
 
+{% if imager_can_build or imager_can_manage %}
+{# ── Sub-tabs: Raspberry Pi / Softplayer / Fleets ──────────────── #}
+<div class="sub-tabs">
+    <button class="sub-tab active" type="button"
+            onclick="showUserTab('imager-pi-tab', this)">Raspberry Pi</button>
+    {% if imager_can_build %}
+    <button class="sub-tab" type="button"
+            onclick="showUserTab('imager-softplayer-tab', this)">Softplayer</button>
+    {% endif %}
+    {% if imager_can_manage %}
+    <button class="sub-tab" type="button"
+            onclick="showUserTab('imager-fleets-tab', this)">Fleets</button>
+    {% endif %}
+</div>
+
+{# ── Pi tab ────────────────────────────────────────────────────── #}
+{# Build .img.xz + Built images + Base image management.  These
+   sections share the "real Pi" mental model so they live behind
+   the same sub-tab; the Provision Softplayer card moves to its
+   own sub-tab below to keep this page from getting noisy. #}
+<div id="imager-pi-tab" class="tab-content active">
+{% endif %}
+
 {% if imager_can_build %}
 {# ── Build section ─────────────────────────────────────────────── #}
 <div class="card" data-imager-build style="margin-bottom:1rem;">
-    <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
-        <h3 style="margin-top:0;">Build Image</h3>
-        {% if imager_can_manage %}
-        <button id="imagerManageFleetsBtn" type="button" class="btn btn-secondary btn-sm">Manage fleets…</button>
-        {% endif %}
-    </div>
+    <h3 style="margin-top:0;">Build Image</h3>
     <p class="text-muted" style="margin-top:0;">
         Choose a fleet and base image, then build a pre-provisioned <code>.img.xz</code>
         ready to flash to an SD card. The output is available for download for
@@ -119,38 +137,10 @@
 </div>
 
 {# - Provision Softplayer section -------------------------------- #}
-{# Sibling tile to "Build Image": same fleet model, but the output is
-   a tiny .env file the operator drops next to agora-softplayer.exe
-   instead of a flashable .img.xz. See
-   ``cms/routers/imager.py::build_softplayer_credentials``. #}
-<div class="card" data-imager-softplayer style="margin-bottom:1rem;">
-    <h3 style="margin-top:0;">Provision Softplayer</h3>
-    <p class="text-muted" style="margin-top:0;">
-        Generate a <code>softplayer.env</code> file for the Windows-native
-        <code>agora-softplayer.exe</code>. Same fleet-HMAC identity as a Pi
-        build; just drop the downloaded file next to the <code>.exe</code>
-        (or under <code>%LOCALAPPDATA%\agora-softplayer\</code>) and run.
-    </p>
-    <form id="imagerSoftplayerForm" autocomplete="off">
-        <div class="form-row" style="gap:0.75rem; flex-wrap:wrap; align-items:flex-end;">
-            <div class="form-group" style="flex:1.4 1 220px; min-width:0; margin-bottom:0;">
-                <label for="imagerSoftplayerFleetSelect">Fleet</label>
-                <select id="imagerSoftplayerFleetSelect" name="fleet_id" required>
-                    <option value="">Loading…</option>
-                </select>
-            </div>
-            <div style="flex:0 0 auto;">
-                <button type="submit" id="imagerSoftplayerDownloadBtn" class="btn btn-primary">
-                    Download softplayer.env
-                </button>
-            </div>
-        </div>
-        <small class="text-muted" style="margin-top:0.5rem; display:inline-block;">
-            The file carries the fleet HMAC secret. Keep it private — anyone
-            with it can enroll a device into this fleet.
-        </small>
-    </form>
-</div>
+{# Moved into its own sub-tab below -- see ``imager-softplayer-tab``.
+   The card itself is rendered there. This comment is left as a
+   breadcrumb so a grep for "Provision Softplayer" still lands
+   somewhere useful. #}
 
 {# ── Built images list ─────────────────────────────────────────── #}
 <div class="card" data-imager-built style="margin-bottom:1rem;">
@@ -237,9 +227,80 @@
         </table>
     </div>
 </div>
+{% endif %}{# imager_can_manage : Base Images card #}
 
+{% if imager_can_build or imager_can_manage %}
+</div>{# /imager-pi-tab #}
+{% endif %}
 
+{% if imager_can_build %}
+{# ── Softplayer tab ────────────────────────────────────────────── #}
+{# The Windows-native ``agora-softplayer.exe`` is provisioned by
+   downloading a fleet-HMAC env file (the .env-file analogue of a
+   Pi .img.xz build). Same fleet identity, same auth flow, just no
+   flashable image. #}
+<div id="imager-softplayer-tab" class="tab-content">
+    <div class="card" data-imager-softplayer style="margin-bottom:1rem;">
+        <h3 style="margin-top:0;">Provision Softplayer</h3>
+        <p class="text-muted" style="margin-top:0;">
+            Generate a <code>softplayer.env</code> file for the Windows-native
+            <code>agora-softplayer.exe</code>. Same fleet-HMAC identity as a Pi
+            build; just drop the downloaded file next to the <code>.exe</code>
+            (or under <code>%LOCALAPPDATA%\agora-softplayer\</code>) and run.
+        </p>
+        <form id="imagerSoftplayerForm" autocomplete="off">
+            <div class="form-row" style="gap:0.75rem; flex-wrap:wrap; align-items:flex-end;">
+                <div class="form-group" style="flex:1.4 1 220px; min-width:0; margin-bottom:0;">
+                    <label for="imagerSoftplayerFleetSelect">Fleet</label>
+                    <select id="imagerSoftplayerFleetSelect" name="fleet_id" required>
+                        <option value="">Loading…</option>
+                    </select>
+                </div>
+                <div style="flex:0 0 auto;">
+                    <button type="submit" id="imagerSoftplayerDownloadBtn" class="btn btn-primary">
+                        Download softplayer.env
+                    </button>
+                </div>
+            </div>
+            <small class="text-muted" style="margin-top:0.5rem; display:inline-block;">
+                The file carries the fleet HMAC secret. Keep it private — anyone
+                with it can enroll a device into this fleet.
+            </small>
+        </form>
+    </div>
+</div>
+{% endif %}
 
+{% if imager_can_manage %}
+{# ── Fleets tab ────────────────────────────────────────────────── #}
+{# Fleets are a shared resource: both Pi builds and Softplayer
+   provisioning enroll into the same fleet. The dedicated tab is the
+   canonical place to create / list / delete them; the dropdown
+   sentinels (``+ Create new fleet…``) on the Pi build form and the
+   Softplayer card stay as in-context shortcuts. #}
+<div id="imager-fleets-tab" class="tab-content">
+    <div class="card" data-imager-fleets style="margin-bottom:1rem;">
+        <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
+            <h3 style="margin:0;">Fleets</h3>
+            <button id="imagerFleetsCreateBtn" type="button" class="btn btn-primary btn-sm">
+                + Create fleet…
+            </button>
+        </div>
+        <p class="text-muted" style="margin-top:0.5rem;">
+            Each fleet has its own HMAC secret. The secret is generated on
+            create and never displayed -- it is only baked into freshly-built
+            Pi images and freshly-downloaded Softplayer <code>.env</code> files.
+            Deleting a fleet revokes the credential for any device that
+            hasn't yet completed first-boot registration.
+        </p>
+        <div class="table-wrap" id="imagerFleetsBody">
+            <p class="empty-state text-muted">Loading…</p>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% if imager_can_manage %}
 {# ── Catalog modal ──────────────────────────────────────────────── #}
 <div id="imagerCatalogModal" class="modal-overlay" style="display:none;">
     <div class="modal-box" style="max-width:680px;">
@@ -257,24 +318,8 @@
     </div>
 </div>
 
-{# ── Manage fleets modal ───────────────────────────────────────── #}
-<div id="imagerFleetsModal" class="modal-overlay" style="display:none;">
-    <div class="modal-box" style="max-width:560px;">
-        <h3 style="margin-top:0;">Manage Fleets</h3>
-        <p class="text-muted" style="margin-top:0;">
-            Each fleet has its own HMAC secret. The secret is generated on
-            create and never displayed -- it is only baked into freshly-built
-            images. Deleting a fleet revokes the credential for any Pi that
-            hasn't yet completed first-boot registration.
-        </p>
-        <div id="imagerFleetsBody" style="max-height:60vh; overflow:auto;">
-            <p class="empty-state text-muted">Loading…</p>
-        </div>
-        <div class="modal-actions">
-            <button type="button" class="btn btn-secondary" id="imagerFleetsCloseBtn">Close</button>
-        </div>
-    </div>
-</div>
+{# Manage Fleets modal removed -- the Fleets sub-tab above is the
+   canonical surface for creating / listing / deleting fleets. #}
 {% endif %}
 
 {% endblock %}
@@ -357,6 +402,7 @@
     var buildSection = $('[data-imager-build]');
     var softplayerSection = $('[data-imager-softplayer]');
     var manageSection = $('[data-imager-manage]');
+    var fleetsSection = $('[data-imager-fleets]');
 
     var fleetsCache = [];
     var basesCache = [];
@@ -392,9 +438,12 @@
                 fleetSel.innerHTML += '<option value="__create__">+ Create new fleet…</option>';
             }
 
-            // Mirror the fleet list (without the create-sentinel) into
-            // the Provision Softplayer card so both tiles share one
-            // fleet dropdown source-of-truth.
+            // Mirror the fleet list into the Provision Softplayer card
+            // so both tiles share one fleet dropdown source-of-truth.
+            // The same ``+ Create new fleet…`` sentinel is shown when
+            // the user has manage permission; the change handler in
+            // the wire-up block intercepts it identically to the build
+            // dropdown.
             if (softplayerSection) {
                 var spSel = $('#imagerSoftplayerFleetSelect', softplayerSection);
                 if (spSel) {
@@ -405,6 +454,9 @@
                             fleetsCache.map(function(f) {
                                 return '<option value="' + escHtml(f.fleet_id) + '">' + escHtml(f.fleet_id) + '</option>';
                             }).join('');
+                    }
+                    if (canManage) {
+                        spSel.innerHTML += '<option value="__create__">+ Create new fleet…</option>';
                     }
                 }
             }
@@ -886,7 +938,8 @@
     // POST /api/imager/softplayer-credentials returns a text/plain body
     // with Content-Disposition: attachment.  Use fetch+blob so the
     // browser saves the response with the server-suggested filename
-    // (softplayer-<fleet>.env) and an XHR error surfaces as a toast
+    // (softplayer.env -- the canonical name the loader picks up from
+    // its default search paths) and an XHR error surfaces as a toast
     // rather than a half-rendered text page.
     async function submitSoftplayerCredentials(ev) {
         ev.preventDefault();
@@ -915,11 +968,11 @@
             }
             var blob = await resp.blob();
             // Pull the suggested filename out of Content-Disposition so
-            // the operator gets softplayer-<fleet>.env instead of the
-            // anchor's plain href fallback.
+            // the operator gets softplayer.env (the loader's canonical
+            // default name) instead of the anchor's plain href fallback.
             var cd = resp.headers.get('content-disposition') || '';
             var match = cd.match(/filename\s*=\s*"?([^";]+)"?/i);
-            var filename = (match && match[1]) || ('softplayer-' + fleetId + '.env');
+            var filename = (match && match[1]) || 'softplayer.env';
 
             var url = URL.createObjectURL(blob);
             var a = document.createElement('a');
@@ -937,21 +990,25 @@
         }
     }
 
-    // ── Fleet create / manage modals ───────────────────────────
+    // ── Fleet create / manage ──────────────────────────────────
     var lastFleetSelectValue = '';
+    var lastSpFleetSelectValue = '';
 
-    async function handleFleetCreateSentinel(sel) {
+    async function handleFleetCreateSentinel(sel, options) {
         // Triggered when the operator picks "+ Create new fleet…" in
-        // the build form's fleet select. Prompts for an id, POSTs to
-        // /api/imager/fleets, then refreshes the dropdown and
-        // re-selects the new id.  Falls back to the previously-selected
-        // value on cancel/error so the form isn't stuck on the sentinel.
+        // the build form's fleet select OR the softplayer card's
+        // fleet select. Prompts for an id, POSTs to /api/imager/fleets,
+        // then refreshes both dropdowns + the Fleets panel and
+        // re-selects the new id in the dropdown that triggered.
+        // Falls back to the previously-selected value on cancel/error.
+        options = options || {};
+        var prevValue = options.prevValue || '';
+        var afterFill = options.afterFill || function() {};
         var newId = await showPrompt(
             'Enter a fleet ID (letters, digits, dot, underscore, dash; 1-64 chars).',
             ''
         );
-        // Always restore the previous value first; we'll overwrite if create succeeds.
-        sel.value = lastFleetSelectValue || '';
+        sel.value = prevValue;
         if (newId === null) return;
         var trimmed = String(newId).trim();
         if (!trimmed) { toast('Fleet ID cannot be empty', 'error'); return; }
@@ -967,13 +1024,9 @@
             });
             toast('Fleet "' + trimmed + '" created', 'success');
             await loadFleetsAndBases();
-            // Re-select the freshly-created fleet so the form is ready.
-            var sel2 = $('#imagerFleetSelect', buildSection);
-            if (sel2) {
-                sel2.value = trimmed;
-                lastFleetSelectValue = trimmed;
-                autoFillName();
-            }
+            if (fleetsSection) loadFleetsPanel();
+            sel.value = trimmed;
+            afterFill(trimmed);
         } catch (e) {
             if (e.status === 409) {
                 toast('Fleet "' + trimmed + '" already exists', 'error');
@@ -983,32 +1036,59 @@
         }
     }
 
-    async function openManageFleetsModal() {
-        var modal = $('#imagerFleetsModal');
+    async function promptAndCreateFleet() {
+        // Standalone create-fleet entry point for the Fleets sub-tab's
+        // "+ Create fleet…" button. Same validation + POST + refresh
+        // pipeline as the dropdown sentinel, minus the dropdown-revert
+        // and re-select bookkeeping.
+        var newId = await showPrompt(
+            'Enter a fleet ID (letters, digits, dot, underscore, dash; 1-64 chars).',
+            ''
+        );
+        if (newId === null) return;
+        var trimmed = String(newId).trim();
+        if (!trimmed) { toast('Fleet ID cannot be empty', 'error'); return; }
+        if (!/^[A-Za-z0-9._-]{1,64}$/.test(trimmed)) {
+            toast('Invalid fleet ID -- use letters, digits, dot, underscore, dash', 'error');
+            return;
+        }
+        try {
+            await jsonFetch('/api/imager/fleets', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ fleet_id: trimmed }),
+            });
+            toast('Fleet "' + trimmed + '" created', 'success');
+            await loadFleetsAndBases();
+            await loadFleetsPanel();
+        } catch (e) {
+            if (e.status === 409) {
+                toast('Fleet "' + trimmed + '" already exists', 'error');
+            } else {
+                toast('Create failed: ' + (e.message || e), 'error');
+            }
+        }
+    }
+
+    async function loadFleetsPanel() {
         var body = $('#imagerFleetsBody');
-        if (!modal || !body) return;
+        if (!body) return;
         body.innerHTML = '<p class="empty-state text-muted">Loading…</p>';
-        modal.style.display = '';
         try {
             var fleets = await jsonFetch('/api/imager/fleets');
-            renderFleetsModalBody(fleets || []);
+            renderFleetsPanel(fleets || []);
         } catch (e) {
             body.innerHTML = '<p class="empty-state text-muted">Failed to load: ' +
                 escHtml(e.message || e) + '</p>';
         }
     }
 
-    function closeManageFleetsModal() {
-        var modal = $('#imagerFleetsModal');
-        if (modal) modal.style.display = 'none';
-    }
-
-    function renderFleetsModalBody(fleets) {
+    function renderFleetsPanel(fleets) {
         var body = $('#imagerFleetsBody');
         if (!body) return;
         if (fleets.length === 0) {
-            body.innerHTML = '<p class="empty-state text-muted">No fleets configured. ' +
-                'Pick "+ Create new fleet…" in the Build form to add one.</p>';
+            body.innerHTML = '<p class="empty-state text-muted">' +
+                'No fleets configured. Click "+ Create fleet…" above to add one.</p>';
             return;
         }
         body.innerHTML = '<table style="width:100%;">' +
@@ -1033,9 +1113,10 @@
     async function deleteFleet(fleetId) {
         var ok = await showConfirm(
             'Delete fleet "' + fleetId + '"?\n\n' +
-            'This revokes the HMAC secret. Pis already flashed with this ' +
-            "fleet that haven't yet completed first-boot registration will " +
-            'fail to register. Already-registered Pis are unaffected.'
+            'This revokes the HMAC secret. Any device (Pi or Softplayer) ' +
+            'flashed/provisioned with this fleet that has not yet completed ' +
+            'first-boot registration will fail to register. Already-registered ' +
+            'devices are unaffected.'
         );
         if (!ok) return;
         try {
@@ -1043,8 +1124,7 @@
                 method: 'DELETE',
             });
             toast('Deleted fleet "' + fleetId + '"', 'success');
-            // Refresh modal AND build form fleet dropdown.
-            await openManageFleetsModal();
+            await loadFleetsPanel();
             loadFleetsAndBases();
         } catch (e) {
             toast('Delete failed: ' + (e.message || e), 'error');
@@ -1419,7 +1499,13 @@
             // running the auto-fill / form-state logic, so the form
             // never carries the placeholder value forward.
             if (fleetSelEl.value === '__create__') {
-                handleFleetCreateSentinel(fleetSelEl);
+                handleFleetCreateSentinel(fleetSelEl, {
+                    prevValue: lastFleetSelectValue,
+                    afterFill: function(newId) {
+                        lastFleetSelectValue = newId;
+                        autoFillName();
+                    },
+                });
                 return;
             }
             lastFleetSelectValue = fleetSelEl.value;
@@ -1439,17 +1525,7 @@
             });
         }
 
-        // Manage Fleets modal (admin only).
-        var mgrBtn = $('#imagerManageFleetsBtn');
-        if (mgrBtn) mgrBtn.addEventListener('click', openManageFleetsModal);
-        var mgrClose = $('#imagerFleetsCloseBtn');
-        if (mgrClose) mgrClose.addEventListener('click', closeManageFleetsModal);
-        var mgrModal = $('#imagerFleetsModal');
-        if (mgrModal) {
-            mgrModal.addEventListener('click', function(e) {
-                if (e.target === mgrModal) closeManageFleetsModal();
-            });
-        }
+        // Manage Fleets modal removed -- the Fleets sub-tab handles it.
 
         loadFleetsAndBases();
         // Resume any in-flight job from a prior page load.
@@ -1460,6 +1536,27 @@
     if (softplayerSection) {
         var spForm = $('#imagerSoftplayerForm', softplayerSection);
         if (spForm) spForm.addEventListener('submit', submitSoftplayerCredentials);
+        var spSelEl = $('#imagerSoftplayerFleetSelect', softplayerSection);
+        if (spSelEl) {
+            spSelEl.addEventListener('change', function() {
+                if (spSelEl.value === '__create__') {
+                    handleFleetCreateSentinel(spSelEl, {
+                        prevValue: lastSpFleetSelectValue,
+                        afterFill: function(newId) {
+                            lastSpFleetSelectValue = newId;
+                        },
+                    });
+                    return;
+                }
+                lastSpFleetSelectValue = spSelEl.value;
+            });
+        }
+    }
+
+    if (fleetsSection) {
+        var createBtn = $('#imagerFleetsCreateBtn', fleetsSection);
+        if (createBtn) createBtn.addEventListener('click', promptAndCreateFleet);
+        loadFleetsPanel();
     }
 
     if (manageSection) {

--- a/cms/templates/imager.html
+++ b/cms/templates/imager.html
@@ -118,6 +118,40 @@
     </div>
 </div>
 
+{# - Provision Softplayer section -------------------------------- #}
+{# Sibling tile to "Build Image": same fleet model, but the output is
+   a tiny .env file the operator drops next to agora-softplayer.exe
+   instead of a flashable .img.xz. See
+   ``cms/routers/imager.py::build_softplayer_credentials``. #}
+<div class="card" data-imager-softplayer style="margin-bottom:1rem;">
+    <h3 style="margin-top:0;">Provision Softplayer</h3>
+    <p class="text-muted" style="margin-top:0;">
+        Generate a <code>softplayer.env</code> file for the Windows-native
+        <code>agora-softplayer.exe</code>. Same fleet-HMAC identity as a Pi
+        build; just drop the downloaded file next to the <code>.exe</code>
+        (or under <code>%LOCALAPPDATA%\agora-softplayer\</code>) and run.
+    </p>
+    <form id="imagerSoftplayerForm" autocomplete="off">
+        <div class="form-row" style="gap:0.75rem; flex-wrap:wrap; align-items:flex-end;">
+            <div class="form-group" style="flex:1.4 1 220px; min-width:0; margin-bottom:0;">
+                <label for="imagerSoftplayerFleetSelect">Fleet</label>
+                <select id="imagerSoftplayerFleetSelect" name="fleet_id" required>
+                    <option value="">Loading…</option>
+                </select>
+            </div>
+            <div style="flex:0 0 auto;">
+                <button type="submit" id="imagerSoftplayerDownloadBtn" class="btn btn-primary">
+                    Download softplayer.env
+                </button>
+            </div>
+        </div>
+        <small class="text-muted" style="margin-top:0.5rem; display:inline-block;">
+            The file carries the fleet HMAC secret. Keep it private — anyone
+            with it can enroll a device into this fleet.
+        </small>
+    </form>
+</div>
+
 {# ── Built images list ─────────────────────────────────────────── #}
 <div class="card" data-imager-built style="margin-bottom:1rem;">
     <h3 style="margin:0 0 0.5rem 0;">Built Images</h3>
@@ -321,6 +355,7 @@
 
     // ── Build section ─────────────────────────────────────────
     var buildSection = $('[data-imager-build]');
+    var softplayerSection = $('[data-imager-softplayer]');
     var manageSection = $('[data-imager-manage]');
 
     var fleetsCache = [];
@@ -355,6 +390,23 @@
             // -- the sentinel is never submitted.
             if (canManage) {
                 fleetSel.innerHTML += '<option value="__create__">+ Create new fleet…</option>';
+            }
+
+            // Mirror the fleet list (without the create-sentinel) into
+            // the Provision Softplayer card so both tiles share one
+            // fleet dropdown source-of-truth.
+            if (softplayerSection) {
+                var spSel = $('#imagerSoftplayerFleetSelect', softplayerSection);
+                if (spSel) {
+                    if (fleetsCache.length === 0) {
+                        spSel.innerHTML = '<option value="">No fleets configured</option>';
+                    } else {
+                        spSel.innerHTML = '<option value="">Select fleet…</option>' +
+                            fleetsCache.map(function(f) {
+                                return '<option value="' + escHtml(f.fleet_id) + '">' + escHtml(f.fleet_id) + '</option>';
+                            }).join('');
+                    }
+                }
             }
 
             baseSel.innerHTML = '';
@@ -825,6 +877,61 @@
             toast('Build failed to start: ' + (e.message || e), 'error');
             // Refresh in case base list changed (e.g. deleted in another tab).
             loadFleetsAndBases();
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    // ── Provision Softplayer ───────────────────────────────────
+    // POST /api/imager/softplayer-credentials returns a text/plain body
+    // with Content-Disposition: attachment.  Use fetch+blob so the
+    // browser saves the response with the server-suggested filename
+    // (softplayer-<fleet>.env) and an XHR error surfaces as a toast
+    // rather than a half-rendered text page.
+    async function submitSoftplayerCredentials(ev) {
+        ev.preventDefault();
+        if (!softplayerSection) return;
+        var btn = $('#imagerSoftplayerDownloadBtn', softplayerSection);
+        var sel = $('#imagerSoftplayerFleetSelect', softplayerSection);
+        var fleetId = sel ? sel.value : '';
+        if (!fleetId) {
+            toast('Pick a fleet', 'error');
+            return;
+        }
+        btn.disabled = true;
+        try {
+            var resp = await fetch('/api/imager/softplayer-credentials', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ fleet_id: fleetId }),
+            });
+            if (!resp.ok) {
+                var ct = resp.headers.get('content-type') || '';
+                var detail = ct.indexOf('application/json') >= 0
+                    ? ((await resp.json()).detail || resp.statusText)
+                    : (await resp.text() || resp.statusText);
+                throw new Error(detail);
+            }
+            var blob = await resp.blob();
+            // Pull the suggested filename out of Content-Disposition so
+            // the operator gets softplayer-<fleet>.env instead of the
+            // anchor's plain href fallback.
+            var cd = resp.headers.get('content-disposition') || '';
+            var match = cd.match(/filename\s*=\s*"?([^";]+)"?/i);
+            var filename = (match && match[1]) || ('softplayer-' + fleetId + '.env');
+
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            toast('Downloaded ' + filename, 'success');
+        } catch (e) {
+            toast('Download failed: ' + (e.message || e), 'error');
         } finally {
             btn.disabled = false;
         }
@@ -1348,6 +1455,11 @@
         // Resume any in-flight job from a prior page load.
         var resumeId = loadActiveJob();
         if (resumeId) startPolling(resumeId);
+    }
+
+    if (softplayerSection) {
+        var spForm = $('#imagerSoftplayerForm', softplayerSection);
+        if (spForm) spForm.addEventListener('submit', submitSoftplayerCredentials);
     }
 
     if (manageSection) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Agora CMS
   description: Central management system for Agora media playback devices
-  version: 1.37.232
+  version: 1.37.233
 paths:
   /api/devices/register:
     post:
@@ -2975,6 +2975,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/imager/softplayer-credentials:
+    post:
+      summary: Build Softplayer Credentials
+      description: |-
+        Render and return the ``softplayer.env`` body for a given fleet.
+
+        The Windows-native ``agora-softplayer`` is bootstrap-v2-only: it
+        authenticates to the CMS via the same fleet-HMAC pairing flow Pis
+        use in production. Operators provision a softplayer by downloading
+        this env file from the Imager tab and dropping it next to the .exe
+        (or under ``%LOCALAPPDATA%\agora-softplayer\``).
+
+        The output mirrors :func:`_fleet_env_payload`'s ``agora-fleet.env``
+        body baked into Pi images -- same keys, same ``AGORA_FLEET_SECRET_HEX``
+        encoding -- just delivered as a downloadable text file instead of
+        inside an ``.img.xz``. The softplayer CLI consumes the same
+        ``KEY=VALUE`` format.
+
+        Validates that:
+
+        * ``fleet_id`` matches ``_FLEET_ID_RE`` and is configured on this CMS
+          (resolves to a secret).
+        * ``settings.device_transport`` is ``local`` or ``wps``.
+        * ``settings.base_url`` is set (the firmware needs an absolute URL).
+
+        Audited via ``imager.softplayer_credentials.download``. No
+        ``ProvisionedImage`` row is written -- the env file is ephemeral and
+        regeneratable from the fleet at any time; revoking access means
+        deleting the fleet (which invalidates the HMAC for every previously
+        downloaded file).
+      operationId: build_softplayer_credentials_api_imager_softplayer_credentials_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SoftplayerCredentialsBody'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/imager/provisioned-images:
     get:
       summary: List Provisioned Images
@@ -5108,6 +5157,23 @@ components:
       required:
       - password
       title: SetPasswordRequest
+    SoftplayerCredentialsBody:
+      properties:
+        fleet_id:
+          type: string
+          maxLength: 64
+          minLength: 1
+          title: Fleet Id
+      type: object
+      required:
+      - fleet_id
+      title: SoftplayerCredentialsBody
+      description: |-
+        Request body for ``POST /api/imager/softplayer-credentials``.
+
+        Just a fleet id -- the softplayer is the .env-file analogue of the Pi
+        .img.xz build, so there's no base image, output filename, or wifi to
+        plumb through.
     ToggleRequest:
       properties:
         enabled:

--- a/local-broker/README.md
+++ b/local-broker/README.md
@@ -40,14 +40,20 @@ GET   /health
 GET   /_debug/users           (dev only — broker is on private net)
 ```
 
-`send` body:
+`send` body matches the **real Azure Web PubSub REST contract**: the
+request body IS the payload, and the `Content-Type` header selects the
+WS frame type:
 
-```json
-{ "data": { ... }, "dataType": "json" }
-```
+| Content-Type                | WS frame delivered                  |
+|-----------------------------|-------------------------------------|
+| `application/json`          | text frame containing the JSON body |
+| `text/plain`                | text frame containing the raw body  |
+| `application/octet-stream`  | binary frame containing the bytes   |
+| (unset / unknown)           | text frame containing the raw body  |
 
-Supported `dataType`: `json`, `text`, `binary` (all delivered as a WS
-text frame today — Pi client doesn't speak binary).
+This matches what the Azure SDK does — `send_to_user(user, payload,
+content_type="application/json")` POSTs the serialized payload as the
+raw body, never a `{data, dataType}` wrapper.
 
 Auth on every `/api/...` route: `Authorization: Bearer <jwt>` where the
 JWT is HS256-signed with `WPS_ACCESS_KEY`. `aud` must start with the

--- a/local-broker/broker.py
+++ b/local-broker/broker.py
@@ -77,7 +77,6 @@ from typing import Any
 import httpx
 import jwt
 from fastapi import (
-    Body,
     FastAPI,
     Header,
     HTTPException,
@@ -87,7 +86,6 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
 logger = logging.getLogger("agora.broker")
 
@@ -170,14 +168,26 @@ class ConnectionRegistry:
 # --------------------------------------------------------------------- auth
 
 
-def _verify_jwt(token: str, *, expected_aud_prefix: str | None = None) -> dict[str, Any]:
+def _verify_jwt(
+    token: str,
+    *,
+    expected_aud_prefix: str | None = None,
+    require_sub: bool = True,
+) -> dict[str, Any]:
     """Verify an HS256 JWT against ACCESS_KEY.  Returns claims on success.
 
     Raises ``jwt.InvalidTokenError`` subclasses on failure.
+
+    ``require_sub`` defaults True (client JWTs identify a device via
+    ``sub``); server JWTs minted by the Azure SDK don't carry ``sub``,
+    so the REST-auth path passes ``require_sub=False``.
     """
     # We check `aud` manually below (prefix match, not exact) — disable
     # PyJWT's exact-audience verification.
-    options = {"require": ["sub", "exp"], "verify_aud": False}
+    required = ["exp"]
+    if require_sub:
+        required.append("sub")
+    options = {"require": required, "verify_aud": False}
     claims = jwt.decode(
         token,
         ACCESS_KEY,
@@ -283,6 +293,7 @@ async def _post_webhook(
     }
     if event_name:
         headers["ce-eventName"] = event_name
+    logger.debug("_post_webhook enter type=%s conn=%s user=%s", event_type, connection_id, user_id)
     try:
         r = await client.post(UPSTREAM_URL, content=raw_body, headers=headers, timeout=UPSTREAM_TIMEOUT_S)
         if r.status_code >= 400:
@@ -290,22 +301,17 @@ async def _post_webhook(
                 "Upstream webhook %s -> %s failed: %s",
                 event_type, UPSTREAM_URL, r.status_code,
             )
+        else:
+            logger.debug(
+                "_post_webhook done type=%s status=%s", event_type, r.status_code,
+            )
     except httpx.HTTPError:
         logger.exception("Upstream webhook %s -> %s errored", event_type, UPSTREAM_URL)
+    except Exception:
+        logger.exception("_post_webhook unexpected error type=%s", event_type)
 
 
 # --------------------------------------------------------------------- app
-
-
-class SendPayload(BaseModel):
-    """WPS user-send body.
-
-    Matches the Azure REST shape:
-        {"data": ..., "dataType": "json"|"text"}
-    """
-
-    data: Any
-    dataType: str = Field(default="json", pattern="^(json|text|binary)$")
 
 
 def create_app() -> FastAPI:
@@ -349,7 +355,11 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=401, detail="missing bearer token")
         token = authorization.split(" ", 1)[1].strip()
         try:
-            return _verify_jwt(token, expected_aud_prefix=aud_prefix)
+            return _verify_jwt(
+                token,
+                expected_aud_prefix=aud_prefix,
+                require_sub=False,
+            )
         except jwt.InvalidTokenError as e:
             raise HTTPException(status_code=401, detail=f"invalid token: {e}") from e
 
@@ -358,8 +368,8 @@ def create_app() -> FastAPI:
         hub: str,
         user_id: str,
         request: Request,
-        payload: SendPayload = Body(...),
         authorization: str | None = Header(default=None),
+        content_type: str | None = Header(default=None),
     ) -> JSONResponse:
         # WPS server-JWT audience is the REST URI root for the hub.
         _require_bearer(
@@ -367,29 +377,40 @@ def create_app() -> FastAPI:
             aud_prefix=str(request.url.replace(query="", fragment="")).split(":send", 1)[0],
         )
 
+        # Match real Azure Web PubSub REST contract: the request body IS
+        # the payload; `Content-Type` selects the WS frame type.  The
+        # Azure SDK (``WebPubSubServiceClient.send_to_user``) sends the
+        # serialized payload as the raw body, never a ``{data, dataType}``
+        # wrapper — wrapping was a local-broker historical mistake.
+        raw_body = await request.body()
+        ct = (content_type or "").split(";", 1)[0].strip().lower()
+
+        if ct == "application/octet-stream":
+            frame_bytes: bytes = raw_body
+            frame_text: str | None = None
+        elif ct == "text/plain":
+            frame_bytes = b""
+            frame_text = raw_body.decode("utf-8", errors="replace")
+        else:
+            # Default + ``application/json``: deliver the body as a text
+            # frame.  For JSON the body is already a UTF-8-encoded JSON
+            # string; for unknown/missing Content-Type Azure WPS treats
+            # the payload as text/JSON.
+            frame_bytes = b""
+            frame_text = raw_body.decode("utf-8", errors="replace")
+
         conns = registry.connections_for_user(user_id)
         if not conns:
             # WPS returns 404 when user has no active connections.
             return JSONResponse(status_code=404, content={"error": "user not connected"})
 
-        # Shape we hand to the client follows WPS dataType semantics.
-        if payload.dataType == "json":
-            # WS text frame with JSON.  If data is already a dict, serialize.
-            text = json.dumps(payload.data) if not isinstance(payload.data, str) else payload.data
-            send_text = True
-        elif payload.dataType == "text":
-            text = payload.data if isinstance(payload.data, str) else json.dumps(payload.data)
-            send_text = True
-        else:  # binary
-            # Devices today only speak JSON; accept but coerce for parity.
-            text = payload.data if isinstance(payload.data, str) else json.dumps(payload.data)
-            send_text = True
-
         delivered = 0
         for conn in conns:
             try:
-                if send_text:
-                    await conn.ws.send_text(text)
+                if frame_text is not None:
+                    await conn.ws.send_text(frame_text)
+                else:
+                    await conn.ws.send_bytes(frame_bytes)
                 delivered += 1
             except Exception:
                 logger.exception(

--- a/local-broker/tests/test_broker.py
+++ b/local-broker/tests/test_broker.py
@@ -118,7 +118,8 @@ class TestRestAuth:
         async with _client(app) as c:
             r = await c.post(
                 "/api/hubs/agora/users/pi-1/:send",
-                json={"data": {"hello": "world"}, "dataType": "json"},
+                content=json.dumps({"hello": "world"}),
+                headers={"content-type": "application/json"},
             )
             assert r.status_code == 401
 
@@ -127,8 +128,11 @@ class TestRestAuth:
         async with _client(app) as c:
             r = await c.post(
                 "/api/hubs/agora/users/pi-1/:send",
-                json={"data": "x", "dataType": "text"},
-                headers={"authorization": "Bearer not.a.jwt"},
+                content="x",
+                headers={
+                    "authorization": "Bearer not.a.jwt",
+                    "content-type": "text/plain",
+                },
             )
             assert r.status_code == 401
 
@@ -139,8 +143,11 @@ class TestRestAuth:
         async with _client(app) as c:
             r = await c.post(
                 "/api/hubs/agora/users/pi-ghost/:send",
-                json={"data": "x", "dataType": "text"},
-                headers={"authorization": f"Bearer {token}"},
+                content="x",
+                headers={
+                    "authorization": f"Bearer {token}",
+                    "content-type": "text/plain",
+                },
             )
             assert r.status_code == 404
 
@@ -256,8 +263,11 @@ class TestWssLoopback:
                 async with _client_base(port) as c:
                     r = await c.post(
                         "/api/hubs/agora/users/pi-loop/:send",
-                        json={"data": {"cmd": "PING"}, "dataType": "json"},
-                        headers={"authorization": f"Bearer {server_token}"},
+                        content=json.dumps({"cmd": "PING"}),
+                        headers={
+                            "authorization": f"Bearer {server_token}",
+                            "content-type": "application/json",
+                        },
                     )
                     assert r.status_code == 202, r.text
                     assert r.json()["delivered"] == 1

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -1158,7 +1158,7 @@ async def test_softplayer_credentials_returns_text_with_env_body(
 
     cd = resp.headers.get("content-disposition", "")
     assert "attachment" in cd
-    assert 'filename="softplayer-fleet-test.env"' in cd
+    assert 'filename="softplayer.env"' in cd
 
     # No caching -- the body carries a secret.
     assert resp.headers.get("cache-control") == "no-store"

--- a/tests/test_imager_api.py
+++ b/tests/test_imager_api.py
@@ -172,6 +172,7 @@ async def test_endpoints_require_auth(unauthed_client):
         ("POST", "/api/imager/base-images"),
         ("DELETE", f"/api/imager/base-images/{uuid.uuid4()}"),
         ("POST", "/api/imager/build"),
+        ("POST", "/api/imager/softplayer-credentials"),
         ("GET", "/api/imager/provisioned-images"),
         ("DELETE", f"/api/imager/provisioned-images/{uuid.uuid4()}"),
         ("GET", f"/api/imager/jobs/{uuid.uuid4()}"),
@@ -216,6 +217,7 @@ async def test_operator_denied_all_imager_endpoints(app, db_session, imager_sett
             ("GET", "/api/imager/catalog"),
             ("POST", "/api/imager/base-images"),
             ("POST", "/api/imager/build"),
+            ("POST", "/api/imager/softplayer-credentials"),
             ("GET", "/api/imager/provisioned-images"),
         ]:
             kwargs = {"json": {}} if method == "POST" else {}
@@ -1134,6 +1136,185 @@ async def test_import_writes_audit_row(client, db_session, patch_catalog_ok):
         select(AuditLog).where(AuditLog.action == "imager.base_image.import")
     )).scalars().all()
     assert len(rows) == 1
+
+
+# ── Softplayer credentials endpoint ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_returns_text_with_env_body(
+    client, db_session, imager_settings
+):
+    """Happy path: text/plain attachment with the full AGORA_* set."""
+    resp = await client.post(
+        "/api/imager/softplayer-credentials",
+        json={"fleet_id": "fleet-test"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    ct = resp.headers.get("content-type", "")
+    assert ct.startswith("text/plain")
+    assert "charset=utf-8" in ct.lower()
+
+    cd = resp.headers.get("content-disposition", "")
+    assert "attachment" in cd
+    assert 'filename="softplayer-fleet-test.env"' in cd
+
+    # No caching -- the body carries a secret.
+    assert resp.headers.get("cache-control") == "no-store"
+
+    body = resp.text
+    # Matches the Pi build's env file body verbatim (same _fleet_env_payload).
+    assert "AGORA_CMS_URL=wss://cms.example.com/ws/device" in body
+    assert "AGORA_CMS_TRANSPORT=direct" in body
+    assert "AGORA_FLEET_ID=fleet-test" in body
+    # Stored secret is base64 of b"secret-base64" -> hex of those bytes.
+    assert "AGORA_FLEET_SECRET_HEX=7365637265742d626173653634" in body
+    # WiFi keys MUST NOT appear -- softplayer is wifi-irrelevant.
+    assert "AGORA_WIFI_SSID" not in body
+    assert "AGORA_WIFI_PASS" not in body
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_wps_transport_baked(
+    client, db_session, imager_settings
+):
+    """A WPS-configured CMS bakes AGORA_CMS_TRANSPORT=wps."""
+    saved_transport = imager_settings.device_transport
+    try:
+        imager_settings.device_transport = "wps"
+        resp = await client.post(
+            "/api/imager/softplayer-credentials",
+            json={"fleet_id": "fleet-test"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert "AGORA_CMS_TRANSPORT=wps" in resp.text
+    finally:
+        imager_settings.device_transport = saved_transport
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_404_when_fleet_unknown(
+    client, db_session, imager_settings
+):
+    resp = await client.post(
+        "/api/imager/softplayer-credentials",
+        json={"fleet_id": "no-such-fleet"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_404_when_fleet_soft_deleted(
+    client, db_session, imager_settings
+):
+    """Soft-deleted fleets must not produce downloadable credentials."""
+    from cms.services import fleet_registry
+
+    await fleet_registry.delete_fleet(db_session, "fleet-test")
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/imager/softplayer-credentials",
+        json={"fleet_id": "fleet-test"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_422_on_invalid_fleet_id(
+    client, imager_settings
+):
+    """Schema layer rejects fleet_ids that don't match _FLEET_ID_RE."""
+    # Pydantic min/max passes (1 char, <=64), but the regex on the
+    # endpoint must catch the slash. (Slash is path-injection-relevant.)
+    resp = await client.post(
+        "/api/imager/softplayer-credentials",
+        json={"fleet_id": "bad/id"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_503_when_base_url_missing(
+    client, db_session, imager_settings
+):
+    """Without AGORA_CMS_BASE_URL there's no CMS URL to embed."""
+    saved_base_url = imager_settings.base_url
+    try:
+        imager_settings.base_url = None
+        resp = await client.post(
+            "/api/imager/softplayer-credentials",
+            json={"fleet_id": "fleet-test"},
+        )
+        assert resp.status_code == 503, resp.text
+        assert "AGORA_CMS_BASE_URL" in resp.text
+    finally:
+        imager_settings.base_url = saved_base_url
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_503_when_device_transport_invalid(
+    client, db_session, imager_settings
+):
+    """Anything other than local/wps should refuse cleanly."""
+    saved_transport = imager_settings.device_transport
+    try:
+        imager_settings.device_transport = "carrier-pigeon"
+        resp = await client.post(
+            "/api/imager/softplayer-credentials",
+            json={"fleet_id": "fleet-test"},
+        )
+        assert resp.status_code == 503, resp.text
+        assert "carrier-pigeon" in resp.json()["detail"]
+    finally:
+        imager_settings.device_transport = saved_transport
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_writes_audit_row_without_secret(
+    client, db_session, imager_settings
+):
+    from cms.models.audit_log import AuditLog
+
+    resp = await client.post(
+        "/api/imager/softplayer-credentials",
+        json={"fleet_id": "fleet-test"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = (await db_session.execute(
+        select(AuditLog).where(
+            AuditLog.action == "imager.softplayer_credentials.download"
+        )
+    )).scalars().all()
+    assert len(rows) == 1
+    details = rows[0].details or {}
+    assert details.get("fleet_id") == "fleet-test"
+    # Sanity: neither the b64 secret nor its hex form leak into the
+    # audit row. (Encoded versions of the b"secret-base64" fixture.)
+    serialized = str(details)
+    assert "c2VjcmV0LWJhc2U2NA==" not in serialized
+    assert "7365637265742d626173653634" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_softplayer_credentials_two_downloads_same_fleet_match(
+    client, db_session, imager_settings
+):
+    """The endpoint is stateless wrt the fleet: same secret on every download.
+
+    Future rotation work (delete-and-recreate) is the only way to
+    invalidate the HMAC.
+    """
+    r1 = await client.post(
+        "/api/imager/softplayer-credentials", json={"fleet_id": "fleet-test"}
+    )
+    r2 = await client.post(
+        "/api/imager/softplayer-credentials", json={"fleet_id": "fleet-test"}
+    )
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.text == r2.text
 
 
 # ── _derive_device_ws_url unit tests ──────────────────────────────

--- a/tests/test_imager_ui.py
+++ b/tests/test_imager_ui.py
@@ -21,7 +21,7 @@ async def test_admin_sees_full_page(client):
     resp = await client.get("/imager")
     assert resp.status_code == 200
     html = resp.text
-    assert "Pi Image Provisioning" in html
+    assert "<h2>Imager</h2>" in html
     assert '<h3 style="margin-top:0;">Build Image</h3>' in html
     assert '<h3 style="margin:0;">Base Images</h3>' in html
     # Catalog modal markup is admin-only.


### PR DESCRIPTION
**DO NOT MERGE** until the end-to-end smoke validates this against the
docker stack alongside sslivins/agora-softplayer#1.

## What

Adds the CMS half of the softplayer fleet-auth pivot:

1. **`POST /api/imager/softplayer-credentials`** -- renders the
   `agora-fleet.env` body (same `_fleet_env_payload` helper Pi
   builds use) and returns it as a text/plain attachment named
   `softplayer-<fleet>.env`. No `ProvisionedImage` row is written;
   the file is ephemeral and regeneratable from the fleet at any
   time. Audited as `imager.softplayer_credentials.download` with
   `details.fleet_id` only (the secret never enters the audit row).
2. **"Provision Softplayer" card** on the Imager tab between
   `Build Image` and `Built Images`. Mirrors the build-card fleet
   picker and downloads the file via `fetch` + blob so the
   server-suggested filename and 4xx/5xx errors are handled
   cleanly. Gated on the same `imager_can_build` template var.

The output mirrors the Pi env file verbatim -- same keys, same
`AGORA_FLEET_SECRET_HEX` encoding, same `local` -> `direct` /
`wps` -> `wps` transport mapping. The softplayer CLI in
sslivins/agora-softplayer#1 consumes this format.

## Auth + RBAC

- New endpoint gated on `IMAGER_BUILD` (same as `/build`).
- Reuses the `FOR SHARE` lock from `fleet_registry.get_fleet_for_build`
  to serialise against a concurrent `DELETE /api/imager/fleets/{id}`.
- Both `test_endpoints_require_auth` and `test_operator_denied_all_imager_endpoints`
  are updated so future regressions that drop `require_permission`
  on this endpoint will be caught.

## Tests

9 new tests in `tests/test_imager_api.py`:

- Happy path (text/plain, attachment header, `Cache-Control: no-store`,
  hex-encoded secret in body, no wifi keys leak).
- Happy path under `wps` device_transport.
- 404 on unknown fleet_id.
- 404 on soft-deleted fleet.
- 422 on `fleet_id` failing `_FLEET_ID_RE`.
- 503 when `AGORA_CMS_BASE_URL` is missing.
- 503 when `device_transport` is neither `local` nor `wps`.
- Audit row written, secret never in `details`.
- Two consecutive downloads return byte-identical bodies (no
  per-request mutation).

Local run: `69 passed` in `tests/test_imager_api.py` (was 60).

## Out of scope

- DPAPI / keychain on the softplayer side (future ticket).
- Filename convention is `softplayer-<fleet>.env`. The softplayer
  loader defaults to plain `softplayer.env`, so the operator
  renames after download (multi-fleet ops fine since fleet_id is
  visible in the filename).

## Pair PR

- sslivins/agora-softplayer#1 (consumer of this endpoint's output)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>