### PR TITLE
ux(assets): support multi-file upload (drag/drop or picker)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1703,82 +1703,112 @@ async function uploadAsset(form) {
 
     const statusEl = document.getElementById("upload-status");
     const submitBtn = form.querySelector("button[type=submit]");
-    const data = new FormData(form);
+    // Snapshot the FileList up front -- form.reset() at the end will clear it.
+    const files = Array.from(fileInput.files);
+    const total = files.length;
+
+    // Build group_ids query param from selected badges (once -- reused per file)
+    const ids = _getUploadGroupIds();
+    const globalCb = document.getElementById("upload-global");
+    let qs = "";
+    if (globalCb && globalCb.checked) {
+        // No group_ids → admin upload becomes global
+    } else if (ids.length) {
+        qs = "?group_ids=" + ids.join(",");
+    }
 
     submitBtn.disabled = true;
-    statusEl.textContent = "Uploading… 0%";
     statusEl.className = "form-status";
 
-    return new Promise((resolve) => {
-        const xhr = new XMLHttpRequest();
-        xhr.upload.addEventListener("progress", (e) => {
-            if (e.lengthComputable) {
-                const pct = Math.round((e.loaded / e.total) * 100);
-                statusEl.textContent = "Uploading… " + pct + "%";
-            }
-        });
-        xhr.addEventListener("load", () => {
-            if (xhr.status === 401) {
-                window.location.href = "/login";
-            } else if (xhr.status >= 200 && xhr.status < 300) {
-                statusEl.textContent = "Upload complete!";
-                statusEl.className = "form-status text-success";
-                let newId = null;
-                try { newId = JSON.parse(xhr.responseText)?.id || null; } catch (_) {}
-                // Reset the form so another upload can start immediately.
-                // form.reset() clears fileInput.files but does NOT fire the
-                // input's change event, so the drop-label and submit-disabled
-                // state must be reset manually to match the initial page load.
-                form.reset();
-                const dropLabel = document.getElementById("drop-label");
-                if (dropLabel) dropLabel.textContent = "Drag \u0026 drop a file here, or";
-                const badges = document.getElementById("upload-groups-badges");
-                if (badges) {
-                    badges.querySelectorAll(".badge[data-group-id]").forEach(b => b.remove());
+    let okCount = 0;
+    const failures = [];
+
+    for (let i = 0; i < total; i++) {
+        const file = files[i];
+        const prefix = total > 1
+            ? "Uploading " + (i + 1) + "/" + total + " (" + file.name + ")… "
+            : "Uploading… ";
+        statusEl.textContent = prefix + "0%";
+
+        const ok = await new Promise((resolve) => {
+            const xhr = new XMLHttpRequest();
+            const data = new FormData();
+            data.append("file", file);
+            xhr.upload.addEventListener("progress", (e) => {
+                if (e.lengthComputable) {
+                    const pct = Math.round((e.loaded / e.total) * 100);
+                    statusEl.textContent = prefix + pct + "%";
                 }
-                const popup = document.getElementById("upload-group-popup");
-                if (popup) popup.querySelectorAll("[data-group-id]").forEach(b => { b.style.display = ""; });
-                submitBtn.disabled = true;
-                // Insert the new row (server-rendered, newest-first)
-                if (newId && window._insertAssetRow) {
-                    window._insertAssetRow(newId).finally(() => {
-                        setTimeout(() => { statusEl.textContent = ""; statusEl.className = "form-status"; }, 1500);
-                    });
+            });
+            xhr.addEventListener("load", () => {
+                if (xhr.status === 401) {
+                    window.location.href = "/login";
+                    resolve(false);
+                    return;
+                }
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    let newId = null;
+                    try { newId = JSON.parse(xhr.responseText)?.id || null; } catch (_) {}
+                    if (newId && window._insertAssetRow) {
+                        // Fire-and-forget; don't block the next upload on row insertion.
+                        window._insertAssetRow(newId);
+                    }
+                    resolve(true);
                 } else {
-                    setTimeout(() => { statusEl.textContent = ""; statusEl.className = "form-status"; }, 1500);
+                    let msg = "Upload failed";
+                    try {
+                        const err = JSON.parse(xhr.responseText);
+                        if (err && err.detail) msg = err.detail;
+                    } catch (_) {}
+                    failures.push({ name: file.name, msg: msg });
+                    resolve(false);
                 }
-                resolve(true);
-                return;
-            } else {
-                try {
-                    const err = JSON.parse(xhr.responseText);
-                    showToast(err.detail || "Upload failed", true);
-                } catch (_) {
-                    showToast("Upload failed", true);
-                }
-                statusEl.textContent = "";
-                submitBtn.disabled = false;
-            }
-            resolve(false);
+            });
+            xhr.addEventListener("error", () => {
+                failures.push({ name: file.name, msg: "Network error" });
+                resolve(false);
+            });
+            xhr.open("POST", "/api/assets/upload" + qs);
+            xhr.send(data);
         });
-        xhr.addEventListener("error", () => {
-            showToast("Upload failed — network error", true);
-            statusEl.textContent = "";
-            submitBtn.disabled = false;
-            resolve(false);
-        });
-        // Build group_ids query param from selected badges
-        const ids = _getUploadGroupIds();
-        const globalCb = document.getElementById("upload-global");
-        let qs = "";
-        if (globalCb && globalCb.checked) {
-            // No group_ids → admin upload becomes global
-        } else if (ids.length) {
-            qs = "?group_ids=" + ids.join(",");
-        }
-        xhr.open("POST", "/api/assets/upload" + qs);
-        xhr.send(data);
-    });
+        if (ok) okCount += 1;
+    }
+
+    // Reset the form so another upload can start immediately. form.reset()
+    // clears fileInput.files but does NOT fire the input's change event, so
+    // the drop-label and submit-disabled state must be reset manually to
+    // match the initial page load.
+    form.reset();
+    const dropLabel = document.getElementById("drop-label");
+    if (dropLabel) dropLabel.textContent = "Drag \u0026 drop files here, or";
+    const badges = document.getElementById("upload-groups-badges");
+    if (badges) {
+        badges.querySelectorAll(".badge[data-group-id]").forEach(b => b.remove());
+    }
+    const popup = document.getElementById("upload-group-popup");
+    if (popup) popup.querySelectorAll("[data-group-id]").forEach(b => { b.style.display = ""; });
+    submitBtn.disabled = true;
+
+    // Final status + per-failure toasts
+    if (failures.length === 0) {
+        statusEl.textContent = total > 1
+            ? "All " + total + " uploads complete!"
+            : "Upload complete!";
+        statusEl.className = "form-status text-success";
+    } else if (okCount === 0) {
+        statusEl.textContent = "";
+        statusEl.className = "form-status";
+    } else {
+        statusEl.textContent = okCount + " of " + total + " uploaded, " + failures.length + " failed.";
+        statusEl.className = "form-status text-warning";
+    }
+    for (const f of failures) {
+        showToast(f.name + ": " + f.msg, true);
+    }
+    if (failures.length === 0) {
+        setTimeout(() => { statusEl.textContent = ""; statusEl.className = "form-status"; }, 1500);
+    }
+    return failures.length === 0;
 }
 
 // ── Upload multi-group selector ──

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -22,10 +22,10 @@
     <div id="add-tab-upload" class="tab-content active" style="padding:1.25rem;">
     <form id="upload-form" onsubmit="event.preventDefault(); uploadAsset(this)" enctype="multipart/form-data">
         <div class="upload-area" id="drop-zone">
-            <p id="drop-label">Drag &amp; drop a file here, or</p>
-            <p class="text-muted" style="font-size:0.85rem; margin-bottom:0.75rem">Accepts video (mp4, mov, mkv, avi, webm) and image (jpg, png, heif, avif, webp, gif, bmp, tiff) files</p>
-            <button type="button" class="btn btn-secondary" onclick="document.getElementById('file-input').click()">Choose File</button>
-            <input type="file" id="file-input" name="file" accept=".mp4,.mov,.mkv,.avi,.webm,.ts,.m4v,.jpg,.jpeg,.png,.heif,.heic,.avif,.webp,.gif,.bmp,.tiff,.tif" required style="display:none">
+            <p id="drop-label">Drag &amp; drop files here, or</p>
+            <p class="text-muted" style="font-size:0.85rem; margin-bottom:0.75rem">Accepts video (mp4, mov, mkv, avi, webm) and image (jpg, png, heif, avif, webp, gif, bmp, tiff) files. Multiple files allowed.</p>
+            <button type="button" class="btn btn-secondary" onclick="document.getElementById('file-input').click()">Choose Files</button>
+            <input type="file" id="file-input" name="file" multiple accept=".mp4,.mov,.mkv,.avi,.webm,.ts,.m4v,.jpg,.jpeg,.png,.heif,.heic,.avif,.webp,.gif,.bmp,.tiff,.tif" style="display:none">
         </div>
         {% if user_groups | length > 0 %}
         <div style="margin-top:0.75rem;">
@@ -428,7 +428,7 @@
         const files = e.dataTransfer.files;
         if (files.length) {
             fileInput.files = files;
-            document.getElementById("drop-label").textContent = files[0].name;
+            document.getElementById("drop-label").textContent = _describeSelectedFiles(files);
             document.getElementById("upload-submit").disabled = false;
         }
     });
@@ -437,13 +437,18 @@
         const label = document.getElementById("drop-label");
         const submitBtn = document.getElementById("upload-submit");
         if (fileInput.files.length) {
-            label.textContent = fileInput.files[0].name;
+            label.textContent = _describeSelectedFiles(fileInput.files);
             submitBtn.disabled = false;
         } else {
-            label.textContent = "Drag \u0026 drop a file here, or";
+            label.textContent = "Drag \u0026 drop files here, or";
             submitBtn.disabled = true;
         }
     });
