### PR TITLE
fix(migration): tolerate pg_trgm being blocked on Azure PG Flex

### DIFF
--- a/alembic/versions/0030_asset_search_indexes.py
+++ b/alembic/versions/0030_asset_search_indexes.py
@@ -5,7 +5,14 @@ Phase 1 of the Asset Library enhancements (see session plan
 
 - Enables ``pg_trgm`` (Postgres only) so substring search across
   ``display_name``, ``original_filename``, and ``filename`` can use a
-  GIN index rather than a sequential scan.
+  GIN index rather than a sequential scan.  On Azure Postgres Flexible
+  Server ``pg_trgm`` must be in the ``azure.extensions`` allow-list
+  server parameter; if it isn't, ``CREATE EXTENSION`` fails with a
+  permission error.  This migration treats that as a soft failure: the
+  trigram indexes are skipped, ``LIKE`` falls back to a sequential
+  scan (acceptable on the current asset volume), and an operator can
+  allow-list pg_trgm and ``CREATE INDEX ... USING gin (... gin_trgm_ops)``
+  manually later without needing another migration.
 - Adds a partial btree on ``uploaded_at DESC WHERE deleted_at IS NULL``
   to cover the common newest-first ordering of the visible asset set.
 
@@ -21,6 +28,9 @@ Revises: 0029
 
 from __future__ import annotations
 
+import logging
+
+import sqlalchemy as sa
 from alembic import op
 
 
@@ -30,24 +40,50 @@ branch_labels = None
 depends_on = None
 
 
+log = logging.getLogger("alembic.runtime.migration")
+
+
+def _try_enable_pg_trgm(bind) -> bool:
+    """Best-effort CREATE EXTENSION pg_trgm.
+
+    Uses a savepoint so a permission failure (typical on Azure PG Flex
+    when the extension isn't allow-listed) doesn't poison the outer
+    migration transaction. Returns True on success, False otherwise.
+    """
+    sp = bind.begin_nested()
+    try:
+        bind.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        sp.commit()
+        return True
+    except Exception as exc:  # pragma: no cover -- exercised on Azure only
+        sp.rollback()
+        log.warning(
+            "pg_trgm extension unavailable (%s); skipping trigram indexes. "
+            "Allow-list pg_trgm via azure.extensions server parameter and "
+            "create the indexes manually to enable accelerated LIKE search.",
+            exc,
+        )
+        return False
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     dialect = bind.dialect.name
 
     if dialect == "postgresql":
-        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-        op.execute(
-            "CREATE INDEX IF NOT EXISTS idx_assets_display_name_trgm "
-            "ON assets USING GIN (display_name gin_trgm_ops)"
-        )
-        op.execute(
-            "CREATE INDEX IF NOT EXISTS idx_assets_original_filename_trgm "
-            "ON assets USING GIN (original_filename gin_trgm_ops)"
-        )
-        op.execute(
-            "CREATE INDEX IF NOT EXISTS idx_assets_filename_trgm "
-            "ON assets USING GIN (filename gin_trgm_ops)"
-        )
+        if _try_enable_pg_trgm(bind):
+            op.execute(
+                "CREATE INDEX IF NOT EXISTS idx_assets_display_name_trgm "
+                "ON assets USING GIN (display_name gin_trgm_ops)"
+            )
+            op.execute(
+                "CREATE INDEX IF NOT EXISTS idx_assets_original_filename_trgm "
+                "ON assets USING GIN (original_filename gin_trgm_ops)"
+            )
+            op.execute(
+                "CREATE INDEX IF NOT EXISTS idx_assets_filename_trgm "
+                "ON assets USING GIN (filename gin_trgm_ops)"
+            )
 
     # Plain btree on uploaded_at — Postgres and SQLite can both scan it
     # in reverse to satisfy ``ORDER BY uploaded_at DESC``. Partial on


### PR DESCRIPTION
## Why

PR #632 (the asset-library Phase 1 work) merged successfully, but the post-merge `Publish & Deploy` failed at verification: the new container revision `agoracms-cms--v1-37-255` never returned 200 on `/healthz` and was auto-deactivated after 5min. Previous revision continues to serve traffic, so prod is unaffected -- but the new build never landed.

## Root cause (most-likely)

Migrations run in-container on startup via `alembic upgrade head`. Migration 0030 (asset-library trigram + uploaded_at indexes) starts with:

`op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")`

On **Azure Postgres Flexible Server**, `pg_trgm` must be explicitly listed in the `azure.extensions` server parameter; otherwise `CREATE EXTENSION` fails with a permission error even for the admin role. That error aborts the migration transaction, `init_db()` raises, the container exits, the deployment verify step waits 5 min for `/healthz`, and Azure rolls back to the prior revision.

## Fix

Wrap `CREATE EXTENSION IF NOT EXISTS pg_trgm` in a savepoint so a permission failure rolls back cleanly without poisoning the outer migration transaction, and skip the three GIN trigram indexes if it failed.

- The unrelated `idx_assets_uploaded_at_live` partial btree is always created (and is the bigger win for the default `ORDER BY uploaded_at DESC` view).
- `LIKE` substring search continues to work; it just falls back to a sequential scan until an operator allow-lists pg_trgm via:

  `az postgres flexible-server parameter set --name azure.extensions --value pg_trgm` (+ server restart)

  then runs the three `CREATE INDEX ... USING gin (... gin_trgm_ops)` statements by hand. No follow-up migration needed.

## Verified locally

- `alembic upgrade head && alembic check` -> `No new upgrade operations detected.`
- Full asset test suite + native-modal lint pass (28 passed).

## Risk

Low. Happy path is byte-identical to before (extension is created, indexes are created). Failure path is the new well-known savepoint-rollback pattern.