### PR TITLE
chore(ci): drop daily cron from Smoke Test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,6 @@
 name: Smoke Test
 
 on:
-  schedule:
-    # 07:00 UTC daily = 00:00 PDT / 23:00 PST
-    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       keep_stack:


### PR DESCRIPTION
The 
ightly.yml `Smoke Test` workflow had a 