### PR TITLE
Move 'update available' badge from Firmware Version to OS Version

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -728,13 +728,13 @@
             </div>
             <div class="detail-item">
                 <span class="detail-label">Firmware Version</span>
-                <span class="detail-value">
-                    <span data-live-firmware-version="{{ d.id }}">{{ d.firmware_version or '—' }}</span>{% if 'devices:manage' in user_perms %} <span class="badge badge-update" data-live-update-badge="{{ d.id }}"{% if not d.update_available %} style="display:none"{% endif %}>{{ latest_version }} available</span>{% endif %}
-                </span>
+                <span class="detail-value" data-live-firmware-version="{{ d.id }}">{{ d.firmware_version or '—' }}</span>
             </div>
             <div class="detail-item">
                 <span class="detail-label">OS Version</span>
-                <span class="detail-value" data-live-os-version="{{ d.id }}">{{ d.os_version or '—' }}</span>
+                <span class="detail-value">
+                    <span data-live-os-version="{{ d.id }}">{{ d.os_version or '—' }}</span>{% if 'devices:manage' in user_perms %} <span class="badge badge-update" data-live-update-badge="{{ d.id }}"{% if not d.update_available %} style="display:none"{% endif %}>{{ latest_version }} available</span>{% endif %}
+                </span>
             </div>
             <div class="detail-item">
                 <span class="detail-label">Storage</span>

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -717,7 +717,9 @@ window._adoptionProfiles = [
             const osEl = document.querySelector(`[data-live-os-version="${d.id}"]`);
             if (osEl) osEl.textContent = d.os_version || '—';
             // The "{latest_version} available" badge is rendered server-
-            // side INSIDE the firmware-version detail cell and gated on
+            // side INSIDE the os-version detail cell (latest_version comes
+            // from bundle_checker polling agora-os releases, so it's an
+            // OS version not a firmware version) and gated on
             // d.update_available + the devices:manage permission. The
             // badge wrapper is always emitted (hidden via style.display
             // when not applicable) so the JS can flip its visibility


### PR DESCRIPTION
The `{latest_version} available` badge in the device detail panel was rendered inside the **Firmware Version** cell, but the version it shows comes from `bundle_checker`, which polls **agora-os** GitHub releases. So it's an OS version, not a firmware version -- and putting it next to `Firmware Version` was misleading.

This PR moves the badge into the **OS Version** detail cell. The live-update wiring (`data-live-update-badge` + the JS that flips `display`) is unchanged; only the parent cell moved. Updated the JS comment in `devices.html` to match.

Tests: `tests/test_device_live_updates.py` (44 passed, including the badge-rendering test that asserts the wrapper is present and starts hidden via `display:none`).