### PR TITLE
fix(slideshow): SlideDescriptor must accept all SLIDE_TRANSITIONS

### DIFF
--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -312,10 +312,13 @@ class SlideDescriptor(BaseModel):
             raise ValueError(
                 "SlideDescriptor.play_to_end=True is only valid for video sources"
             )
-        if self.transition not in ("cut", "fade", "dissolve", "wipe"):
+        # Keep this allow-list in sync with cms.schemas.asset.SLIDE_TRANSITIONS
+        # and the JS shell's KNOWN_TRANSITIONS in agora/player/shell/player.js.
+        from cms.schemas.asset import SLIDE_TRANSITIONS
+        if self.transition not in SLIDE_TRANSITIONS:
             raise ValueError(
                 f"SlideDescriptor.transition must be one of "
-                f"cut/fade/dissolve/wipe, got {self.transition!r}"
+                f"{SLIDE_TRANSITIONS}, got {self.transition!r}"
             )
         if self.transition_ms < 0 or self.transition_ms > 5000:
             raise ValueError(

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -199,3 +199,43 @@ class TestSlideshowSchemaFieldDefaults:
         cms_msg = _build_cms_slideshow_msg(manifest_schema_version="1.1")
         wire = json.loads(cms_msg.model_dump_json())
         assert wire["manifest_schema_version"] == "1.1"
+
+
+class TestSlideDescriptorTransitionAllowList:
+    """Regression: SlideDescriptor must accept every transition ID listed
+    in cms.schemas.asset.SLIDE_TRANSITIONS.  These two lists drifted once
+    (the Pydantic validator hard-coded ``cut/fade/dissolve/wipe`` while
+    SLIDE_TRANSITIONS grew to include fade_black/push/zoom), which made
+    the slideshow fetch path 500 for any slide using the new modes and
+    devices stuck in a fetch-retry loop.
+    """
+
+    @pytest.mark.parametrize("transition", list(__import__("cms.schemas.asset", fromlist=["SLIDE_TRANSITIONS"]).SLIDE_TRANSITIONS))
+    def test_every_known_transition_accepted(self, transition: str) -> None:
+        from cms.schemas.protocol import SlideDescriptor
+
+        SlideDescriptor(
+            asset_name="slide.png",
+            asset_type="image",
+            download_url="/x",
+            checksum="a" * 64,
+            size_bytes=1024,
+            duration_ms=2000,
+            transition=transition,
+            transition_ms=600,
+        )
+
+    def test_unknown_transition_rejected(self) -> None:
+        from cms.schemas.protocol import SlideDescriptor
+
+        with pytest.raises(ValueError, match="transition must be one of"):
+            SlideDescriptor(
+                asset_name="slide.png",
+                asset_type="image",
+                download_url="/x",
+                checksum="a" * 64,
+                size_bytes=1024,
+                duration_ms=2000,
+                transition="kaleidoscope",
+                transition_ms=600,
+            )


### PR DESCRIPTION
## Why

PR #629 expanded the slideshow transition set to include `fade_black`, `push`, and `zoom` -- but the Pydantic validator on `SlideDescriptor` (the wire-format model used by the device fetch path) still hard-coded the old four-mode allow-list `cut/fade/dissolve/wipe`.

Result: any slideshow whose slides used one of the new IDs raised `ValidationError` inside `build_fetch_for_slideshow`, the `device_inbound` `fetch_request` handler 500'd, and both real Pis and softplayer got stuck in a perpetual:

    Schedule: asset <name> not on device, requesting fetch

retry loop -- the manifest never made it to the device.

## What

- `cms/schemas/protocol.py`: validator now references the canonical `cms.schemas.asset.SLIDE_TRANSITIONS` tuple rather than a hard-coded literal, so the two lists can't drift again.
- `tests/test_slideshow_schema_contract.py`: new `TestSlideDescriptorTransitionAllowList` parametrized over every entry in `SLIDE_TRANSITIONS` -- this would have caught the original drift immediately.

15/15 `test_slideshow_schema_contract.py` pass locally.

## Validation

After merge + deploy, restart the slideshow flow on Pi100 / softplayer -- the asset fetch should complete and the slideshow should start.