### PR TITLE
local-broker: implement WPS json subprotocol wrap/unwrap + fix wps_transport double-encode

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -33,9 +33,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cms.auth import get_settings
 from cms.config import Settings
 from cms.database import get_db
-from cms.models.device import Device, DeviceGroup
+from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.services.alert_service import alert_service
-from cms.services.device_inbound import InboundContext, dispatch_device_message
+from cms.services.device_inbound import InboundContext, dispatch_device_message, rotate_api_key
 from cms.services.device_manager import device_manager
 from cms.services.device_register import register_known_device
 from cms.services.transport import get_transport
@@ -314,6 +314,25 @@ async def events_receiver(
                 group_name=_group_name,
                 status=_device_status,
             )
+
+            # Push (or rotate) the device API key, mirroring the legacy
+            # WS register path in ``cms/routers/ws.py``.  Without this,
+            # WPS-adopted devices have ``device_api_key_hash IS NULL``
+            # in the DB and their asset-download GETs (which carry
+            # ``X-Device-API-Key``) all 401.  ``rotate_api_key`` is
+            # idempotent in the sense that it always generates a fresh
+            # key and preserves the prior hash for a grace window —
+            # safe to call on every register/reconnect.
+            if device.status == DeviceStatus.ADOPTED:
+                async def _wps_send(message: dict) -> None:
+                    await transport.send_to_device(ce_user_id, message)
+                try:
+                    await rotate_api_key(device=device, db=db, send=_wps_send)
+                except Exception:
+                    logger.exception(
+                        "Failed to rotate API key for WPS device %s",
+                        ce_user_id,
+                    )
             return Response(status_code=204)
 
         base_url = _get_asset_base_url(request, settings)

--- a/cms/services/wps_transport.py
+++ b/cms/services/wps_transport.py
@@ -97,9 +97,16 @@ class WPSTransport(DeviceTransport):
 
         metrics.wps_send_attempt_total.add(1)
         try:
+            # Pass the dict directly: the Azure SDK serializes once for
+            # `content_type="application/json"` (sets ``_json = message``
+            # in azure.messaging.webpubsubservice._operations._patch).
+            # Passing ``json.dumps(message)`` here caused a double-encode
+            # so the device received `"{\"type\":\"sync\",...}"` -- a
+            # JSON string -- and ``json.loads`` on the wire returned a
+            # str, crashing the device transport iterator.
             await self._client.send_to_user(
                 device_id,
-                json.dumps(message),
+                message,
                 content_type="application/json",
             )
             metrics.wps_send_success_total.add(1)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Agora CMS
   description: Central management system for Agora media playback devices
-  version: 1.37.233
+  version: 1.37.234
 paths:
   /api/devices/register:
     post:

--- a/local-broker/broker.py
+++ b/local-broker/broker.py
@@ -106,6 +106,18 @@ UPSTREAM_TIMEOUT_S = float(_getenv("WPS_UPSTREAM_TIMEOUT_S", "5.0"))
 
 JWT_ALG = "HS256"
 
+# Azure Web PubSub's JSON subprotocol.  When a client connects with
+# ``Sec-WebSocket-Protocol: json.webpubsub.azure.v1`` the service:
+#   * Wraps server->client payloads as
+#     ``{"type":"message","from":"server","dataType":<…>,"data":<…>}``
+#     on the WS wire.
+#   * Unwraps client->server ``{"type":"event","event":<name>,"dataType":<…>,
+#     "data":<…>}`` envelopes and forwards just ``data`` to the upstream
+#     webhook.
+# Real Azure WPS reference:
+# https://learn.microsoft.com/en-us/azure/azure-web-pubsub/reference-json-webpubsub-subprotocol
+WPS_JSON_SUBPROTOCOL = "json.webpubsub.azure.v1"
+
 
 # ----------------------------------------------------------------- connections
 
@@ -116,6 +128,10 @@ class _Conn:
     user_id: str
     hub: str
     ws: WebSocket
+    # Negotiated WebSocket subprotocol (empty string if none).  The
+    # broker wraps/unwraps payloads when this is ``json.webpubsub.azure.v1``
+    # and passes them through verbatim otherwise.
+    subprotocol: str = ""
     connected_at: float = field(default_factory=time.time)
 
 
