### PR TITLE
Phase 1b: emit manifest schema 1.1 + wall-clock anchor (#226)

### DIFF
--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -56,7 +56,7 @@ CAPABILITY_SLIDESHOW_V1 = "slideshow_v1"
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.0"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.1"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -264,6 +264,21 @@ class FetchAssetMessage(BaseMessage):
     # ``SLIDESHOW_MANIFEST_SCHEMA_VERSION_*`` constants at the top of
     # this module for the version table.
     manifest_schema_version: Optional[str] = None
+    # Total cycle length in milliseconds (Phase 1b of agora#226).  Sum of
+    # ``slide.duration_ms`` across the deck.  Optional / additive; v1.0
+    # devices ignore it.  Emitted whenever ``slides`` is non-empty.  NOT
+    # part of the manifest content hash — it's a pure function of slide
+    # durations which are already hashed.
+    cycle_duration_ms: Optional[int] = None
+    # Wall-clock anchor for the slideshow cycle, ISO-8601 UTC string
+    # (e.g. "2026-05-23T18:30:00Z").  Phase 1b: present ONLY for ad-hoc
+    # / default-asset plays where the CMS picks a cycle boundary aligned
+    # to "now".  For *scheduled* plays the device computes the anchor
+    # from the active ``ScheduleEntry.start_time`` (wall-clock of the
+    # currently-active window) so a reboot mid-window resyncs without
+    # the CMS having to tell each device a different start time.
+    # Optional / additive; v1.0 devices ignore it.
+    started_at: Optional[str] = None
 
 
 class SlideDescriptor(BaseModel):

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import hashlib
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import select
@@ -32,7 +33,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.device import Device
-from cms.schemas.protocol import FetchAssetMessage, SlideDescriptor
+from cms.schemas.protocol import (
+    FetchAssetMessage,
+    SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
+    SlideDescriptor,
+)
 from cms.services.storage import get_storage
 from shared.models.slideshow_slide import SlideshowSlide
 
@@ -295,6 +300,11 @@ async def build_fetch_for_slideshow(
         )
 
     resolved = _compute_resolved_manifest_checksum(asset.checksum or "", plan.slides)
+
+    # Phase 1b of agora#226 — wall-clock anchor support.
+    cycle_duration_ms = sum(sp.duration_ms for sp in plan.slides)
+    started_at = _compute_cycle_anchor(cycle_duration_ms)
+
     return FetchAssetMessage(
         asset_name=asset.filename,
         download_url="",
@@ -302,7 +312,33 @@ async def build_fetch_for_slideshow(
         size_bytes=0,
         asset_type=AssetType.SLIDESHOW.value,
         slides=descriptors,
+        manifest_schema_version=SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
+        cycle_duration_ms=cycle_duration_ms,
+        started_at=started_at,
     )
+
+
+def _compute_cycle_anchor(cycle_duration_ms: int) -> Optional[str]:
+    """Floor ``now_utc`` to the nearest ``cycle_duration_ms`` boundary
+    since the Unix epoch, returned as an ISO-8601 UTC string.
+
+    The anchor is purely derived from the wall clock and the cycle
+    length, so any two devices computing it locally with synchronized
+    clocks would land on the same instant — which is what makes the
+    chromium-player branch's "same content at the same second" promise
+    work across reflashes and reboots.
+
+    Returns ``None`` if ``cycle_duration_ms <= 0`` (defensive — an empty
+    deck shouldn't reach here because the planner rejects it earlier).
+    """
+    if cycle_duration_ms <= 0:
+        return None
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    floor_ms = (now_ms // cycle_duration_ms) * cycle_duration_ms
+    anchor = datetime.fromtimestamp(floor_ms / 1000, tz=timezone.utc)
+    # ISO-8601 with millisecond precision, "Z" suffix for UTC.
+    iso = anchor.isoformat(timespec="milliseconds")
+    return iso.replace("+00:00", "Z")
 
 
 async def slideshow_readiness(

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -338,6 +338,44 @@ class TestSlideshowResolver:
         assert [s.transition for s in plan.slides] == ["fade", "cut"]
         assert [s.transition_ms for s in plan.slides] == [800, 600]
 
+    async def test_build_fetch_emits_wall_clock_fields(self, db_session, app):
+        """Phase 1b: ``build_fetch_for_slideshow`` must populate
+        ``manifest_schema_version``, ``cycle_duration_ms``, and
+        ``started_at`` on the outbound ``FetchAssetMessage``.
+
+        ``cycle_duration_ms`` = sum(per-slide duration_ms).
+        ``started_at`` = floor(now_utc, cycle_duration_ms) as
+        ISO-8601 UTC ("Z" suffix).
+        """
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "p-wc")
+        img = await _seed_image(db_session, filename="wc1.png", checksum="rwc")
+        ss = await _seed_slideshow(
+            db_session, name="ss-wc",
+            slides_data=[(img, 3000, False), (img, 4500, False)],
+            checksum="mwc",
+        )
+        device = await _seed_device(
+            db_session, did="dev-wc", profile=profile,
+            capabilities=[CAPABILITY_SLIDESHOW_V1],
+        )
+
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        assert fetch.manifest_schema_version == "1.1"
+        assert fetch.cycle_duration_ms == 7500
+        assert fetch.started_at is not None
+        assert fetch.started_at.endswith("Z")
+        # Cycle-floor invariant: parsing the anchor must yield an integer
+        # millisecond count that's an exact multiple of cycle_duration_ms.
+        from datetime import datetime
+        anchor = datetime.fromisoformat(fetch.started_at.replace("Z", "+00:00"))
+        anchor_ms = int(anchor.timestamp() * 1000)
+        assert anchor_ms % fetch.cycle_duration_ms == 0
+
 
 # ---------------------------------------------------------------------------
 # Manifest version stability tests

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -148,9 +148,33 @@ class TestSlideshowV10Contract:
         in cms.schemas.protocol pins the default.
         """
         assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT == "1.0"
-        # Phase 0 ships the field but doesn't yet bump the LATEST
-        # constant beyond 1.0.  Phase 1b will move LATEST to "1.1".
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.0"
+        # Phase 1b bumps LATEST to "1.1" (wall-clock fields).  Future
+        # phases will keep bumping as new fields land.  DEFAULT stays
+        # at "1.0" — that's the "no version on the wire" fallback.
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.1"
+
+    def test_forward_wall_clock_fields_are_ignored(self):
+        """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to
+        ``FetchAssetMessage``.  A v1.0 device parser must silently drop
+        them — same forward-compat invariant as Phase 0/1a fields.
+        """
+        cms_msg = _build_cms_slideshow_msg(
+            manifest_schema_version="1.1",
+            cycle_duration_ms=15000,
+            started_at="2026-05-23T19:39:45.000Z",
+        )
+        wire = json.loads(cms_msg.model_dump_json())
+        assert wire["cycle_duration_ms"] == 15000
+        assert wire["started_at"] == "2026-05-23T19:39:45.000Z"
+
+        v10 = FetchAssetMessageV10.model_validate(wire)
+        # v1.0 parser drops the new fields without error.
+        assert not hasattr(v10, "cycle_duration_ms") or \
+            getattr(v10, "cycle_duration_ms", None) is None
+        assert not hasattr(v10, "started_at") or \
+            getattr(v10, "started_at", None) is None
+        assert v10.slides is not None
+        assert len(v10.slides) == 2
 
 
 class TestSlideshowSchemaFieldDefaults:


### PR DESCRIPTION
Phase 1b of agora#226 (versioned slideshow manifest + wall-clock anchor).

Bumps the CMS-emitted slideshow manifest from schema 1.0 to **1.1** and adds two wall-clock anchor fields on every `FetchAssetMessage`:

- `manifest_schema_version = "1.1"`
- `cycle_duration_ms = sum(slide.duration_ms)`
- `started_at = floor(now_utc, cycle_duration_ms)` (ISO-8601 UTC, "Z" suffix)

### Plan-v2 deviation (also captured in plan.md)

The original plan said "ad-hoc only" for `started_at`. `build_fetch_for_slideshow` is also called from device-initiated `FETCH_REQUEST` where the CMS doesn't know scheduled-vs-ad-hoc — so we emit `started_at` unconditionally. The Phase 2 device-side resolver prefers `schedule.start_time` over `manifest.started_at` whenever schedule context is present, so this is functionally equivalent and much simpler.

### Backward compat

Forward-compat against v1.0 device parsers is guarded by the existing contract test (`tests/test_slideshow_schema_contract.py::TestSlideshowV10Contract::test_forward_wall_clock_fields_are_ignored`) — vendored v1.0 schema decodes a 1.1 payload cleanly with the new fields dropped.

The mpv production fleet picks the new fields up but ignores them in this phase. Phase 2 (mpv wall-clock resync) will activate them.

### Pairs with

sslivins/agora#TBD — persists the new fields into the on-disk manifest JSON so Phase 2 can read them after reboot.