### PR TITLE
feat(infra): provision Azure OpenAI for the Assistant feature (PR 1 of 6)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -104,6 +104,23 @@ param alertEmail string = ''
 @description('When true, replace the legacy request-count CMS heartbeat alert with an Application Insights standard availability test against /healthz. Recommended for low-traffic / idle-friendly environments (dev, fresh prod) where the OTel SDK filters probe traffic and the legacy alert produces false positives. Currently opt-in; will be flipped to default-true after dev validation.')
 param useSyntheticHeartbeat bool = false
 
+// ── Assistant feature (Azure OpenAI) ──
+@description('When true, deploy an Azure OpenAI account + chat model deployment and wire it to the CMS container app. Required by the Assistant feature; safe to leave false in environments that are not opted in yet — the CMS treats missing endpoint env vars as "feature disabled" at runtime.')
+param deployAzureOpenAI bool = false
+
+@description('Azure region for the Azure OpenAI account when deployAzureOpenAI=true. Defaults to the RG location; override when the RG region has no quota for the requested model. westus has GPT-4o; eastus2 has best GPT-5 quota.')
+param azureOpenAIRegion string = ''
+
+@description('Chat model to deploy under the "chat" deployment name on the Azure OpenAI account. Only used when deployAzureOpenAI=true.')
+@allowed(['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4.1-mini'])
+param azureOpenAIChatModel string = 'gpt-4o'
+
+@description('Chat model version pinned for the "chat" deployment. Validate against the Azure OpenAI model-versions doc for the chosen azureOpenAIRegion.')
+param azureOpenAIChatModelVersion string = '2024-11-20'
+
+@description('TPM capacity for the chat deployment, in thousands (30 = 30k TPM). Phase-1 default of 30 is generous for a single-org pilot.')
+param azureOpenAIChatCapacity int = 30
+
 var tags = {
   project: 'agora-cms'
   managedBy: 'bicep'
@@ -119,6 +136,7 @@ var cmsAppName = '${prefix}-cms'
 var mcpAppName = '${prefix}-mcp'
 var workerJobName = '${prefix}-worker'
 var webPubSubName = '${prefix}-cms-wps'
+var azureOpenAIAccountName = '${prefix}-aoai'
 
 // ── Networking ──
 module networking 'modules/networking.bicep' = {
@@ -178,6 +196,22 @@ module webPubSub 'modules/webPubSub.bicep' = if (deviceTransport == 'wps') {
     location: location
     webPubSubName: webPubSubName
     skuName: webPubSubSku
+    tags: tags
+  }
+}
+
+// ── Azure OpenAI (Assistant feature backend) ──
+// Optional: only deployed when deployAzureOpenAI=true. Account
+// region defaults to the RG region; override via azureOpenAIRegion
+// when the RG region lacks quota for the requested model.
+module azureOpenAI 'modules/azureOpenAI.bicep' = if (deployAzureOpenAI) {
+  name: 'azureOpenAI'
+  params: {
+    location: empty(azureOpenAIRegion) ? location : azureOpenAIRegion
+    accountName: azureOpenAIAccountName
+    chatModel: azureOpenAIChatModel
+    chatModelVersion: azureOpenAIChatModelVersion
+    chatModelCapacity: azureOpenAIChatCapacity
     tags: tags
   }
 }
@@ -245,6 +279,31 @@ module containerApps 'modules/containerApps.bicep' = {
 
     // Public CMS URL override (custom domain). Propagated to AGORA_CMS_BASE_URL.
     cmsBaseUrlOverride: cmsBaseUrlOverride
+
+    // Azure OpenAI (Assistant feature). Empty when not deployed —
+    // CMS treats empty endpoint as "feature disabled" at runtime.
+    azureOpenAIEndpoint: deployAzureOpenAI ? azureOpenAI.outputs.endpoint : ''
+    azureOpenAIDeployment: deployAzureOpenAI ? azureOpenAI.outputs.deploymentName : ''
+  }
+}
+
+// ── Azure OpenAI RBAC ──
+// Grant the CMS container app's managed identity the
+// 'Cognitive Services OpenAI User' role on the AOAI account so it
+// can call chat.completions with DefaultAzureCredential, no keys
+// required. Role guid 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd is the
+// built-in 'Cognitive Services OpenAI User' definition.
+resource existingAzureOpenAI 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = if (deployAzureOpenAI) {
+  name: azureOpenAIAccountName
+}
+
+resource cmsAzureOpenAIRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployAzureOpenAI && deployRoleAssignments) {
+  name: guid(existingAzureOpenAI.id, cmsAppName, '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+  scope: existingAzureOpenAI
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+    principalId: containerApps.outputs.cmsPrincipalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -314,3 +373,5 @@ output mcpLatestRevisionName string = containerApps.outputs.mcpLatestRevisionNam
 output postgresServerFqdn string = postgres.outputs.serverFqdn
 output keyVaultUri string = keyVault.outputs.keyVaultUri
 output storageAccountName string = storage.outputs.storageAccountName
+output azureOpenAIEndpoint string = deployAzureOpenAI ? azureOpenAI.outputs.endpoint : ''
+output azureOpenAIDeployment string = deployAzureOpenAI ? azureOpenAI.outputs.deploymentName : ''

--- a/infra/modules/azureOpenAI.bicep
+++ b/infra/modules/azureOpenAI.bicep
@@ -1,0 +1,89 @@
+// ──────────────────────────────────────────────────────────────
+// azureOpenAI.bicep — Azure OpenAI account + chat model deployment
+//
+// Provisions the LLM backend for the in-CMS Assistant feature
+// (PR series starting with "feat: assistant infra"). Deployed only
+// when main.bicep's deployAzureOpenAI=true; otherwise omitted
+// entirely so non-opted-in environments (prod) carry zero cost.
+//
+// Auth model: managed identity only (disableLocalAuth=true). The
+// CMS container app's system-assigned identity is granted the
+// 'Cognitive Services OpenAI User' role at the account scope in
+// main.bicep. No API keys are minted, stored, or rotated.
+//
+// Model deployment: a single 'chat' deployment of the configured
+// model (default gpt-4o). One deployment is enough for Phase 1 —
+// add additional deployments here when we need fallback models or
+// per-tier routing.
+//
+// Quota gotcha: TPM is per-subscription-per-region-per-model. If
+// the deployment fails with InsufficientQuota, file an Azure
+// support quota-increase request for `OpenAI.Standard.{model}` in
+// `azureOpenAIRegion` before retrying.
+// ──────────────────────────────────────────────────────────────
+
+@description('Azure region for the Azure OpenAI account. May differ from the parent RG location to follow model quota. westus has GPT-4o; eastus2 has best GPT-5 quota.')
+param location string
+
+@description('Name of the Azure OpenAI account.')
+param accountName string
+
+@description('Model family to deploy as the "chat" deployment.')
+@allowed(['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4.1-mini'])
+param chatModel string = 'gpt-4o'
+
+@description('Model version to pin. Check the Azure OpenAI model-versions doc for currently-supported values per region.')
+param chatModelVersion string = '2024-11-20'
+
+@description('Tokens-per-minute capacity (in thousands). 30 = 30k TPM, plenty for Phase 1 / single-org pilot. Bump when monthly budget caps stop biting first.')
+param chatModelCapacity int = 30
+
+param tags object = {}
+
+resource account 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: accountName
+  location: location
+  tags: tags
+  kind: 'OpenAI'
+  sku: {
+    name: 'S0'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    // Force managed-identity auth so we never have to plumb API
+    // keys through Key Vault. CMS uses azure-identity's
+    // DefaultAzureCredential at runtime.
+    disableLocalAuth: true
+    customSubDomainName: accountName
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: account
+  name: 'chat'
+  sku: {
+    // Standard = pay-per-token, regional. GlobalStandard would
+    // spread load across regions; not needed at Phase 1 volumes
+    // and complicates quota accounting.
+    name: 'Standard'
+    capacity: chatModelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: chatModel
+      version: chatModelVersion
+    }
+    // Default content-filter policy is fine for an internal admin
+    // assistant; revisit if we ever expose this to end-users.
+    raiPolicyName: 'Microsoft.DefaultV2'
+  }
+}
+
+output accountName string = account.name
+output accountId string = account.id
+output endpoint string = account.properties.endpoint
+output deploymentName string = chatDeployment.name

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -62,6 +62,13 @@ param githubIssuesToken string = ''
 @description('Public CMS URL override (e.g. https://agora.example.com, no trailing slash). When non-empty, takes precedence over the auto-derived "https://<cmsAppName>.<defaultDomain>" for AGORA_CMS_BASE_URL -- needed when a custom domain fronts the app so invite/setup-account links, imager URLs, and the wss://host/ws/device baked into Pi fleet env all point at the real public hostname.')
 param cmsBaseUrlOverride string = ''
 
+// ── Azure OpenAI (Assistant feature) ──
+@description('Azure OpenAI endpoint URL (e.g. https://agoragwdev-aoai.openai.azure.com/). Empty when the Assistant feature is not deployed in this environment; CMS treats empty as "feature disabled" at runtime.')
+param azureOpenAIEndpoint string = ''
+
+@description('Azure OpenAI deployment name to use for chat completions (matches the deployment provisioned in azureOpenAI.bicep, default "chat"). Empty when the Assistant feature is not deployed in this environment.')
+param azureOpenAIDeployment string = ''
+
 // ── Blue/green deploy controls (Multiple revision mode) ──
 @description('Revision suffix for the CMS Container App. Each deploy MUST pass a unique value (e.g. "v1-12-34") so a brand-new revision is created at 0% traffic. The workflow flips traffic to it after smoke probes pass.')
 param cmsRevisionSuffix string = ''
@@ -307,6 +314,19 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
               // docker-compose) telemetry export is silently disabled.
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               secretRef: 'app-insights-connection-string'
+            }
+            {
+              // Azure OpenAI endpoint for the Assistant feature.
+              // Empty string in environments that haven't opted into
+              // the feature; the runtime treats empty as "Assistant
+              // disabled" so non-opted-in envs ship with the same
+              // image but the feature stays dark.
+              name: 'AGORA_CMS_AZURE_OPENAI_ENDPOINT'
+              value: azureOpenAIEndpoint
+            }
+            {
+              name: 'AGORA_CMS_AZURE_OPENAI_DEPLOYMENT'
+              value: azureOpenAIDeployment
             }
             {
               // Tag every emitted record so we can distinguish prod from

--- a/infra/parameters/goodwill-dev.bicepparam
+++ b/infra/parameters/goodwill-dev.bicepparam
@@ -57,6 +57,17 @@ param workerMemory = '2Gi'
 // here we'll flip the default for the other envs too.
 param useSyntheticHeartbeat = true
 
+// Opt this environment into the Assistant feature backend.
+// Phase 1: dev only. Prod opts in after the dev pilot validates the
+// budget caps + approval UX.
+param deployAzureOpenAI = true
+// westus has GPT-4o quota out of the box; pin chat model + version
+// so deploys are reproducible regardless of Azure's "latest" drift.
+param azureOpenAIRegion = 'westus'
+param azureOpenAIChatModel = 'gpt-4o'
+param azureOpenAIChatModelVersion = '2024-11-20'
+param azureOpenAIChatCapacity = 30
+
 // Secure params — passed via the deploy-goodwill-dev workflow, never commit values:
 // param postgresAdminPassword = '<set-via-cli>'
 // param cmsSecretKey = '<set-via-cli>'


### PR DESCRIPTION
First PR in the in-CMS Assistant series (6 planned).

## What this does
Pure infra. Stands up an Azure OpenAI account + GPT-4o `chat` deployment in **goodwill-dev only**, and grants the CMS container app's managed identity `Cognitive Services OpenAI User` on the account. No app code changes -- the runtime treats empty `AGORA_CMS_AZURE_OPENAI_ENDPOINT` as `Assistant feature disabled`, so every env that hasn't opted in is a no-op.

## Why managed identity (not API keys)
Avoids a key-rotation rotation and a KV secret. CMS uses `DefaultAzureCredential` at runtime; AOAI account is created with `disableLocalAuth=true` so the only auth path is RBAC.

## Files
- `infra/modules/azureOpenAI.bicep` -- new. Account + single `chat` deployment. Defaults: gpt-4o, version 2024-11-20, 30k TPM.
- `infra/main.bicep` -- new params (`deployAzureOpenAI`, `azureOpenAIRegion`, model, version, capacity). Module call gated on the bool. Inline role assignment. New outputs.
- `infra/modules/containerApps.bicep` -- new `azureOpenAIEndpoint` / `azureOpenAIDeployment` params surfaced as `AGORA_CMS_AZURE_OPENAI_ENDPOINT` / `AGORA_CMS_AZURE_OPENAI_DEPLOYMENT` on the CMS container.
- `infra/parameters/goodwill-dev.bicepparam` -- opts in: `deployAzureOpenAI=true`, `azureOpenAIRegion=westus` (has GPT-4o quota).

## Verification before merge
- `az bicep build` clean (only the pre-existing BCP318 warnings on conditional modules).
- After the goodwill-dev deploy pipeline runs, an `agoragwdev-aoai` AOAI account + `chat` deployment should exist in `agoragw-cms-dev-rg` and the CMS container should have the two new env vars populated.

## Quota gotcha
If the dev deploy fails with `InsufficientQuota`, file an Azure support quota-increase for `OpenAI.Standard.gpt-4o` in westus before retrying. 30k TPM is generally approved by default for new AOAI accounts in westus.

## Next PRs in the series (already sketched in session plan.md)
2. Backend skeleton: tables (chat_threads / chat_messages / chat_pending_approvals / chat_user_budget), feature-flag helper, thread CRUD endpoints.
3. Agent loop: LLM client, MCP client, end-to-end `what's offline?`.
4. Approval flow for write tools.
5. Frontend (`/assistant` page, SSE consumer, approval cards).
6. Settings + budget UI + telemetry.
