### PR TITLE
fix(register): treat null/empty string fields as no-op refresh

### DIFF
--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -124,13 +124,18 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
         if device is None:
             # New device — create as pending, prefer device_name over raw ID
             device_name = raw.get("device_name", "") or device_id
+            # NOT NULL string columns -- coerce None/missing -> "" so
+            # a device that ships ``"os_version": null`` (e.g.
+            # softplayer on Windows) does not blow the INSERT with an
+            # IntegrityError and have its register dropped by Azure
+            # WPS retry-then-drop.
             device = Device(
                 id=device_id,
                 name=device_name,
                 status=DeviceStatus.PENDING,
-                firmware_version=raw.get("firmware_version", ""),
-                os_version=raw.get("os_version", ""),
-                device_type=raw.get("device_type", ""),
+                firmware_version=raw.get("firmware_version") or "",
+                os_version=raw.get("os_version") or "",
+                device_type=raw.get("device_type") or "",
                 supported_codecs=",".join(raw.get("supported_codecs", [])),
                 storage_capacity_mb=raw.get("storage_capacity_mb", 0),
                 storage_used_mb=raw.get("storage_used_mb", 0),

--- a/cms/services/device_register.py
+++ b/cms/services/device_register.py
@@ -159,10 +159,21 @@ async def register_known_device(
         ).model_dump(mode="json")
         logger.info("Auth token assigned to existing device %s", device.id)
 
-    # Refresh metadata from the register payload.
-    device.firmware_version = raw.get("firmware_version", device.firmware_version)
-    device.os_version = raw.get("os_version", device.os_version)
-    device.device_type = raw.get("device_type", device.device_type)
+    # Refresh metadata from the register payload.  Treat empty / null
+    # incoming string fields as "keep existing value" rather than
+    # overwriting -- the columns are NOT NULL with default "", and a
+    # device that legitimately omits a field (e.g. softplayer on
+    # Windows with no /etc/agora/version) must not 500 the webhook
+    # and get its register dropped by Azure WPS retry-then-drop.
+    new_fw = raw.get("firmware_version")
+    if new_fw:
+        device.firmware_version = new_fw
+    new_os = raw.get("os_version")
+    if new_os:
+        device.os_version = new_os
+    new_type = raw.get("device_type")
+    if new_type:
+        device.device_type = new_type
     reg_codecs = raw.get("supported_codecs")
     if reg_codecs is not None:
         device.supported_codecs = ",".join(reg_codecs)

--- a/tests/test_device_register.py
+++ b/tests/test_device_register.py
@@ -194,6 +194,38 @@ class TestRegisterKnownDevice:
         assert device.storage_used_mb == 100
         assert device.last_seen is not None
 
+    async def test_null_string_fields_preserve_prior_value(self):
+        """A device sending ``os_version: null`` / empty string / missing
+        key must not overwrite the existing column value -- the columns
+        are NOT NULL with default "" and a NULL UPDATE would crash the
+        webhook and get the register message silently dropped by Azure
+        WPS retry-then-drop.  Regression: softplayer on Windows.
+        """
+        device = _make_device(
+            device_auth_token_hash=hash_token("t"),
+            firmware_version="1.0.0",
+            os_version="0.0.16-test",
+            device_type="Raspberry Pi 5",
+        )
+        db = _FakeDB()
+
+        await register_known_device(
+            device,
+            {
+                "type": "register",
+                "device_id": "pi-1",
+                "auth_token": "t",
+                "firmware_version": None,
+                "os_version": None,
+                "device_type": "",
+            },
+            db,
+        )
+
+        assert device.firmware_version == "1.0.0"
+        assert device.os_version == "0.0.16-test"
+        assert device.device_type == "Raspberry Pi 5"
+
     async def test_device_name_not_overridden_unless_custom(self):
         """Register payloads only update device.name when the captive-portal
         flag device_name_custom=True is set — otherwise keep the CMS-side


### PR DESCRIPTION
## Why

Companion to sslivins/agora-softplayer#12.

Softplayer on Windows sends `os_version: null` in its WPS register payload (it has no `/etc/agora/version` file). That hits `device.os_version = raw.get("os_version", device.os_version)`, which returns `None` (not the default) because the key is present-with-None. SQLAlchemy then flushes a NULL into a `Mapped[str]` NOT NULL column, Postgres raises `NotNullViolationError`, the `/internal/wps/events` webhook returns 500, and Azure WPS retries 3-4× before silently dropping the register message. The device never gets `auth_assigned`, never finishes adoption, and is stuck in PENDING.

App Insights, last ~10 h on live: **35× IntegrityError on `os_version` NOT NULL**, including the 4-in-5-min spike that fired `agoracms-alert-cms-exceptions` Sev2 at 02:18 UTC today.

## What

Make the register path defensive against null / empty-string string fields for `firmware_version`, `os_version`, `device_type`:

- **UPDATE path** (`cms/services/device_register.py`): use `if new_X: device.X = new_X` so null/empty incoming preserves the existing column value (rather than nulling it out).
- **INSERT path** (`cms/routers/ws.py`): coerce null incoming to `""` via `raw.get("X") or ""` so we honour the column's empty-string default.

Even after softplayer#12 ships, any future client bug that sends `null` for these fields should be a no-op refresh, not a 500.

## Test

New regression test `test_null_string_fields_preserve_prior_value` in `tests/test_device_register.py` covers all three (None / empty / missing) → existing value preserved.

`tests/test_device_register.py` + `tests/test_wps_webhook.py` = 41/41 pass.

## Risk

Low. Behaviour change is opt-in: only triggers when an incoming field is null/empty/missing, which previously crashed the entire register transaction.
