### PR TITLE
fix(infra): serialize Postgres configuration writes to avoid ServerIsBusy

### DIFF
--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -68,6 +68,15 @@ resource sslConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@202
 // on /healthz for ~50 min) was exactly this: the parameter was unset, so
 // init_db()'s alembic upgrade hung the container at "Running upgrade 0029
 // -> 0030" without surfacing the error before Azure SIGKILL'd it.
+//
+// dependsOn sslConfig is load-bearing: Azure Postgres Flexible Server
+// serialises all `configurations` writes on the server, and Bicep would
+// otherwise dispatch the two sibling configuration resources in parallel.
+// When that happens the loser fails with `ServerIsBusy` ("Cannot complete
+// operation while server '<name>' is busy processing another operation"),
+// which has tripped both first-bootstrap and routine redeploys on the
+// Goodwill dev B1ms SKU. The explicit chain forces sequential apply so
+// the race cannot occur on any SKU.
 resource extensionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
   parent: postgresServer
   name: 'azure.extensions'
@@ -75,6 +84,9 @@ resource extensionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurati
     value: 'pg_trgm'
     source: 'user-override'
   }
+  dependsOn: [
+    sslConfig
+  ]
 }
 
 // max_connections is intentionally left at the B1ms default (50). The


### PR DESCRIPTION
Add `dependsOn: [sslConfig]` to `extensionsConfig` so the two sibling `Microsoft.DBforPostgreSQL/flexibleServers/configurations` resources apply sequentially instead of being dispatched in parallel.

**Root cause:** Azure Postgres Flexible Server serialises all configuration writes on the server. Bicep was dispatching `sslConfig` (`require_secure_transport`) and `extensionsConfig` (`azure.extensions`) at the same time. Activity log showed the two ARM ops starting ~15ms apart from the same correlation ID; one succeeded, the other failed with `ServerIsBusy`. Hit consistently on Goodwill dev (B1ms) both at first bootstrap and on routine redeploy. Structural race — any SKU can lose.

**Fix:** Force sequential apply via `dependsOn`. Order is irrelevant; only concurrency mattered.