### PR TITLE
Parse rc<N> pre-release suffix so devices on rc1 see rc2 as an update

### DIFF
--- a/cms/services/bundle_checker.py
+++ b/cms/services/bundle_checker.py
@@ -166,28 +166,54 @@ def _parse_version(v: str) -> tuple:
     """Parse a version string into a comparable tuple of ints.
 
     Handles our ``MAJOR.MINOR.PATCH[-LABEL]`` convention by splitting
-    on both ``.`` and ``-`` and taking the leading run of numeric
-    segments.  ``"0.0.17-test"`` → ``(0, 0, 17)`` so that
-    ``parse("0.0.17-test") > parse("0.0.16-test")`` is True and
-    ``parse("0.0.17-test") == parse("0.0.17")`` is True (we treat
-    ``-test`` as the same release as the non-suffixed form).
+    on ``.``, ``-``, and ``+`` and taking the leading run of numeric
+    segments, then attaching a trailing (tier, pre_number) pair so
+    pre-release labels order correctly:
+
+    * No suffix or a non-numeric label like ``-test`` -> ``(..., 1, 0)``
+      ("released" tier).  We treat ``-test`` as the same release as the
+      non-suffixed form, which keeps dev-tag builds comparable with
+      their eventual public version.
+    * ``-rc<N>`` -> ``(..., 0, N)`` ("pre-release" tier, lower than 1),
+      so ``1.0.0-rc1 < 1.0.0-rc2 < 1.0.0``.  Without this special-case
+      the parser drops ``rcN`` entirely and rc1/rc2 compare equal --
+      see #625.
+
+    Examples:
+        ``"0.0.17-test"`` -> ``(0, 0, 17, 1, 0)``
+        ``"0.0.17"``      -> ``(0, 0, 17, 1, 0)``  (equal to ``-test``)
+        ``"1.0.0-rc1"``   -> ``(1, 0, 0, 0, 1)``
+        ``"1.0.0-rc2"``   -> ``(1, 0, 0, 0, 2)``   (greater than rc1)
+        ``"1.0.0"``       -> ``(1, 0, 0, 1, 0)``   (greater than any rc)
 
     Returns the empty tuple on parse failure, which compares less than
-    any populated tuple — the same fall-back behaviour as the old
+    any populated tuple -- the same fall-back behaviour as the old
     version_checker._parse_version.
     """
     if not v:
         return ()
     v = v.lstrip("v")
-    out: list[int] = []
+    nums: list[int] = []
+    pre_number: Optional[int] = None
     for chunk in re.split(r"[.\-+]", v):
         if not chunk:
             break
         try:
-            out.append(int(chunk))
+            nums.append(int(chunk))
+            continue
         except ValueError:
