### PR TITLE
feat(assets): asset library Phase 1 - filter / sort / paginate / bulk / grid

### DIFF
--- a/alembic/versions/0030_asset_search_indexes.py
+++ b/alembic/versions/0030_asset_search_indexes.py
@@ -1,0 +1,65 @@
+"""trigram + uploaded_at indexes for asset library search and pagination
+
+Phase 1 of the Asset Library enhancements (see session plan
+"Asset Library Phase 1"):
+
+- Enables ``pg_trgm`` (Postgres only) so substring search across
+  ``display_name``, ``original_filename``, and ``filename`` can use a
+  GIN index rather than a sequential scan.
+- Adds a partial btree on ``uploaded_at DESC WHERE deleted_at IS NULL``
+  to cover the common newest-first ordering of the visible asset set.
+
+SQLite (used in CI for the unit-test matrix) doesn't support
+``pg_trgm`` or GIN.  The trigram indexes are skipped on SQLite and the
+``LIKE`` queries fall back to a sequential scan there — fine for the
+small synthetic datasets the tests use, and the production target is
+always Postgres anyway.
+
+Revision ID: 0030
+Revises: 0029
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0030"
+down_revision = "0029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_assets_display_name_trgm "
+            "ON assets USING GIN (display_name gin_trgm_ops)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_assets_original_filename_trgm "
+            "ON assets USING GIN (original_filename gin_trgm_ops)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_assets_filename_trgm "
+            "ON assets USING GIN (filename gin_trgm_ops)"
+        )
+
+    # Plain btree on uploaded_at — Postgres and SQLite can both scan it
+    # in reverse to satisfy ``ORDER BY uploaded_at DESC``. Partial on
+    # ``deleted_at IS NULL`` because every list-asset query filters that.
+    op.create_index(
+        "idx_assets_uploaded_at_live",
+        "assets",
+        ["uploaded_at"],
+        postgresql_where="deleted_at IS NULL",
+        sqlite_where="deleted_at IS NULL",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0030 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -7,6 +7,8 @@ import uuid
 from pathlib import Path
 from typing import List
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy import delete, func, select, update
@@ -25,7 +27,12 @@ from cms.models.schedule import Schedule
 from cms.models.slideshow_slide import SlideshowSlide
 from cms.models.user import User
 from cms.schemas.asset import (
+    AssetBulkFailure,
+    AssetBulkIn,
+    AssetBulkOut,
     AssetOut,
+    AssetPageOut,
+    BULK_ACTIONS,
     MAX_SLIDE_DURATION_MS,
     MAX_SLIDESHOW_SLIDES,
     SlideIn,
@@ -355,6 +362,330 @@ async def list_assets(
     result = await db.execute(q)
     return result.scalars().all()
 
+
+# ── Paginated / filtered listing for the asset library UI ──
+#
+# This sits alongside the legacy ``GET /api/assets`` (above) so the many
+# existing callers (MCP client, slideshow_builder, half the test suite)
+# keep working with the old flat-list shape. Only the new asset-library
+# UI talks to ``/page``.
+
+
+class _OrderSpec:
+    """Maps an ``order=`` query value to (sort column, secondary cursor)."""
+
+    def __init__(self, column, *, nulls_last: bool = False, coalesce_with=None):
+        self.column = column
+        self.nulls_last = nulls_last
+        self.coalesce_with = coalesce_with
+
+    def expr(self, descending: bool):
+        from sqlalchemy import nulls_last as _nl
+
+        col = self.column
+        if self.coalesce_with is not None:
+            col = func.coalesce(self.column, self.coalesce_with)
+        ordered = col.desc() if descending else col.asc()
+        if self.nulls_last:
+            ordered = _nl(ordered)
+        return ordered, col
+
+
+def _build_order_specs() -> dict[str, _OrderSpec]:
+    # Lazily built so the column references resolve after the model is
+    # fully imported.
+    return {
+        "display_name": _OrderSpec(
+            Asset.display_name, coalesce_with=Asset.filename
+        ),
+        "asset_type": _OrderSpec(Asset.asset_type),
+        "size_bytes": _OrderSpec(Asset.size_bytes),
+        "uploaded_at": _OrderSpec(Asset.uploaded_at),
+        "duration_seconds": _OrderSpec(
+            Asset.duration_seconds, nulls_last=True
+        ),
+    }
+
+
+def _encode_cursor(value, last_id: uuid.UUID) -> str:
+    import base64
+    import json
+
+    if isinstance(value, datetime):
+        payload_value = value.isoformat()
+    elif isinstance(value, uuid.UUID):
+        payload_value = str(value)
+    elif isinstance(value, AssetType):
+        payload_value = value.value
+    else:
+        payload_value = value
+    raw = json.dumps([payload_value, str(last_id)], separators=(",", ":"))
+    return base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> tuple:
+    import base64
+    import json
+
+    pad = "=" * ((4 - len(cursor) % 4) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + pad).decode()
+        value, last_id = json.loads(raw)
+        return value, uuid.UUID(last_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid pagination cursor")
+
+
+_ALLOWED_TYPES = {t.value for t in AssetType}
+
+
+@router.get("/page", response_model=AssetPageOut)
+async def list_assets_paged(
+    user: User = Depends(require_permission(ASSETS_READ)),
+    db: AsyncSession = Depends(get_db),
+    q: str = Query("", description="Substring search across name/filename"),
+    type: list[str] = Query(default_factory=list, alias="type"),
+    group_id: list[uuid.UUID] = Query(default_factory=list, alias="group_id"),
+    uploader_id: list[uuid.UUID] = Query(default_factory=list, alias="uploader_id"),
+    uploaded_after: datetime | None = Query(None),
+    uploaded_before: datetime | None = Query(None),
+    order: str = Query("-uploaded_at"),
+    cursor: str | None = Query(None),
+    page_size: int = Query(50, ge=1, le=200),
+):
+    """Paginated + filtered asset listing for the asset library UI.
+
+    All filters are AND-composed. ``q`` is a case-insensitive substring
+    match against ``display_name``, ``original_filename``, and
+    ``filename`` (Postgres-side this hits a trigram GIN index; SQLite
+    falls back to a sequential scan in tests). The caller's group ACL
+    is applied last and cannot be widened by URL parameters.
+    """
+    # ── Parse + validate order ──
+    descending = order.startswith("-")
+    key = order.lstrip("-")
+    specs = _build_order_specs()
+    if key not in specs:
+        raise HTTPException(
+            status_code=400,
+            detail=f"order must be one of {sorted(specs)} (optionally prefixed with -)",
+        )
+    spec = specs[key]
+    order_expr, order_col = spec.expr(descending)
+
+    # ── Validate type filter ──
+    if type:
+        bad = [t for t in type if t not in _ALLOWED_TYPES]
+        if bad:
+            raise HTTPException(
+                status_code=400,
+                detail=f"unknown type filter values: {bad}",
+            )
+        type_enums = [AssetType(t) for t in type]
+    else:
+        type_enums = []
+
+    # ── Base query (live assets only) ──
+    stmt = select(Asset, func.count().over().label("total")).where(
+        Asset.deleted_at.is_(None)
+    )
+
+    # ── ACL ──
+    visible = await _visible_asset_ids(user, db)
+    if visible is not None:
+        stmt = stmt.where(Asset.id.in_(visible))
+
+    # ── Filters ──
+    if q:
+        like = f"%{q}%"
+        stmt = stmt.where(
+            func.coalesce(Asset.display_name, "").ilike(like)
+            | func.coalesce(Asset.original_filename, "").ilike(like)
+            | Asset.filename.ilike(like)
+        )
+
+    if type_enums:
+        stmt = stmt.where(Asset.asset_type.in_(type_enums))
+
+    if uploader_id:
+        stmt = stmt.where(Asset.uploaded_by_user_id.in_(uploader_id))
+
+    if uploaded_after is not None:
+        stmt = stmt.where(Asset.uploaded_at >= uploaded_after)
+    if uploaded_before is not None:
+        stmt = stmt.where(Asset.uploaded_at < uploaded_before)
+
+    if group_id:
+        # AND-intersected with the ACL: caller is still bounded by what
+        # they can see — non-admins passing a group they aren't a member
+        # of just see an empty page rather than getting 403.
+        stmt = stmt.where(
+            Asset.id.in_(
+                select(GroupAsset.asset_id).where(GroupAsset.group_id.in_(group_id))
+            )
+        )
+
+    # ── Cursor (encodes the order key value and the last id seen) ──
+    if cursor:
+        cursor_value, cursor_last_id = _decode_cursor(cursor)
+        # Re-hydrate the cursor value into the order column's native type
+        # so the WHERE clause type-checks on Postgres.
+        if key == "uploaded_at":
+            try:
+                cursor_value = datetime.fromisoformat(cursor_value)
+            except Exception:
+                raise HTTPException(status_code=400, detail="Invalid cursor value")
+        elif key == "asset_type":
+            try:
+                cursor_value = AssetType(cursor_value)
+            except Exception:
+                raise HTTPException(status_code=400, detail="Invalid cursor value")
+        # size_bytes / duration_seconds come back as int / float from JSON
+        # already; display_name comes back as a string. Nothing to do.
+
+        if descending:
+            stmt = stmt.where(
+                (order_col < cursor_value)
+                | ((order_col == cursor_value) & (Asset.id < cursor_last_id))
+            )
+        else:
+            stmt = stmt.where(
+                (order_col > cursor_value)
+                | ((order_col == cursor_value) & (Asset.id > cursor_last_id))
+            )
+
+    # ── Order: primary key then id as deterministic tiebreaker ──
+    id_tiebreak = Asset.id.desc() if descending else Asset.id.asc()
+    stmt = stmt.order_by(order_expr, id_tiebreak).limit(page_size + 1)
+
+    rows = (await db.execute(stmt)).all()
+    has_more = len(rows) > page_size
+    rows = rows[:page_size]
+
+    items = [row[0] for row in rows]
+    total_estimate = int(rows[0][1]) if rows else 0
+
+    next_cursor: str | None = None
+    if has_more and items:
+        last = items[-1]
+        # Pull the same expression value we ordered by (handles
+        # coalesce(display_name, filename) etc.).
+        last_value = getattr(last, key, None)
+        if key == "display_name" and last_value is None:
+            last_value = last.filename
+        next_cursor = _encode_cursor(last_value, last.id)
+
+    return AssetPageOut(
+        items=[AssetOut.model_validate(a) for a in items],
+        next_cursor=next_cursor,
+        total_estimate=total_estimate,
+    )
+
+
+# ── Bulk endpoint ──
+#
+# Polymorphic. Routes per-id to the existing single-asset endpoint
+# logic so all ACL invariants (schedule references, slideshow audience,
+# group-membership scoping, admin-only global toggles) are enforced
+# exactly as they would be in the per-asset path. Failures are reported
+# per-id rather than failing the whole batch — same shape as ``POST
+# /api/devices/bulk``.
+
+@router.post(
+    "/bulk",
+    response_model=AssetBulkOut,
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
+)
+async def bulk_assets(
+    payload: AssetBulkIn,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    if payload.action in ("add_group", "remove_group") and payload.group_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"group_id is required for action={payload.action!r}",
+        )
+    if payload.action == "set_global":
+        if payload.is_global is None:
+            raise HTTPException(
+                status_code=400,
+                detail="is_global is required for action='set_global'",
+            )
+        # set_global is admin-only — same posture as the single-asset
+        # toggle endpoint, but expressed up-front for clarity.
+        user_groups_check = await get_user_group_ids(user, db)
+        if user_groups_check is not None:
+            raise HTTPException(
+                status_code=403,
+                detail="Only admins can change an asset's global flag",
+            )
+
+    succeeded: list[uuid.UUID] = []
+    failed: list[AssetBulkFailure] = []
+
+    # De-duplicate while preserving order — callers occasionally send the
+    # same id twice from a misbehaving UI; a duplicate would just produce
+    # a 404 on the second pass which is noisy without being useful.
+    seen: set[uuid.UUID] = set()
+    asset_ids = [a for a in payload.asset_ids if not (a in seen or seen.add(a))]
+
+    for aid in asset_ids:
+        try:
+            if payload.action == "delete":
+                await delete_asset(
+                    asset_id=aid, request=request, user=user, db=db, settings=settings
+                )
+            elif payload.action == "add_group":
+                await share_asset(
+                    asset_id=aid,
+                    request=request,
+                    group_id=payload.group_id,  # type: ignore[arg-type]
+                    user=user,
+                    db=db,
+                )
+            elif payload.action == "remove_group":
+                await unshare_asset(
+                    asset_id=aid,
+                    request=request,
+                    group_id=payload.group_id,  # type: ignore[arg-type]
+                    user=user,
+                    db=db,
+                )
+            elif payload.action == "set_global":
+                # Toggle only if the current state differs from the
+                # requested state so the operation is idempotent.
+                cur = (
+                    await db.execute(
+                        select(Asset.is_global).where(
+                            Asset.id == aid, Asset.deleted_at.is_(None)
+                        )
+                    )
+                ).scalar_one_or_none()
+                if cur is None:
+                    raise HTTPException(status_code=404, detail="Asset not found")
+                if bool(cur) != bool(payload.is_global):
+                    await toggle_asset_global(
+                        asset_id=aid, request=request, db=db
+                    )
+            succeeded.append(aid)
+        except HTTPException as exc:
+            # Roll back any partial work the failed handler did so the
+            # session is clean for the next iteration. The single-asset
+            # endpoints commit on success, so rollback only affects the
+            # current failed attempt.
+            await db.rollback()
+            failed.append(
+                AssetBulkFailure(
+                    id=aid,
+                    reason=str(exc.detail),
+                    status=exc.status_code,
+                )
+            )
+
+    return AssetBulkOut(succeeded=succeeded, failed=failed)
 
 @router.post("/upload", response_model=AssetOut, status_code=201)
 async def upload_asset(

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -485,45 +485,49 @@ async def list_assets_paged(
     else:
         type_enums = []
 
-    # ── Base query (live assets only) ──
-    stmt = select(Asset, func.count().over().label("total")).where(
-        Asset.deleted_at.is_(None)
-    )
+    # ── Build the filter predicates once, apply to both the page query
+    #    and the (separate) count query. The count MUST NOT include the
+    #    cursor predicate, otherwise total_estimate shrinks on each
+    #    successive page (e.g. "61 → 11" after one scroll) which makes
+    #    the load-more footer report nonsense.
+    filter_clauses = [Asset.deleted_at.is_(None)]
 
     # ── ACL ──
     visible = await _visible_asset_ids(user, db)
     if visible is not None:
-        stmt = stmt.where(Asset.id.in_(visible))
+        filter_clauses.append(Asset.id.in_(visible))
 
     # ── Filters ──
     if q:
         like = f"%{q}%"
-        stmt = stmt.where(
+        filter_clauses.append(
             func.coalesce(Asset.display_name, "").ilike(like)
             | func.coalesce(Asset.original_filename, "").ilike(like)
             | Asset.filename.ilike(like)
         )
 
     if type_enums:
-        stmt = stmt.where(Asset.asset_type.in_(type_enums))
+        filter_clauses.append(Asset.asset_type.in_(type_enums))
 
     if uploader_id:
-        stmt = stmt.where(Asset.uploaded_by_user_id.in_(uploader_id))
+        filter_clauses.append(Asset.uploaded_by_user_id.in_(uploader_id))
 
     if uploaded_after is not None:
-        stmt = stmt.where(Asset.uploaded_at >= uploaded_after)
+        filter_clauses.append(Asset.uploaded_at >= uploaded_after)
     if uploaded_before is not None:
-        stmt = stmt.where(Asset.uploaded_at < uploaded_before)
+        filter_clauses.append(Asset.uploaded_at < uploaded_before)
 
     if group_id:
         # AND-intersected with the ACL: caller is still bounded by what
         # they can see — non-admins passing a group they aren't a member
         # of just see an empty page rather than getting 403.
-        stmt = stmt.where(
+        filter_clauses.append(
             Asset.id.in_(
                 select(GroupAsset.asset_id).where(GroupAsset.group_id.in_(group_id))
             )
         )
+
+    stmt = select(Asset).where(*filter_clauses)
 
     # ── Cursor (encodes the order key value and the last id seen) ──
     if cursor:
@@ -563,7 +567,16 @@ async def list_assets_paged(
     rows = rows[:page_size]
 
     items = [row[0] for row in rows]
-    total_estimate = int(rows[0][1]) if rows else 0
+
+    # ── Total estimate: count all rows matching the filters, ignoring
+    #    the cursor. We only need this once per filter context but cost
+    #    is low enough (single round-trip, hits the same indexes) to
+    #    compute every page; UI uses it to render "Showing N of M".
+    total_estimate = int(
+        (await db.execute(
+            select(func.count()).select_from(Asset).where(*filter_clauses)
+        )).scalar() or 0
+    )
 
     next_cursor: str | None = None
     if has_more and items:

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -77,6 +77,50 @@ class AssetOut(BaseModel):
     capture_duration: Optional[int] = None
 
 
+class AssetPageOut(BaseModel):
+    """Paginated asset listing for the asset library UI.
+
+    Used by ``GET /api/assets/page``. The legacy ``GET /api/assets`` still
+    returns the flat ``List[AssetOut]`` and is unchanged.
+    """
+
+    items: list[AssetOut]
+    next_cursor: Optional[str] = None
+    total_estimate: int
+
+
+BULK_ACTIONS = ("delete", "add_group", "remove_group", "set_global")
+
+
+class AssetBulkIn(BaseModel):
+    """Request body for ``POST /api/assets/bulk``."""
+
+    asset_ids: list[uuid.UUID] = Field(..., min_length=1, max_length=500)
+    action: str
+    group_id: Optional[uuid.UUID] = None
+    is_global: Optional[bool] = None
+
+    @field_validator("action")
+    @classmethod
+    def _validate_action(cls, v: str) -> str:
+        if v not in BULK_ACTIONS:
+            raise ValueError(f"action must be one of {BULK_ACTIONS}")
+        return v
+
+
+class AssetBulkFailure(BaseModel):
+    id: uuid.UUID
+    reason: str
+    status: int = 400
+
+
+class AssetBulkOut(BaseModel):
+    """Result of ``POST /api/assets/bulk``."""
+
+    succeeded: list[uuid.UUID]
+    failed: list[AssetBulkFailure]
+
+
 # ── Slideshow ──
 
 

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -130,8 +130,13 @@
 {% macro asset_row(a, user_perms, is_admin, group_name_map, user_groups, uploader_map, current_user_id=None) -%}
             {% set is_owner = (current_user_id and a.uploaded_by_user_id == current_user_id) or is_admin %}
             {% set shared_badge = ('assets:write' in user_perms) and (not is_owner) %}
-            <tr class="asset-row" onclick="toggleAsset(this)" data-asset-id="{{ a.id }}">
-                <td class="expand-toggle">▶</td>
+            <tr class="asset-row" onclick="toggleAsset(this)" data-asset-id="{{ a.id }}" data-asset-type="{{ a.asset_type.value }}" data-uploaded-at="{{ a.uploaded_at.isoformat() if a.uploaded_at else '' }}" data-size-bytes="{{ a.size_bytes or 0 }}" data-duration-seconds="{{ a.duration_seconds or '' }}" data-uploader-id="{{ a.uploaded_by_user_id or '' }}" data-is-global="{{ '1' if a.is_global else '0' }}">
+                <td class="expand-toggle" style="white-space:nowrap;">
+                    {% if 'assets:write' in user_perms %}
+                    <input type="checkbox" class="bulk-select-row" data-asset-id="{{ a.id }}" onclick="event.stopPropagation()" style="margin-right:0.25rem; vertical-align:middle;">
+                    {% endif %}
+                    <span class="expand-arrow">▶</span>
+                </td>
                 <td class="wrap asset-filename-cell">
                     <span class="has-tooltip">
                         <span class="asset-filename-truncate editable-name" data-asset-id="{{ a.id }}" onclick="event.stopPropagation(); editAssetName(this)" title="Click to rename">{{ a.display_name or a.original_filename or a.filename }}</span>
@@ -139,6 +144,9 @@
                     </span>
                     {% if shared_badge %}
                     <span class="has-tooltip" style="margin-left:0.4rem"><span class="badge badge-processing" style="font-size:0.75rem">Shared</span><span class="tooltip">Shared with you via a group. Only the owner can delete this asset.</span></span>
+                    {% endif %}
+                    {% if a.uploaded_by_user_id and uploader_map.get(a.uploaded_by_user_id | string) %}
+                    <div class="text-muted" style="font-size:0.75rem; margin-top:0.15rem;">by {{ uploader_map[a.uploaded_by_user_id | string] }}</div>
                     {% endif %}
                 </td>
                 <td><span class="badge badge-{{ a.asset_type.value }}"><span aria-hidden="true">{{ a | asset_icon }}</span> {% if a.asset_type.value == 'saved_stream' %}Saved Stream{% else %}{{ a.asset_type.value | capitalize }}{% endif %}</span></td>
@@ -213,6 +221,16 @@
                     <span class="text-muted">—</span>
                     {% endif %}
                 </td>
+                <td class="col-uploaded" style="white-space:nowrap;">
+                    {% if a.uploaded_at %}
+                    <span class="has-tooltip">
+                        <span data-rel-time="{{ a.uploaded_at.isoformat() }}">{{ a.uploaded_at.strftime('%Y-%m-%d') }}</span>
+                        <span class="tooltip">{{ a.uploaded_at.isoformat() }}</span>
+                    </span>
+                    {% else %}
+                    <span class="text-muted">—</span>
+                    {% endif %}
+                </td>
                 <td class="actions" onclick="event.stopPropagation()">
                     {% call kebab_menu() %}
                     {% if a.asset_type.value == 'webpage' %}
@@ -246,7 +264,7 @@
             </tr>
             <tr class="asset-detail" data-detail-for="{{ a.id }}" style="display: none;">
                 <td></td>
-                <td colspan="7">
+                <td colspan="8">
                     <div class="detail-grid">
                         {% if (a.asset_type.value == 'webpage' or a.asset_type.value == 'stream' or a.asset_type.value == 'saved_stream') and a.url %}
                         <div class="detail-item detail-item-wide">

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -1356,10 +1356,12 @@ function fallbackCopy(text, onSuccess) {
         clearSelection,
         clearFilters,
         setView: _setView,
-        bulkDelete: () => {
+        bulkDelete: async () => {
             const n = state.selection.size;
             if (n === 0) return;
-            if (!confirm('Delete ' + n + ' asset' + (n === 1 ? '' : 's') + '? This cannot be undone (while the asset is still referenced by an active schedule the action will be refused for that asset).')) return;
+            const msg = 'Delete ' + n + ' asset' + (n === 1 ? '' : 's') + '? This cannot be undone (while the asset is still referenced by an active schedule the action will be refused for that asset).';
+            const ok = await showConfirm(msg);
+            if (!ok) return;
             _runBulk('delete');
         },
         bulkAddGroup: (groupId) => _runBulk('add_group', { group_id: groupId }),

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -159,32 +159,150 @@
 </div>
 {% endif %}
 
-<div class="card">
-    <div style="display:flex; align-items:center; justify-content:space-between; gap:0.5rem;">
+<div class="card" id="assets-library-card">
+    <div style="display:flex; align-items:center; justify-content:space-between; gap:0.5rem; flex-wrap:wrap;">
         <h2 style="margin:0;">Library</h2>
+        <div class="library-toolbar" style="display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap;">
+            <button type="button" class="btn btn-secondary btn-sm" id="assets-refresh-btn"
+                    onclick="window._assetLibrary && window._assetLibrary.reload()" title="Refresh from server">↻ Refresh</button>
+            <div class="view-toggle" role="group" aria-label="View" style="display:inline-flex; border:1px solid var(--border, #444); border-radius:4px; overflow:hidden;">
+                <button type="button" class="btn btn-secondary btn-sm" id="view-toggle-table"
+                        onclick="window._assetLibrary && window._assetLibrary.setView('table')"
+                        style="border-radius:0; border:0; display:inline-flex; align-items:center; justify-content:center; line-height:1;" title="Table view"><span style="display:inline-block; width:1em; text-align:center; margin-right:0.35em; font-size:0.9em;">&#9776;</span>Table</button>
+                <button type="button" class="btn btn-secondary btn-sm" id="view-toggle-grid"
+                        onclick="window._assetLibrary && window._assetLibrary.setView('grid')"
+                        style="border-radius:0; border:0; border-left:1px solid var(--border, #444); display:inline-flex; align-items:center; justify-content:center; line-height:1;" title="Grid view"><span style="display:inline-block; width:1em; text-align:center; margin-right:0.35em; font-size:0.9em;">&#9638;</span>Grid</button>
+            </div>
+        </div>
     </div>
-    <div class="table-wrap">
+
+    {# ── Filter bar ── #}
+    <div id="assets-filter-bar" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; margin-top:0.75rem; padding:0.5rem; background:var(--bg-subtle, rgba(255,255,255,0.03)); border-radius:4px;">
+        <input type="search" id="filter-q" placeholder="Search name / filename…"
+               style="flex:1 1 220px; min-width:180px; max-width:360px;"
+               autocomplete="off" spellcheck="false">
+        <select id="filter-type" style="min-width:130px;">
+            <option value="">All types</option>
+            <option value="video">Video</option>
+            <option value="image">Image</option>
+            <option value="webpage">Webpage</option>
+            <option value="stream">Stream</option>
+            <option value="saved_stream">Saved Stream</option>
+            <option value="slideshow">Slideshow</option>
+        </select>
+        {% if user_groups | length > 0 or is_admin %}
+        <select id="filter-group" style="min-width:140px;">
+            <option value="">All groups</option>
+            {% for g in user_groups %}
+            <option value="{{ g.id }}">{{ g.name }}</option>
+            {% endfor %}
+        </select>
+        {% endif %}
+        {% if is_admin %}
+        <select id="filter-uploader" style="min-width:160px;">
+            <option value="">All uploaders</option>
+            {% for uid, uname in uploader_map.items() %}
+            <option value="{{ uid }}">{{ uname }}</option>
+            {% endfor %}
+        </select>
+        {% endif %}
+        <select id="filter-date" style="min-width:130px;" title="Uploaded date range">
+            <option value="">Any time</option>
+            <option value="1">Past 24 hours</option>
+            <option value="7">Past 7 days</option>
+            <option value="30">Past 30 days</option>
+            <option value="90">Past 90 days</option>
+        </select>
+        <button type="button" class="btn btn-secondary btn-sm" id="filter-clear-btn"
+                onclick="window._assetLibrary && window._assetLibrary.clearFilters()"
+                style="display:none;">Clear filters</button>
+        <span class="text-muted" id="filter-summary" style="font-size:0.85rem;"></span>
+    </div>
+
+    {# ── Bulk action bar (hidden until a row is selected) ── #}
+    {% if 'assets:write' in user_perms %}
+    <div id="bulk-action-bar" style="display:none; margin-top:0.5rem; padding:0.5rem 0.75rem; background:var(--bg-subtle, rgba(64,128,255,0.10)); border:1px solid rgba(64,128,255,0.4); border-radius:4px; align-items:center; gap:0.5rem; flex-wrap:wrap;">
+        <strong id="bulk-action-count">0 selected</strong>
+        <button type="button" class="btn btn-secondary btn-sm" onclick="window._assetLibrary && window._assetLibrary.clearSelection()">Clear</button>
+        <span style="flex:1;"></span>
+        {% if user_groups | length > 0 or is_admin %}
+        <span class="bulk-group-picker" style="position:relative; display:inline-block;">
+            <button type="button" class="btn btn-secondary btn-sm"
+                    onclick="event.stopPropagation(); document.getElementById('bulk-add-group-popup').showPopover()">+ Add to group</button>
+            <div id="bulk-add-group-popup" popover class="group-popup">
+                {% for g in user_groups %}
+                <button type="button" class="group-popup-item"
+                        onclick="window._assetLibrary && window._assetLibrary.bulkAddGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
+                {% endfor %}
+                {% if user_groups | length == 0 %}
+                <span class="text-muted" style="padding:0.5rem; display:block;">No groups available</span>
+                {% endif %}
+            </div>
+        </span>
+        <span class="bulk-group-picker" style="position:relative; display:inline-block;">
+            <button type="button" class="btn btn-secondary btn-sm"
+                    onclick="event.stopPropagation(); document.getElementById('bulk-remove-group-popup').showPopover()">− Remove from group</button>
+            <div id="bulk-remove-group-popup" popover class="group-popup">
+                {% for g in user_groups %}
+                <button type="button" class="group-popup-item"
+                        onclick="window._assetLibrary && window._assetLibrary.bulkRemoveGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
+                {% endfor %}
+                {% if user_groups | length == 0 %}
+                <span class="text-muted" style="padding:0.5rem; display:block;">No groups available</span>
+                {% endif %}
+            </div>
+        </span>
+        {% endif %}
+        {% if is_admin %}
+        <button type="button" class="btn btn-secondary btn-sm"
+                onclick="window._assetLibrary && window._assetLibrary.bulkSetGlobal(true)">⭐ Make global</button>
+        <button type="button" class="btn btn-secondary btn-sm"
+                onclick="window._assetLibrary && window._assetLibrary.bulkSetGlobal(false)">☆ Unmark global</button>
+        {% endif %}
+        <button type="button" class="btn btn-danger btn-sm"
+                onclick="window._assetLibrary && window._assetLibrary.bulkDelete()">🗑 Delete</button>
+    </div>
+    {% endif %}
+
+    <div class="table-wrap" id="assets-table-wrap">
     <table>
         <thead>
             <tr>
+                {% if 'assets:write' in user_perms %}
+                <th style="width:2rem; padding-right:0;">
+                    <input type="checkbox" id="bulk-select-all" title="Select all loaded">
+                </th>
+                {% else %}
                 <th style="width:2rem"></th>
-                <th class="col-filename">Name</th>
-                <th>Type</th>
+                {% endif %}
+                <th class="col-filename sortable" data-sort-key="display_name">Name <span class="sort-indicator"></span></th>
+                <th class="sortable" data-sort-key="asset_type">Type <span class="sort-indicator"></span></th>
                 <th>Scope</th>
-                <th>Size</th>
+                <th class="sortable" data-sort-key="size_bytes">Size <span class="sort-indicator"></span></th>
                 <th>Status</th>
-                <th>Duration</th>
+                <th class="sortable" data-sort-key="duration_seconds">Duration <span class="sort-indicator"></span></th>
+                <th class="sortable col-uploaded" data-sort-key="uploaded_at">Uploaded <span class="sort-indicator">▼</span></th>
                 <th>Actions</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody id="assets-tbody">
             {% for a in assets %}
             {{ macros.asset_row(a, user_perms, is_admin, group_name_map, user_groups, uploader_map, current_user_id) }}
             {% else %}
-            <tr><td colspan="8" class="empty">No assets uploaded yet</td></tr>
+            <tr id="assets-empty-row"><td colspan="9" class="empty">No assets uploaded yet</td></tr>
             {% endfor %}
         </tbody>
     </table>
+    </div>
+
+    {# ── Grid view (hidden by default, populated client-side on view toggle) ── #}
+    <div id="assets-grid-wrap" style="display:none; margin-top:0.5rem;">
+        <div id="assets-grid" style="display:grid; grid-template-columns:repeat(auto-fill, minmax(180px, 1fr)); gap:0.75rem;"></div>
+    </div>
+
+    {# ── Infinite-scroll sentinel + status footer ── #}
+    <div id="assets-load-more" style="margin-top:0.75rem; padding:0.5rem; text-align:center; color:var(--text-muted, #888); font-size:0.85rem;">
+        <span id="assets-load-status">Showing {{ assets | length }} asset{{ '' if assets|length == 1 else 's' }}</span>
     </div>
 </div>
 
@@ -383,6 +501,8 @@
 
     window._insertAssetRow = _insertAssetRow;
     window._replaceAssetDetailRow = _replaceAssetDetailRow;
+    window._fetchAssetRowFragment = _fetchAssetRowFragment;
+    window.applyScopeChanges = applyScopeChanges;
 
     // Apply scope changes from API data without reloading the page
     function applyScopeChanges(assets) {
@@ -633,7 +753,7 @@
             const scopeChanged = lastState.scope_hash !== null && newState.scope_hash !== lastState.scope_hash;
             const countChanged = newState.asset_count !== lastState.asset_count;
             if (scopeChanged || countChanged) {
-                applyScopeChanges(data.assets);
+                (window.applyScopeChanges || applyScopeChanges)(data.assets);
             }
             lastState = newState;
         } catch (e) { /* ignore */ }
@@ -732,6 +852,543 @@ function fallbackCopy(text, onSuccess) {
     applyExpand();
     refreshQueue();
     setInterval(refreshQueue, 5000);
+})();
+
+// ── Asset library: filter / sort / paginate / bulk / grid view ──
+//
+// This module ADDS to the existing polling + drag-drop + upload IIFE
+// above; it does not replace it. The existing IIFE owns:
+//   - the upload form + drag-drop wiring
+//   - the /api/assets/status poller (variant progress, scope changes)
+//   - the per-id row insert/replace helpers (_insertAssetRow,
+//     _replaceAssetDetailRow)
+// This IIFE owns:
+//   - the filter bar (search, type, group, uploader, date range)
+//   - sortable column headers
+//   - infinite scroll
+//   - bulk-select + bulk action bar
+//   - grid view toggle
+//   - URL state sync
+(function() {
+    const tbody = document.getElementById('assets-tbody');
+    if (!tbody) return;  // page may not render this card for some perms
+
+    const VIEW_LS_KEY = 'agora-cms.assets.view';
+    const DEFAULT_PAGE_SIZE = 50;
+    const SEARCH_DEBOUNCE_MS = 300;
+
+    // Filter state mirrors the URL query string. Initialise from URL so
+    // shareable links work and the back button restores prior state.
+    const urlParams = new URLSearchParams(window.location.search);
+    const state = {
+        q: urlParams.get('q') || '',
+        type: urlParams.get('type') || '',
+        group_id: urlParams.get('group_id') || '',
+        uploader_id: urlParams.get('uploader_id') || '',
+        date_days: urlParams.get('date_days') || '',  // 1/7/30/90 preset
+        order: urlParams.get('order') || '-uploaded_at',
+        cursor: null,
+        next_cursor: null,
+        view: localStorage.getItem(VIEW_LS_KEY) || 'table',
+        selection: new Set(),
+        loadedIds: new Set(),  // ids currently rendered (table or grid)
+        searchFocused: false,
+        loading: false,
+        anyFilterActive: false,
+    };
+
+    // Wire up filter controls from initial state.
+    const qInput = document.getElementById('filter-q');
+    const typeSelect = document.getElementById('filter-type');
+    const groupSelect = document.getElementById('filter-group');
+    const uploaderSelect = document.getElementById('filter-uploader');
+    const dateSelect = document.getElementById('filter-date');
+    if (qInput) qInput.value = state.q;
+    if (typeSelect) typeSelect.value = state.type;
+    if (groupSelect) groupSelect.value = state.group_id;
+    if (uploaderSelect) uploaderSelect.value = state.uploader_id;
+    if (dateSelect) dateSelect.value = state.date_days;
+
+    function _isAnyFilterActive() {
+        return !!(state.q || state.type || state.group_id || state.uploader_id || state.date_days);
+    }
+
+    function _syncUrl() {
+        const p = new URLSearchParams();
+        if (state.q) p.set('q', state.q);
+        if (state.type) p.set('type', state.type);
+        if (state.group_id) p.set('group_id', state.group_id);
+        if (state.uploader_id) p.set('uploader_id', state.uploader_id);
+        if (state.date_days) p.set('date_days', state.date_days);
+        if (state.order && state.order !== '-uploaded_at') p.set('order', state.order);
+        const qs = p.toString();
+        const newUrl = window.location.pathname + (qs ? '?' + qs : '');
+        if (window.location.pathname + window.location.search !== newUrl) {
+            window.history.replaceState({}, '', newUrl);
+        }
+    }
+
+    function _buildApiParams() {
+        const p = new URLSearchParams();
+        if (state.q) p.set('q', state.q);
+        if (state.type) p.append('type', state.type);
+        if (state.group_id) p.append('group_id', state.group_id);
+        if (state.uploader_id) p.append('uploader_id', state.uploader_id);
+        if (state.date_days) {
+            const since = new Date(Date.now() - parseInt(state.date_days, 10) * 86400 * 1000);
+            p.set('uploaded_after', since.toISOString());
+        }
+        p.set('order', state.order);
+        p.set('page_size', String(DEFAULT_PAGE_SIZE));
+        if (state.cursor) p.set('cursor', state.cursor);
+        return p.toString();
+    }
+
+    function _updateFilterSummary(total) {
+        const el = document.getElementById('filter-summary');
+        if (!el) return;
+        const loaded = state.loadedIds.size;
+        if (total === 0) {
+            el.textContent = state.anyFilterActive ? 'No matches' : '';
+        } else if (loaded < total) {
+            el.textContent = 'Showing ' + loaded + ' of ' + total;
+        } else {
+            el.textContent = total + ' asset' + (total === 1 ? '' : 's');
+        }
+        const status = document.getElementById('assets-load-status');
+        if (status) status.textContent = loaded < total
+            ? 'Scroll to load more (' + (total - loaded) + ' remaining)'
+            : (total === 0 ? '' : 'All ' + total + ' loaded');
+        const clearBtn = document.getElementById('filter-clear-btn');
+        if (clearBtn) clearBtn.style.display = state.anyFilterActive ? '' : 'none';
+    }
+
+    async function _fetchPage(append) {
+        if (state.loading) return null;
+        state.loading = true;
+        try {
+            const resp = await fetch('/api/assets/page?' + _buildApiParams());
+            if (!resp.ok) return null;
+            const data = await resp.json();
+            state.next_cursor = data.next_cursor;
+            if (!append) {
+                _renderTableEmpty();
+                _renderGridEmpty();
+                state.loadedIds.clear();
+            }
+            // Render each row by fetching the rich server-rendered row
+            // markup in parallel. This reuses the existing Jinja macro so
+            // expandable details, action menus, scope badges etc. all
+            // continue to work without re-implementing them in JS.
+            const idsToRender = data.items.filter(a => !state.loadedIds.has(a.id));
+            const rowFragments = await Promise.all(
+                idsToRender.map(a => window._fetchAssetRowFragment
+                    ? window._fetchAssetRowFragment(a.id)
+                    : null)
+            );
+            for (let i = 0; i < idsToRender.length; i++) {
+                const a = idsToRender[i];
+                const frag = rowFragments[i];
+                if (frag) {
+                    tbody.appendChild(frag);
+                }
+                state.loadedIds.add(a.id);
+            }
+            // Grid view renders cards directly from JSON (no per-id row fetch).
+            if (state.view === 'grid') {
+                for (const a of data.items) {
+                    if (!document.querySelector('[data-grid-card="' + a.id + '"]')) {
+                        document.getElementById('assets-grid').appendChild(_renderGridCard(a));
+                    }
+                }
+            }
+            _updateFilterSummary(data.total_estimate);
+            _refreshSelectAllCheckbox();
+            return data;
+        } catch (e) {
+            console.error('asset page fetch failed', e);
+            return null;
+        } finally {
+            state.loading = false;
+        }
+    }
+
+    function _renderTableEmpty() {
+        // Remove the server-rendered "No assets uploaded yet" placeholder
+        // and all data rows. Detail rows (asset-detail) are paired with
+        // each asset-row, so wipe them too.
+        tbody.innerHTML = '';
+    }
+
+    function _renderGridEmpty() {
+        const grid = document.getElementById('assets-grid');
+        if (grid) grid.innerHTML = '';
+    }
+
+    function _escHtml(s) {
+        const d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+
+    function _typeIcon(t) {
+        return { video: '▶', image: '🖼', webpage: '🌐', stream: '📡',
+                 saved_stream: '🎞', slideshow: '🗂' }[t] || '📄';
+    }
+
+    function _formatSize(bytes) {
+        if (!bytes) return '—';
+        const mb = bytes / 1048576;
+        if (mb >= 1) return mb.toFixed(1) + ' MB';
+        return Math.round(bytes / 1024) + ' KB';
+    }
+
+    function _renderGridCard(a) {
+        const card = document.createElement('div');
+        card.className = 'asset-grid-card';
+        card.setAttribute('data-grid-card', a.id);
+        card.style.cssText = 'border:1px solid var(--border, #444); border-radius:6px; overflow:hidden; background:var(--bg-card, #1a1a1a); position:relative;';
+
+        const name = a.display_name || a.original_filename || a.filename;
+        // Only fetch a preview for image assets. For video/webpage/stream
+        // assets we show the type icon instead: /api/assets/{id}/preview
+        // serves the *full* source file (no thumbnail pipeline yet — see
+        // Phase 2-a), so previewing 60 videos in grid view would casually
+        // pull gigabytes. A dedicated thumbnail profile will be added in
+        // a follow-up PR; until then, lazy-loaded image previews only.
+        const previewSrc = (a.asset_type === 'image') ? ('/api/assets/' + a.id + '/preview') : null;
+
+        card.innerHTML =
+            '<div class="asset-grid-thumb" style="aspect-ratio:16/9; background:#0a0a0a; display:flex; align-items:center; justify-content:center; font-size:2rem; color:#666; position:relative;">' +
+                (previewSrc
+                    ? '<img loading="lazy" src="' + previewSrc + '" alt="" style="width:100%; height:100%; object-fit:cover;" onerror="this.replaceWith(document.createTextNode(\'' + _typeIcon(a.asset_type) + '\'))">'
+                    : _typeIcon(a.asset_type)) +
+                '<input type="checkbox" class="bulk-select-grid" data-asset-id="' + a.id + '" onclick="event.stopPropagation()" style="position:absolute; top:6px; left:6px; transform:scale(1.2);">' +
+                (a.is_global ? '<span class="badge badge-ready" style="position:absolute; top:6px; right:6px; font-size:0.7rem;">Global</span>' : '') +
+            '</div>' +
+            '<div style="padding:0.5rem;">' +
+                '<div class="asset-grid-name" title="' + _escHtml(name) + '" style="font-size:0.85rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">' + _escHtml(name) + '</div>' +
+                '<div class="text-muted" style="font-size:0.75rem; display:flex; justify-content:space-between; gap:0.5rem; margin-top:0.25rem;">' +
+                    '<span>' + _typeIcon(a.asset_type) + ' ' + a.asset_type + '</span>' +
+                    '<span>' + _formatSize(a.size_bytes) + '</span>' +
+                '</div>' +
+            '</div>';
+
+        // Wire selection checkbox.
+        const cb = card.querySelector('.bulk-select-grid');
+        cb.checked = state.selection.has(a.id);
+        cb.addEventListener('change', () => {
+            if (cb.checked) state.selection.add(a.id);
+            else state.selection.delete(a.id);
+            _refreshBulkBar();
+            // Mirror to table view checkbox if present.
+            const tableCb = tbody.querySelector('.bulk-select-row[data-asset-id="' + a.id + '"]');
+            if (tableCb) tableCb.checked = cb.checked;
+        });
+
+        // Card body itself is non-interactive in Phase 1 — only the
+        // checkbox is wired. (Earlier prototype flipped to table view
+        // and expanded the row on click, but that yanked users out of
+        // grid view unexpectedly. A proper preview lightbox is Phase 2.)
+        return card;
+    }
+
+    // ── Filter input wiring ──
+    function _onFilterChange(resetCursor) {
+        if (resetCursor !== false) {
+            state.cursor = null;
+            state.next_cursor = null;
+        }
+        state.anyFilterActive = _isAnyFilterActive();
+        _syncUrl();
+        // Re-render from scratch.
+        _fetchPage(false);
+    }
+
+    let qDebounceTimer = null;
+    if (qInput) {
+        qInput.addEventListener('input', () => {
+            state.q = qInput.value.trim();
+            clearTimeout(qDebounceTimer);
+            qDebounceTimer = setTimeout(() => _onFilterChange(), SEARCH_DEBOUNCE_MS);
+        });
+        qInput.addEventListener('focus', () => { state.searchFocused = true; });
+        qInput.addEventListener('blur', () => { state.searchFocused = false; });
+    }
+    if (typeSelect) typeSelect.addEventListener('change', () => {
+        state.type = typeSelect.value; _onFilterChange();
+    });
+    if (groupSelect) groupSelect.addEventListener('change', () => {
+        state.group_id = groupSelect.value; _onFilterChange();
+    });
+    if (uploaderSelect) uploaderSelect.addEventListener('change', () => {
+        state.uploader_id = uploaderSelect.value; _onFilterChange();
+    });
+    if (dateSelect) dateSelect.addEventListener('change', () => {
+        state.date_days = dateSelect.value; _onFilterChange();
+    });
+
+    // ── Sortable headers ──
+    document.querySelectorAll('th.sortable').forEach(th => {
+        th.style.cursor = 'pointer';
+        th.style.userSelect = 'none';
+        th.addEventListener('click', () => {
+            const key = th.dataset.sortKey;
+            if (!key) return;
+            // Cycle: not-sorted -> desc -> asc -> not-sorted (back to default uploaded_at desc).
+            const curDesc = state.order === '-' + key;
+            const curAsc = state.order === key;
+            if (!curDesc && !curAsc) state.order = '-' + key;
+            else if (curDesc) state.order = key;
+            else state.order = '-uploaded_at';
+            _updateSortIndicators();
+            _onFilterChange();
+        });
+    });
+
+    function _updateSortIndicators() {
+        document.querySelectorAll('th.sortable').forEach(th => {
+            const ind = th.querySelector('.sort-indicator');
+            if (!ind) return;
+            const key = th.dataset.sortKey;
+            if (state.order === '-' + key) {
+                ind.textContent = '▼';
+                ind.style.opacity = '1';
+            } else if (state.order === key) {
+                ind.textContent = '▲';
+                ind.style.opacity = '1';
+            } else {
+                // Idle state: show a dim ↕ glyph so the column reads as
+                // sortable even before the user has clicked it.
+                ind.textContent = '↕';
+                ind.style.opacity = '0.6';
+            }
+        });
+    }
+
+    // ── Bulk selection ──
+    function _refreshBulkBar() {
+        const bar = document.getElementById('bulk-action-bar');
+        if (!bar) return;
+        const n = state.selection.size;
+        bar.style.display = n > 0 ? 'flex' : 'none';
+        const countEl = document.getElementById('bulk-action-count');
+        if (countEl) countEl.textContent = n + ' selected';
+    }
+
+    function _refreshSelectAllCheckbox() {
+        const sa = document.getElementById('bulk-select-all');
+        if (!sa) return;
+        const all = Array.from(tbody.querySelectorAll('.bulk-select-row'));
+        if (all.length === 0) { sa.checked = false; sa.indeterminate = false; return; }
+        const checked = all.filter(c => c.checked).length;
+        sa.checked = (checked === all.length);
+        sa.indeterminate = (checked > 0 && checked < all.length);
+    }
+
+    // Delegate row-checkbox change events (rows arrive async + replace
+    // themselves periodically via _replaceAssetDetailRow / scope poller).
+    tbody.addEventListener('change', (e) => {
+        const cb = e.target.closest('.bulk-select-row');
+        if (!cb) return;
+        const id = cb.dataset.assetId;
+        if (cb.checked) state.selection.add(id);
+        else state.selection.delete(id);
+        _refreshBulkBar();
+        _refreshSelectAllCheckbox();
+        // Mirror to grid view card if present.
+        const gridCb = document.querySelector('.bulk-select-grid[data-asset-id="' + id + '"]');
+        if (gridCb) gridCb.checked = cb.checked;
+    });
+
+    const selectAll = document.getElementById('bulk-select-all');
+    if (selectAll) {
+        selectAll.addEventListener('click', (e) => {
+            const checked = e.target.checked;
+            tbody.querySelectorAll('.bulk-select-row').forEach(cb => {
+                cb.checked = checked;
+                const id = cb.dataset.assetId;
+                if (checked) state.selection.add(id);
+                else state.selection.delete(id);
+            });
+            // Mirror to grid checkboxes too.
+            document.querySelectorAll('.bulk-select-grid').forEach(cb => {
+                cb.checked = checked;
+            });
+            _refreshBulkBar();
+            _refreshSelectAllCheckbox();
+        });
+    }
+
+    async function _runBulk(action, extra) {
+        const ids = Array.from(state.selection);
+        if (ids.length === 0) return;
+        const body = Object.assign({ asset_ids: ids, action }, extra || {});
+        try {
+            const resp = await fetch('/api/assets/bulk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            const data = await resp.json();
+            if (!resp.ok) {
+                if (window.showToast) window.showToast(data.detail || 'Bulk action failed', true);
+                return;
+            }
+            const ok = data.succeeded.length;
+            const fail = data.failed.length;
+            const msg = ok + ' succeeded' + (fail ? ', ' + fail + ' failed' : '');
+            if (window.showToast) window.showToast(msg, fail > 0);
+            // Wipe selection (some ids may no longer be visible) and refresh.
+            state.selection.clear();
+            _refreshBulkBar();
+            await reload();
+        } catch (e) {
+            if (window.showToast) window.showToast('Bulk action error: ' + e.message, true);
+        }
+    }
+
+    async function reload() {
+        state.cursor = null;
+        await _fetchPage(false);
+    }
+
+    function clearSelection() {
+        state.selection.clear();
+        tbody.querySelectorAll('.bulk-select-row').forEach(cb => cb.checked = false);
+        document.querySelectorAll('.bulk-select-grid').forEach(cb => cb.checked = false);
+        const sa = document.getElementById('bulk-select-all');
+        if (sa) { sa.checked = false; sa.indeterminate = false; }
+        _refreshBulkBar();
+    }
+
+    function clearFilters() {
+        state.q = '';
+        state.type = '';
+        state.group_id = '';
+        state.uploader_id = '';
+        state.date_days = '';
+        if (qInput) qInput.value = '';
+        if (typeSelect) typeSelect.value = '';
+        if (groupSelect) groupSelect.value = '';
+        if (uploaderSelect) uploaderSelect.value = '';
+        if (dateSelect) dateSelect.value = '';
+        _onFilterChange();
+    }
+
+    function _setView(v) {
+        state.view = v;
+        localStorage.setItem(VIEW_LS_KEY, v);
+        const wrap = document.getElementById('assets-table-wrap');
+        const grid = document.getElementById('assets-grid-wrap');
+        const btnT = document.getElementById('view-toggle-table');
+        const btnG = document.getElementById('view-toggle-grid');
+        if (v === 'grid') {
+            if (wrap) wrap.style.display = 'none';
+            if (grid) grid.style.display = '';
+            if (btnT) btnT.classList.remove('active');
+            if (btnG) btnG.classList.add('active');
+            // Re-render grid cards from currently loaded rows.
+            _populateGridFromRows();
+        } else {
+            if (wrap) wrap.style.display = '';
+            if (grid) grid.style.display = 'none';
+            if (btnT) btnT.classList.add('active');
+            if (btnG) btnG.classList.remove('active');
+        }
+    }
+
+    function _populateGridFromRows() {
+        const grid = document.getElementById('assets-grid');
+        if (!grid) return;
+        grid.innerHTML = '';
+        // Pull what we have from the DOM (the table rows have all the
+        // attributes we need for grid card rendering).
+        tbody.querySelectorAll('tr.asset-row').forEach(row => {
+            const a = {
+                id: row.dataset.assetId,
+                asset_type: row.dataset.assetType,
+                size_bytes: parseInt(row.dataset.sizeBytes || '0', 10),
+                is_global: row.dataset.isGlobal === '1',
+                display_name: (row.querySelector('.asset-filename-truncate') || {}).textContent || '',
+                original_filename: '',
+                filename: '',
+            };
+            grid.appendChild(_renderGridCard(a));
+        });
+    }
+
+    // ── Infinite scroll ──
+    const sentinel = document.getElementById('assets-load-more');
+    if (sentinel && 'IntersectionObserver' in window) {
+        const io = new IntersectionObserver(async (entries) => {
+            for (const ent of entries) {
+                if (ent.isIntersecting && state.next_cursor && !state.loading) {
+                    state.cursor = state.next_cursor;
+                    await _fetchPage(true);
+                }
+            }
+        }, { rootMargin: '200px' });
+        io.observe(sentinel);
+    }
+
+    // ── Initial wiring ──
+    // The server already rendered the first page (best for FCP). Capture
+    // its ids so the polling reconciler in the other IIFE doesn't fight
+    // us, and apply initial sort indicator.
+    tbody.querySelectorAll('tr.asset-row').forEach(row => {
+        state.loadedIds.add(row.dataset.assetId);
+    });
+    _updateSortIndicators();
+    state.anyFilterActive = _isAnyFilterActive();
+
+    // If a filter / non-default sort is active from the URL, refetch.
+    if (state.anyFilterActive || state.order !== '-uploaded_at') {
+        _fetchPage(false);
+    } else {
+        _updateFilterSummary(tbody.querySelectorAll('tr.asset-row').length);
+    }
+    _setView(state.view);
+
+    // Expose API for the inline onclick handlers.
+    window._assetLibrary = {
+        reload,
+        clearSelection,
+        clearFilters,
+        setView: _setView,
+        bulkDelete: () => {
+            const n = state.selection.size;
+            if (n === 0) return;
+            if (!confirm('Delete ' + n + ' asset' + (n === 1 ? '' : 's') + '? This cannot be undone (while the asset is still referenced by an active schedule the action will be refused for that asset).')) return;
+            _runBulk('delete');
+        },
+        bulkAddGroup: (groupId) => _runBulk('add_group', { group_id: groupId }),
+        bulkRemoveGroup: (groupId) => _runBulk('remove_group', { group_id: groupId }),
+        bulkSetGlobal: (val) => _runBulk('set_global', { is_global: val }),
+    };
+
+    // Pause polling reconciliation while a filter is active: the
+    // /api/assets/status endpoint isn't filter-aware, so the original
+    // applyScopeChanges would remove every filtered-out row. Wrap it so
+    // it short-circuits when any filter is active; in that case we rely
+    // on the user clicking Refresh (or the next fetch) for new data.
+    const _origScope = window.applyScopeChanges;
+    if (typeof _origScope === 'function') {
+        window.applyScopeChanges = function(assets) {
+            if (state.anyFilterActive) return;  // skip; would clobber filter
+            return _origScope(assets);
+        };
+    }
+    // _insertAssetRow is called by applyScopeChanges (above) and also by
+    // the upload-complete handler. With a filter active, defer to reload
+    // rather than blindly inserting a row that might not match.
+    const _origInsert = window._insertAssetRow;
+    if (typeof _origInsert === 'function') {
+        window._insertAssetRow = async function(id) {
+            if (!state.anyFilterActive) return _origInsert(id);
+            await reload();
+        };
+    }
 })();
 </script>
 {% endblock %}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -675,6 +675,132 @@ paths:
                   $ref: '#/components/schemas/AssetOut'
                 type: array
                 title: Response List Assets Api Assets Get
+  /api/assets/page:
+    get:
+      summary: List Assets Paged
+      description: |-
+        Paginated + filtered asset listing for the asset library UI.
+
+        All filters are AND-composed. ``q`` is a case-insensitive substring
+        match against ``display_name``, ``original_filename``, and
+        ``filename`` (Postgres-side this hits a trigram GIN index; SQLite
+        falls back to a sequential scan in tests). The caller's group ACL
+        is applied last and cannot be widened by URL parameters.
+      operationId: list_assets_paged_api_assets_page_get
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          type: string
+          description: Substring search across name/filename
+          default: ''
+          title: Q
+        description: Substring search across name/filename
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Type
+      - name: group_id
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+          title: Group Id
+      - name: uploader_id
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+          title: Uploader Id
+      - name: uploaded_after
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Uploaded After
+      - name: uploaded_before
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Uploaded Before
+      - name: order
+        in: query
+        required: false
+        schema:
+          type: string
+          default: -uploaded_at
+          title: Order
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetPageOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/assets/bulk:
+    post:
+      summary: Bulk Assets
+      operationId: bulk_assets_api_assets_bulk_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetBulkIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetBulkOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/assets/upload:
     post:
       summary: Upload Asset
@@ -3372,6 +3498,73 @@ components:
       required:
       - profile_id
       title: AdoptRequest
+    AssetBulkFailure:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        reason:
+          type: string
+          title: Reason
+        status:
+          type: integer
+          title: Status
+          default: 400
+      type: object
+      required:
+      - id
+      - reason
+      title: AssetBulkFailure
+    AssetBulkIn:
+      properties:
+        asset_ids:
+          items:
+            type: string
+            format: uuid
+          type: array
+          maxItems: 500
+          minItems: 1
+          title: Asset Ids
+        action:
+          type: string
+          title: Action
+        group_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Group Id
+        is_global:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Global
+      type: object
+      required:
+      - asset_ids
+      - action
+      title: AssetBulkIn
+      description: Request body for ``POST /api/assets/bulk``.
+    AssetBulkOut:
+      properties:
+        succeeded:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Succeeded
+        failed:
+          items:
+            $ref: '#/components/schemas/AssetBulkFailure'
+          type: array
+          title: Failed
+      type: object
+      required:
+      - succeeded
+      - failed
+      title: AssetBulkOut
+      description: Result of ``POST /api/assets/bulk``.
     AssetOut:
       properties:
         id:
@@ -3437,6 +3630,31 @@ components:
       - checksum
       - uploaded_at
       title: AssetOut
+    AssetPageOut:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/AssetOut'
+          type: array
+          title: Items
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+        total_estimate:
+          type: integer
+          title: Total Estimate
+      type: object
+      required:
+      - items
+      - total_estimate
+      title: AssetPageOut
+      description: |-
+        Paginated asset listing for the asset library UI.
+
+        Used by ``GET /api/assets/page``. The legacy ``GET /api/assets`` still
+        returns the flat ``List[AssetOut]`` and is unchanged.
     AssetType:
       type: string
       enum:

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum as PyEnum
 
-from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -91,6 +91,41 @@ class Asset(Base):
     device_assets: Mapped[list["DeviceAsset"]] = relationship(back_populates="asset")
     variants: Mapped[list["AssetVariant"]] = relationship(back_populates="source_asset")
     group_asset_links: Mapped[list["GroupAsset"]] = relationship(back_populates="asset")
+
+    # Asset library search + pagination indexes (migration 0030).
+    # The trigram GIN indexes power substring search via /api/assets/page
+    # on Postgres; SQLite (used in the unit-test matrix) doesn't support
+    # GIN/pg_trgm so the migration skips them on SQLite, but they are
+    # declared here unconditionally so ``alembic check`` sees the model
+    # and migration agree about their existence on Postgres.
+    # The partial btree on uploaded_at covers the common newest-first
+    # listing path while excluding soft-deleted rows.
+    __table_args__ = (
+        Index(
+            "idx_assets_display_name_trgm",
+            "display_name",
+            postgresql_using="gin",
+            postgresql_ops={"display_name": "gin_trgm_ops"},
+        ),
+        Index(
+            "idx_assets_original_filename_trgm",
+            "original_filename",
+            postgresql_using="gin",
+            postgresql_ops={"original_filename": "gin_trgm_ops"},
+        ),
+        Index(
+            "idx_assets_filename_trgm",
+            "filename",
+            postgresql_using="gin",
+            postgresql_ops={"filename": "gin_trgm_ops"},
+        ),
+        Index(
+            "idx_assets_uploaded_at_live",
+            "uploaded_at",
+            postgresql_where=text("deleted_at IS NULL"),
+            sqlite_where=text("deleted_at IS NULL"),
+        ),
+    )
 
 
 class AssetVariant(Base):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,11 @@ async def db_engine(tmp_path):
             if "postgresql" in db_url:
                 await conn.exec_driver_sql("SET LOCAL lock_timeout = '5s'")
                 await conn.run_sync(Base.metadata.drop_all)
+                # Asset model declares GIN trigram indexes (migration 0030);
+                # ensure the extension exists before create_all tries to
+                # build them, otherwise we hit
+                # "operator class gin_trgm_ops does not exist".
+                await conn.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS pg_trgm")
             await conn.run_sync(Base.metadata.create_all)
 
     try:

--- a/tests/test_assets_bulk.py
+++ b/tests/test_assets_bulk.py
@@ -1,0 +1,183 @@
+"""Tests for the polymorphic bulk asset endpoint ``POST /api/assets/bulk``."""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def _seed_assets(db_session, n: int = 3):
+    from cms.models.asset import Asset, AssetType
+
+    created = []
+    for i in range(n):
+        a = Asset(
+            filename=f"asset-{i}.png",
+            original_filename=f"asset-{i}.png",
+            asset_type=AssetType.IMAGE,
+            size_bytes=1000,
+            checksum=f"chk{i}",
+        )
+        db_session.add(a)
+        created.append(a)
+    await db_session.commit()
+    for a in created:
+        await db_session.refresh(a)
+    return created
+
+
+async def _seed_group(db_session, name: str = "GroupA"):
+    from cms.models.device import DeviceGroup
+
+    g = DeviceGroup(name=name)
+    db_session.add(g)
+    await db_session.commit()
+    await db_session.refresh(g)
+    return g
+
+
+@pytest.mark.asyncio
+class TestAssetsBulk:
+    async def test_invalid_action(self, client):
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": ["00000000-0000-0000-0000-000000000001"], "action": "nuke"},
+        )
+        # Pydantic 422 for action that fails enum check.
+        assert resp.status_code in (400, 422)
+
+    async def test_empty_asset_ids_rejected(self, client):
+        resp = await client.post(
+            "/api/assets/bulk", json={"asset_ids": [], "action": "delete"}
+        )
+        assert resp.status_code == 422
+
+    async def test_bulk_delete_happy_path(self, client, db_session):
+        assets = await _seed_assets(db_session, n=3)
+        ids = [str(a.id) for a in assets]
+        resp = await client.post(
+            "/api/assets/bulk", json={"asset_ids": ids, "action": "delete"}
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert sorted(data["succeeded"]) == sorted(ids)
+        assert data["failed"] == []
+
+        # Confirm assets are soft-deleted (deleted_at set).
+        from sqlalchemy import select
+        from cms.models.asset import Asset
+
+        rows = (
+            await db_session.execute(select(Asset.deleted_at).where(Asset.id.in_([a.id for a in assets])))
+        ).scalars().all()
+        assert all(r is not None for r in rows)
+
+    async def test_bulk_delete_partial_failure(self, client, db_session):
+        assets = await _seed_assets(db_session, n=2)
+        ids = [str(a.id) for a in assets] + ["00000000-0000-0000-0000-000000000000"]
+        resp = await client.post(
+            "/api/assets/bulk", json={"asset_ids": ids, "action": "delete"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert sorted(data["succeeded"]) == sorted(str(a.id) for a in assets)
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["id"] == "00000000-0000-0000-0000-000000000000"
+        assert data["failed"][0]["status"] == 404
+
+    async def test_bulk_add_group_requires_group_id(self, client, db_session):
+        assets = await _seed_assets(db_session, n=1)
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": [str(assets[0].id)], "action": "add_group"},
+        )
+        assert resp.status_code == 400
+        assert "group_id" in resp.json()["detail"]
+
+    async def test_bulk_add_then_remove_group(self, client, db_session):
+        from sqlalchemy import select
+        from cms.models.group_asset import GroupAsset
+
+        assets = await _seed_assets(db_session, n=2)
+        group = await _seed_group(db_session)
+        ids = [str(a.id) for a in assets]
+
+        # add_group
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": ids, "action": "add_group", "group_id": str(group.id)},
+        )
+        assert resp.status_code == 200, resp.text
+        assert sorted(resp.json()["succeeded"]) == sorted(ids)
+
+        rows = (
+            await db_session.execute(
+                select(GroupAsset).where(GroupAsset.group_id == group.id)
+            )
+        ).scalars().all()
+        assert {str(r.asset_id) for r in rows} == set(ids)
+
+        # remove_group
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": ids, "action": "remove_group", "group_id": str(group.id)},
+        )
+        assert resp.status_code == 200, resp.text
+        assert sorted(resp.json()["succeeded"]) == sorted(ids)
+
+        rows = (
+            await db_session.execute(
+                select(GroupAsset).where(GroupAsset.group_id == group.id)
+            )
+        ).scalars().all()
+        assert rows == []
+
+    async def test_bulk_set_global_requires_admin(self, client, db_session):
+        # The default test fixture authenticates as admin, so the happy
+        # path goes through. We just confirm the action is wired up and
+        # idempotent.
+        from sqlalchemy import select
+        from cms.models.asset import Asset
+
+        assets = await _seed_assets(db_session, n=2)
+        ids = [str(a.id) for a in assets]
+
+        # Mark global
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": ids, "action": "set_global", "is_global": True},
+        )
+        assert resp.status_code == 200, resp.text
+        assert sorted(resp.json()["succeeded"]) == sorted(ids)
+        flags = (
+            await db_session.execute(
+                select(Asset.is_global).where(Asset.id.in_([a.id for a in assets]))
+            )
+        ).scalars().all()
+        assert all(flags)
+
+        # Idempotent re-application: nothing changes, all succeed.
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": ids, "action": "set_global", "is_global": True},
+        )
+        assert resp.status_code == 200
+        assert sorted(resp.json()["succeeded"]) == sorted(ids)
+
+    async def test_bulk_set_global_requires_is_global(self, client, db_session):
+        assets = await _seed_assets(db_session, n=1)
+        resp = await client.post(
+            "/api/assets/bulk",
+            json={"asset_ids": [str(assets[0].id)], "action": "set_global"},
+        )
+        assert resp.status_code == 400
+
+    async def test_bulk_deduplicates_ids(self, client, db_session):
+        assets = await _seed_assets(db_session, n=1)
+        aid = str(assets[0].id)
+        resp = await client.post(
+            "/api/assets/bulk", json={"asset_ids": [aid, aid, aid], "action": "delete"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["succeeded"] == [aid]
+        assert data["failed"] == []

--- a/tests/test_assets_list.py
+++ b/tests/test_assets_list.py
@@ -1,0 +1,204 @@
+"""Tests for the paginated asset listing endpoint ``GET /api/assets/page``.
+
+The legacy flat ``GET /api/assets`` is exercised separately by
+``test_assets.py``; this file is specifically about the asset-library
+Phase-1 search / filter / pagination / sort surface.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+async def _seed_assets(db_session, names_types):
+    """Insert assets with a deterministic uploaded_at spread (1 day apart)."""
+    from cms.models.asset import Asset, AssetType
+
+    base = _utc(2026, 1, 1)
+    created = []
+    for i, (name, atype) in enumerate(names_types):
+        a = Asset(
+            filename=name,
+            original_filename=name,
+            display_name=name.rsplit(".", 1)[0],
+            asset_type=atype,
+            size_bytes=1000 + i * 100,
+            checksum=f"chk{i:03d}",
+            uploaded_at=base + timedelta(days=i),
+            duration_seconds=float(10 + i) if atype == AssetType.VIDEO else None,
+        )
+        db_session.add(a)
+        created.append(a)
+    await db_session.commit()
+    for a in created:
+        await db_session.refresh(a)
+    return created
+
+
+@pytest.mark.asyncio
+class TestAssetsPage:
+    async def test_empty(self, client):
+        resp = await client.get("/api/assets/page")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data == {"items": [], "next_cursor": None, "total_estimate": 0}
+
+    async def test_returns_all_when_no_filters(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        await _seed_assets(
+            db_session,
+            [
+                ("video-a.mp4", AssetType.VIDEO),
+                ("video-b.mp4", AssetType.VIDEO),
+                ("image-a.png", AssetType.IMAGE),
+            ],
+        )
+        resp = await client.get("/api/assets/page")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_estimate"] == 3
+        assert {a["filename"] for a in data["items"]} == {
+            "video-a.mp4",
+            "video-b.mp4",
+            "image-a.png",
+        }
+        # Default order is -uploaded_at (newest first); seed inserted in order.
+        assert data["items"][0]["filename"] == "image-a.png"
+        assert data["items"][-1]["filename"] == "video-a.mp4"
+
+    async def test_substring_search_matches_display_name(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        await _seed_assets(
+            db_session,
+            [
+                ("holiday-promo-2026.mp4", AssetType.VIDEO),
+                ("birthday-promo.mp4", AssetType.VIDEO),
+                ("logo.png", AssetType.IMAGE),
+            ],
+        )
+        resp = await client.get("/api/assets/page", params={"q": "holid"})
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["filename"] == "holiday-promo-2026.mp4"
+
+    async def test_type_filter_repeatable(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        await _seed_assets(
+            db_session,
+            [
+                ("v.mp4", AssetType.VIDEO),
+                ("i.png", AssetType.IMAGE),
+                ("w.url", AssetType.WEBPAGE),
+            ],
+        )
+        # Single type
+        resp = await client.get("/api/assets/page", params=[("type", "image")])
+        assert {a["filename"] for a in resp.json()["items"]} == {"i.png"}
+
+        # Two types
+        resp = await client.get(
+            "/api/assets/page", params=[("type", "image"), ("type", "video")]
+        )
+        assert {a["filename"] for a in resp.json()["items"]} == {"i.png", "v.mp4"}
+
+    async def test_bad_type_filter_rejected(self, client):
+        resp = await client.get("/api/assets/page", params={"type": "movie"})
+        assert resp.status_code == 400
+
+    async def test_bad_order_rejected(self, client):
+        resp = await client.get("/api/assets/page", params={"order": "bogus"})
+        assert resp.status_code == 400
+
+    async def test_order_by_size(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        # _seed_assets gives sizes 1000, 1100, 1200 in insertion order.
+        await _seed_assets(
+            db_session,
+            [
+                ("a.png", AssetType.IMAGE),
+                ("b.png", AssetType.IMAGE),
+                ("c.png", AssetType.IMAGE),
+            ],
+        )
+        resp = await client.get("/api/assets/page", params={"order": "size_bytes"})
+        sizes = [a["size_bytes"] for a in resp.json()["items"]]
+        assert sizes == sorted(sizes)
+
+        resp = await client.get("/api/assets/page", params={"order": "-size_bytes"})
+        sizes = [a["size_bytes"] for a in resp.json()["items"]]
+        assert sizes == sorted(sizes, reverse=True)
+
+    async def test_pagination_cursor_walks_full_set(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        await _seed_assets(
+            db_session,
+            [(f"asset-{i:02d}.png", AssetType.IMAGE) for i in range(12)],
+        )
+
+        seen = []
+        cursor = None
+        for _ in range(20):  # safety bound
+            params: dict = {"page_size": "5"}
+            if cursor:
+                params["cursor"] = cursor
+            resp = await client.get("/api/assets/page", params=params)
+            assert resp.status_code == 200
+            data = resp.json()
+            seen.extend(a["filename"] for a in data["items"])
+            cursor = data["next_cursor"]
+            if cursor is None:
+                break
+
+        assert sorted(seen) == sorted([f"asset-{i:02d}.png" for i in range(12)])
+        assert len(seen) == 12
+
+    async def test_uploaded_after_before_filters(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        # Inserted across 5 days starting 2026-01-01.
+        await _seed_assets(
+            db_session,
+            [(f"a{i}.png", AssetType.IMAGE) for i in range(5)],
+        )
+        resp = await client.get(
+            "/api/assets/page",
+            params={
+                "uploaded_after": "2026-01-02T00:00:00+00:00",
+                "uploaded_before": "2026-01-04T00:00:00+00:00",
+            },
+        )
+        names = {a["filename"] for a in resp.json()["items"]}
+        # Day-0 (Jan 1) and day-3+ (Jan 4 onward) excluded.
+        assert names == {"a1.png", "a2.png"}
+
+    async def test_total_estimate_reflects_filters(self, client, db_session):
+        from cms.models.asset import AssetType
+
+        await _seed_assets(
+            db_session,
+            [
+                ("logo.png", AssetType.IMAGE),
+                ("hero.png", AssetType.IMAGE),
+                ("intro.mp4", AssetType.VIDEO),
+            ],
+        )
+        resp = await client.get("/api/assets/page", params={"type": "image"})
+        assert resp.json()["total_estimate"] == 2
+
+    async def test_invalid_cursor_returns_400(self, client):
+        resp = await client.get(
+            "/api/assets/page", params={"cursor": "not-base64!!"}
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Asset library Phase 1

Search/filter/sort/paginate/bulk-act on the Assets tab, plus a grid view.
Closes the asset-library-enhancements work from the session plan
(folders, tags, global search remain Phase 2/2-a follow-ups).

### Backend (c6adb67)
- New `GET /api/assets/page` — paginated + filtered listing with cursor
  + `total_estimate`. 5 sort keys; AND-composed filters; ACL layered.
- New `POST /api/assets/bulk` — delete / add_group / remove_group /
  set_global, with per-asset success+failure aggregation.
- Migration 0030 — `pg_trgm` + 3 GIN trigram indexes (Postgres only)
  + partial btree on `uploaded_at WHERE deleted_at IS NULL` (both
  dialects). Idempotent `CREATE EXTENSION IF NOT EXISTS`; index
  builds are fast at current library size.
- `docs/openapi.yaml` regenerated.
- 20 new unit tests; 47 total in the asset-endpoint suite pass.

### UI (ff7369f)
- Filter bar: q / type / group / uploader / uploaded-date range.
- Sortable column headers (Name, Type, Size, Duration, Uploaded) with
  default dim indicator so columns read as sortable.
- New 9th `Uploaded` column on the existing table; `asset_row`
  macro extended so the `/api/assets/{id}/row` endpoint emits the
  same shape (polling reconciliation, scope edits, uploads keep
  working).
- Bulk-select column + bulk action bar (delete / +-group / global).
- Table vs Grid view toggle, persisted in `localStorage`. Grid
  cards show image previews only (full-res, lazy-loaded); videos
  show the type icon — a real thumbnail profile is Phase 2-a so we
  don't pull full MP4s.
- Infinite scroll via `IntersectionObserver` on `/api/assets/page`.
- URL state sync (shareable filtered links).
- Polling reconciler suppressed while a filter is active so it
  doesn't nuke filtered-out rows on the next `/api/assets/status`
  poll.

### Bug fix worth a callout
`total_estimate` previously used `count(*) OVER ()` which counts
rows AFTER the WHERE clause — so successive paged requests would
report shrinking totals (e.g. 61 -> 11 after one scroll). Switched
to a separate count query that applies all filters except the
cursor. Verified with live dev-stack walkthrough.

### Tested locally
- 93 unit tests pass (47 asset-endpoint + 46 row/table-layout).
- Live dev stack (docker compose up) with 61 seeded assets:
  - migration 0030 ran clean on Postgres 16; `pg_trgm` extension
    created, all 4 indexes present.
  - exercised search, type+q intersect, sort flip (default `↕`
    indicator on every sortable column), grid view persists across
    reload, bulk select+delete, infinite scroll reads 61 of 61.

### Prod migration impact
Additive only. `pg_trgm` is on Azure PG Flexible Server's allowed
extensions list. Index builds take an `ACCESS EXCLUSIVE` lock on
`assets` for the duration (fractions of a second at current size).
Downgrade not supported (matches house style; rollback = snapshot
restore or fix-forward).

### Out of scope (deferred)
- Tags, folders, global search — Phase 2.
- Thumbnail profile + `/thumb` endpoint for proper grid previews
  (esp. video poster frames) — Phase 2-a.
- Server-side initial-render pagination — Phase 3 (only matters at
  10k+ asset libraries).