### PR TITLE
fix: surface stuck-tryboot state so upgrades don't silently no-op (#626)

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -73,6 +73,21 @@ SEND_FAILURE_COOLDOWN = timedelta(seconds=10)
 # tryboot that never confirms, etc.).
 OTA_FRESH_TTL = timedelta(minutes=2)
 
+# Issue agora-cms#626 — how long a device may sit in the ``tryboot``
+# phase before we treat it as stuck mid-upgrade.  The device emits
+# ``tryboot_initiated`` right before rebooting into the new slot and we
+# expect ``slot_confirmed`` / ``promoted`` (success) or ``failed`` /
+# ``declined`` (failure) within at most a few minutes -- the actual
+# reboot + slot-mgr aging gate on the device is bounded at ~5 minutes
+# by default.  If 15 minutes pass with no terminal event, the device's
+# slot-mgr / os-updater are stuck (see ``sslivins/agora#243``) and any
+# upgrade dispatch the CMS sends will be silently rejected by the
+# on-device state machine.  We surface this as ``upgrade_stuck`` on
+# ``DeviceOut`` so the UI can warn the operator and the upgrade
+# endpoint can refuse new claims with a clear 409 instead of silently
+# no-op'ing on the device.
+STUCK_TRYBOOT_TTL = timedelta(minutes=15)
+
 
 def _as_utc(dt: datetime) -> datetime:
     """Promote a naive ``datetime`` to UTC.
@@ -95,6 +110,27 @@ def _is_upgrading(device: Device, *, now: datetime | None = None) -> bool:
         return False
     ref = now or datetime.now(timezone.utc)
     return (ref - _as_utc(device.upgrade_started_at)) < UPGRADE_TTL
+
+
+def _is_upgrade_stuck(device: Device, *, now: datetime | None = None) -> bool:
+    """Return whether *device* is stuck mid-tryboot (issue agora-cms#626).
+
+    True iff the last lifecycle event we received was
+    ``tryboot_initiated`` AND it landed more than ``STUCK_TRYBOOT_TTL``
+    ago without any subsequent ``slot_confirmed`` / ``promoted`` /
+    ``failed`` / ``declined`` event clearing the row.  Reads the raw
+    ``ota_phase`` / ``ota_updated_at`` columns -- NOT the
+    ``_ota_fields_for_out`` projection, which already zeroes after
+    ``OTA_FRESH_TTL=2min`` for live-progress purposes.  The stuck flag
+    is precisely the case where the projection has gone stale because
+    no further events arrived.
+    """
+    if device.ota_phase != "ota_tryboot_initiated":
+        return False
+    if device.ota_updated_at is None:
+        return False
+    ref = now or datetime.now(timezone.utc)
+    return (ref - _as_utc(device.ota_updated_at)) >= STUCK_TRYBOOT_TTL
 
 
 def _ota_fields_for_out(device: Device, *, now: datetime | None = None) -> dict:
@@ -293,6 +329,7 @@ async def list_devices(request: Request, db: AsyncSession = Depends(get_db)):
             group_name=d.group.name if d.group else None,
             is_online=d.id in connected_ids,
             is_upgrading=_is_upgrading(d, now=now),
+            upgrade_stuck=_is_upgrade_stuck(d, now=now),
             playback_mode=live_states[d.id]["mode"] if d.id in live_states else None,
             playback_asset=_resolve_asset_name(d.id),
             pipeline_state=live_states[d.id]["pipeline_state"] if d.id in live_states else None,
@@ -353,6 +390,7 @@ async def get_device(device_id: str, request: Request, db: AsyncSession = Depend
         group_name=device.group.name if device.group else None,
         is_online=is_online,
         is_upgrading=_is_upgrading(device, now=now),
+        upgrade_stuck=_is_upgrade_stuck(device, now=now),
         playback_mode=live_states[device.id]["mode"] if device.id in live_states else None,
         playback_asset=raw_asset,
         pipeline_state=live_states[device.id]["pipeline_state"] if device.id in live_states else None,
@@ -545,6 +583,24 @@ async def upgrade_device(
 
     if not await get_transport().is_connected(device_id):
         raise HTTPException(status_code=409, detail="Device is not connected")
+
+    # Issue agora-cms#626 -- if the device is stuck mid-tryboot, the
+    # on-device os-updater FSM is in ``state=tryboot_running`` and will
+    # silently drop every dispatch we send.  Refuse the upgrade here
+    # *before* taking a claim so we don't lock the row for 15 minutes
+    # behind a dispatch the device will never act on.  The UI ought to
+    # already be greying out the Update kebab off the ``upgrade_stuck``
+    # flag in ``DeviceOut``; this is the server-side belt-and-braces
+    # for stale UI / API clients / etc.
+    if _is_upgrade_stuck(device):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Device is stuck mid-upgrade (tryboot did not complete). "
+                "Wait for the device to recover, or reboot it manually, "
+                "before retrying."
+            ),
+        )
 
     # Stage 4: atomic claim — set ``upgrade_started_at`` iff it's NULL
     # or older than the TTL.  The timestamp we just wrote is captured

--- a/cms/schemas/device.py
+++ b/cms/schemas/device.py
@@ -30,6 +30,15 @@ class DeviceOut(BaseModel):
     registered_at: datetime
     is_online: bool = False
     is_upgrading: bool = False
+    # Issue agora-cms#626 -- True iff the device has been in the
+    # ``tryboot`` phase for more than ``STUCK_TRYBOOT_TTL`` (15 min)
+    # without progress.  In that state the on-device os-updater FSM
+    # is wedged in ``tryboot_running`` and will silently drop every
+    # upgrade dispatch.  The UI uses this flag to (a) render a "Upgrade
+    # stalled" warning badge, (b) disable the Update kebab item with an
+    # explanatory tooltip, and (c) short-circuit ``upgradeDevice()``
+    # with a toast.  The upgrade endpoint also refuses 409 server-side.
+    upgrade_stuck: bool = False
     # ── OTA progress (issue agora-cms#574) ──
     # While a device is in the middle of an OS OTA, these fields drive
     # the live progress badge in the UI.  All None when no OTA is in

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -522,8 +522,11 @@
 {% if d.is_online and (d.error or d.pipeline_state == 'ERROR') %}
 <span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">{% if d.error %}{{ d.error }}{% else %}Player pipeline reported an error{% endif %}</span></span>
 {% endif %}
+{# Upgrade stalled (agora-cms#626) — wins over the in-flight upgrade chip because the in-flight state is the cause of the stuck signal. #}
+{% if d.upgrade_stuck %}
+<span class="has-tooltip"><span class="badge badge-error">Upgrade stalled</span><span class="tooltip">Device has been mid-upgrade for over 15 minutes without completing. New upgrade commands will be ignored until the device recovers — reboot it manually, or wait for the on-device slot manager to roll back.</span></span>
 {# Upgrading — show live OTA progress bar when available, else fall back to static "Upgrading…" chip #}
-{% if d.is_upgrading and d.ota_phase and d.ota_pct is not none %}
+{% elif d.is_upgrading and d.ota_phase and d.ota_pct is not none %}
 <span class="has-tooltip"><span class="badge badge-progress" style="--pct: {{ "%.1f"|format(d.ota_pct) }}%">{{ d.ota_label or 'Upgrading' }} {{ d.ota_pct | round(0) | int }}%</span><span class="tooltip">{{ d.ota_label or 'Upgrading' }} — device will reboot when done</span></span>
 {% elif d.is_upgrading and d.ota_phase %}
 <span class="has-tooltip"><span class="badge badge-processing">{{ d.ota_label or 'Upgrading…' }}</span><span class="tooltip">{{ d.ota_label or 'Upgrading' }} — device will reboot when done</span></span>
@@ -605,7 +608,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}|{{ 1 if d.upgrade_stuck else 0 }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">This device matches a known device but couldn't authenticate, likely due to a factory reset or SD card replacement. It needs to be re-adopted.</span></span>
         {% elif d.status.value == 'pending' %}
@@ -661,10 +664,12 @@
     </td>
     {% endif %}
     {% if 'devices:manage' in user_perms %}
-    <td class="actions" data-live-actions="{{ d.id }}" data-actions-sig="{{ d.status.value }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.ssh_enabled else 0 }}|{{ 0 if d.local_api_enabled is false else 1 }}" onclick="event.stopPropagation()">
+    <td class="actions" data-live-actions="{{ d.id }}" data-actions-sig="{{ d.status.value }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.ssh_enabled else 0 }}|{{ 0 if d.local_api_enabled is false else 1 }}|{{ 1 if d.upgrade_stuck else 0 }}" onclick="event.stopPropagation()">
         {% call kebab_menu() %}
         {% if d.status.value == 'pending' or d.status.value == 'orphaned' %}
         <button type="button" role="menuitem" onclick="adoptDevice({{ d.id | tojson | forceescape }}, {{ (d.name or d.id) | tojson | forceescape }})" title="Register this device so it can receive content">Adopt</button>
+        {% elif d.upgrade_stuck %}
+        <button type="button" role="menuitem" disabled title="Device is stuck mid-upgrade (tryboot did not complete). Reboot the device or wait for the on-device slot manager to recover before retrying.">Upgrade stalled</button>
         {% elif d.is_upgrading %}
         <button type="button" role="menuitem" disabled title="Firmware upgrade in progress — device will reboot when done">Upgrading…</button>
         {% elif d.is_online and d.update_available %}
@@ -872,7 +877,7 @@
         {{ d.name or d.id }}
         {% endif %}
     </td>
-    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}">
+    <td data-live-status="{{ d.id }}" data-device-status="{{ d.status.value }}" data-alerts-sig="{{ d.status.value }}|{{ 1 if d.is_online else 0 }}|{{ 1 if d.is_upgrading else 0 }}|{{ 1 if d.update_available else 0 }}|{{ 1 if d.error or d.pipeline_state == 'ERROR' else 0 }}|{{ ((d.cpu_temp_c | round(0)) | int) if d.cpu_temp_c is not none else 'n' }}|{{ 1 if (d.display_ports and (d.display_ports | rejectattr('connected') | list | length) == (d.display_ports | length)) or ((not d.display_ports) and d.display_connected is false) else 0 }}|{{ (((d.storage_capacity_mb - d.storage_used_mb) / d.storage_capacity_mb * 100) | round(0) | int) if d.storage_capacity_mb else 'n' }}|{{ d.ota_phase or 'n' }}|{{ (d.ota_pct | round(0) | int) if d.ota_pct is not none else 'n' }}|{{ 1 if d.upgrade_stuck else 0 }}">
         {% if d.status.value == 'orphaned' %}
         <span class="has-tooltip"><span class="badge badge-orphaned">Orphaned</span><span class="tooltip">Re-flashed device — needs re-adoption</span></span>
         {% elif d.status.value == 'pending' %}

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -510,6 +510,8 @@ window._adoptionProfiles = [
         let items = '';
         if (adoptable) {
             items += '<button type="button" role="menuitem" onclick="adoptDevice(\'' + d.id + '\', \'' + nameEsc + '\')" title="Register this device so it can receive content">Adopt</button>';
+        } else if (d.upgrade_stuck) {
+            items += '<button type="button" role="menuitem" disabled title="Device is stuck mid-upgrade (tryboot did not complete). Reboot the device or wait for the on-device slot manager to recover before retrying.">Upgrade stalled</button>';
         } else if (d.is_upgrading) {
             items += '<button type="button" role="menuitem" disabled title="Firmware upgrade in progress — device will reboot when done">Upgrading…</button>';
         } else if (d.is_online && d.update_available) {
@@ -547,8 +549,14 @@ window._adoptionProfiles = [
             const msg = d.error ? String(d.error).replace(/[<>&]/g, '') : 'Player pipeline reported an error';
             out.push('<span class="has-tooltip"><span class="badge badge-error">Error</span><span class="tooltip">' + msg + '</span></span>');
         }
-        // Upgrading — live OTA progress bar if available, else legacy chip.
-        if (d.is_upgrading && d.ota_phase && d.ota_pct != null) {
+        // Upgrade stalled — device is wedged in mid-tryboot.  Takes
+        // precedence over the in-flight "Upgrading…" / progress chip
+        // because the in-flight state is the *cause* of the stuck
+        // signal; we want the operator to see the warning, not a stale
+        // progress bar.  See agora-cms#626 / agora#243.
+        if (d.upgrade_stuck) {
+            out.push('<span class="has-tooltip"><span class="badge badge-error">Upgrade stalled</span><span class="tooltip">Device has been mid-upgrade for over 15 minutes without completing. New upgrade commands will be ignored until the device recovers — reboot it manually, or wait for the on-device slot manager to roll back.</span></span>');
+        } else if (d.is_upgrading && d.ota_phase && d.ota_pct != null) {
             const pct = Math.round(d.ota_pct);
             const label = (d.ota_label || 'Upgrading').replace(/[<>&]/g, '');
             const tooltip = label + ' — device will reboot when done';
@@ -618,7 +626,7 @@ window._adoptionProfiles = [
         return [
             d.status, d.is_online ? 1 : 0, d.is_upgrading ? 1 : 0,
             d.update_available ? 1 : 0, errFlag, tempBucket, displayOff, storageBucket,
-            otaPhase, otaPctBucket
+            otaPhase, otaPctBucket, d.upgrade_stuck ? 1 : 0
         ].join('|');
     }
 
@@ -671,6 +679,7 @@ window._adoptionProfiles = [
                     d.status, d.is_upgrading ? 1 : 0, d.is_online ? 1 : 0,
                     d.update_available ? 1 : 0, d.ssh_enabled ? 1 : 0,
                     d.local_api_enabled === false ? 0 : 1,
+                    d.upgrade_stuck ? 1 : 0,
                 ].join("|");
                 if (actionsEl.dataset.actionsSig !== sig) {
                     actionsEl.innerHTML = buildActionButtons(d);

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3988,6 +3988,10 @@ components:
           type: boolean
           title: Is Upgrading
           default: false
+        upgrade_stuck:
+          type: boolean
+          title: Upgrade Stuck
+          default: false
         ota_phase:
           anyOf:
           - type: string

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1831,3 +1831,129 @@ class TestGroupDeleteButtonUI:
         html = resp.text
 
         assert f"deleteGroup('{group.id}')" in html
+
+
+# ── agora-cms#626: stuck-tryboot surfacing ────────────────────────────────
+
+
+def test_is_upgrade_stuck_returns_false_when_no_ota_phase():
+    from datetime import datetime, timezone, timedelta
+    from cms.routers.devices import _is_upgrade_stuck, STUCK_TRYBOOT_TTL
+    from cms.models.device import Device, DeviceStatus
+
+    d = Device(id="x", name="x", status=DeviceStatus.ADOPTED)
+    d.ota_phase = None
+    d.ota_updated_at = datetime.now(timezone.utc) - STUCK_TRYBOOT_TTL - timedelta(minutes=5)
+    assert _is_upgrade_stuck(d) is False
+
+
+def test_is_upgrade_stuck_returns_false_when_wrong_phase():
+    from datetime import datetime, timezone, timedelta
+    from cms.routers.devices import _is_upgrade_stuck, STUCK_TRYBOOT_TTL
+    from cms.models.device import Device, DeviceStatus
+
+    d = Device(id="x", name="x", status=DeviceStatus.ADOPTED)
+    d.ota_phase = "ota_download_progress"
+    d.ota_updated_at = datetime.now(timezone.utc) - STUCK_TRYBOOT_TTL - timedelta(minutes=5)
+    assert _is_upgrade_stuck(d) is False
+
+
+def test_is_upgrade_stuck_returns_false_when_tryboot_fresh():
+    from datetime import datetime, timezone
+    from cms.routers.devices import _is_upgrade_stuck
+    from cms.models.device import Device, DeviceStatus
+
+    d = Device(id="x", name="x", status=DeviceStatus.ADOPTED)
+    d.ota_phase = "ota_tryboot_initiated"
+    d.ota_updated_at = datetime.now(timezone.utc)
+    assert _is_upgrade_stuck(d) is False
+
+
+def test_is_upgrade_stuck_returns_true_when_tryboot_stale():
+    from datetime import datetime, timezone, timedelta
+    from cms.routers.devices import _is_upgrade_stuck, STUCK_TRYBOOT_TTL
+    from cms.models.device import Device, DeviceStatus
+
+    d = Device(id="x", name="x", status=DeviceStatus.ADOPTED)
+    d.ota_phase = "ota_tryboot_initiated"
+    d.ota_updated_at = datetime.now(timezone.utc) - STUCK_TRYBOOT_TTL - timedelta(minutes=1)
+    assert _is_upgrade_stuck(d) is True
+
+
+def test_is_upgrade_stuck_returns_false_when_ota_updated_at_is_none():
+    from cms.routers.devices import _is_upgrade_stuck
+    from cms.models.device import Device, DeviceStatus
+
+    d = Device(id="x", name="x", status=DeviceStatus.ADOPTED)
+    d.ota_phase = "ota_tryboot_initiated"
+    d.ota_updated_at = None
+    assert _is_upgrade_stuck(d) is False
+
+
+@pytest.mark.asyncio
+class TestUpgradeStuckSurfacing:
+    """Issue agora-cms#626 -- a device that's been mid-tryboot for >15
+    min must surface as ``upgrade_stuck=True`` via the device API AND
+    refuse new upgrade dispatches with a 409 instead of silently no-op'ing.
+    """
+
+    async def _make_stuck_device(self, db_session, device_id="stuck-pi-001"):
+        from datetime import datetime, timezone, timedelta
+        from cms.models.device import Device, DeviceStatus
+        from cms.routers.devices import STUCK_TRYBOOT_TTL
+
+        device = Device(
+            id=device_id,
+            name=device_id,
+            status=DeviceStatus.ADOPTED,
+            ota_phase="ota_tryboot_initiated",
+            ota_updated_at=datetime.now(timezone.utc) - STUCK_TRYBOOT_TTL - timedelta(minutes=1),
+        )
+        db_session.add(device)
+        await db_session.commit()
+        return device
+
+    async def test_get_device_exposes_upgrade_stuck_true(self, client, db_session):
+        await self._make_stuck_device(db_session, "stuck-pi-get")
+        resp = await client.get("/api/devices/stuck-pi-get")
+        assert resp.status_code == 200
+        assert resp.json()["upgrade_stuck"] is True
+
+    async def test_list_devices_exposes_upgrade_stuck(self, client, db_session):
+        await self._make_stuck_device(db_session, "stuck-pi-list")
+        resp = await client.get("/api/devices")
+        assert resp.status_code == 200
+        rows = {d["id"]: d for d in resp.json()}
+        assert rows["stuck-pi-list"]["upgrade_stuck"] is True
+
+    async def test_upgrade_endpoint_refuses_stuck_device(self, client, db_session):
+        """POST /upgrade on a stuck device returns 409 BEFORE taking a claim."""
+        from cms.services.device_manager import device_manager
+        from cms.services import device_presence
+
+        await self._make_stuck_device(db_session, "stuck-pi-upgrade")
+
+        class FakeWS:
+            async def send_json(self, data): pass
+        device_manager.register("stuck-pi-upgrade", FakeWS())
+        await device_presence.mark_online(db_session, "stuck-pi-upgrade")
+        try:
+            resp = await client.post("/api/devices/stuck-pi-upgrade/upgrade")
+            assert resp.status_code == 409
+            detail = resp.json()["detail"]
+            assert "stuck" in detail.lower()
+            assert "tryboot" in detail.lower()
+
+            # And critically: no claim was taken -- a follow-up GET must
+            # still show upgrade_stuck=True and upgrade_started_at=None
+            # on the row (i.e. the row isn't now locked for 15 min behind
+            # a dispatch the device would have dropped).
+            from cms.models.device import Device
+            from sqlalchemy import select
+            row = (await db_session.execute(
+                select(Device).where(Device.id == "stuck-pi-upgrade")
+            )).scalar_one()
+            await db_session.refresh(row)
+            assert row.upgrade_started_at is None
+        finally:
+            device_manager.disconnect("stuck-pi-upgrade")


### PR DESCRIPTION
Fixes #626. Companion to sslivins/agora#243.

## Problem

A device wedged in `os-updater state=tryboot_running` silently drops every CMS upgrade dispatch. CMS accepts the dispatch, takes a claim, sends to device, gets no acknowledgement and no error. Operator clicks Update and sees nothing happen. After 15 min the claim expires and the next click reproduces the same silent drop -- a permanently broken device with no UI signal.

Concretely on Pi100 on 2026-05-23 with agora 1.11.81 / agora-os 1.0.0-rc1 (see linked issue for the full journal). The device-side fix landed in sslivins/agora#243; this PR is purely the CMS surfacing side.

## Approach

Derive a new boolean `upgrade_stuck` on `DeviceOut` from existing columns -- True iff `ota_phase == "ota_tryboot_initiated"` AND `ota_updated_at` is more than `STUCK_TRYBOOT_TTL` (15 min) old. The CMS already has both columns from the WPS lifecycle-event projection, so no device-side wire changes are needed. Two terminal events (`slot_confirmed`/`promoted`) and two failure events (`failed`/`declined`) already clear `ota_phase` to NULL via `_TERMINAL` in `cms.services.ota_progress`, so the only way to satisfy the check is if none of those four ever arrived.

This is exactly the "state has been tryboot_* for > Nmin without progress" derivation the issue called out as acceptable for v1. A broader signal that surfaces full `os_updater.state` from device heartbeats would need a wire change in `agora` and is not in scope here.

## Surfacing

- **API**: `GET /api/devices` and `GET /api/devices/{id}` now include `upgrade_stuck: bool` (defaults to False).
- **Upgrade endpoint**: `POST /api/devices/{id}/upgrade` returns **409 before taking a claim** when the device is stuck, with `detail` explaining the cause and the manual recovery path. No more silent 15-min lock on a dispatch the device would have dropped.
- **Status chips** (`buildAlertChips` + `_macros.html`): render a red `Upgrade stalled` badge with a tooltip. Takes precedence over the in-flight `Upgrading…` / progress chip because the in-flight state is the *cause* of the stuck signal.
- **Kebab menu** (`buildActionButtons` + `_macros.html`): the Update item is replaced with a disabled `Upgrade stalled` item carrying the same explanatory tooltip.
- **Re-render signatures**: both `alerts-sig` and `actions-sig` (Jinja + JS) include the new flag so live-refresh fires when it flips.

The disabled kebab item is the primary "don't no-op" guard. The server-side 409 is the belt-and-braces against stale UI / API clients / race between fresh data and click -- whichever wins, the operator gets a clear toast with the detail string instead of silence.

## Tests

- 5 unit tests for `_is_upgrade_stuck` (no phase / wrong phase / fresh tryboot / stale tryboot / `ota_updated_at` is None).
- 3 integration tests:
  - `GET /api/devices/{id}` exposes `upgrade_stuck=True` for a stuck row.
  - `GET /api/devices` exposes it in the list payload.
  - `POST /api/devices/{id}/upgrade` returns 409 *without* mutating `upgrade_started_at` -- the row is not locked for 15 min behind a dispatch the device would have dropped.
- All 17 upgrade-related tests pass. 94 tests across `test_devices.py`, `test_ota_progress.py`, and `test_lifecycle_events.py` pass locally with no regressions.

## Verification on devices

After this PR merges + deploys, on a Pi that's stuck in `tryboot_running` (induce by setting `ota_phase='ota_tryboot_initiated', ota_updated_at = now - 20min` on the row, or wait for the real failure mode):
1. Refresh the device list -- the row should render the `Upgrade stalled` chip.
2. Open the kebab -- `Upgrade stalled` is disabled with the tooltip.
3. Force a click via curl: `POST /api/devices/{id}/upgrade` returns 409 with the explanatory detail.
4. `upgrade_started_at` on the DB row is unchanged (no claim was taken).

## Out of scope (file separately if wanted)

- Surfacing full `os_updater.state` from device heartbeats (general signal, not just the tryboot-stalled derivation). Would need a wire change in `agora`.
- Auto-recovery from the CMS side. Belongs in `agora`'s slot-mgr / os-updater, which is exactly what sslivins/agora#243 already addresses.
