### PR TITLE
feat: expand slideshow transitions (cut/fade/fade_black/dissolve/push/wipe/zoom) + add per-slide duration UI

### DIFF
--- a/alembic/versions/0029_slideshow_transitions_expand.py
+++ b/alembic/versions/0029_slideshow_transitions_expand.py
@@ -1,0 +1,48 @@
+"""slideshow_slides: expand allowed ``transition`` set
+
+Adds three new pro-grade transition IDs to the
+``ck_slideshow_slide_transition_known`` CHECK constraint:
+
+* ``fade_black`` — fade through black (two-stage opacity)
+* ``push``      — incoming slide pushes outgoing off-screen (translateX)
+* ``zoom``      — incoming scales 0.9 → 1.0 + opacity 0 → 1
+
+The previously-allowed ``cut`` / ``fade`` / ``dissolve`` / ``wipe`` IDs
+remain valid. ``dissolve`` is re-cast as a Ken-Burns variant in the
+JS shell (crossfade + outgoing scales 1.00 → 1.05), but the wire ID
+is unchanged so no data migration is needed.
+
+Revision ID: 0029
+Revises: 0028
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+ALLOWED = ("cut", "fade", "fade_black", "dissolve", "push", "wipe", "zoom")
+NEW_SQL = "transition IN (" + ",".join(f"'{v}'" for v in ALLOWED) + ")"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_slideshow_slide_transition_known",
+        "slideshow_slides",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_transition_known",
+        "slideshow_slides",
+        NEW_SQL,
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0029 is not supported")

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -20,13 +20,20 @@ MAX_SLIDESHOW_SLIDES = 50
 MIN_SLIDE_DURATION_MS = 500
 MAX_SLIDE_DURATION_MS = 60 * 60 * 1000
 
-# Per-slide transition controls (Phase 1a of agora#226).  ``cut`` means an
-# instant swap (no transition) and is the only transition the mpv-based
-# player actually renders today — ``fade``/``dissolve``/``wipe`` are
-# accepted on the wire so the chromium-player branch can render them
-# without a follow-up schema bump.  The mpv player ignores anything other
-# than ``cut`` (renders the slide instantly).
-SLIDE_TRANSITIONS = ("cut", "fade", "dissolve", "wipe")
+# Per-slide transition controls (Phase 1a of agora#226, expanded in 0029).
+# ``cut`` is an instant swap (no transition) and is the only mode the
+# legacy mpv-based player renders — it ignores everything else.  The
+# chromium-player shell renders the rest.  Wire IDs are kept short
+# (snake_case) so they round-trip through DB CHECK + JSON cleanly.
+SLIDE_TRANSITIONS = (
+    "cut",
+    "fade",
+    "fade_black",
+    "dissolve",
+    "push",
+    "wipe",
+    "zoom",
+)
 DEFAULT_SLIDE_TRANSITION = "cut"
 # Transition duration bounds.  ``0`` is valid (and required for ``cut``);
 # upper bound is a soft sanity limit — anything longer would dominate the

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -315,6 +315,37 @@
     color: #888;
     font-style: italic;
 }
+.ssb-trans-opt-sel {
+    background: rgba(22,160,133,0.25);
+}
+.ssb-trans-opt-sel .ssb-trans-opt-icon {
+    color: #1abc9c;
+}
+.ssb-trans-dur {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.7rem;
+    border-top: 1px solid #333;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #bbb;
+}
+.ssb-trans-dur-label { flex: 0 0 auto; }
+.ssb-trans-dur-input {
+    width: 4.5rem;
+    background: #111;
+    color: #ddd;
+    border: 1px solid #444;
+    border-radius: 0.25rem;
+    padding: 0.15rem 0.3rem;
+    font-size: 0.75rem;
+}
+.ssb-trans-dur-input:disabled {
+    color: #555;
+    background: #1a1a1a;
+}
+.ssb-trans-dur-unit { color: #888; }
 
 /* Drop zone at end of timeline / when empty */
 .ssb-end {
@@ -647,17 +678,19 @@ function makeSlot(s, i) {
     return slot;
 }
 
-// Transition types — only ``cut`` is exposed in the UI today.  The wire
-// schema (Phase 1a of agora#226) accepts ``fade``/``dissolve``/``wipe``
-// too, but the mpv-based fleet renders any non-``cut`` value as an
-// instant swap (same visual result as cut) — so enabling those options
-// in the picker would be a UX trap.  The chromium-player branch flips
-// these to ``enabled: true`` once it can render them for real.
+// Transition types — all wire IDs come from cms.schemas.asset.SLIDE_TRANSITIONS.
+// The mpv-based legacy fleet renders any non-``cut`` value as an instant
+// swap (it ignores transitions entirely); the chromium-player shell that
+// ships on every supported Pi today renders the rest. ``cut`` keeps
+// transition_ms forced to 0 since there's nothing to time.
 const SS_TRANSITIONS = [
-    {id: 'cut',      label: 'Cut',      icon: '\u2702',    enabled: true},   // ✂
-    {id: 'fade',     label: 'Fade',     icon: '\u25D0',    enabled: false},  // ◐
-    {id: 'dissolve', label: 'Dissolve', icon: '\u2592',    enabled: false},  // ▒
-    {id: 'wipe',     label: 'Wipe',     icon: '\u21E8',    enabled: false},  // ⇨
+    {id: 'cut',        label: 'Cut',                icon: '\u2702'},   // ✂
+    {id: 'fade',       label: 'Crossfade',          icon: '\u25D0'},   // ◐
+    {id: 'fade_black', label: 'Fade through black', icon: '\u25D1'},   // ◑
+    {id: 'dissolve',   label: 'Dissolve (Ken Burns)', icon: '\u2299'}, // ⊙
+    {id: 'push',       label: 'Push',               icon: '\u21E2'},   // ⇢
+    {id: 'wipe',       label: 'Wipe',               icon: '\u21E8'},   // ⇨
+    {id: 'zoom',       label: 'Zoom',               icon: '\u2295'},   // ⊕
 ];
 function transitionDef(id) {
     return SS_TRANSITIONS.find(t => t.id === id) || SS_TRANSITIONS[0];
@@ -686,28 +719,65 @@ function makeGap(index, isLeading) {
             const opt = document.createElement('button');
             opt.type = 'button';
             opt.className = 'ssb-trans-opt';
-            opt.disabled = !t.enabled;
-            opt.title = t.enabled ? t.label : `${t.label} — coming soon`;
+            opt.title = t.label;
             opt.innerHTML = `
                 <span class="ssb-trans-opt-icon">${t.icon}</span>
-                <span>${t.label}</span>
-                ${t.enabled ? '' : '<span class="ssb-trans-opt-soon">soon</span>'}`;
+                <span>${t.label}</span>`;
             opt.addEventListener('click', (e) => {
                 e.stopPropagation();
-                if (!t.enabled) return;
                 if (slides[slideIdx]) {
                     const prev = slides[slideIdx].transition || 'cut';
                     if (prev !== t.id) {
                         slides[slideIdx].transition = t.id;
+                        // ``cut`` has no duration; clamp to 0 so the wire/UI agree.
+                        if (t.id === 'cut') {
+                            slides[slideIdx].transition_ms = 0;
+                        } else if (!slides[slideIdx].transition_ms) {
+                            slides[slideIdx].transition_ms = 600;
+                        }
                         markDirty();
                     }
                 }
-                try { menu.hidePopover(); } catch {}
                 btn.textContent = t.icon;
                 btn.title = `${t.label} transition — click to change`;
+                // Refresh duration input enabled state without closing the popover.
+                const di = menu.querySelector('.ssb-trans-dur-input');
+                if (di) {
+                    di.disabled = (t.id === 'cut');
+                    di.value = slides[slideIdx].transition_ms || 0;
+                }
+                // Mark selected option visually.
+                menu.querySelectorAll('.ssb-trans-opt').forEach(o => o.classList.remove('ssb-trans-opt-sel'));
+                opt.classList.add('ssb-trans-opt-sel');
             });
+            if (t.id === current.id) opt.classList.add('ssb-trans-opt-sel');
             menu.appendChild(opt);
         });
+        // Duration footer — numeric ms input bound to slides[slideIdx].transition_ms.
+        const dur = document.createElement('div');
+        dur.className = 'ssb-trans-dur';
+        const curMs = (slides[slideIdx] && typeof slides[slideIdx].transition_ms === 'number')
+            ? slides[slideIdx].transition_ms : 600;
+        const isCut = (current.id === 'cut');
+        dur.innerHTML = `
+            <label class="ssb-trans-dur-label">Duration</label>
+            <input type="number" class="ssb-trans-dur-input"
+                   min="0" max="5000" step="50"
+                   value="${isCut ? 0 : curMs}" ${isCut ? 'disabled' : ''}>
+            <span class="ssb-trans-dur-unit">ms</span>`;
+        const di = dur.querySelector('.ssb-trans-dur-input');
+        di.addEventListener('click', (e) => e.stopPropagation());
+        di.addEventListener('input', (e) => {
+            if (!slides[slideIdx]) return;
+            let v = parseInt(e.target.value, 10);
+            if (isNaN(v)) v = 0;
+            v = Math.max(0, Math.min(5000, v));
+            if (slides[slideIdx].transition_ms !== v) {
+                slides[slideIdx].transition_ms = v;
+                markDirty();
+            }
+        });
+        menu.appendChild(dur);
         btn.addEventListener('click', (e) => {
             e.stopPropagation();
             const open = menu.matches(':popover-open');

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -42,7 +42,7 @@ class SlideshowSlide(Base):
         # transition_ms upper bound (5000 ms) matches MAX_SLIDE_TRANSITION_MS
         # in cms.schemas.asset.
         CheckConstraint(
-            "transition IN ('cut','fade','dissolve','wipe')",
+            "transition IN ('cut','fade','fade_black','dissolve','push','wipe','zoom')",
             name="ck_slideshow_slide_transition_known",
         ),
         CheckConstraint(

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -500,6 +500,31 @@ class TestSlideTransitions:
         )
         assert resp.status_code in (400, 422), resp.text
 
+    @pytest.mark.parametrize("tx", ["fade_black", "push", "zoom"])
+    async def test_new_transition_ids_round_trip(self, client, db_session, tx):
+        """The transition set expanded in 0029 — make sure each new ID
+        passes Pydantic validation, the DB CHECK constraint, and round-trips
+        through GET /slides."""
+        img = await _seed_image(db_session, filename=f"t-{tx}.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": f"slideshow-{tx}",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "transition": tx,
+                    "transition_ms": 500,
+                }],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        ss_id = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{ss_id}/slides")).json()["slides"]
+        assert slides[0]["transition"] == tx
+        assert slides[0]["transition_ms"] == 500
+
+
     async def test_rejects_transition_ms_above_cap(self, client, db_session):
         img = await _seed_image(db_session, filename="t5.png", is_global=True)
         resp = await client.post(


### PR DESCRIPTION
Expands the per-slide `transition` allowed set and surfaces all of them (plus a duration input) in the slideshow builder.

## Transition set

| ID           | Display name           | Notes                                                       |
|--------------|------------------------|-------------------------------------------------------------|
| `cut`        | Cut                    | Instant swap. Default. Only mode mpv backend renders.       |
| `fade`       | Crossfade              | Already JS-implemented. Default 'pro' mode.                 |
| `fade_black` | Fade through black     | New. Two-stage opacity (out to black, then in from black).  |
| `dissolve`   | Dissolve (Ken Burns)   | Crossfade + outgoing scales 1.00 to 1.05.                   |
| `push`       | Push                   | New. translateX off-screen.                                 |
| `wipe`       | Wipe                   | clip-path L to R reveal.                                    |
| `zoom`       | Zoom                   | New. Incoming scales 0.9 to 1.0 with opacity fade.          |

## Changes

- `alembic/versions/0029_slideshow_transitions_expand.py` — drop + recreate `ck_slideshow_slide_transition_known` with the expanded ID set.
- `shared/models/slideshow_slide.py` — matching inline CHECK literal.
- `cms/schemas/asset.py` — `SLIDE_TRANSITIONS` extended.
- `cms/templates/slideshow_builder.html`:
  - All transition options are now enabled (no more 'soon' badge).
  - Per-slide gap popover gets a numeric ms duration input bound to `transition_ms`.
  - Switching to `cut` clamps duration to 0 and disables the input.
- Tests: parametrized round-trip for `fade_black` / `push` / `zoom`.

## Follow-ups

- Pi `player/shell/player.js` will be updated in the follow-up `agora` PR to actually render the new modes. Unknown modes already fall back to `cut` on the device, so this CMS PR is safe to ship first.
- Then agora-os v1.0.0-rc7 to bake the new `.deb`.