### PR TITLE
Remove per-process sync dedup that silently dropped device pushes

### DIFF
--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -18,7 +18,7 @@ from cms.models.device import Device, DeviceStatus
 from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.schemas.schedule import ScheduleCreate, ScheduleOut, ScheduleUpdate
-from cms.services.scheduler import push_sync_to_affected_devices, push_sync_to_device, _get_target_device_ids, skip_schedule_until, clear_schedule_skip, clear_sync_hash, schedules_conflict, evaluate_schedules
+from cms.services.scheduler import push_sync_to_affected_devices, push_sync_to_device, _get_target_device_ids, skip_schedule_until, clear_schedule_skip, schedules_conflict, evaluate_schedules
 from cms.services.audit_service import audit_log, compute_diff
 from cms.services.asset_readiness import require_asset_ready
 
@@ -627,9 +627,8 @@ async def end_schedule_now(
             ))
         await db.commit()
 
-    # Clear sync hash and re-push so affected devices drop this schedule immediately
+    # Re-push so affected devices drop this schedule immediately.
     for did in affected_ids:
-        clear_sync_hash(did)
         await push_sync_to_device(did, db)
 
     return {

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -1,7 +1,6 @@
 """Schedule evaluator — background task that syncs schedules to devices."""
 
 import asyncio
-import hashlib
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -32,12 +31,6 @@ def _asset_display_name(asset) -> str:
     if asset is None:
         return "—"
     return asset.display_name or asset.original_filename or asset.filename
-
-# Track last sync hash per device to avoid re-sending identical syncs.
-# NOTE: this is replica-local. Under N>1 replicas two replicas may both
-# push to the same device, but the device firmware deduplicates via the
-# sync_hash echoed in acks. See docs/multi-replica.md.
-_last_sync_hash: dict[str, str] = {}
 
 # Confirmed playback: a **replica-local optimization cache** of what each
 # device has confirmed it's playing. Populated by WS PLAYBACK_STARTED,
@@ -317,11 +310,6 @@ def clear_schedule_skip(schedule_id: str, device_id: str | None = None) -> None:
     no in-memory cleanup is needed.
     """
     _ = schedule_id, device_id  # signature-compat only
-
-
-def clear_sync_hash(device_id: str) -> None:
-    """Clear the cached sync hash for a device so the next eval re-sends."""
-    _last_sync_hash.pop(device_id, None)
 
 
 async def compute_now_playing(db, tz: ZoneInfo, now: datetime) -> list[dict]:
@@ -919,11 +907,6 @@ def _schedule_to_entry(
     )
 
 
-def _sync_hash(sync: SyncMessage) -> str:
-    """Compute a hash of a sync message for dedup."""
-    return hashlib.md5(sync.model_dump_json().encode()).hexdigest()
-
-
 async def build_device_sync(
     device_id: str,
     db,
@@ -1117,12 +1100,10 @@ async def push_sync_to_device(
     if sync is None:
         return
 
-    h = _sync_hash(sync)
-    if _last_sync_hash.get(device_id) == h:
+    ok = await get_transport().send_to_device(device_id, sync.model_dump(mode="json"))
+    if not ok:
+        logger.warning("Sync send to device %s failed at transport layer", device_id)
         return
-
-    await get_transport().send_to_device(device_id, sync.model_dump(mode="json"))
-    _last_sync_hash[device_id] = h
     logger.info("Pushed full sync to device %s (%d schedules)", device_id, len(sync.schedules))
 
 
@@ -1187,9 +1168,6 @@ async def evaluate_schedules() -> None:
                 .where(Schedule.id == sid)
                 .values(skipped_until=None)
             )
-            # Clear sync hash so the schedule gets re-pushed on next eval
-            for did in connected:
-                _last_sync_hash.pop(did, None)
         if expired:
             await db.commit()
 
@@ -1203,7 +1181,6 @@ async def evaluate_schedules() -> None:
                     & (ScheduleDeviceSkip.device_id == did)
                 )
             )
-            _last_sync_hash.pop(did, None)
         if dev_expired:
             await db.commit()
 

--- a/tests/test_end_now_per_device.py
+++ b/tests/test_end_now_per_device.py
@@ -30,10 +30,8 @@ from cms.services.scheduler import build_device_sync, load_skip_snapshot
 def _reset_scheduler_state():
     """Clear the remaining replica-local scheduler caches between tests."""
     sched_mod._confirmed_playing.clear()
-    sched_mod._last_sync_hash.clear()
     yield
     sched_mod._confirmed_playing.clear()
-    sched_mod._last_sync_hash.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler_advanced.py
+++ b/tests/test_scheduler_advanced.py
@@ -1,5 +1,6 @@
 """Advanced scheduler tests: priorities, skip/end-now, upcoming, unique names, evaluate_schedules."""
 
+import asyncio
 import uuid
 from datetime import datetime, time, timedelta, timezone
 from unittest.mock import AsyncMock, patch, PropertyMock
@@ -17,10 +18,8 @@ from cms.models.setting import CMSSetting
 from cms.services.scheduler import (
     _matches_now,
     _now_playing,
-    _last_sync_hash,
     MISSED_GRACE_SECONDS,
     build_device_sync,
-    clear_sync_hash,
     clear_now_playing,
     evaluate_schedules,
     get_now_playing,
@@ -95,11 +94,9 @@ class TestSkipScheduleBehavior:
 
     def setup_method(self):
         _now_playing.clear()
-        _last_sync_hash.clear()
 
     def teardown_method(self):
         _now_playing.clear()
-        _last_sync_hash.clear()
 
     def test_skipped_schedule_hidden_from_upcoming(self):
         low = _make_schedule(
@@ -135,21 +132,175 @@ class TestSkipScheduleBehavior:
         assert any(r.get("preempted") for r in result)
 
 
-class TestClearSyncHash:
-    def setup_method(self):
-        _last_sync_hash.clear()
+class TestClearSyncHash_REMOVED:
+    """The per-process sync-dedup cache was removed; see fix/remove-sync-dedup.
 
-    def teardown_method(self):
-        _last_sync_hash.clear()
+    The tests that lived here verified clear_sync_hash() — that helper is
+    gone along with the dedup it supported. Regression coverage for the
+    "every push_sync_to_device call actually pushes" invariant now lives
+    in TestPushSyncToDevice below.
+    """
 
-    def test_clear_existing(self):
-        _last_sync_hash["device-1"] = "abc123"
-        clear_sync_hash("device-1")
-        assert "device-1" not in _last_sync_hash
 
-    def test_clear_nonexistent_is_harmless(self):
-        clear_sync_hash("no-such-device")
-        assert len(_last_sync_hash) == 0
+@pytest.mark.asyncio
+class TestPushSyncToDevice:
+    """Regression tests for the dedup-removal fix.
+
+    The bug (pre-fix): ``push_sync_to_device`` consulted a per-process
+    ``_last_sync_hash`` dict and silently dropped any send whose payload
+    matched the previous send for that device. This caused three
+    distinct failure modes:
+
+      1. Under N>=2 replicas, each pod's cache was independent. A PATCH
+         that reverted a device to a state replica X had previously sent
+         was suppressed even though the device may have only ever heard
+         it from a different replica.
+      2. The cache was poisoned by transport failures — send_to_device's
+         bool return was discarded, so a WPS failure stamped the cache
+         as "we sent X" even though the device never received it.
+      3. Concurrent PATCHes on a single replica could race on the
+         DB read, both compute the same hash, and the second be dropped.
+
+    The fix: removed the cache entirely. Every push_sync_to_device call
+    that gets past the connected+adopted gate now invokes the transport.
+
+    These tests assert the new invariant: **N calls in => N sends out.**
+    """
+
+    async def test_n_calls_n_sends_alternating_state(self, monkeypatch):
+        """Six sequential calls => six transport sends regardless of payload.
+
+        This is the user-reproduced single-stream repro: alternating
+        between two splash assets used to drop mid-stream PATCHes.
+        """
+        from cms.services import scheduler as sched_mod
+        from cms.schemas.protocol import SyncMessage
+
+        sends: list[dict] = []
+
+        fake_transport = AsyncMock()
+        fake_transport.is_connected = AsyncMock(return_value=True)
+        fake_transport.send_to_device = AsyncMock(
+            side_effect=lambda did, msg: (sends.append(msg) or True)
+        )
+        monkeypatch.setattr(sched_mod, "get_transport", lambda: fake_transport)
+
+        # Bypass the DB read by stubbing build_device_sync.
+        # Alternate splash filenames across calls, mirroring user repro.
+        names = ["pipes.jpg", "goodwill_splash.png"] * 3
+        idx = {"i": 0}
+
+        async def _fake_build(device_id, db, skips=None):
+            name = names[idx["i"]]
+            idx["i"] += 1
+            return SyncMessage(schedules=[], default_asset=name, splash=name)
+
+        monkeypatch.setattr(sched_mod, "build_device_sync", _fake_build)
+
+        # Bypass the adopted-status DB check.
+        fake_db = AsyncMock()
+        fake_db.execute = AsyncMock(
+            return_value=type(
+                "R", (), {"scalar_one_or_none": lambda self: DeviceStatus.ADOPTED}
+            )()
+        )
+
+        for _ in range(6):
+            await sched_mod.push_sync_to_device("dev-1", fake_db)
+
+        assert len(sends) == 6, (
+            f"Expected 6 sends for 6 calls; got {len(sends)}. "
+            "Dedup must not silently drop pushes."
+        )
+
+    async def test_concurrent_calls_all_fire(self, monkeypatch):
+        """asyncio.gather of two pushes on the same device => both send.
+
+        Pre-fix, two concurrent push_sync_to_device coroutines could
+        both read the post-commit DB state, compute the same hash, and
+        one's send would be dedup-suppressed by the other's store.
+        Post-fix, both must fire.
+        """
+        from cms.services import scheduler as sched_mod
+        from cms.schemas.protocol import SyncMessage
+
+        sends: list[dict] = []
+
+        async def _send(did, msg):
+            # Force an await boundary so the scheduler can interleave.
+            await asyncio.sleep(0)
+            sends.append(msg)
+            return True
+
+        fake_transport = AsyncMock()
+        fake_transport.is_connected = AsyncMock(return_value=True)
+        fake_transport.send_to_device = AsyncMock(side_effect=_send)
+        monkeypatch.setattr(sched_mod, "get_transport", lambda: fake_transport)
+
+        async def _fake_build(device_id, db, skips=None):
+            await asyncio.sleep(0)
+            # Both coroutines see the same post-commit DB state.
+            return SyncMessage(schedules=[], default_asset="pipes.jpg", splash="pipes.jpg")
+
+        monkeypatch.setattr(sched_mod, "build_device_sync", _fake_build)
+
+        fake_db = AsyncMock()
+        fake_db.execute = AsyncMock(
+            return_value=type(
+                "R", (), {"scalar_one_or_none": lambda self: DeviceStatus.ADOPTED}
+            )()
+        )
+
+        await asyncio.gather(
+            sched_mod.push_sync_to_device("dev-1", fake_db),
+            sched_mod.push_sync_to_device("dev-1", fake_db),
+        )
+
+        assert len(sends) == 2, (
+            f"Expected 2 sends for 2 concurrent calls; got {len(sends)}. "
+            "Concurrent pushes must not dedup against each other."
+        )
+
+    async def test_transport_failure_does_not_poison_future_sends(self, monkeypatch):
+        """A False return from send_to_device must not suppress the next call.
+
+        Pre-fix, a transport failure still stamped _last_sync_hash, so
+        the next equivalent state was dedup-suppressed forever. Post-fix,
+        there's no cache to poison: the next call rebuilds and resends.
+        """
+        from cms.services import scheduler as sched_mod
+        from cms.schemas.protocol import SyncMessage
+
+        sends: list[dict] = []
+        return_values = iter([False, True, True])
+
+        async def _send(did, msg):
+            sends.append(msg)
+            return next(return_values)
+
+        fake_transport = AsyncMock()
+        fake_transport.is_connected = AsyncMock(return_value=True)
+        fake_transport.send_to_device = AsyncMock(side_effect=_send)
+        monkeypatch.setattr(sched_mod, "get_transport", lambda: fake_transport)
+
+        async def _fake_build(device_id, db, skips=None):
+            return SyncMessage(schedules=[], default_asset="pipes.jpg", splash="pipes.jpg")
+
+        monkeypatch.setattr(sched_mod, "build_device_sync", _fake_build)
+
+        fake_db = AsyncMock()
+        fake_db.execute = AsyncMock(
+            return_value=type(
+                "R", (), {"scalar_one_or_none": lambda self: DeviceStatus.ADOPTED}
+            )()
+        )
+
+        for _ in range(3):
+            await sched_mod.push_sync_to_device("dev-1", fake_db)
+
+        assert len(sends) == 3, (
+            "Transport failures must not cache-poison subsequent sends."
+        )
 
 
 # ── Priority tests (pure logic, no DB) ──
@@ -666,11 +817,9 @@ class TestNowPlayingCleanup:
 
     def setup_method(self):
         _now_playing.clear()
-        _last_sync_hash.clear()
 
     def teardown_method(self):
         _now_playing.clear()
-        _last_sync_hash.clear()
 
     async def test_now_playing_cleared_when_schedule_deleted(self, app, db_session):
         """Deleting a schedule should clear its _now_playing entries."""


### PR DESCRIPTION
## Summary

Removes the per-process `_last_sync_hash` cache in `cms/services/scheduler.py` that was silently dropping device pushes under three distinct failure modes. The cache was an optimization layered over a correctness boundary it couldn't safely cross.

## User-visible symptom

In the agora-cms UI, changing a device's splash image (or any field on the device PATCH route) sometimes didn't reach the Pi. Observed lag ranged from "fixed by next scheduler tick (~15s)" to **"stuck for 7+ minutes, only resolved by forcing a re-PATCH via the API."** Deterministic repro: PATCH `default_asset_id` six times in rapid succession toggling pipes ↔ goodwill, ~500ms apart → device receives only 4 of 6 syncs.

## Root cause (three co-bugs)

1. **Multi-replica drop.** `_last_sync_hash` was per-process. Each pod had an independent cache. A PATCH that landed on replica X reverting the device to a state X had previously sent matched X's cache and was silently dropped — even though the device may have only ever heard that state from a different replica.

2. **Cache poisoning on transport failure.** `get_transport().send_to_device(...)` returns `bool`, but its return value was discarded. A WPS 404/429/timeout stamped the cache as "we sent hash X" while the device never received it; the next equivalent state was then dedup-suppressed indefinitely. Single-replica deployments would hit this too.

3. **Concurrent-PATCH race within one replica.** Two PATCHes commit in sequence; two `push_sync_to_device` coroutines run; both `build_device_sync` calls read the same post-commit DB state and compute the same hash; the first stores it; the second dedups against itself. This is what explained the deterministic single-stream repro.

The docstring on the cache (`scheduler.py:36-39`, pre-fix) claimed devices ack via a `sync_hash` field echoed back over the wire and the firmware would re-dedup as a safety net. Grep confirms no such field exists on `SyncMessage` (`cms/schemas/protocol.py:195`), no inbound handler consumes one, and `_sync_hash` was only ever used as the cache key in this one file. The "safety net" was fiction; a dropped send was unrecoverable.

## Fix

Delete the cache entirely. Every `push_sync_to_device` call that gets past the connected + adopted gate now invokes the transport. Log at WARN on transport failure so visibility no longer depends on dedup state.

```python
# was:
h = _sync_hash(sync)
if _last_sync_hash.get(device_id) == h:
    return
await get_transport().send_to_device(...)
_last_sync_hash[device_id] = h

# now:
ok = await get_transport().send_to_device(device_id, sync.model_dump(mode="json"))
if not ok:
    logger.warning("Sync send to device %s failed at transport layer", device_id)
    return
```

Also drops `clear_sync_hash` callers in `schedules.py` and test fixtures.

## Why "just remove dedup" instead of "fix the cache"

Considered and rejected:

| Option | Why not |
|---|---|
| Add `clear_sync_hash()` calls on user-write paths | Reduces failure rate; doesn't fix the read-vs-commit race or the cache poisoning. Clear+set is non-atomic across concurrent awaits. The user explicitly asked for a durable fix, not a band-aid. |
| Move dedup to Redis/DB | Eliminates the multi-replica leg but leaves the read-vs-commit race and the poisoning-on-failure leg unchanged. Adds infra dependency. |
| Dedup only on the scheduler tick, never on user writes | Tick's own cache can still go stale (leader-elected scheduler means non-leader replicas can't self-heal) — would still need the leader to periodically bypass dedup. Becomes a band-aid on a band-aid. |

Removing dedup outright eliminates all three failure modes in one move. Cost is increased WPS message volume from the scheduler tick re-sending equivalent state every ~15s. Back-of-envelope: 100 devices × 1 tick / 15s = ~400 msg/min, well under WPS Standard's 1000/s headroom. If volume ever becomes a measurable problem, the right place to reintroduce dedup is a separate tick-scoped, bounded-TTL cache that lives only on the scheduler-tick path and is never consulted on user-initiated writes.

## Tests

New `tests/test_scheduler_advanced.py::TestPushSyncToDevice`:

- `test_n_calls_n_sends_alternating_state` — drives 6 calls with alternating state, asserts 6 transport sends (reproduces the user repro).
- `test_concurrent_calls_all_fire` — `asyncio.gather` of two pushes on the same device, asserts both fire (covers the single-replica race).
- `test_transport_failure_does_not_poison_future_sends` — first call returns `False` from the transport, next two return `True`; asserts all three invocations actually happen.

The existing `TestClearSyncHash` class is replaced by a `TestClearSyncHash_REMOVED` placeholder docstring pointing readers to the new tests. Test fixtures that did `_last_sync_hash.clear()` in setup/teardown were updated.

## Out of scope (followup issues to file)

- `_confirmed_playing` (`scheduler.py:42-58`) has the same replica-local-cache shape and the docstring already admits the hazard. Separate PR.
- ACK protocol with versioned `sync_hash` for true at-least-once semantics — only worth doing if dedup is ever reintroduced.
- Leader-only scheduler tick under N≥2: non-leader replicas can't self-heal any state drift today. Broader architectural review.

## Risk

Failure mode if this regresses: small uptick in WPS message volume per minute and slightly more log lines from `push_sync_to_device`. No code path that was previously safe becomes unsafe; we are removing a "skip the send" branch, not adding one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
