### PR TITLE
fix(alerts): debounce OFFLINE/ONLINE event log onto grace window

### DIFF
--- a/cms/services/alert_service.py
+++ b/cms/services/alert_service.py
@@ -5,13 +5,21 @@ so they survive replica failover and don't double-fire across replicas:
 
 1. **Offline detection** — the disconnect path only transitions
    ``offline_since`` NULL→timestamp (duplicate disconnects don't reset
-   the grace window).  A leader-gated sweep loop
-   (:func:`offline_sweep_once` driven from ``cms/main.py``) flips
-   ``offline_notified`` and emits the "offline" notification + event
-   in a single transaction.  The reconnect path CAS-consumes
-   ``offline_notified`` in the same transaction that emits the "back
-   online" notification, so a race between two replicas handling the
-   reconnect only lets one of them fire the alert.
+   the grace window).  Neither the OFFLINE event row nor the
+   notification fire from the disconnect path itself; a leader-gated
+   sweep loop (:func:`offline_sweep_once` driven from ``cms/main.py``)
+   flips ``offline_notified`` and emits both the OFFLINE event and the
+   "offline" notification in a single transaction once the grace
+   window has elapsed.  The reconnect path CAS-consumes
+   ``offline_notified`` in the same transaction that emits the
+   matching ONLINE event + "back online" notification, so brief
+   disconnect→reconnect blips (notably the every-50-minute clean
+   reconnect the device does after a successful WPS JWT refresh) are
+   suppressed entirely from the event log.  A genuinely silent
+   disconnect (Pi power-cut, dead link the WPS gateway never reports)
+   is still surfaced within ~1 minute by
+   :func:`stale_presence_sweep_once`, which writes its own immediate
+   OFFLINE event with ``details={"kind": "stale_heartbeat"}``.
 
 2. **Temperature monitoring** — STATUS heartbeats land on whichever
    replica the WPS webhook is routed to.  ``check_temperature`` locks
@@ -185,12 +193,22 @@ class AlertService:
     ):
         """Called from ws.py when a device's WebSocket closes.
 
-        Spawns a detached task that (a) logs an OFFLINE event for the
-        adopted+grouped device and (b) transitions ``device_alert_state``
+        Spawns a detached task that transitions ``device_alert_state``
         from online→offline by writing ``offline_since = NOW()`` *only
         when it is currently NULL*.  Duplicate disconnects do not reset
-        the grace window.  The actual notification is fired later by
-        the leader-gated sweep loop once ``offline_since + grace < now``.
+        the grace window.
+
+        The OFFLINE event log row and the notification are both fired
+        later by the leader-gated sweep loop once
+        ``offline_since + grace < now``.  Debouncing the event row (not
+        just the notification) keeps short blips — most notably the
+        every-50-minute clean close + reconnect the device does after
+        a successful WPS JWT refresh — from spamming the event log.
+        A genuinely silent disconnect (Pi power-cut, network drop where
+        the WPS gateway never sees ``sys.disconnected``) is still
+        surfaced within ~1 minute by ``stale_presence_sweep_once``,
+        which writes its own immediate OFFLINE event with
+        ``details={"kind": "stale_heartbeat"}``.
         """
         if status != "adopted" or not group_id:
             return
@@ -236,27 +254,29 @@ class AlertService:
         group_id: str,
         group_name: str,
     ) -> None:
-        """Persist the disconnect: OFFLINE event + offline_since transition."""
+        """Persist the disconnect: offline_since transition.
+
+        The OFFLINE event row is NOT written here — it's deferred to
+        ``offline_sweep_once``, which emits the OFFLINE event together
+        with the notification after the grace window expires.  This
+        debounces the every-50-minute clean close+reconnect the device
+        does after a successful WPS JWT refresh, which would otherwise
+        spam an OFFLINE+ONLINE pair into the event log every hour for
+        every adopted device.  Genuinely silent disconnects are still
+        surfaced quickly by ``stale_presence_sweep_once``, which writes
+        its own immediate OFFLINE event with
+        ``details={"kind": "stale_heartbeat"}``.
+        """
         try:
             from cms.database import get_db
-            gid = _to_uuid(group_id)
             async for db in get_db():
