### PR TITLE
feat(slideshow): introduce manifest_schema_version (Phase 0 / no behavior change)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -909,10 +909,10 @@ def _compute_slideshow_duration_seconds(
     return total_ms / 1000.0
 
 
-def _compute_slideshow_manifest_version(
+def _compute_slideshow_manifest_content_hash(
     slides: list[SlideIn], sources_by_id: dict[uuid.UUID, Asset]
 ) -> str:
-    """Structural manifest hash stored on ``Asset.checksum``.
+    """Structural manifest content hash stored on ``Asset.checksum``.
 
     Hashes ordered slide structure plus each source asset's own checksum
     so that any change to the slide list (reorder, add/remove, durations,
@@ -920,6 +920,13 @@ def _compute_slideshow_manifest_version(
     The *resolved* per-device checksum (which additionally folds in the
     selected READY variant checksum for the device's profile) is computed
     at sync/resolve time on top of this base value.
+
+    Renamed from ``_compute_slideshow_manifest_version`` to free up the
+    word "version" for ``manifest_schema_version`` on the wire (the
+    protocol-semver string added in agora#226 / slideshow wall-clock
+    work). This hash and the schema version are independent concepts:
+    the hash detects content edits, the schema version describes which
+    fields the wire format carries.
     """
     h = hashlib.sha256()
     for idx, s in enumerate(slides):
@@ -1069,7 +1076,7 @@ async def create_slideshow_asset(
     )
 
     duration_seconds = _compute_slideshow_duration_seconds(slides, sources_by_id)
-    manifest_version = _compute_slideshow_manifest_version(slides, sources_by_id)
+    manifest_content_hash = _compute_slideshow_manifest_content_hash(slides, sources_by_id)
 
     filename = await _unique_filename(db, name)
 
@@ -1077,7 +1084,7 @@ async def create_slideshow_asset(
         filename=filename,
         asset_type=AssetType.SLIDESHOW,
         size_bytes=0,
-        checksum=manifest_version,
+        checksum=manifest_content_hash,
         url=None,
         duration_seconds=duration_seconds,
         is_global=make_global,
@@ -1227,7 +1234,7 @@ async def replace_slideshow_slides(
     )
 
     duration_seconds = _compute_slideshow_duration_seconds(slides, sources_by_id)
-    manifest_version = _compute_slideshow_manifest_version(slides, sources_by_id)
+    manifest_content_hash = _compute_slideshow_manifest_content_hash(slides, sources_by_id)
 
     await db.execute(
         delete(SlideshowSlide).where(SlideshowSlide.slideshow_asset_id == asset_id)
@@ -1244,7 +1251,7 @@ async def replace_slideshow_slides(
             )
         )
     asset.duration_seconds = duration_seconds
-    asset.checksum = manifest_version
+    asset.checksum = manifest_content_hash
 
     await audit_log(
         db, user=user, action="asset.replace_slides", resource_type="asset",

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -35,6 +35,30 @@ SUPPORTED_PROTOCOL_VERSIONS = frozenset({1, 2})
 # is gated out of slideshow scheduling / default-asset assignment.
 CAPABILITY_SLIDESHOW_V1 = "slideshow_v1"
 
+# Slideshow manifest schema version (semver, additive minor bumps).  The
+# wire format of the slideshow manifest is independent of the
+# higher-level ``PROTOCOL_VERSION``: protocol bumps describe the WS
+# message envelope and binary frame encoding, schema bumps describe
+# which optional fields a ``FetchAssetMessage`` slideshow payload
+# (and its persisted on-device JSON) carries.
+#
+#   "1.0" — historical implicit version. ``slides`` only; no extras.
+#           A FetchAssetMessage with no ``manifest_schema_version``
+#           field is implicitly 1.0.
+#   "1.1" — adds optional ``cycle_duration_ms`` (sibling of ``slides``),
+#           optional ``started_at`` (wall-clock anchor, only present
+#           for ad-hoc / default-asset plays), and per-slide
+#           ``transition``/``transition_ms`` on ``SlideDescriptor``.
+#           Devices that don't understand 1.1 ignore the extras and
+#           keep playing the deck with the legacy relative-timer chain.
+#           Not yet emitted by the CMS — Phase 1a/1b lights it up.
+#
+# Rule for future bumps: minor bumps are additive (old players ignore
+# unknown fields).  A breaking change bumps the *major* and is gated
+# via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.0"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
+
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
 # firmware advertising the ``logs_chunk_v1`` capability sends these as
 # WS binary frames when a log bundle exceeds the single-message cap.
@@ -224,14 +248,22 @@ class FetchAssetMessage(BaseMessage):
     # ``slideshow``: an ordered list of resolved source slides the device
     # should fetch and play in sequence.  ``download_url`` and
     # ``size_bytes`` on the outer message are empty/zero for slideshows
-    # (no top-level file); ``checksum`` is the resolved manifest version
-    # (hash of structural metadata + per-slide variant checksums) so the
-    # device can short-circuit when nothing has changed.  Older firmware
-    # without ``slideshow_v1`` capability never receives a slideshow
-    # FETCH_ASSET (capability gate in the scheduler / default-asset
-    # endpoints prevents slideshows being assigned to incompatible
-    # devices in the first place).
+    # (no top-level file); ``checksum`` is the resolved manifest content
+    # hash (hash of structural metadata + per-slide variant checksums)
+    # so the device can short-circuit when nothing has changed.  Older
+    # firmware without ``slideshow_v1`` capability never receives a
+    # slideshow FETCH_ASSET (capability gate in the scheduler /
+    # default-asset endpoints prevents slideshows being assigned to
+    # incompatible devices in the first place).
     slides: Optional[list["SlideDescriptor"]] = None
+    # Schema version of the slideshow manifest carried in ``slides`` and
+    # the persisted on-device JSON.  Optional for backward compatibility
+    # with the unversioned v1.0 shape — a missing field is treated as
+    # ``"1.0"`` by both sides.  Bumped in Phase 1b to ``"1.1"`` to
+    # advertise wall-clock-anchor support.  See
+    # ``SLIDESHOW_MANIFEST_SCHEMA_VERSION_*`` constants at the top of
+    # this module for the version table.
+    manifest_schema_version: Optional[str] = None
 
 
 class SlideDescriptor(BaseModel):

--- a/tests/contract/slideshow_v1_0_schema.py
+++ b/tests/contract/slideshow_v1_0_schema.py
@@ -1,0 +1,77 @@
+# Vendored v1.0 slideshow manifest schema for contract pinning.
+#
+# Snapshot of the FetchAssetMessage slideshow shape as it existed BEFORE the
+# manifest_schema_version field was introduced (see plan.md Phase 0,
+# agora#226 wall-clock work).  This file is the contract gate: every future
+# minor bump to the slideshow wire format MUST keep a v1.0 device parser
+# able to deserialize the CMS-emitted payload by ignoring unknown fields.
+#
+# tests/test_slideshow_schema_contract.py round-trips current CMS output
+# through these models to catch additive-evolution regressions.
+#
+# If you find yourself needing to MODIFY this file to make tests pass, that
+# is a red flag: the new field is probably not actually additive, or the
+# v1.0 contract has been broken.  Bump the slideshow schema major (not
+# minor) and gate via a new capability string instead.
+#
+# DO NOT MODIFY MANUALLY.
+# ruff: noqa
+"""Pinned v1.0 slideshow manifest validator.
+
+Mirrors the pre-versioning shape:
+
+    FetchAssetMessage (slideshow variant):
+      - type, asset_name, download_url, checksum, size_bytes
+      - asset_type = "slideshow"
+      - slides: list[SlideDescriptor]
+
+    SlideDescriptor:
+      - asset_name, asset_type ("image"|"video"), download_url
+      - checksum, size_bytes, duration_ms, play_to_end (default False)
+
+Both models set ``extra="ignore"`` so a v1.0 device parsing a forward
+v1.x payload keeps the fields it knows and silently drops the rest.
+That's the whole point of the additive-evolution model.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SlideDescriptorV10(BaseModel):
+    """v1.0 SlideDescriptor.  Unknown fields ignored (forward compat)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    asset_name: str
+    asset_type: str  # "image" or "video"
+    download_url: str
+    checksum: str
+    size_bytes: int
+    duration_ms: int
+    play_to_end: bool = False
+
+
+class FetchAssetMessageV10(BaseModel):
+    """v1.0 FetchAssetMessage (slideshow variant).  Unknown fields ignored.
+
+    A v1.0 device sees a v1.x slideshow payload and successfully decodes
+    the slide list — any new sibling fields on the envelope
+    (``manifest_schema_version``, ``cycle_duration_ms``, ``started_at``)
+    or new per-slide fields (``transition``, ``transition_ms``) are
+    silently dropped.  The device continues to play the deck via the
+    legacy relative-timer chain.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: str
+    asset_name: str
+    download_url: str
+    checksum: str
+    size_bytes: int
+    asset_type: Optional[str] = None
+    slides: Optional[List[SlideDescriptorV10]] = None

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -3,7 +3,7 @@
 Covers the new code in:
 - ``cms/services/slideshow_resolver.py`` (plan_slideshow,
   build_fetch_for_slideshow, slideshow_readiness, resolved checksum)
-- ``cms/routers/assets.py`` (manifest_version baked into Asset.checksum)
+- ``cms/routers/assets.py`` (manifest_content_hash baked into Asset.checksum)
 - ``cms/routers/schedules.py`` (slideshow_v1 capability gate)
 - ``cms/routers/devices.py`` (slideshow_v1 gate on default-asset)
 - ``cms/services/scheduler.py`` (per-device resolved manifest checksum

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -1,0 +1,167 @@
+"""Slideshow manifest schema contract tests.
+
+Pins the wire format so that future minor bumps to the slideshow schema
+(``manifest_schema_version`` 1.0 → 1.1 → …) remain backward-compatible
+with the v1.0 device parser.  See ``tests/contract/slideshow_v1_0_schema.py``
+for the vendored v1.0 shape; see ``plan.md`` Phase 0 for why this gate
+exists.
+
+The contract:
+
+* CMS may add NEW optional fields to ``FetchAssetMessage`` (slideshow
+  variant) or to ``SlideDescriptor``.
+* A v1.0 device parser MUST still be able to deserialize the payload
+  — it just ignores fields it doesn't know.
+
+If a test in this file fails after a schema change, the change is not
+actually additive and the slideshow schema major should be bumped (gated
+via a new capability), not the minor.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from cms.schemas.protocol import (
+    FetchAssetMessage,
+    MessageType,
+    SlideDescriptor,
+    SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT,
+    SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
+)
+from tests.contract.slideshow_v1_0_schema import (
+    FetchAssetMessageV10,
+    SlideDescriptorV10,
+)
+
+
+def _build_cms_slideshow_msg(**overrides: Any) -> FetchAssetMessage:
+    """Build a representative CMS-emitted slideshow FetchAssetMessage."""
+    defaults: dict[str, Any] = {
+        "asset_name": "Lobby Slideshow.slideshow",
+        "download_url": "",
+        "checksum": "deadbeef" * 8,
+        "size_bytes": 0,
+        "asset_type": "slideshow",
+        "slides": [
+            SlideDescriptor(
+                asset_name="intro.png",
+                asset_type="image",
+                download_url="/assets/intro.png",
+                checksum="a" * 64,
+                size_bytes=2048,
+                duration_ms=5000,
+                play_to_end=False,
+            ),
+            SlideDescriptor(
+                asset_name="promo.mp4",
+                asset_type="video",
+                download_url="/assets/promo.mp4",
+                checksum="b" * 64,
+                size_bytes=1_000_000,
+                duration_ms=10000,
+                play_to_end=True,
+            ),
+        ],
+    }
+    defaults.update(overrides)
+    return FetchAssetMessage(**defaults)
+
+
+class TestSlideshowV10Contract:
+    """v1.0 device parser must still decode current CMS-emitted payloads."""
+
+    def test_current_cms_payload_decodes_under_v10(self):
+        """The baseline contract: a CMS-emitted slideshow message decodes
+        cleanly under the vendored v1.0 schema, even when new optional
+        fields are present.
+        """
+        cms_msg = _build_cms_slideshow_msg()
+
+        wire = json.loads(cms_msg.model_dump_json())
+
+        v10 = FetchAssetMessageV10.model_validate(wire)
+        assert v10.asset_name == cms_msg.asset_name
+        assert v10.asset_type == "slideshow"
+        assert v10.slides is not None
+        assert len(v10.slides) == 2
+        assert v10.slides[0].asset_name == "intro.png"
+        assert v10.slides[0].duration_ms == 5000
+        assert v10.slides[1].play_to_end is True
+
+    def test_forward_envelope_field_is_ignored(self):
+        """Adding a new sibling field on FetchAssetMessage doesn't break
+        v1.0.  Phase 1b will populate manifest_schema_version="1.1" on
+        the wire; a v1.0 device must ignore it.
+        """
+        cms_msg = _build_cms_slideshow_msg(manifest_schema_version="1.1")
+
+        wire = json.loads(cms_msg.model_dump_json())
+        assert wire.get("manifest_schema_version") == "1.1"
+
+        v10 = FetchAssetMessageV10.model_validate(wire)
+        # v1.0 parser doesn't surface the field, but doesn't error either.
+        assert not hasattr(v10, "manifest_schema_version") or \
+            getattr(v10, "manifest_schema_version", None) is None
+        assert v10.slides is not None
+        assert len(v10.slides) == 2
+
+    def test_forward_per_slide_field_is_ignored(self):
+        """Per-slide additions (e.g. transition/transition_ms in Phase 1a)
+        must also be silently dropped by a v1.0 parser.
+        """
+        # We can't yet construct a CMS SlideDescriptor with a
+        # ``transition`` field (Phase 1a adds it).  Simulate the
+        # forward shape by editing the wire dict directly.
+        cms_msg = _build_cms_slideshow_msg()
+        wire = json.loads(cms_msg.model_dump_json())
+        for slide in wire["slides"]:
+            slide["transition"] = "fade"
+            slide["transition_ms"] = 800
+
+        v10 = FetchAssetMessageV10.model_validate(wire)
+        assert v10.slides is not None
+        # Known fields preserved; unknown ones dropped.
+        assert v10.slides[0].duration_ms == 5000
+        for slide in v10.slides:
+            assert not hasattr(slide, "transition") or \
+                getattr(slide, "transition", None) is None
+
+    def test_missing_manifest_schema_version_implies_v1_0(self):
+        """A payload without the field is, by convention, v1.0.
+
+        This isn't enforced by the schema (the field is optional and
+        defaults to None) — it's a documented invariant.  The constant
+        in cms.schemas.protocol pins the default.
+        """
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT == "1.0"
+        # Phase 0 ships the field but doesn't yet bump the LATEST
+        # constant beyond 1.0.  Phase 1b will move LATEST to "1.1".
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.0"
+
+
+class TestSlideshowSchemaFieldDefaults:
+    """The new field must serialize cleanly when None (Phase 0 emit shape)."""
+
+    def test_field_omitted_when_none(self):
+        """Phase 0 doesn't yet emit ``manifest_schema_version`` — the
+        field is None and should be omitted from the JSON unless a
+        future phase explicitly populates it.
+
+        We use ``exclude_none=True`` here because that's what the actual
+        send path uses; if the round-trip default changes, this guards
+        the wire shape.
+        """
+        cms_msg = _build_cms_slideshow_msg()
+        assert cms_msg.manifest_schema_version is None
+
+        wire = json.loads(cms_msg.model_dump_json(exclude_none=True))
+        assert "manifest_schema_version" not in wire
+
+    def test_field_serializes_when_set(self):
+        cms_msg = _build_cms_slideshow_msg(manifest_schema_version="1.1")
+        wire = json.loads(cms_msg.model_dump_json())
+        assert wire["manifest_schema_version"] == "1.1"


### PR DESCRIPTION
Phase 0 of agora#226 (wall-clock-anchored slideshow playback) + the broader scope of versioning the slideshow manifest so future CMS additions don't break older players.

## What this changes

* New `SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST` / `_DEFAULT` constants (both `"1.0"`) in `cms/schemas/protocol.py`.
* New optional `manifest_schema_version: Optional[str] = None` field on `FetchAssetMessage` -- a **sibling** of `slides`, not an inner envelope (an inner envelope would break v1.0 device deserializers that parse `manifest["slides"]` directly).
* Renamed `_compute_slideshow_manifest_version` -> `_compute_slideshow_manifest_content_hash` so the existing structural-hash function stops squatting on the `version` name we now need for the wire field. Behavior unchanged.
* Pinned contract test: `tests/contract/slideshow_v1_0_schema.py` is a vendored copy of the pre-versioning `FetchAssetMessage` shape; `tests/test_slideshow_schema_contract.py` round-trips current CMS output through it and exercises forward-compat for both envelope-level (`manifest_schema_version`, `cycle_duration_ms`) and per-slide (`transition`, `transition_ms`) additions.

## What this does NOT change

No behavior. The field defaults to `None` and is omitted from the wire when unset; current emit shape is byte-identical to `main`. Phase 1a (transitions) and Phase 1b (`cycle_duration_ms` + `started_at`) are separate PRs.

## Paired device PR

[sslivins/agora#feat/slideshow-manifest-schema-version](https://github.com/sslivins/agora/pull/new/feat/slideshow-manifest-schema-version) -- device-side plumbing that reads + persists the new field. Either PR can merge first; they're mutually forward-compat.