@@ -253,6 +269,62 @@ def verify_webhook_signature(
 # --------------------------------------------------------------------- webhook
 
 
+def _unwrap_inbound_text(
+    text: str, *, subprotocol: str,
+) -> tuple[bytes, str, str]:
+    """Translate one client-to-server text frame into ``(body, content_type, event_name)``.
+
+    Clients using the ``json.webpubsub.azure.v1`` subprotocol wrap every
+    application message in an envelope::
+
+        {"type": "event", "event": "<name>", "dataType": "<…>", "data": <…>}
+
+    Real Azure WPS strips that envelope and posts the inner ``data`` as
+    the upstream webhook body, with ``ce-eventName`` set to ``<name>`` and
+    ``Content-Type`` derived from ``dataType``.  Match that behaviour so
+    CMS handlers see the same shape they would in production.
+
+    Frames that don't fit the envelope (bad JSON, missing fields, wrong
+    type) — and frames from clients NOT using the WPS subprotocol — are
+    passed through verbatim with content-type ``application/json`` and
+    event name ``message``, preserving the legacy behaviour.
+    """
+    encoded = text.encode("utf-8")
+    if subprotocol != WPS_JSON_SUBPROTOCOL:
+        return encoded, "application/json", "message"
+    try:
+        envelope = json.loads(text)
+    except json.JSONDecodeError:
+        return encoded, "application/json", "message"
+    if not isinstance(envelope, dict) or envelope.get("type") != "event":
+        return encoded, "application/json", "message"
+    event_name = envelope.get("event")
+    if not isinstance(event_name, str) or not event_name:
+        event_name = "message"
+    data_type = envelope.get("dataType", "json")
+    data = envelope.get("data")
+    if data_type == "json":
+        # Re-serialize the parsed object so the body is the JSON
+        # representation of just the data payload.
+        return json.dumps(data).encode("utf-8"), "application/json", event_name
+    if data_type == "text":
+        if not isinstance(data, str):
+            data = "" if data is None else str(data)
+        return data.encode("utf-8"), "text/plain", event_name
+    if data_type == "binary":
+        # Binary inside the JSON subproto is base64.  Best effort: decode
+        # if possible, else hand bytes of the string through.
+        import base64
+        if isinstance(data, str):
+            try:
+                return base64.b64decode(data, validate=False), "application/octet-stream", event_name
+            except Exception:  # pragma: no cover - degenerate
+                pass
+        return encoded, "application/json", event_name
+    # Unknown dataType — pass through.
+    return encoded, "application/json", event_name
+
+
 async def _post_webhook(
     client: httpx.AsyncClient,
     *,
@@ -378,26 +450,46 @@ def create_app() -> FastAPI:
         )
 
         # Match real Azure Web PubSub REST contract: the request body IS
-        # the payload; `Content-Type` selects the WS frame type.  The
-        # Azure SDK (``WebPubSubServiceClient.send_to_user``) sends the
+        # the payload; ``Content-Type`` selects the WS dataType.  The
+        # Azure SDK ``WebPubSubServiceClient.send_to_user`` sends the
         # serialized payload as the raw body, never a ``{data, dataType}``
-        # wrapper — wrapping was a local-broker historical mistake.
+        # wrapper.
         raw_body = await request.body()
         ct = (content_type or "").split(";", 1)[0].strip().lower()
 
+        # Parse the payload + tag a dataType the way real Azure WPS does
+        # for clients on the ``json.webpubsub.azure.v1`` subprotocol.  For
+        # plain WS clients we drop the wrapping and forward verbatim.
+        wps_data: Any
+        wps_data_type: str
+        passthrough_text: str | None
+        passthrough_bytes: bytes
         if ct == "application/octet-stream":
-            frame_bytes: bytes = raw_body
-            frame_text: str | None = None
+            wps_data = raw_body  # placeholder; binary not yet supported on json subproto
+            wps_data_type = "binary"
+            passthrough_text = None
+            passthrough_bytes = raw_body
         elif ct == "text/plain":
-            frame_bytes = b""
-            frame_text = raw_body.decode("utf-8", errors="replace")
+            text = raw_body.decode("utf-8", errors="replace")
+            wps_data = text
+            wps_data_type = "text"
+            passthrough_text = text
+            passthrough_bytes = b""
         else:
-            # Default + ``application/json``: deliver the body as a text
-            # frame.  For JSON the body is already a UTF-8-encoded JSON
-            # string; for unknown/missing Content-Type Azure WPS treats
-            # the payload as text/JSON.
-            frame_bytes = b""
-            frame_text = raw_body.decode("utf-8", errors="replace")
+            # Default + application/json: parse the body as JSON when
+            # possible.  Azure WPS does this server-side so the on-wire
+            # ``data`` field holds the parsed value, not the raw string.
+            text = raw_body.decode("utf-8", errors="replace")
+            try:
+                wps_data = json.loads(text) if text else None
+                wps_data_type = "json"
+            except json.JSONDecodeError:
+                # Not JSON despite the content type — fall back to text
+                # so the device still gets *something* it can inspect.
+                wps_data = text
+                wps_data_type = "text"
+            passthrough_text = text
+            passthrough_bytes = b""
 
         conns = registry.connections_for_user(user_id)
         if not conns:
@@ -407,10 +499,27 @@ def create_app() -> FastAPI:
         delivered = 0
         for conn in conns:
             try:
-                if frame_text is not None:
-                    await conn.ws.send_text(frame_text)
+                if conn.subprotocol == WPS_JSON_SUBPROTOCOL:
+                    envelope = {
+                        "type": "message",
+                        "from": "server",
+                        "dataType": wps_data_type,
+                        "data": wps_data,
+                    }
+                    if wps_data_type == "binary":
+                        # ``json.webpubsub.azure.v1`` carries binary as
+                        # base64 in the JSON ``data`` field.  Only handle
+                        # when we actually have bytes.
+                        import base64
+                        envelope["data"] = base64.b64encode(passthrough_bytes).decode("ascii")
+                    await conn.ws.send_text(json.dumps(envelope))
                 else:
-                    await conn.ws.send_bytes(frame_bytes)
+                    # No subprotocol negotiated — forward the raw payload
+                    # exactly as it arrived on the REST request body.
+                    if passthrough_text is not None:
+                        await conn.ws.send_text(passthrough_text)
+                    else:
+                        await conn.ws.send_bytes(passthrough_bytes)
                 delivered += 1
             except Exception:
                 logger.exception(
@@ -463,13 +572,27 @@ def create_app() -> FastAPI:
             await websocket.close(code=4401)
             return
 
+        # Negotiate the WebSocket subprotocol.  Real Azure WPS picks the
+        # ``json.webpubsub.azure.v1`` protocol when offered, and that
+        # choice toggles the wrap/unwrap behaviour below.  Anything else
+        # is accepted without negotiating a subprotocol — plain WS clients
+        # continue to see raw payloads (matches the legacy contract).
+        requested = list(websocket.scope.get("subprotocols", []) or [])
+        negotiated = (
+            WPS_JSON_SUBPROTOCOL if WPS_JSON_SUBPROTOCOL in requested else ""
+        )
+
         connection_id = uuid.uuid4().hex
-        await websocket.accept()
+        if negotiated:
+            await websocket.accept(subprotocol=negotiated)
+        else:
+            await websocket.accept()
         conn = _Conn(
             connection_id=connection_id,
             user_id=user_id,
             hub=hub,
             ws=websocket,
+            subprotocol=negotiated,
         )
         await registry.add(conn)
 
@@ -495,20 +618,26 @@ def create_app() -> FastAPI:
                     break
                 if "text" in msg and msg["text"] is not None:
                     text = msg["text"]
+                    body, ct, event_name = _unwrap_inbound_text(
+                        text, subprotocol=negotiated,
+                    )
                     asyncio.create_task(
                         _post_webhook(
                             http_client,
-                            event_type="azure.webpubsub.user.message",
+                            event_type="azure.webpubsub.user." + event_name,
                             hub=hub,
                             connection_id=connection_id,
                             user_id=user_id,
-                            event_name="message",
-                            raw_body=text.encode("utf-8"),
-                            content_type="application/json",
+                            event_name=event_name,
+                            raw_body=body,
+                            content_type=ct,
                         )
                     )
                 elif "bytes" in msg and msg["bytes"] is not None:
-                    # Binary frames — not used by current Pi agent but honour the shape.
+                    # Binary frames — not unwrapped (the WPS JSON subproto
+                    # carries data as a base64 string inside the JSON
+                    # envelope, so a true binary WS frame from the client
+                    # is an out-of-band payload either way).
                     asyncio.create_task(
                         _post_webhook(
                             http_client,

--- a/local-broker/tests/test_broker.py
+++ b/local-broker/tests/test_broker.py
@@ -369,3 +369,159 @@ class TestUpstreamWebhooks:
         assert msg_ev["headers"].get("ce-eventname") == "message"
         assert json.loads(msg_ev["body"]) == {"type": "HEARTBEAT"}
         assert msg_ev["headers"].get("content-type", "").startswith("application/json")
+
+
+# ---------------------------------------------------------------- WPS json subprotocol
+
+
+WPS_SUBPROTO = "json.webpubsub.azure.v1"
+
+
+@pytest.mark.asyncio
+class TestWpsJsonSubprotocol:
+    """When the client negotiates ``json.webpubsub.azure.v1`` the broker
+    must mirror Azure WPS: wrap server->client payloads in a ``message``
+    envelope, and unwrap client->server ``event`` envelopes before
+    forwarding upstream."""
+
+    async def test_send_wraps_payload_for_subprotocol_clients(self):
+        app = broker.create_app()
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+
+            token = broker.mint_client_token(user_id="pi-wps")
+            uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
+
+            async with websockets.connect(uri, subprotocols=[WPS_SUBPROTO]) as ws:
+                assert ws.subprotocol == WPS_SUBPROTO
+                for _ in range(50):
+                    await asyncio.sleep(0.02)
+                    if app.state.registry.user_exists("pi-wps"):
+                        break
+                assert app.state.registry.user_exists("pi-wps")
+
+                aud = f"http://127.0.0.1:{port}/api/hubs/agora/users/pi-wps/"
+                server_token = broker.mint_server_token(audience=aud)
+
+                async with _client_base(port) as c:
+                    r = await c.post(
+                        "/api/hubs/agora/users/pi-wps/:send",
+                        content=json.dumps({"cmd": "PING", "n": 1}),
+                        headers={
+                            "authorization": f"Bearer {server_token}",
+                            "content-type": "application/json",
+                        },
+                    )
+                    assert r.status_code == 202, r.text
+
+                received = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                envelope = json.loads(received)
+                assert envelope["type"] == "message"
+                assert envelope["from"] == "server"
+                assert envelope["dataType"] == "json"
+                assert envelope["data"] == {"cmd": "PING", "n": 1}
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+    async def test_send_does_not_wrap_for_plain_clients(self):
+        """A plain WS client (no subprotocol) still gets the raw payload —
+        the legacy contract is preserved for compose smoke tests and any
+        non-WPS consumer."""
+        app = broker.create_app()
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+
+            token = broker.mint_client_token(user_id="pi-plain")
+            uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
+
+            async with websockets.connect(uri) as ws:
+                assert ws.subprotocol is None
+                for _ in range(50):
+                    await asyncio.sleep(0.02)
+                    if app.state.registry.user_exists("pi-plain"):
+                        break
+
+                aud = f"http://127.0.0.1:{port}/api/hubs/agora/users/pi-plain/"
+                server_token = broker.mint_server_token(audience=aud)
+
+                async with _client_base(port) as c:
+                    r = await c.post(
+                        "/api/hubs/agora/users/pi-plain/:send",
+                        content=json.dumps({"cmd": "PING"}),
+                        headers={
+                            "authorization": f"Bearer {server_token}",
+                            "content-type": "application/json",
+                        },
+                    )
+                    assert r.status_code == 202
+
+                received = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                # Raw payload, NOT an envelope.
+                assert json.loads(received) == {"cmd": "PING"}
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+    async def test_inbound_event_envelope_is_unwrapped(self, monkeypatch):
+        """Client wraps its outgoing message in
+        ``{"type":"event","event":"<name>","dataType":"json","data":<…>}``.
+        Broker must forward only ``<data>`` upstream with
+        ``ce-eventName=<name>``."""
+        received: list[dict] = []
+
+        async def _capture(request):
+            import httpx as _httpx
+            body = await request.aread()
+            received.append({
+                "type": request.headers.get("ce-type"),
+                "event": request.headers.get("ce-eventname"),
+                "body": body,
+                "content_type": request.headers.get("content-type", ""),
+            })
+            return _httpx.Response(200)
+
+        import httpx as _httpx
+        transport = _httpx.MockTransport(_capture)
+
+        app = broker.create_app()
+        await app.state.http_client.aclose()
+        app.state.http_client = _httpx.AsyncClient(transport=transport)
+        monkeypatch.setattr(broker, "UPSTREAM_URL", "http://cms/internal/wps/events")
+
+        port = _free_port()
+        server = _run_uvicorn_in_thread(app, port)
+        try:
+            import websockets
+
+            token = broker.mint_client_token(user_id="pi-evt")
+            uri = f"ws://127.0.0.1:{port}/client/hubs/agora?access_token={token}"
+
+            async with websockets.connect(uri, subprotocols=[WPS_SUBPROTO]) as ws:
+                envelope = {
+                    "type": "event",
+                    "event": "register",
+                    "dataType": "json",
+                    "data": {"type": "register", "ip_address": "192.168.1.50"},
+                }
+                await ws.send(json.dumps(envelope))
+                for _ in range(100):
+                    await asyncio.sleep(0.05)
+                    if any(r["event"] == "register" for r in received):
+                        break
+        finally:
+            server.should_exit = True
+            await asyncio.sleep(0.2)
+
+        reg = next(r for r in received if r["event"] == "register")
+        assert reg["type"] == "azure.webpubsub.user.register"
+        # The body must be JUST the inner data — not the whole envelope.
+        assert json.loads(reg["body"]) == {
+            "type": "register",
+            "ip_address": "192.168.1.50",
+        }
+        assert reg["content_type"].startswith("application/json")

--- a/tests/test_wps_transport.py
+++ b/tests/test_wps_transport.py
@@ -58,9 +58,12 @@ class TestSendToDevice:
         assert ok is True
         c.send_to_user.assert_awaited_once()
         args, kwargs = c.send_to_user.call_args
-        # (user_id, body_str, content_type=...)
+        # (user_id, body_dict, content_type=...). The dict is passed
+        # straight through -- the Azure SDK serializes once when
+        # content_type=application/json. Passing json.dumps(...) here
+        # used to double-encode and crash the device transport.
         assert args[0] == "pi-1"
-        assert json.loads(args[1]) == {"type": "ping"}
+        assert args[1] == {"type": "ping"}
         assert kwargs.get("content_type") == "application/json"
 
     async def test_404_returns_false(self):

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -1173,6 +1173,117 @@ class TestAlertServiceHooks:
         mock_alert.device_disconnected.assert_not_called()
 
 
+# ---------------------------------------------------------------- api_key rotation
+
+
+@pytest.mark.asyncio
+class TestApiKeyRotationOnRegister:
+    """When an ADOPTED device sends ``register`` over WPS, the webhook
+    must rotate-and-push the device API key — mirrors the legacy
+    ``cms/routers/ws.py`` register path (line ~304).  Without this,
+    asset downloads 401 because ``Device.device_api_key_hash`` is
+    ``NULL`` until the first rotation."""
+
+    async def test_adopted_register_rotates_and_pushes_api_key(
+        self, client, app_and_session,
+    ):
+        from cms.models.device import DeviceStatus
+
+        _, session = app_and_session
+        # Real DeviceStatus enum so the ``device.status == DeviceStatus.ADOPTED``
+        # guard in the handler evaluates True.
+        device = MagicMock(
+            id="pi-key", group_id=None, status=DeviceStatus.ADOPTED,
+        )
+        device.name = "Lobby"
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-key"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ), patch(
+            "cms.routers.wps_webhook.rotate_api_key",
+            new=AsyncMock(return_value=None),
+        ) as mock_rotate:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-key",
+                    "auth_token": "valid",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-key",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_rotate.assert_awaited_once()
+        # ``rotate_api_key`` is invoked with kwargs (device, db, send).
+        kwargs = mock_rotate.call_args.kwargs
+        assert kwargs["device"] is device
+        # The ``send`` adapter should route through the WPS transport.
+        sender = kwargs["send"]
+        await sender({"type": "config", "api_key": "newkey"})
+        fake_transport.send_to_device.assert_awaited_once_with(
+            "pi-key", {"type": "config", "api_key": "newkey"},
+        )
+
+    async def test_non_adopted_register_does_not_rotate(
+        self, client, app_and_session,
+    ):
+        """A PENDING / ORPHANED device must not get a rotated key —
+        same guard the legacy WS handler enforces."""
+        from cms.models.device import DeviceStatus
+
+        _, session = app_and_session
+        device = MagicMock(
+            id="pi-pend", group_id=None, status=DeviceStatus.PENDING,
+        )
+        device.name = "New"
+        session.device_row = device
+
+        cid = "conn-pend"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.rotate_api_key",
+            new=AsyncMock(return_value=None),
+        ) as mock_rotate:
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-pend",
+                    "auth_token": "valid",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-pend",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        mock_rotate.assert_not_awaited()
+
+
 # ---------------------------------------------------------------- multi-key
 
 


### PR DESCRIPTION
Stacked on top of #610. Fixes the local-broker so the Windows softplayer can actually receive CMS sync messages over the WPS path.

## Problem

Two distinct bugs prevented the softplayer's desired.json from ever being written when the CMS pushed a sync:

1. **CMS double-encoded the WPS payload.** `WPSTransport.send_to_device` called `send_to_user(user, json.dumps(message), content_type='application/json')`. The Azure aio SDK serializes once more for that content type, so the wire body was a JSON-encoded string like `""{\""type\"":\""sync\"",...}""` instead of an object. `json.loads` on the device returned a `str`, crashing the transport iterator with `AttributeError: 'str' object has no attribute 'get'`.

2. **Local broker did not honour the `json.webpubsub.azure.v1` subprotocol.** Real Azure WPS wraps server-to-client REST `:send` payloads as `{type:'message', from:'server', dataType:<…>, data:<…>}` on the wire, and unwraps client-to-server `{type:'event', event:<name>, dataType:<…>, data:<…>}` envelopes before forwarding `data` upstream. The broker did neither, so devices that negotiated the subprotocol saw raw payloads (their decoder ignored them as unknown frame types) and their outbound event envelopes were forwarded verbatim — meaning every CMS `user.*` webhook handler (`register`, heartbeats, etc.) silently never matched.

## Fix

* `local-broker/broker.py`:
  - Negotiate `json.webpubsub.azure.v1` when the client offers it (matches real WPS).
  - Track the negotiated subprotocol on the connection record.
  - Wrap `:send` payloads in the `message` envelope for subprotocol clients; plain WS clients still see raw payloads (so the existing `test_full_loopback` and compose smoke flows are unchanged).
  - Unwrap inbound `event` envelopes for subprotocol clients before posting upstream, deriving `ce-eventName` from the envelope.

* `cms/services/wps_transport.py`: pass the dict directly to `send_to_user` instead of pre-serializing it.

## Tests

* Three new broker tests: `test_send_wraps_payload_for_subprotocol_clients`, `test_send_does_not_wrap_for_plain_clients`, `test_inbound_event_envelope_is_unwrapped`. All 21 broker tests pass.
* Updated `test_basic_send_ok` to assert against the dict.

## Verified end-to-end on Windows

After rebuild, the Windows softplayer connects with subprotocol `json.webpubsub.azure.v1`, the CMS push lands as `< TEXT '{""type"":""message"",""from"":""server"",""dataType"":""json"",""data"":{""type"":""sync"",...}}'` on the device wire, `desired.json` is written, and the device starts evaluating the schedule. (Asset download is failing with HTTP 401 — separate auth issue, out of scope.)

Database confirms the connection: `online=t, connection_id=2da43b1d906f4404b24527a24e5e69da`.