-                # 1. Always log an OFFLINE event immediately.
-                db.add(DeviceEvent(
-                    device_id=device_id,
-                    device_name=device_name,
-                    group_id=gid,
-                    group_name=group_name,
-                    event_type=DeviceEventType.OFFLINE,
-                ))
-
-                # 2. Transition-only update: set offline_since=NOW() if
-                #    currently NULL, otherwise leave it alone.  We use a
-                #    SELECT-then-write pattern so it works across
-                #    SQLite+Postgres (SQLite's ORM INSERT..ON CONFLICT
-                #    support is dialect-fiddly); the transaction isolation
-                #    from the surrounding session gives us the
-                #    atomicity we need.
+                # Transition-only update: set offline_since=NOW() if
+                # currently NULL, otherwise leave it alone.  We use a
+                # SELECT-then-write pattern so it works across
+                # SQLite+Postgres (SQLite's ORM INSERT..ON CONFLICT
+                # support is dialect-fiddly); the transaction isolation
+                # from the surrounding session gives us the
+                # atomicity we need.
                 state = (await db.execute(
                     select(DeviceAlertState).where(
                         DeviceAlertState.device_id == device_id
@@ -274,7 +294,9 @@ class AlertService:
 
                 await db.commit()
                 logger.debug(
-                    "Offline event + state recorded for device %s", device_id,
+                    "Offline state recorded for device %s "
+                    "(event deferred to grace expiry)",
+                    device_id,
                 )
                 break
         except Exception:
@@ -291,21 +313,21 @@ class AlertService:
         group_id: str,
         group_name: str,
     ) -> None:
-        """Persist the reconnect: ONLINE event + CAS-consume offline_notified."""
+        """Persist the reconnect: CAS-consume offline_notified; ONLINE event only on real recovery.
+
+        Stage-4-debounce note: the ONLINE event row is now only written
+        when ``was_notified`` is TRUE — i.e., when the grace window had
+        expired and ``offline_sweep_once`` had already fired the
+        matching OFFLINE event + notification.  Reconnects within the
+        grace window (the common case for JWT-refresh blips) are
+        suppressed entirely: no OFFLINE was logged, so logging a lone
+        ONLINE would look like a phantom recovery in the event log.
+        """
         try:
             from cms.database import get_db
             gid = _to_uuid(group_id)
             async for db in get_db():
-                # 1. Always log an ONLINE event.
-                db.add(DeviceEvent(
-                    device_id=device_id,
-                    device_name=device_name,
-                    group_id=gid,
-                    group_name=group_name,
-                    event_type=DeviceEventType.ONLINE,
-                ))
-
-                # 2. Atomically CAS-consume offline_notified.  Only the
+                # 1. Atomically CAS-consume offline_notified.  Only the
                 #    replica whose UPDATE lands first gets a returned
                 #    row — other replicas handling the same reconnect
                 #    event see an empty result and skip the "back
@@ -337,10 +359,9 @@ class AlertService:
                         # simultaneously for the same device's first
                         # reconnect.  The second INSERT would violate
                         # the PK constraint and poison the outer
-                        # transaction (rolling back our ONLINE event).
-                        # Isolate the INSERT in a SAVEPOINT and treat
-                        # IntegrityError as benign — the other replica
-                        # already created the row.
+                        # transaction.  Isolate the INSERT in a
+                        # SAVEPOINT and treat IntegrityError as benign
+                        # — the other replica already created the row.
                         from sqlalchemy.exc import IntegrityError
                         try:
                             async with db.begin_nested():
@@ -357,11 +378,20 @@ class AlertService:
                     elif existing.offline_since is not None:
                         existing.offline_since = None
 
-                # 3. If we'd previously fired an offline notification,
-                #    emit the matching back-online notification in the
-                #    same transaction — so a crash between commit and
-                #    INSERT can't lose the signal.
+                # 2. If we'd previously fired an offline notification,
+                #    emit the matching ONLINE event + back-online
+                #    notification in the same transaction — so a crash
+                #    between commit and INSERT can't lose the signal.
+                #    Reconnects within the grace window write nothing
+                #    (the matching OFFLINE event was never written).
                 if was_notified:
+                    db.add(DeviceEvent(
+                        device_id=device_id,
+                        device_name=device_name,
+                        group_id=gid,
+                        group_name=group_name,
+                        event_type=DeviceEventType.ONLINE,
+                    ))
                     db.add(Notification(
                         scope="group",
                         level="success",
@@ -380,11 +410,14 @@ class AlertService:
                 await db.commit()
                 if was_notified:
                     logger.info(
-                        "Online notification created for device %s", device_id,
+                        "Online event + notification created for device %s",
+                        device_id,
                     )
                 else:
                     logger.debug(
-                        "Online event recorded for device %s", device_id,
+                        "Reconnect within grace window for device %s "
+                        "— ONLINE event suppressed",
+                        device_id,
                     )
                 break
         except Exception:

--- a/tests/test_alert_event_notification_split.py
+++ b/tests/test_alert_event_notification_split.py
@@ -1,6 +1,11 @@
 """Tests for the event/notification split in AlertService.
 
-Events always fire immediately; notifications are gated by the grace period.
+OFFLINE and ONLINE event rows are debounced together with their
+notifications — written by the leader-gated grace-expiry sweep, not by
+the immediate disconnect/reconnect handlers — so brief blips (notably
+the every-50-min WPS JWT-refresh reconnect) leave no event-log trail.
+A genuinely silent disconnect still surfaces immediately via the
+stale-presence sweep's ``kind=stale_heartbeat`` event.
 """
 
 import asyncio
@@ -71,17 +76,17 @@ async def _count_notifications(app, group_id):
         return result.scalars().all()
 
 
-# ── Event fires immediately ──
+# ── Disconnect path defers events (debounced by grace) ──
 
 
 @pytest.mark.asyncio
-async def test_disconnect_creates_offline_event_before_grace(
+async def test_disconnect_does_not_create_offline_event_before_grace(
     app, seed_group_and_device, fresh_alert_service,
 ):
-    """An OFFLINE DeviceEvent is created immediately on disconnect — no wait."""
+    """Disconnect path only stamps offline_since — no immediate OFFLINE event."""
     info = seed_group_and_device
     svc = fresh_alert_service
-    svc._offline_grace_seconds = 30  # Long grace — ensure event fires before
+    svc._offline_grace_seconds = 30  # Long grace — ensure no sweep tick fires
 
     svc.device_disconnected(info["device_id"], info["device_name"],
                              info["group_id"], info["group_name"], status="adopted")
@@ -89,20 +94,36 @@ async def test_disconnect_creates_offline_event_before_grace(
     await asyncio.sleep(0.2)
 
     events = await _count_events(app, info["device_id"], DeviceEventType.OFFLINE)
-    assert len(events) == 1
+    assert len(events) == 0
 
-    # No notification yet (grace hasn't fired)
+    # No notification yet either (grace hasn't fired)
     notifs = await _count_notifications(app, info["group_id"])
     assert len(notifs) == 0
 
+    # But offline_since must be stamped so the sweep can find it.
+    from cms.database import get_db
+    from cms.models.device_alert_state import DeviceAlertState
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        state = (await db.execute(
+            select(DeviceAlertState).where(
+                DeviceAlertState.device_id == info["device_id"]
+            )
+        )).scalar_one_or_none()
+        assert state is not None
+        assert state.offline_since is not None
+        assert state.offline_notified is False
+        break
 
-# ── Reconnect before grace: ONLINE event, no notifications ──
+
+# ── Reconnect before grace: no events, no notifications ──
 
 
 @pytest.mark.asyncio
-async def test_reconnect_before_grace_no_notification_but_events_logged(
+async def test_reconnect_before_grace_writes_no_events_or_notifications(
     app, seed_group_and_device, fresh_alert_service,
 ):
+    """A blip (disconnect+reconnect within grace) leaves no trail."""
     info = seed_group_and_device
     svc = fresh_alert_service
     svc._offline_grace_seconds = 30  # Make sure grace never expires during test
@@ -114,13 +135,13 @@ async def test_reconnect_before_grace_no_notification_but_events_logged(
                             info["group_id"], info["group_name"], status="adopted")
     await asyncio.sleep(0.3)
 
-    # Both OFFLINE and ONLINE events were logged
+    # Neither OFFLINE nor ONLINE was logged
     offline_events = await _count_events(app, info["device_id"], DeviceEventType.OFFLINE)
     online_events = await _count_events(app, info["device_id"], DeviceEventType.ONLINE)
-    assert len(offline_events) == 1
-    assert len(online_events) == 1
+    assert len(offline_events) == 0
+    assert len(online_events) == 0
 
-    # But NO notifications (neither offline nor back-online)
+    # No notifications (neither offline nor back-online)
     notifs = await _count_notifications(app, info["group_id"])
     assert len(notifs) == 0
 
@@ -225,12 +246,17 @@ async def test_fresh_grace_timer_after_quick_reconnect(
     offline_notifs = [n for n in notifs if "offline" in n.title.lower()]
     assert len(offline_notifs) == 1
 
-    # Two OFFLINE events from the disconnect signals themselves
-    # (offline_sweep_once also emits a grace_expired OFFLINE event, so
-    # we exclude those when counting the disconnect-driven events).
+    # Only the grace_expired OFFLINE event from the sweep exists now —
+    # the immediate-on-disconnect OFFLINE write was removed when we
+    # debounced the event log onto the grace window.
     offline_events = await _count_events(app, info["device_id"], DeviceEventType.OFFLINE)
     disconnect_events = [
         e for e in offline_events
         if (e.details or {}).get("kind") != "grace_expired"
     ]
-    assert len(disconnect_events) == 2
+    grace_events = [
+        e for e in offline_events
+        if (e.details or {}).get("kind") == "grace_expired"
+    ]
+    assert len(disconnect_events) == 0
+    assert len(grace_events) == 1

--- a/tests/test_device_alerts.py
+++ b/tests/test_device_alerts.py
@@ -100,6 +100,18 @@ def fresh_alert_service():
     return svc
 
 
+async def _drive_offline_sweep(app, svc):
+    """Run one offline_sweep_once tick — used in tests that expect an
+    OFFLINE event/notification to materialize.  The disconnect path no
+    longer writes the event row directly; both event and notification
+    fire from this sweep once the grace window has elapsed."""
+    from cms.database import get_db
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await svc.offline_sweep_once(db)
+        break
+
+
 # ── Alert Service Unit Tests ──
 
 class TestOfflineDetection:
@@ -154,12 +166,11 @@ class TestOfflineDetection:
 
     @pytest.mark.asyncio
     async def test_reconnect_cancels_grace_period(self, app, seed_group_and_device, fresh_alert_service):
-        """Reconnecting before grace period expires prevents the offline *notification*.
+        """Reconnecting before grace period expires prevents the offline notification.
 
-        Note: since the event/notification split, the OFFLINE DeviceEvent is
-        logged immediately on disconnect regardless of grace, but the bell
-        notification is only created after grace expires. A quick reconnect
-        cancels the pending notification timer.
+        Both the OFFLINE DeviceEvent and the notification are debounced
+        by the grace window — a quick reconnect leaves no event-log
+        entry and fires no bell notification.
         """
         info = seed_group_and_device
         svc = fresh_alert_service
@@ -658,6 +669,7 @@ class TestDeviceEventsAPI:
             status="adopted",
         )
         await asyncio.sleep(1.5)
+        await _drive_offline_sweep(app, svc)
 
         resp = await client.get("/api/device-events")
         assert resp.status_code == 200
@@ -676,6 +688,7 @@ class TestDeviceEventsAPI:
             status="adopted",
         )
         await asyncio.sleep(1.5)
+        await _drive_offline_sweep(app, svc)
 
         resp = await client.get(f"/api/device-events?device_id={info['device_id']}")
         assert resp.status_code == 200
@@ -695,6 +708,7 @@ class TestDeviceEventsAPI:
             status="adopted",
         )
         await asyncio.sleep(1.5)
+        await _drive_offline_sweep(app, svc)
 
         resp = await client.get("/api/device-events?event_type=offline")
         assert resp.status_code == 200
@@ -714,6 +728,7 @@ class TestDeviceEventsAPI:
             status="adopted",
         )
         await asyncio.sleep(1.5)
+        await _drive_offline_sweep(app, svc)
 
         resp = await client.get("/api/device-events/count")
         assert resp.status_code == 200
@@ -730,6 +745,7 @@ class TestDeviceEventsAPI:
             status="adopted",
         )
         await asyncio.sleep(1.5)
+        await _drive_offline_sweep(app, svc)
 
         resp = await operator_client.get("/api/device-events")
         assert resp.status_code == 200


### PR DESCRIPTION
## Problem
Devices clean-close + reconnect every 50 min after a successful WPS JWT refresh (TTL 60min minus 10min lead, `agora/cms_client/service.py:879-882`). Pre-fix, CMS wrote an OFFLINE+ONLINE pair into the event log every hour for **every adopted device** — pure noise, no human-meaningful disconnect ever happened. User-facing notifications were already debounced by `offline_grace_seconds`; just the event log was leaking.

## Fix
- `_record_disconnect`: stop writing the immediate OFFLINE event row. Still stamps `device_alert_state.offline_since` so the sweep can find it.
- `_record_reconnect`: only write ONLINE event when `was_notified=True` (real recovery after grace expired). Reconnects within the grace window write nothing.
- `offline_sweep_once`: unchanged — it already writes the OFFLINE event with `details={'kind': 'grace_expired'}` together with the notification.

A reconnect within the grace window now leaves no trace in the event log. Real WPS-clean disconnects show up after `offline_grace_seconds` (default 5 min). Genuinely silent disconnects (Pi power-cut etc.) still surface within ~60s via the stale-presence sweep's immediate `kind=stale_heartbeat` event.

## Trade-off
Clean disconnects appear in the event log up to 5 min after the fact instead of instantly. Worth it to kill the hourly chatter; stale-presence sweep still covers the catastrophic-outage case promptly.

## Tests
Inverted the documented "events fire immediately, notifications are gated" contract in `test_alert_event_notification_split.py` to match the new "both gated by grace" behavior. Added a `_drive_offline_sweep` helper in `test_device_alerts.py` for the 5 API tests that previously expected an immediate OFFLINE event from a bare disconnect call.

Targeted suites all pass locally:
- `test_alert_event_notification_split.py` + `test_device_alerts.py` + `test_stale_presence_sweep.py`: 43 passed
- `test_wps_webhook.py` + `test_device_presence.py` + `test_event_log_page.py` + `test_wps_transport.py`: 80 passed