### PR TITLE
feat(slideshow): per-slide transition fields, end-to-end (Phase 1a)

### DIFF
--- a/alembic/versions/0028_slideshow_slide_transitions.py
+++ b/alembic/versions/0028_slideshow_slide_transitions.py
@@ -1,0 +1,76 @@
+"""slideshow_slides: per-slide transition + transition_ms columns
+
+Phase 1a of agora#226 (wall-clock slideshow + manifest schema versioning).
+
+Adds two new columns to ``slideshow_slides``:
+
+* ``transition VARCHAR(16) NOT NULL DEFAULT 'cut'`` — which transition the
+  player should run BEFORE the slide appears (i.e. the transition is
+  attached to the slide on the right of a gap).  Allowed values:
+  ``cut``, ``fade``, ``dissolve``, ``wipe`` — enforced both by the
+  Pydantic input schema (``cms.schemas.asset.SLIDE_TRANSITIONS``) and a
+  DB-level CHECK constraint as the belt-and-braces guard against
+  out-of-band INSERTs.
+* ``transition_ms INTEGER NOT NULL DEFAULT 600`` — duration of the
+  transition in milliseconds.  ``0`` is valid (and required for
+  ``cut``).  Upper bound 5000 ms matches
+  ``cms.schemas.asset.MAX_SLIDE_TRANSITION_MS``.
+
+The DEFAULTs ensure existing rows pick up the pre-Phase-1a behaviour
+(``cut`` / ``600 ms`` — which the mpv player renders as an instant
+swap anyway since it ignores anything other than ``cut``).  The
+manifest content hash WILL change for slideshows once the columns are
+backfilled (a transition edit is a user-visible content change and we
+want devices to refetch), but since every existing row picks up the
+same defaults, the hash effectively rolls over once at deploy time and
+then only on actual edits.
+
+Revision ID: 0028
+Revises: 0027
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "transition",
+            sa.String(length=16),
+            nullable=False,
+            server_default="cut",
+        ),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "transition_ms",
+            sa.Integer(),
+            nullable=False,
+            server_default="600",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_transition_known",
+        "slideshow_slides",
+        "transition IN ('cut','fade','dissolve','wipe')",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_transition_ms_range",
+        "slideshow_slides",
+        "transition_ms >= 0 AND transition_ms <= 5000",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0028 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -934,7 +934,7 @@ def _compute_slideshow_manifest_content_hash(
         src_checksum = src.checksum or ""
         h.update(
             f"{idx}|{s.source_asset_id}|{src_checksum}|{s.duration_ms}|"
-            f"{int(s.play_to_end)}|".encode()
+            f"{int(s.play_to_end)}|{s.transition}|{s.transition_ms}|".encode()
         )
     return h.hexdigest()
 
@@ -1104,6 +1104,8 @@ async def create_slideshow_asset(
                 position=idx,
                 duration_ms=s.duration_ms,
                 play_to_end=s.play_to_end,
+                transition=s.transition,
+                transition_ms=s.transition_ms,
             )
         )
 
@@ -1169,6 +1171,8 @@ async def list_slideshow_slides(
                 "position": slide.position,
                 "duration_ms": slide.duration_ms,
                 "play_to_end": slide.play_to_end,
+                "transition": slide.transition,
+                "transition_ms": slide.transition_ms,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.filename,
                 "source_asset_type": src.asset_type.value,
@@ -1248,6 +1252,8 @@ async def replace_slideshow_slides(
                 position=idx,
                 duration_ms=s.duration_ms,
                 play_to_end=s.play_to_end,
+                transition=s.transition,
+                transition_ms=s.transition_ms,
             )
         )
     asset.duration_seconds = duration_seconds

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from cms.models.asset import AssetType, VariantStatus
 
@@ -19,6 +19,21 @@ MAX_SLIDESHOW_SLIDES = 50
 # reasonable slide length and prevents a single slide starving a schedule.
 MIN_SLIDE_DURATION_MS = 500
 MAX_SLIDE_DURATION_MS = 60 * 60 * 1000
+
+# Per-slide transition controls (Phase 1a of agora#226).  ``cut`` means an
+# instant swap (no transition) and is the only transition the mpv-based
+# player actually renders today — ``fade``/``dissolve``/``wipe`` are
+# accepted on the wire so the chromium-player branch can render them
+# without a follow-up schema bump.  The mpv player ignores anything other
+# than ``cut`` (renders the slide instantly).
+SLIDE_TRANSITIONS = ("cut", "fade", "dissolve", "wipe")
+DEFAULT_SLIDE_TRANSITION = "cut"
+# Transition duration bounds.  ``0`` is valid (and required for ``cut``);
+# upper bound is a soft sanity limit — anything longer would dominate the
+# slide duration and look broken.
+MIN_SLIDE_TRANSITION_MS = 0
+MAX_SLIDE_TRANSITION_MS = 5000
+DEFAULT_SLIDE_TRANSITION_MS = 600
 
 
 class AssetVariantOut(BaseModel):
@@ -64,6 +79,25 @@ class SlideIn(BaseModel):
     source_asset_id: uuid.UUID
     duration_ms: int = Field(..., ge=MIN_SLIDE_DURATION_MS, le=MAX_SLIDE_DURATION_MS)
     play_to_end: bool = False
+    # Per-slide transition that runs BEFORE the slide appears (i.e. attached
+    # to the slide on the right of a gap).  Optional on the wire — old UI
+    # clients that don't send the field land on ``cut`` / ``0`` which is
+    # exactly the pre-Phase-1a behaviour.
+    transition: str = Field(DEFAULT_SLIDE_TRANSITION)
+    transition_ms: int = Field(
+        DEFAULT_SLIDE_TRANSITION_MS,
+        ge=MIN_SLIDE_TRANSITION_MS,
+        le=MAX_SLIDE_TRANSITION_MS,
+    )
+
+    @field_validator("transition")
+    @classmethod
+    def _validate_transition(cls, v: str) -> str:
+        if v not in SLIDE_TRANSITIONS:
+            raise ValueError(
+                f"transition must be one of {SLIDE_TRANSITIONS}, got {v!r}"
+            )
+        return v
 
 
 class SlideOut(BaseModel):
@@ -79,6 +113,8 @@ class SlideOut(BaseModel):
     position: int
     duration_ms: int
     play_to_end: bool
+    transition: str = DEFAULT_SLIDE_TRANSITION
+    transition_ms: int = DEFAULT_SLIDE_TRANSITION_MS
     source_asset_id: uuid.UUID
     source_filename: str
     source_asset_type: AssetType

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -276,6 +276,12 @@ class SlideDescriptor(BaseModel):
     size_bytes: int
     duration_ms: int
     play_to_end: bool = False
+    # Per-slide transition controls (Phase 1a of agora#226).  Optional on
+    # the wire so a v1.0 device parser ignores them; a v1.1+ player reads
+    # them.  ``transition`` is one of cut/fade/dissolve/wipe.  Default
+    # behaviour (``cut`` / 600 ms) matches the pre-versioning era.
+    transition: str = "cut"
+    transition_ms: int = 600
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> "SlideDescriptor":
@@ -290,6 +296,16 @@ class SlideDescriptor(BaseModel):
         if self.play_to_end and self.asset_type != "video":
             raise ValueError(
                 "SlideDescriptor.play_to_end=True is only valid for video sources"
+            )
+        if self.transition not in ("cut", "fade", "dissolve", "wipe"):
+            raise ValueError(
+                f"SlideDescriptor.transition must be one of "
+                f"cut/fade/dissolve/wipe, got {self.transition!r}"
+            )
+        if self.transition_ms < 0 or self.transition_ms > 5000:
+            raise ValueError(
+                f"SlideDescriptor.transition_ms must be in [0, 5000], "
+                f"got {self.transition_ms}"
             )
         return self
 

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -55,6 +55,11 @@ class _SlidePlan:
     source_asset_type: AssetType
     duration_ms: int
     play_to_end: bool
+    # Per-slide transition (Phase 1a of agora#226).  Default ``cut`` / 600
+    # ms matches the pre-Phase-1a behaviour for slides created before the
+    # column existed.
+    transition: str = "cut"
+    transition_ms: int = 600
     # Populated for ready slides only:
     download_path: Optional[str] = None  # storage path for get_device_download_url
     api_url_path: Optional[str] = None  # CMS-relative API URL for fallback
@@ -162,6 +167,8 @@ async def plan_slideshow(
             source_asset_type=src.asset_type,
             duration_ms=slide_row.duration_ms,
             play_to_end=slide_row.play_to_end,
+            transition=slide_row.transition,
+            transition_ms=slide_row.transition_ms,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -226,7 +233,7 @@ def _compute_resolved_manifest_checksum(
     for s in slides:
         h.update(
             f"|{s.position}|{s.source_asset_id}|{s.checksum or ''}|"
-            f"{s.duration_ms}|{int(s.play_to_end)}".encode()
+            f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}".encode()
         )
     return h.hexdigest()
 
@@ -282,6 +289,8 @@ async def build_fetch_for_slideshow(
                 size_bytes=sp.size_bytes or 0,
                 duration_ms=sp.duration_ms,
                 play_to_end=sp.play_to_end,
+                transition=sp.transition,
+                transition_ms=sp.transition_ms,
             )
         )
 

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -647,7 +647,12 @@ function makeSlot(s, i) {
     return slot;
 }
 
-// Transition types — only 'cut' is implemented today; the rest are placeholders.
+// Transition types — only ``cut`` is exposed in the UI today.  The wire
+// schema (Phase 1a of agora#226) accepts ``fade``/``dissolve``/``wipe``
+// too, but the mpv-based fleet renders any non-``cut`` value as an
+// instant swap (same visual result as cut) — so enabling those options
+// in the picker would be a UX trap.  The chromium-player branch flips
+// these to ``enabled: true`` once it can render them for real.
 const SS_TRANSITIONS = [
     {id: 'cut',      label: 'Cut',      icon: '\u2702',    enabled: true},   // ✂
     {id: 'fade',     label: 'Fade',     icon: '\u25D0',    enabled: false},  // ◐
@@ -796,6 +801,11 @@ function addSlideFromAsset(assetId, atIndex) {
             ? Math.round(a.duration_seconds * 1000)
             : 10000,
         play_to_end: a.asset_type === 'video',
+        // New slides default to ``cut`` / 600 ms — matches the server-side
+        // default and the legacy mpv player's "instant swap" behaviour.
+        // Phase 1a of agora#226 makes these editable per slide.
+        transition: 'cut',
+        transition_ms: 600,
         source_filename: a.display_name || a.original_filename || a.filename,
         source_asset_type: a.asset_type,
         source_duration_seconds: a.duration_seconds,
@@ -894,6 +904,8 @@ async function saveSlideshow(opts) {
             source_asset_id: s.source_asset_id,
             duration_ms: s.duration_ms,
             play_to_end: !!s.play_to_end,
+            transition: s.transition || 'cut',
+            transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
         }));
         if (SS_EDIT_MODE) {
             const r = await fetch(`/api/assets/${SS_ASSET_ID}/slides`, {

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1591,6 +1591,8 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                 "position": slide.position,
                 "duration_ms": slide.duration_ms,
                 "play_to_end": slide.play_to_end,
+                "transition": slide.transition,
+                "transition_ms": slide.transition_ms,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.display_name or src.original_filename or src.filename,
                 "source_asset_type": src.asset_type.value,

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    String,
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -35,6 +36,19 @@ class SlideshowSlide(Base):
         ),
         CheckConstraint("duration_ms > 0", name="ck_slideshow_slide_duration_pos"),
         CheckConstraint("position >= 0", name="ck_slideshow_slide_position_nonneg"),
+        # Transition fields (Phase 1a of agora#226).  The allowed transition
+        # set is enforced in the Pydantic input schema; the DB check is the
+        # belt-and-braces guard against an out-of-band INSERT.  The
+        # transition_ms upper bound (5000 ms) matches MAX_SLIDE_TRANSITION_MS
+        # in cms.schemas.asset.
+        CheckConstraint(
+            "transition IN ('cut','fade','dissolve','wipe')",
+            name="ck_slideshow_slide_transition_known",
+        ),
+        CheckConstraint(
+            "transition_ms >= 0 AND transition_ms <= 5000",
+            name="ck_slideshow_slide_transition_ms_range",
+        ),
         # FK columns are not auto-indexed in Postgres; the source-delete guard
         # and ACL re-check queries scan by source_asset_id.
         Index("ix_slideshow_slides_source_asset_id", "source_asset_id"),
@@ -58,6 +72,18 @@ class SlideshowSlide(Base):
     duration_ms: Mapped[int] = mapped_column(Integer, nullable=False)
     play_to_end: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
+    )
+    # Per-slide transition that runs BEFORE this slide appears (i.e. the
+    # transition is attached to the slide on the right of a gap).  Stored
+    # as a short string for forward-compatibility — the allowed set is
+    # validated in the Pydantic input schema and re-asserted at the DB
+    # level via a CHECK constraint.  Phase 1a only ``cut`` is rendered by
+    # the mpv player; the chromium-player branch renders the rest.
+    transition: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="cut", server_default="cut"
+    )
+    transition_ms: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=600, server_default="600"
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -423,6 +423,173 @@ class TestSlideshowSlidesEndpoints:
         assert ss.duration_seconds == pytest.approx(5.5)
 
 
+@pytest.mark.asyncio
+class TestSlideTransitions:
+    """Phase 1a of agora#226: per-slide transition + transition_ms."""
+
+    async def test_create_defaults_transition_to_cut_600(self, client, db_session):
+        img = await _seed_image(db_session, filename="t1.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "td",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 1000}],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["transition"] == "cut"
+        assert slides[0]["transition_ms"] == 600
+
+    async def test_create_round_trips_explicit_transition(self, client, db_session):
+        img = await _seed_image(db_session, filename="t2.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "te",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "transition": "fade",
+                    "transition_ms": 800,
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["transition"] == "fade"
+        assert slides[0]["transition_ms"] == 800
+
+    async def test_replace_round_trips_explicit_transition(self, client, db_session):
+        img = await _seed_image(db_session, filename="t3.png", is_global=True)
+        sid = (await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "tr",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 1000}],
+            },
+        )).json()["id"]
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{
+                "source_asset_id": str(img.id),
+                "duration_ms": 1000,
+                "transition": "dissolve",
+                "transition_ms": 1500,
+            }]},
+        )
+        assert put.status_code == 200, put.text
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["transition"] == "dissolve"
+        assert slides[0]["transition_ms"] == 1500
+
+    async def test_rejects_unknown_transition(self, client, db_session):
+        img = await _seed_image(db_session, filename="t4.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "tx",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "transition": "warp_speed",
+                }],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.text
+
+    async def test_rejects_transition_ms_above_cap(self, client, db_session):
+        img = await _seed_image(db_session, filename="t5.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "th",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "transition": "fade",
+                    "transition_ms": 99999,
+                }],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.text
+
+    async def test_transition_change_flips_manifest_content_hash(
+        self, client, db_session
+    ):
+        """Editing the transition is a user-visible content change → the
+        structural manifest content hash MUST flip so the device refetches.
+        Documented in plan.md Phase 1a (deliberate refetch-storm decision).
+        """
+        img = await _seed_image(db_session, filename="t6.png", is_global=True)
+        sid = (await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "th2",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "transition": "cut",
+                    "transition_ms": 600,
+                }],
+            },
+        )).json()["id"]
+        ss = await db_session.get(Asset, uuid.UUID(sid))
+        await db_session.refresh(ss)
+        original_hash = ss.checksum
+
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{
+                "source_asset_id": str(img.id),
+                "duration_ms": 1000,
+                "transition": "fade",  # only this changed
+                "transition_ms": 600,
+            }]},
+        )
+        assert put.status_code == 200, put.text
+        await db_session.refresh(ss)
+        assert ss.checksum != original_hash, (
+            "transition edit must flip the manifest content hash so devices "
+            "refetch on the next sync"
+        )
+
+    async def test_transition_ms_change_flips_manifest_content_hash(
+        self, client, db_session
+    ):
+        img = await _seed_image(db_session, filename="t7.png", is_global=True)
+        sid = (await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "th3",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "transition": "fade",
+                    "transition_ms": 600,
+                }],
+            },
+        )).json()["id"]
+        ss = await db_session.get(Asset, uuid.UUID(sid))
+        await db_session.refresh(ss)
+        original_hash = ss.checksum
+
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{
+                "source_asset_id": str(img.id),
+                "duration_ms": 1000,
+                "transition": "fade",
+                "transition_ms": 1200,  # only this changed
+            }]},
+        )
+        assert put.status_code == 200, put.text
+        await db_session.refresh(ss)
+        assert ss.checksum != original_hash
+
+
 # ── Source-delete guard ──
 
 

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -88,7 +88,9 @@ async def _seed_variant(
 async def _seed_slideshow(db, *, name, slides_data, checksum=""):
     """Seed a slideshow asset directly (bypasses API ACL flow).
 
-    ``slides_data`` is a list of (source_asset, duration_ms, play_to_end).
+    ``slides_data`` is a list of ``(source_asset, duration_ms, play_to_end)``
+    or ``(source_asset, duration_ms, play_to_end, transition, transition_ms)``
+    for tests that need to assert on transition propagation.
     """
     ss = Asset(
         filename=name,
@@ -100,13 +102,20 @@ async def _seed_slideshow(db, *, name, slides_data, checksum=""):
     db.add(ss)
     await db.commit()
     await db.refresh(ss)
-    for idx, (src, dur_ms, pte) in enumerate(slides_data):
+    for idx, row in enumerate(slides_data):
+        if len(row) == 3:
+            src, dur_ms, pte = row
+            trans, trans_ms = "cut", 600
+        else:
+            src, dur_ms, pte, trans, trans_ms = row
         db.add(SlideshowSlide(
             slideshow_asset_id=ss.id,
             source_asset_id=src.id,
             position=idx,
             duration_ms=dur_ms,
             play_to_end=pte,
+            transition=trans,
+            transition_ms=trans_ms,
         ))
     await db.commit()
     await db.refresh(ss)
@@ -308,6 +317,26 @@ class TestSlideshowResolver:
 
         c2 = await resolved_slideshow_checksum(ss, profile.id, db_session)
         assert c1 != c2 and c1 is not None and c2 is not None
+
+    async def test_plan_propagates_transition_fields(self, db_session):
+        """Phase 1a: per-slide transition + transition_ms must reach the
+        wire ``SlideDescriptor`` via the plan."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "p-trans")
+        img = await _seed_image(db_session, filename="tr1.png", checksum="raw")
+        ss = await _seed_slideshow(
+            db_session, name="ss-trans",
+            slides_data=[
+                (img, 3000, False, "fade", 800),
+                (img, 4000, False, "cut", 600),
+            ],
+            checksum="m",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        assert [s.transition for s in plan.slides] == ["fade", "cut"]
+        assert [s.transition_ms for s in plan.slides] == [800, 600]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -110,17 +110,27 @@ class TestSlideshowV10Contract:
         assert len(v10.slides) == 2
 
     def test_forward_per_slide_field_is_ignored(self):
-        """Per-slide additions (e.g. transition/transition_ms in Phase 1a)
-        must also be silently dropped by a v1.0 parser.
+        """Per-slide additions (transition/transition_ms, Phase 1a) must
+        be silently dropped by a v1.0 parser.
         """
-        # We can't yet construct a CMS SlideDescriptor with a
-        # ``transition`` field (Phase 1a adds it).  Simulate the
-        # forward shape by editing the wire dict directly.
-        cms_msg = _build_cms_slideshow_msg()
+        cms_msg = _build_cms_slideshow_msg(
+            slides=[
+                SlideDescriptor(
+                    asset_name="intro.png",
+                    asset_type="image",
+                    download_url="/assets/intro.png",
+                    checksum="a" * 64,
+                    size_bytes=2048,
+                    duration_ms=5000,
+                    play_to_end=False,
+                    transition="fade",
+                    transition_ms=800,
+                ),
+            ]
+        )
         wire = json.loads(cms_msg.model_dump_json())
-        for slide in wire["slides"]:
-            slide["transition"] = "fade"
-            slide["transition_ms"] = 800
+        assert wire["slides"][0]["transition"] == "fade"
+        assert wire["slides"][0]["transition_ms"] == 800
 
         v10 = FetchAssetMessageV10.model_validate(wire)
         assert v10.slides is not None


### PR DESCRIPTION
Phase 1a of agora#226 (versioned slideshow manifest + wall-clock-anchored playback).

## What

Adds `transition` (`cut`/`fade`/`dissolve`/`wipe`) and `transition_ms` (0..5000) to:

- `slideshow_slides` table (alembic 0028) with server defaults `cut` / 600 and CHECK constraints
- `SlideIn` / `SlideOut` Pydantic schemas
- `SlideDescriptor` on the wire (additive — v1.0 device parsers ignore)
- Builder UI save payload + slide initialization

## Decisions

- **Defaults**: `cut` / 600 ms — matches existing builder placeholder; makes pre-1a rows behave identically.
- **Validation**: Pydantic enum + range, plus DB CHECK constraints belt-and-braces.
- **Content hash**: transition fields **enter** both `_compute_slideshow_manifest_content_hash` and `_compute_resolved_manifest_checksum`. A transition edit is a user-visible content change → we want devices to refetch on next sync. One-time fleet-wide refetch storm on initial deploy is acceptable (small manifests). Deploy off-hours.
- **UI rollout**: only `cut` is enabled in the picker (fade/dissolve/wipe disabled). The wire accepts them already; the chromium-player branch will flip the picker flags on once it ships, so the mpv fleet won't silently hard-cut something the UI promised would fade.

## Tests

- `TestSlideTransitions` (7 tests): create/replace round-trip; default-population; rejects unknown transition + out-of-range transition_ms; content hash flips on transition or transition_ms edit.
- `TestSlideshowResolver::test_plan_propagates_transition_fields`: plan → wire `SlideDescriptor` carries the fields.
- `TestSlideshowV10Contract::test_forward_per_slide_field_is_ignored`: v1.0 device parser still decodes a payload with the new fields (silently drops them).

Targeted suite: `tests/test_slideshow_assets.py tests/test_slideshow_resolver.py tests/test_slideshow_schema_contract.py` — 56+ passed locally.

## Pairs with

sslivins/agora PR for the device side (persists the fields into the on-disk slideshow manifest so the chromium-player branch can consume them).