### PR TITLE
Make 'update available' badge visible when OS version string is long

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -967,6 +967,7 @@ tr.highlight-new td {
 .detail-label { font-size: 0.75rem; text-transform: uppercase; color: var(--text-muted); font-weight: 600; }
 .detail-value { font-size: 0.9rem; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .detail-value:has(.has-tooltip), .detail-value.has-tooltip { overflow: visible; }
+.detail-value:has(.badge-update) { overflow: visible; white-space: normal; }
 .asset-name-truncate { display: inline-block; max-width: 18ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
 .asset-filename-cell { max-width: 0; width: 40%; }
 .asset-filename-truncate { display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -728,12 +728,12 @@
             </div>
             <div class="detail-item">
                 <span class="detail-label">Firmware Version</span>
-                <span class="detail-value" data-live-firmware-version="{{ d.id }}">{{ d.firmware_version or '—' }}</span>
+                <span class="detail-value" data-live-firmware-version="{{ d.id }}" title="{{ d.firmware_version or '' }}">{{ d.firmware_version or '—' }}</span>
             </div>
             <div class="detail-item">
                 <span class="detail-label">OS Version</span>
                 <span class="detail-value">
-                    <span data-live-os-version="{{ d.id }}">{{ d.os_version or '—' }}</span>{% if 'devices:manage' in user_perms %} <span class="badge badge-update" data-live-update-badge="{{ d.id }}"{% if not d.update_available %} style="display:none"{% endif %}>{{ latest_version }} available</span>{% endif %}
+                    <span data-live-os-version="{{ d.id }}" title="{{ d.os_version or '' }}">{{ d.os_version or '—' }}</span>{% if 'devices:manage' in user_perms %} <span class="has-tooltip" data-live-update-badge-wrap="{{ d.id }}"{% if not d.update_available %} style="display:none"{% endif %}><span class="badge badge-update" data-live-update-badge="{{ d.id }}">{{ latest_version }} available</span><span class="tooltip">A newer OS version ({{ latest_version }}) is available — open the row's actions menu to update</span></span>{% endif %}
                 </span>
             </div>
             <div class="detail-item">

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -713,23 +713,33 @@ window._adoptionProfiles = [
             // but the page didn't repaint them, so operators thought the
             // upgrade hadn't completed until they hit F5.
             const fwEl = document.querySelector(`[data-live-firmware-version="${d.id}"]`);
-            if (fwEl) fwEl.textContent = d.firmware_version || '—';
+            if (fwEl) {
+                fwEl.textContent = d.firmware_version || '—';
+                fwEl.title = d.firmware_version || '';
+            }
             const osEl = document.querySelector(`[data-live-os-version="${d.id}"]`);
-            if (osEl) osEl.textContent = d.os_version || '—';
+            if (osEl) {
+                osEl.textContent = d.os_version || '—';
+                osEl.title = d.os_version || '';
+            }
             // The "{latest_version} available" badge is rendered server-
             // side INSIDE the os-version detail cell (latest_version comes
             // from bundle_checker polling agora-os releases, so it's an
             // OS version not a firmware version) and gated on
             // d.update_available + the devices:manage permission. The
-            // badge wrapper is always emitted (hidden via style.display
-            // when not applicable) so the JS can flip its visibility
-            // without rebuilding the whole cell, even when the device
-            // initially had no badge. latest_version itself only changes
-            // via bundle_checker (~30 min cadence), so its text is left
-            // as the server-rendered value -- not worth wiring through
-            // the per-device payload.
-            const badgeEl = document.querySelector(`[data-live-update-badge="${d.id}"]`);
-            if (badgeEl) badgeEl.style.display = d.update_available ? '' : 'none';
+            // badge wrapper (the .has-tooltip span -- tagged with
+            // data-live-update-badge-wrap so we flip the whole wrapper,
+            // not just the inner badge, otherwise the tooltip child
+            // would still hover-render against an invisible badge) is
+            // always emitted (hidden via style.display when not
+            // applicable) so the JS can flip its visibility without
+            // rebuilding the whole cell, even when the device initially
+            // had no badge. latest_version itself only changes via
+            // bundle_checker (~30 min cadence), so its text is left as
+            // the server-rendered value -- not worth wiring through the
+            // per-device payload.
+            const badgeWrapEl = document.querySelector(`[data-live-update-badge-wrap="${d.id}"]`);
+            if (badgeWrapEl) badgeWrapEl.style.display = d.update_available ? '' : 'none';
 
             // ── Detail panel: storage detail ──
             // Same stale-capacity fix as the collapsed-row percentage above:

--- a/tests/test_device_live_updates.py
+++ b/tests/test_device_live_updates.py
@@ -453,12 +453,14 @@ class TestDevicesUILiveUpdates:
 
         resp = await client.get("/devices")
         assert resp.status_code == 200
-        # Badge hook is present even with no update available...
-        assert f'data-live-update-badge="{device_id}"' in resp.text
+        # Badge wrapper is present even with no update available...
+        assert f'data-live-update-badge-wrap="{device_id}"' in resp.text
         # ...and is hidden via inline style so the JS can simply flip
         # display='' / 'none' instead of rebuilding the cell innerHTML.
+        # (The wrapper -- not the inner badge -- carries the display style
+        # so the tooltip child sitting next to the badge gets hidden too.)
         text = resp.text
-        idx = text.find(f'data-live-update-badge="{device_id}"')
+        idx = text.find(f'data-live-update-badge-wrap="{device_id}"')
         assert idx > -1
         context = text[idx:idx + 200]
         assert "display:none" in context


### PR DESCRIPTION
Follow-up to #623.

PR #623 moved the `{latest_version} available` badge from the Firmware Version detail cell to the OS Version cell (since `latest_version` is an OS version, not firmware). That part worked: the HTML renders correctly in dev tools.

But the badge wasn't visible on screen. The `.detail-value` class has:

\\\css
.detail-value { ... overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
\\\

Firmware version strings are short (e.g. `1.11.74`) so the badge fit on the same line. OS version strings are longer (e.g. `0.1.1-test-unpin`) which pushes the badge past the cell edge where `overflow: hidden` clips it.

Fix: add `.detail-value:has(.badge-update) { overflow: visible; white-space: normal; }` — same pattern as the existing `:has(.has-tooltip)` exception right above it. Lets the badge wrap to a second line when needed.