### PR TITLE
fix(schedules): 'Set to now' chip uses server clock, not browser clock

### DIFF
--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -424,6 +424,43 @@ async def update_schedule(
         select(Schedule).options(*_eager_options()).where(Schedule.id == schedule.id)
     )
     schedule = result.scalar_one()
+
+    # "Set to now" invisibility-window debugging (#issue TBD).  When
+    # start_time/end_time/start_date/end_date change, log the immediate
+    # post-commit state vs the server's wall clock so we can tell
+    # whether the saved row should have matched ``_matches_now`` right
+    # away, or whether it landed slightly in the future (e.g. browser
+    # clock skew via the "Set to now" chip).  Remove once the
+    # invisibility-window report is fully understood.
+    _time_keys = {"start_time", "end_time", "start_date", "end_date"}
+    if _time_keys & set(updates):
+        try:
+            from datetime import datetime as _dt, timezone as _tz
+            from zoneinfo import ZoneInfo as _ZI
+            from cms.auth import SETTING_TIMEZONE, get_setting as _gs
+            from cms.services.scheduler import _matches_now as _mn
+            tz_name = await _gs(db, SETTING_TIMEZONE) or "UTC"
+            srv_now_utc = _dt.now(_tz.utc)
+            srv_now_local = srv_now_utc.astimezone(_ZI(tz_name)).replace(tzinfo=None)
+            today_start = _dt.combine(srv_now_local.date(), schedule.start_time)
+            logger.info(
+                "schedule.update.timing schedule_id=%s changed=%s "
+                "server_local_now=%s server_tz=%s "
+                "saved_start_time=%s saved_end_time=%s "
+                "saved_start_date=%s saved_end_date=%s "
+                "matches_now=%s today_start_vs_now=%s "
+                "delta_secs_to_start=%s",
+                schedule.id, sorted(_time_keys & set(updates)),
+                srv_now_local.isoformat(timespec="seconds"), tz_name,
+                schedule.start_time, schedule.end_time,
+                schedule.start_date, schedule.end_date,
+                _mn(schedule, srv_now_local),
+                "future" if today_start > srv_now_local else "past_or_now",
+                int((today_start - srv_now_local).total_seconds()),
+            )
+        except Exception:
+            logger.debug("schedule.update.timing log failed", exc_info=True)
+
     await push_sync_to_affected_devices(schedule, db)
     await _trigger_eval()
     return _schedule_to_out(schedule)

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -201,6 +201,33 @@ window._playingScheduleIds = {{ playing_schedule_ids | tojson }};
 const _tzList = JSON.parse(document.getElementById('_tzOptions').value);
 const _currentTz = document.getElementById('_tz').value;
 
+// Browser-vs-server clock skew in ms (browser - server).  The "Set to
+// now" chip needs server time, not browser time -- if the browser is
+// running a few seconds ahead of the server (common on Windows where
+// w32time syncs only weekly), formatting Date.now() to HH:MM truncates
+// into a *future* minute, the saved start_time is briefly > server's
+// current time, _matches_now() returns False on the next dashboard
+// poll, and the schedule is invisible until the server clock catches
+// up -- "appears about a minute after start_time".
+let _serverClockSkewMs = 0;
+async function _refreshServerSkew() {
+    try {
+        const before = Date.now();
+        const res = await fetch('/api/server-time', { cache: 'no-store' });
+        const after = Date.now();
+        if (!res.ok) return;
+        const data = await res.json();
+        const serverMs = new Date(data.utc).getTime();
+        // Subtract half the round-trip so we approximate the server's
+        // clock at the midpoint of the request.
+        const browserMidpoint = (before + after) / 2;
+        _serverClockSkewMs = browserMidpoint - serverMs;
+    } catch (e) { /* keep last known offset */ }
+}
+// Kick off once on page load; also refreshed when the edit modal opens.
+_refreshServerSkew();
+function _serverNow() { return new Date(Date.now() - _serverClockSkewMs); }
+
 function saveTimezone(tz) {
     fetch('/settings/timezone', {
         method: 'POST',
@@ -742,6 +769,9 @@ document.getElementById("schedule-summary").addEventListener('click', function(e
 
 // ── Edit modal ──
 function editSchedule(s) {
+    // Refresh server-clock skew on each modal open so the "Set to now"
+    // chip uses an up-to-date offset (best-effort; non-blocking).
+    _refreshServerSkew();
     const overlay = document.createElement("div");
     overlay.className = "modal-overlay";
 
@@ -928,10 +958,10 @@ function editSchedule(s) {
             return new Intl.DateTimeFormat('en-GB', {
                 hour: '2-digit', minute: '2-digit', hour12: false,
                 timeZone: tz || undefined,
-            }).format(new Date());
+            }).format(_serverNow());
         } catch (e) {
             // Bad/unknown IANA name -- fall back to browser local time.
-            const now = new Date();
+            const now = _serverNow();
             return String(now.getHours()).padStart(2, '0') + ':' +
                    String(now.getMinutes()).padStart(2, '0');
         }


### PR DESCRIPTION
## Symptom

> _"I'm noticing that sometimes when I create a schedule that starts 'now' — as in I go into the schedule and I take an old schedule and then I modify the start time to be 'set to now', it will occasionally not show up at all on the dashboard as either a 'coming up' or 'currently playing', but after a minute (which is usually a 1 minute delay of the actual start time) it will then appear in the 'currently playing'."_

The schedule IS being delivered to the device (the asset plays immediately) — it's *only* the dashboard that doesn't see it for up to a minute.

## Root cause

The "Set to now" chip in the edit-schedule modal formats `new Date()` (browser clock) to `HH:MM`, truncating seconds to `:00`. If the browser is even a few seconds **ahead** of the CMS server clock, `Set to now` ends up rounding *into a future minute* relative to the server.

Concrete example:
- Browser clock: `08:51:05` → chip formats to `"08:51"`
- Saved `start_time`: `08:51:00`
- Server clock at the moment the next dashboard poll runs: `08:50:58`
- `_matches_now()`: `start_time(08:51:00) <= current_time(08:50:58)` → **False**
- Schedule is invisible everywhere on the dashboard
- ~2 s later (when server clock reaches `08:51:00`) the schedule begins matching → appears in "Now Playing"

This is essentially guaranteed on Windows clients, where `w32time` defaults to NTP-syncing only **once a week** and routinely drifts by 5–30 seconds.

## Fix

The CMS already exposes `/api/server-time`. Use it to compute browser-vs-server skew on schedules-page load (and again whenever the edit modal opens), and have `_currentTimeInTz()` format `Date.now() - skewMs` instead of `Date.now()`.

Round-trip latency is discounted by anchoring the server snapshot to the midpoint of the request (`(before + after) / 2`) rather than either endpoint.

## Tests

- `tests/test_schedules.py` + `tests/test_scheduler.py`: **100 / 100 pass** locally with `-p no:timeout`.
- The change is JS-template-only inside the schedules page; no Python contract changes.

## Followups not addressed here

- I noticed `_confirmed_playing` retains stale `since` timestamps across schedule-window edits (so an immediately-recurring schedule shows a `since` time from the prior window). Cosmetic, separate.