-            break
-    return tuple(out)
+            pass
+        m = re.match(r"^rc(\d+)$", chunk, re.IGNORECASE)
+        if m:
+            pre_number = int(m.group(1))
+        # Any non-numeric chunk (rc match or not) ends the leading
+        # numeric run -- we don't try to mix multiple labels.
+        break
+    if not nums:
+        return ()
+    if pre_number is not None:
+        return tuple(nums) + (0, pre_number)
+    return tuple(nums) + (1, 0)
 
 
 def is_os_update_available(

--- a/tests/test_bundle_checker.py
+++ b/tests/test_bundle_checker.py
@@ -38,12 +38,13 @@ class TestParseVersion:
     def test_basic_three_part(self):
         from cms.services.bundle_checker import _parse_version
 
-        assert _parse_version("1.2.3") == (1, 2, 3)
+        # Trailing (1, 0) marks "released" tier so it sorts above any rc-N pre-release.
+        assert _parse_version("1.2.3") == (1, 2, 3, 1, 0)
 
     def test_strips_v_prefix(self):
         from cms.services.bundle_checker import _parse_version
 
-        assert _parse_version("v1.2.3") == (1, 2, 3)
+        assert _parse_version("v1.2.3") == (1, 2, 3, 1, 0)
 
     def test_test_suffix_equals_unsuffixed(self):
         """``0.0.17-test`` and ``0.0.17`` should compare equal -- we treat the
@@ -51,13 +52,23 @@ class TestParseVersion:
         from cms.services.bundle_checker import _parse_version
 
         assert _parse_version("0.0.17-test") == _parse_version("0.0.17")
-        assert _parse_version("0.0.17-test") == (0, 0, 17)
+        assert _parse_version("0.0.17-test") == (0, 0, 17, 1, 0)
 
     def test_ordering(self):
         from cms.services.bundle_checker import _parse_version
 
         assert _parse_version("0.0.16-test") < _parse_version("0.0.17-test")
         assert _parse_version("1.0.0") > _parse_version("0.99.99")
+
+    def test_rc_suffix_orders_pre_release(self):
+        """#625: ``1.0.0-rc1`` and ``1.0.0-rc2`` must compare distinct so
+        a device on rc1 sees rc2 as an available update.  Bare ``1.0.0``
+        outranks any rc (matches semver pre-release semantics)."""
+        from cms.services.bundle_checker import _parse_version
+
+        assert _parse_version("1.0.0-rc1") < _parse_version("1.0.0-rc2")
+        assert _parse_version("1.0.0-rc2") < _parse_version("1.0.0")
+        assert _parse_version("1.0.0-rc9") < _parse_version("1.0.0-rc10")
 
     def test_garbage_returns_empty_tuple(self):
         """Empty tuple compares less than any populated tuple -- same
@@ -110,6 +121,20 @@ class TestIsOsUpdateAvailable:
 
         assert bundle_checker.is_os_update_available("0.0.17", "0.0.17-test") is False
         assert bundle_checker.is_os_update_available("0.0.17-test", "0.0.17-test") is False
+
+    def test_rc_suffix_reports_update(self):
+        """#625: device on ``1.0.0-rc1`` must see ``1.0.0-rc2`` as an
+        available update.  Pre-fix the parser dropped the ``rcN`` chunk
+        and both versions compared equal, so the badge stayed dark."""
+        from cms.services import bundle_checker
+
+        assert bundle_checker.is_os_update_available("1.0.0-rc1", "1.0.0-rc2") is True
+        assert bundle_checker.is_os_update_available("1.0.0-rc2", "1.0.0-rc1") is False
+        assert bundle_checker.is_os_update_available("1.0.0-rc2", "1.0.0-rc2") is False
+        # rc N -> released N is still an update.
+        assert bundle_checker.is_os_update_available("1.0.0-rc2", "1.0.0") is True
+        # Released -> rc of same N is NOT an update (the rc is older).
+        assert bundle_checker.is_os_update_available("1.0.0", "1.0.0-rc2") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

A device on `1.0.0-rc1` was not showing the 'update available' badge even though `bundle_checker` had `latest_version` set to `1.0.0-rc2`.

## Root cause

`_parse_version()` in `cms/services/bundle_checker.py` splits the version on `.`/`-`/`+` and takes only the leading run of numeric chunks; the first non-numeric chunk breaks the loop. So:

\\\
_parse_version('1.0.0-rc1')  ->  (1, 0, 0)
_parse_version('1.0.0-rc2')  ->  (1, 0, 0)
is_os_update_available('1.0.0-rc1', '1.0.0-rc2')  ->  False
\\\

## Fix

Extend the parser to attach a trailing `(tier, pre_number)` pair:

* Released versions (no suffix, or label-only suffixes like `-test`) -> `(..., 1, 0)` (released tier).
* `-rc<N>` -> `(..., 0, N)` (pre-release tier, lower than released).

Result:

\\\
1.0.0-rc1 < 1.0.0-rc2 < 1.0.0
0.0.17-test == 0.0.17  (existing behaviour preserved)
\\\

## Tests

* Updated `TestParseVersion` for the new tuple shape (e.g. `(1, 2, 3, 1, 0)` instead of `(1, 2, 3)`).
* Added `test_rc_suffix_orders_pre_release` covering rc1 < rc2 < released, plus rc9 < rc10 (so we don't accidentally string-compare).
* Added `test_rc_suffix_reports_update` against `is_os_update_available` -- direct repro of the original bug.