+
+    function _describeSelectedFiles(files) {
+        if (files.length === 1) return files[0].name;
+        return files.length + " files selected";
+    }
 
     // Prevent browser from opening dropped files outside the zone
     document.addEventListener("dragover", (e) => e.preventDefault());

--- a/tests_e2e/test_ui_upload_cancel.py
+++ b/tests_e2e/test_ui_upload_cancel.py
@@ -8,7 +8,7 @@ button must be disabled, so the form looks fresh for the next upload.
 import pytest
 
 
-DEFAULT_LABEL = "Drag & drop a file here, or"
+DEFAULT_LABEL = "Drag & drop files here, or"
 
 
 def test_cancel_file_picker_resets_label_after_drop(page: "Page"):


### PR DESCRIPTION
## What

Multi-file upload on the Assets > Upload File tab.

- `<input type="file">` now has `multiple` (and the drop-zone copy + button label updated to plural).
- Drop-label now reads `N files selected` (or the single filename when only one).
- `uploadAsset()` iterates the FileList and POSTs to the existing single-file `/api/assets/upload` endpoint once per file, sequentially. Per-file progress: `Uploading 2/5 (clip.mp4)… 42%`.
- Each successful upload immediately inserts its asset row (fire-and-forget so the next file's POST doesn't wait on row insertion).
- Failures are collected, not fatal — final status reads e.g. `3 of 5 uploaded, 2 failed.` with a per-failure toast for each.
- Group selection and "Make Global" snapshotted before the batch starts and applied to every file in the batch.

## Why

User asked for multi-file upload — single-file-at-a-time is tedious when seeding a library.

## Risk

Pure frontend. Existing single-file path is unchanged (still works exactly as before for `N == 1`). No backend, no schema, no API change — `openapi-check` passes trivially. The existing playwright nightly test (`tests/nightly/test_02_assets.py`) uses `set_input_files` with a single path, which the `multiple` attribute still supports.
