### PR TITLE
ci(bump-main): regenerate docs/openapi.yaml alongside version bump

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -659,9 +659,10 @@ jobs:
           # downgrading to github-actions[bot] and hiding the misconfig.
           token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
-      - name: Bump version and push
+      - name: Bump version + regenerate openapi.yaml and push
         env:
           NEW_VERSION: ${{ needs.publish.outputs.version }}
+          CMS_IMAGE: ghcr.io/sslivins/agora-cms:${{ needs.publish.outputs.version }}
         run: |
           set -euo pipefail
           current=$(python3 -c "exec(open('cms/__init__.py').read()); print(__version__)")
@@ -670,9 +671,29 @@ jobs:
             exit 0
           fi
           sed -i "s/^__version__ = .*/__version__ = \"$NEW_VERSION\"/" cms/__init__.py
+
+          # Regenerate docs/openapi.yaml so the committed spec keeps its
+          # ``info.version`` field in sync with cms/__init__.py. Without
+          # this, every PR rebased onto post-bump main inherits a stale
+          # openapi.yaml and trips the openapi-check job (1.37.234 in
+          # the live FastAPI app vs 1.37.233 still committed in
+          # docs/openapi.yaml). We piggy-back on the just-published cms
+          # image so we don't have to spin up a separate setup-python +
+          # pip install step — its runtime deps (fastapi, pyyaml,
+          # pydantic, ...) are exactly what the script needs. The
+          # bind-mount + sys.path.insert(REPO_ROOT) in
+          # scripts/generate_openapi.py makes the script import the
+          # host's freshly-bumped cms/ rather than the image-baked copy.
+          docker pull "$CMS_IMAGE"
+          docker run --rm \
+            -v "$PWD:/repo" -w /repo \
+            --entrypoint python \
+            "$CMS_IMAGE" \
+            scripts/generate_openapi.py
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add cms/__init__.py
+          git add cms/__init__.py docs/openapi.yaml
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]" \
                      -m "Auto-bumped by publish-image.yml after successful deploy." \
                      -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Agora CMS
   description: Central management system for Agora media playback devices
-  version: 1.37.234
+  version: 1.37.236
 paths:
   /api/devices/register:
     post:


### PR DESCRIPTION
Without this, the `bump-main` job leaves `docs/openapi.yaml`'s
`info.version` field one patch behind `cms/__init__.py`. Every PR
rebased onto post-bump `main` inherits that stale `openapi.yaml` and
trips `openapi-check` on the version line alone, forcing a
regen-and-recommit on every PR.

Real example from this morning: PRs #610 and #611 both shipped a
`chore(openapi): regenerate` commit purely to update the version line
that `bump-main` should have updated.

## What this changes

In the `bump-main` job of `publish-image.yml`, after the `sed` that
bumps `cms/__init__.py`, also:

1. `docker pull` the just-published `ghcr.io/sslivins/agora-cms:<version>`.
2. `docker run` it with the workspace bind-mounted at `/repo` and
   `scripts/generate_openapi.py` as the entrypoint. The script's
   `sys.path.insert(REPO_ROOT)` makes the host's freshly-bumped
   `cms/` take precedence over the image-baked copy, so the
   regenerated yaml reflects the NEW version.
3. `git add` both files, single bump commit.

## Why piggy-back on the cms image?

The regen script imports `cms.main` and needs the cms runtime deps
(fastapi, pyyaml, pydantic, ...). Rather than `setup-python` + `pip
install -r requirements.txt` (another ~30 s of cold installs every
deploy), we reuse the image we *just* built and pushed in this same
workflow. The version tag in `CMS_IMAGE` ties the regen tightly to
the deploy we're bumping for.

## Risk

Touches only the post-deploy bump step. Idempotent: existing `current
== NEW_VERSION` short-circuit still applies. If the regen step itself
fails, the commit doesn't happen and the next deploy will retry --
worst case is openapi-check fails on the next PR until the bump
catches up, which is exactly the status quo we're trying to fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>