### PR TITLE
fix(infra): goodwill-dev RG is in westus, not westus2

### DIFF
--- a/.github/workflows/deploy-goodwill-dev.yml
+++ b/.github/workflows/deploy-goodwill-dev.yml
@@ -27,7 +27,10 @@ name: Deploy Goodwill Dev
 #      register a separate dev app — either way grant Contributor on
 #      agoragw-cms-dev-rg only)
 #   * Pre-create the resource group in the Goodwill tenant:
-#       az group create -n agoragw-cms-dev-rg -l westus2
+#       az group create -n agoragw-cms-dev-rg -l westus
+#     (Note: dev is in westus, not westus2. If you want westus2 for
+#      proximity to prod, delete the RG first and recreate, then also
+#      update `location` in infra/parameters/goodwill-dev.bicepparam.)
 #
 # Bicep is the source of truth.  If a deployment fails, fix the
 # template (infra/main.bicep / infra/parameters/goodwill-dev.bicepparam)

--- a/infra/parameters/goodwill-dev.bicepparam
+++ b/infra/parameters/goodwill-dev.bicepparam
@@ -17,7 +17,10 @@ using '../main.bicep'
 //   mcp    : 0.25 vCPU / 0.5Gi (main.bicep default for mcp at this scale)
 //   worker : 1.0 vCPU / 2Gi
 //
-// Region: westus2 — same as Goodwill prod for proximity / quota parity.
+// Region: westus — matches the pre-created agoragw-cms-dev-rg.
+// (Goodwill prod uses westus2; dev is in westus for cost/region
+// flexibility. westus has full Container Apps + Postgres Flexible
+// + Web PubSub coverage so all bicep modules apply unchanged.)
 //
 // Manual deploy (rare — prefer the workflow):
 //   az deployment group create \
@@ -35,7 +38,7 @@ using '../main.bicep'
 // ──────────────────────────────────────────────────────────────
 
 param prefix = 'agoragwdev'
-param location = 'westus2'
+param location = 'westus'
 
 param postgresAdminLogin = 'agoraadmin'
 param cmsAdminUsername = 'admin'


### PR DESCRIPTION
Matches the pre-created agoragw-cms-dev-rg's actual region. RG location is mostly metadata but bicep deploys resources at the param's location — keeping them aligned avoids cross-region surprises.