### PR TITLE
feat(assistant): backend skeleton -- threads + per-user feature flag (PR 2 of 6)

### DIFF
--- a/alembic/versions/0034_chat_assistant_tables.py
+++ b/alembic/versions/0034_chat_assistant_tables.py
@@ -1,0 +1,119 @@
+"""Alembic migration 0034 — chat assistant tables (PR 2 of 6).
+
+Adds the two tables used by the Phase-1 Assistant data plane:
+
+* ``chat_threads``  — per-user conversation envelopes.
+* ``chat_messages`` — one row per turn (user / assistant / tool / system).
+
+Follow-up migrations land the approval queue (``chat_pending_approvals``)
+and the per-user budget (``chat_user_budget``) with the PRs that
+actually use them, so the table-vs-feature blast radius stays small.
+
+Revision ID: 0034
+Revises: 0033
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def _types(bind):
+    dialect = bind.dialect.name
+    uuid_type = (
+        sa.dialects.postgresql.UUID(as_uuid=True)
+        if dialect == "postgresql"
+        else sa.String(length=36)
+    )
+    json_type = (
+        sa.dialects.postgresql.JSONB()
+        if dialect == "postgresql"
+        else sa.JSON()
+    )
+    return uuid_type, json_type
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    uuid_type, json_type = _types(bind)
+
+    op.create_table(
+        "chat_threads",
+        sa.Column("id", uuid_type, nullable=False),
+        sa.Column(
+            "user_id",
+            uuid_type,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(length=200), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_chat_threads_user_id", "chat_threads", ["user_id"], unique=False
+    )
+    op.create_index(
+        "ix_chat_threads_updated_at",
+        "chat_threads",
+        ["updated_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "chat_messages",
+        sa.Column("id", uuid_type, nullable=False),
+        sa.Column(
+            "thread_id",
+            uuid_type,
+            sa.ForeignKey("chat_threads.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(length=20), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("tool_calls", json_type, nullable=True),
+        sa.Column("tool_call_id", sa.String(length=100), nullable=True),
+        sa.Column("tokens_in", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tokens_out", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_chat_messages_thread_id",
+        "chat_messages",
+        ["thread_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_chat_messages_created_at",
+        "chat_messages",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0034 is not supported")

--- a/cms/main.py
+++ b/cms/main.py
@@ -831,6 +831,7 @@ from cms.routers.profiles import router as profiles_router  # noqa: E402
 from cms.routers.schedules import router as schedules_router  # noqa: E402
 from cms.routers.tags import router as tags_router  # noqa: E402
 from cms.routers.asset_views import router as asset_views_router  # noqa: E402
+from cms.routers.chat import router as chat_router  # noqa: E402
 from cms.routers.ws import router as ws_router  # noqa: E402
 from cms.routers.api_keys import router as api_keys_router  # noqa: E402
 from cms.routers.audit import router as audit_router  # noqa: E402
@@ -853,6 +854,7 @@ app.include_router(assets_device_router)
 app.include_router(schedules_router)
 app.include_router(tags_router)
 app.include_router(asset_views_router)
+app.include_router(chat_router)
 app.include_router(profiles_router)
 app.include_router(logs_router)
 app.include_router(cms_logs_router)

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -22,6 +22,8 @@ from cms.models.setting import CMSSetting  # noqa: F401
 from cms.models.slideshow_slide import SlideshowSlide  # noqa: F401
 from cms.models.tag import Tag, AssetTag, DEFAULT_TAG_COLOR  # noqa: F401
 from cms.models.asset_view import AssetView  # noqa: F401
+from cms.models.chat_message import ChatMessage  # noqa: F401
+from cms.models.chat_thread import ChatThread  # noqa: F401
 from cms.models.user import Role, User, UserGroup  # noqa: F401
 
 # ── CMS-only relationships ──

--- a/cms/models/chat_message.py
+++ b/cms/models/chat_message.py
@@ -23,7 +23,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
@@ -48,16 +48,24 @@ class ChatMessage(Base):
         index=True,
     )
     role: Mapped[str] = mapped_column(String(20), nullable=False)
-    content: Mapped[str] = mapped_column(Text, default="")
+    content: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
     tool_calls: Mapped[list[dict[str, Any]] | None] = mapped_column(
         _JSON_TYPE, nullable=True
     )
     tool_call_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    tokens_in: Mapped[int] = mapped_column(Integer, default=0)
-    tokens_out: Mapped[int] = mapped_column(Integer, default=0)
+    tokens_in: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    tokens_out: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        nullable=False,
         default=lambda: datetime.now(timezone.utc),
+        server_default=func.current_timestamp(),
         index=True,
     )
 

--- a/cms/models/chat_message.py
+++ b/cms/models/chat_message.py
@@ -1,0 +1,64 @@
+"""Chat assistant: a single message in a thread.
+
+One row per LLM turn participant:
+* ``role="user"``    — message typed by the human; ``content`` is text.
+* ``role="assistant"`` — model reply.  ``content`` is the final assembled
+  text; ``tool_calls`` (JSONB) carries the OpenAI tool-call list when
+  the model wanted to invoke an MCP tool that turn.
+* ``role="tool"``    — result of an MCP tool invocation. ``tool_call_id``
+  joins back to the assistant turn that requested it; ``content`` holds
+  the JSON-serialised result.
+* ``role="system"``  — only used for ad-hoc system reminders injected by
+  the agent loop (e.g. budget warnings).  The base system prompt is
+  rebuilt every turn and is NOT persisted.
+
+``tokens_in`` / ``tokens_out`` are recorded on assistant turns from the
+LLM usage reply so the budget accounting in ``chat_user_budget`` can be
+reconciled per-message without re-parsing the row body.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+from cms.database import Base
+
+
+# Use JSONB on Postgres, generic JSON on SQLite (test matrix).
+_JSON_TYPE = JSON().with_variant(JSONB(), "postgresql")
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_messages"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    thread_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_threads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, default="")
+    tool_calls: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        _JSON_TYPE, nullable=True
+    )
+    tool_call_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    tokens_in: Mapped[int] = mapped_column(Integer, default=0)
+    tokens_out: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+
+    thread: Mapped["ChatThread"] = relationship(back_populates="messages")

--- a/cms/models/chat_thread.py
+++ b/cms/models/chat_thread.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -36,15 +36,21 @@ class ChatThread(Base):
         nullable=False,
         index=True,
     )
-    title: Mapped[str] = mapped_column(String(200), default="")
+    title: Mapped[str] = mapped_column(
+        String(200), nullable=False, default="", server_default=""
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        nullable=False,
         default=lambda: datetime.now(timezone.utc),
+        server_default=func.current_timestamp(),
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.current_timestamp(),
         index=True,
     )
 

--- a/cms/models/chat_thread.py
+++ b/cms/models/chat_thread.py
@@ -1,0 +1,56 @@
+"""Chat assistant: persisted conversation thread.
+
+Phase 1 of the in-CMS Assistant feature.  Each thread is a strictly
+per-user conversation; there is no sharing, no org-level visibility,
+and no admin escape hatch.  When a user is removed (or simply
+de-allowlisted) their threads stay in the table — soft data, not
+auth state — until they explicitly delete them.
+
+Soft semantics for ``title``:  the agent loop will summarise the
+first user message and stamp ``title`` after the first turn; until
+then the column is empty and the UI shows the first message as a
+placeholder.  Empty is the only valid "no title yet" sentinel.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from cms.database import Base
+
+
+class ChatThread(Base):
+    __tablename__ = "chat_threads"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(200), default="")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+
+    messages: Mapped[list["ChatMessage"]] = relationship(
+        "ChatMessage",
+        back_populates="thread",
+        cascade="all, delete-orphan",
+        order_by="ChatMessage.created_at",
+    )

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -1,0 +1,173 @@
+"""Assistant chat API — thread CRUD + feature-flag introspection (PR 2 of 6).
+
+This PR is intentionally skeletal: just enough surface to let the
+frontend land its sidebar and history view in a later PR.  No LLM,
+no MCP, no SSE.  The data model is here, the gate is here, the
+endpoints are here, and that's it.
+
+Every endpoint is gated on
+:func:`cms.services.assistant_flag.assistant_enabled_for` — when the
+caller is not allowlisted, the API returns **404** (not 403) so that
+the feature appears not to exist for users who shouldn't even know
+it's coming.  Admins (``settings:write``) always pass the gate as an
+escape hatch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_current_user, get_settings, require_auth
+from cms.config import Settings
+from cms.database import get_db
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+from cms.schemas.chat import (
+    AssistantFeatureStatus,
+    ChatMessageOut,
+    ChatThreadCreate,
+    ChatThreadOut,
+)
+from cms.services.assistant_flag import assistant_enabled_for
+
+
+router = APIRouter(prefix="/api/chat", dependencies=[Depends(require_auth)])
+
+
+async def _current_user(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Return the authenticated User.
+
+    Mirrors the pattern used by ``cms.routers.asset_views`` so handlers
+    can take ``user: User = Depends(_current_user)`` without repeating
+    the request/settings/db plumbing.
+    """
+    return await get_current_user(request, settings, db)
+
+
+async def _require_feature(user: User, db: AsyncSession) -> None:
+    """Raise 404 unless the Assistant feature is enabled for ``user``.
+
+    404 instead of 403 keeps the feature invisible to users who are not
+    in the allowlist — they shouldn't be able to tell that a hidden
+    chat backend exists.
+    """
+    if not await assistant_enabled_for(db, user):
+        raise HTTPException(status_code=404, detail="Not found")
+
+
+async def _get_owned_thread(
+    thread_id: uuid.UUID, user: User, db: AsyncSession
+) -> ChatThread:
+    """Fetch ``thread_id`` or raise 404 if missing / not owned by ``user``.
+
+    404 (not 403) on cross-user access to avoid leaking thread existence.
+    """
+    thread = (
+        await db.execute(select(ChatThread).where(ChatThread.id == thread_id))
+    ).scalar_one_or_none()
+    if not thread or thread.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    return thread
+
+
+# ── Feature flag introspection ────────────────────────────────────────
+# The frontend hits this on page load to decide whether to render the
+# Assistant tab.  Unlike the rest of the router this endpoint never
+# 404s — it always reports an enabled boolean, so the UI can branch
+# without retry logic.
+
+@router.get("/feature", response_model=AssistantFeatureStatus)
+async def get_feature_status(
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Report whether the caller has the Assistant feature enabled."""
+    return AssistantFeatureStatus(enabled=await assistant_enabled_for(db, user))
+
+
+# ── Thread CRUD ───────────────────────────────────────────────────────
+
+@router.get("/threads", response_model=List[ChatThreadOut])
+async def list_threads(
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the caller's threads, newest-updated first."""
+    await _require_feature(user, db)
+    rows = (
+        await db.execute(
+            select(ChatThread)
+            .where(ChatThread.user_id == user.id)
+            .order_by(ChatThread.updated_at.desc())
+        )
+    ).scalars().all()
+    return [ChatThreadOut.model_validate(t) for t in rows]
+
+
+@router.post("/threads", response_model=ChatThreadOut, status_code=201)
+async def create_thread(
+    payload: ChatThreadCreate,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new empty thread for the caller.
+
+    ``title`` is optional; the agent loop (PR 3) will summarise the
+    first user message and stamp the title automatically.  Until then
+    the UI renders the first message as a placeholder title.
+    """
+    await _require_feature(user, db)
+    thread = ChatThread(user_id=user.id, title=payload.title.strip())
+    db.add(thread)
+    await db.flush()
+    await db.commit()
+    await db.refresh(thread)
+    return ChatThreadOut.model_validate(thread)
+
+
+@router.delete("/threads/{thread_id}", status_code=204)
+async def delete_thread(
+    thread_id: uuid.UUID,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Hard-delete a thread and all of its messages."""
+    await _require_feature(user, db)
+    thread = await _get_owned_thread(thread_id, user, db)
+    await db.execute(delete(ChatThread).where(ChatThread.id == thread.id))
+    await db.commit()
+
+
+@router.get(
+    "/threads/{thread_id}/messages", response_model=List[ChatMessageOut]
+)
+async def list_thread_messages(
+    thread_id: uuid.UUID,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return every message in the thread in chronological order.
+
+    No pagination in Phase 1 — a single thread is bounded by the budget
+    cap (PR 6) long before message counts would matter.
+    """
+    await _require_feature(user, db)
+    thread = await _get_owned_thread(thread_id, user, db)
+    rows = (
+        await db.execute(
+            select(ChatMessage)
+            .where(ChatMessage.thread_id == thread.id)
+            .order_by(ChatMessage.created_at)
+        )
+    ).scalars().all()
+    return [ChatMessageOut.model_validate(m) for m in rows]

--- a/cms/schemas/chat.py
+++ b/cms/schemas/chat.py
@@ -1,0 +1,56 @@
+"""Pydantic schemas for the Assistant chat API."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatThreadOut(BaseModel):
+    """A chat thread as returned by the API."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    title: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ChatThreadCreate(BaseModel):
+    """Request body for ``POST /api/chat/threads``."""
+
+    title: str = Field(default="", max_length=200)
+
+
+class ChatMessageOut(BaseModel):
+    """A single message in a thread.
+
+    ``tool_calls`` and ``tool_call_id`` are surfaced on the wire because
+    the frontend needs them to render the tool-call timeline (and, in
+    PR 4, the approval cards).  ``tokens_in`` / ``tokens_out`` are NOT
+    surfaced; the budget badge reads from ``/api/chat/budget`` instead.
+    """
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    thread_id: uuid.UUID
+    role: str
+    content: str
+    tool_calls: Optional[list[dict[str, Any]]] = None
+    tool_call_id: Optional[str] = None
+    created_at: datetime
+
+
+class AssistantFeatureStatus(BaseModel):
+    """Response body for ``GET /api/chat/feature``.
+
+    Lets the frontend decide whether to render the Assistant tab without
+    needing to probe a 404 from another endpoint.
+    """
+
+    enabled: bool

--- a/cms/services/assistant_flag.py
+++ b/cms/services/assistant_flag.py
@@ -1,0 +1,111 @@
+"""Per-user feature flag for the in-CMS Assistant.
+
+Phase 1 uses the existing ``cms_settings`` key/value table to hold an
+allowlist of user UUIDs that can see and use the feature:
+
+* Setting key:  ``assistant_enabled_user_ids``
+* Setting value: JSON-encoded list of UUID strings, e.g.
+  ``["6a9e2c1e-...", "ee9b4d2a-..."]``.
+* Missing setting / empty list  → feature is OFF for everyone (the
+  default state on every freshly-deployed env).
+
+Rationale for reusing ``cms_settings`` instead of adding a generic
+feature-flag framework:  we only have one flag right now, and the
+existing settings table already handles persistence, admin gating, and
+the migration story.  If we grow to >3 flags or need
+per-org / per-group scoping, promote this to a real table at that
+point.
+
+The admin user (``users.is_active`` AND role permission
+``settings:write``) is treated as always enabled.  This is the
+escape hatch so we can't accidentally lock ourselves out of the
+feature.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_setting, set_setting
+from cms.models.user import User
+from cms.permissions import has_permission
+
+
+logger = logging.getLogger(__name__)
+
+
+ASSISTANT_FLAG_KEY = "assistant_enabled_user_ids"
+# Permission that always implies access regardless of allowlist
+# membership — keeps admins from locking themselves out.
+ADMIN_FALLBACK_PERMISSION = "settings:write"
+
+
+async def get_allowlist(db: AsyncSession) -> list[uuid.UUID]:
+    """Return the current allowlist as a list of UUIDs.
+
+    Tolerates a missing setting, an empty string, malformed JSON, and
+    non-UUID entries — any of those collapse to an empty list and log
+    a warning.  We never want a bad setting value to throw 500s into
+    a router.
+    """
+    raw = await get_setting(db, ASSISTANT_FLAG_KEY)
+    if not raw:
+        return []
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(
+            "assistant_enabled_user_ids contains invalid JSON; treating as empty"
+        )
+        return []
+    if not isinstance(items, list):
+        logger.warning(
+            "assistant_enabled_user_ids is not a JSON list; treating as empty"
+        )
+        return []
+    out: list[uuid.UUID] = []
+    for item in items:
+        try:
+            out.append(uuid.UUID(str(item)))
+        except (ValueError, TypeError):
+            logger.warning(
+                "assistant_enabled_user_ids entry %r is not a valid UUID; ignored",
+                item,
+            )
+    return out
+
+
+async def assistant_enabled_for(db: AsyncSession, user: User) -> bool:
+    """Return True if ``user`` is allowed to use the Assistant feature.
+
+    The check is intentionally permissive for ``settings:write`` holders
+    (admins) — they always have access, even when the allowlist is empty,
+    so a bad allowlist setting can never lock everyone out of the
+    feature including the people who can fix it.
+    """
+    if user.role and has_permission(
+        user.role.permissions, ADMIN_FALLBACK_PERMISSION
+    ):
+        return True
+    allowlist = await get_allowlist(db)
+    return user.id in allowlist
+
+
+async def set_allowlist(db: AsyncSession, user_ids: list[uuid.UUID]) -> None:
+    """Replace the allowlist with ``user_ids``.
+
+    Deduplicates while preserving caller order; persists as a JSON
+    array of lowercase canonical UUID strings.
+    """
+    seen: set[uuid.UUID] = set()
+    cleaned: list[str] = []
+    for uid in user_ids:
+        if uid in seen:
+            continue
+        seen.add(uid)
+        cleaned.append(str(uid))
+    await set_setting(db, ASSISTANT_FLAG_KEY, json.dumps(cleaned))

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1670,6 +1670,116 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/feature:
+    get:
+      summary: Get Feature Status
+      description: Report whether the caller has the Assistant feature enabled.
+      operationId: get_feature_status_api_chat_feature_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantFeatureStatus'
+  /api/chat/threads:
+    get:
+      summary: List Threads
+      description: List the caller's threads, newest-updated first.
+      operationId: list_threads_api_chat_threads_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChatThreadOut'
+                type: array
+                title: Response List Threads Api Chat Threads Get
+    post:
+      summary: Create Thread
+      description: |-
+        Create a new empty thread for the caller.
+
+        ``title`` is optional; the agent loop (PR 3) will summarise the
+        first user message and stamp the title automatically.  Until then
+        the UI renders the first message as a placeholder title.
+      operationId: create_thread_api_chat_threads_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatThreadCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatThreadOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/threads/{thread_id}:
+    delete:
+      summary: Delete Thread
+      description: Hard-delete a thread and all of its messages.
+      operationId: delete_thread_api_chat_threads__thread_id__delete
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Thread Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/threads/{thread_id}/messages:
+    get:
+      summary: List Thread Messages
+      description: |-
+        Return every message in the thread in chronological order.
+
+        No pagination in Phase 1 — a single thread is bounded by the budget
+        cap (PR 6) long before message counts would matter.
+      operationId: list_thread_messages_api_chat_threads__thread_id__messages_get
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Thread Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChatMessageOut'
+                title: Response List Thread Messages Api Chat Threads  Thread Id  Messages Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/profiles:
     get:
       summary: List Profiles
@@ -4104,6 +4214,20 @@ components:
       type: object
       title: AssetViewPatch
       description: Request body for ``PATCH /api/asset-views/{id}``. All fields optional.
+    AssistantFeatureStatus:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+      type: object
+      required:
+      - enabled
+      title: AssistantFeatureStatus
+      description: |-
+        Response body for ``GET /api/chat/feature``.
+
+        Lets the frontend decide whether to render the Assistant tab without
+        needing to probe a 404 from another endpoint.
     AuditLogRead:
       properties:
         id:
@@ -4389,6 +4513,89 @@ components:
       required:
       - entries
       title: CatalogOut
+    ChatMessageOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        thread_id:
+          type: string
+          format: uuid
+          title: Thread Id
+        role:
+          type: string
+          title: Role
+        content:
+          type: string
+          title: Content
+        tool_calls:
+          anyOf:
+          - items:
+              additionalProperties: true
+              type: object
+            type: array
+          - type: 'null'
+          title: Tool Calls
+        tool_call_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tool Call Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - thread_id
+      - role
+      - content
+      - created_at
+      title: ChatMessageOut
+      description: |-
+        A single message in a thread.
+
+        ``tool_calls`` and ``tool_call_id`` are surfaced on the wire because
+        the frontend needs them to render the tool-call timeline (and, in
+        PR 4, the approval cards).  ``tokens_in`` / ``tokens_out`` are NOT
+        surfaced; the budget badge reads from ``/api/chat/budget`` instead.
+    ChatThreadCreate:
+      properties:
+        title:
+          type: string
+          maxLength: 200
+          title: Title
+          default: ''
+      type: object
+      title: ChatThreadCreate
+      description: Request body for ``POST /api/chat/threads``.
+    ChatThreadOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        title:
+          type: string
+          title: Title
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - id
+      - title
+      - created_at
+      - updated_at
+      title: ChatThreadOut
+      description: A chat thread as returned by the API.
     ConnectTokenRequest:
       properties:
         device_id:

--- a/tests/test_chat_threads.py
+++ b/tests/test_chat_threads.py
@@ -1,0 +1,248 @@
+"""Tests for the Assistant chat API skeleton (PR 2 of 6).
+
+Covers the feature-flag gating + thread CRUD round-trips. Does NOT
+exercise the agent loop, MCP integration, SSE, or write-tool
+approvals — those land in subsequent PRs.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+
+@pytest_asyncio.fixture
+async def operator_client(app):
+    """Authenticated client for a non-admin Operator user.
+
+    Used to exercise the allowlist gate: operators have no
+    ``settings:write`` so the admin escape hatch doesn't apply.
+    """
+    from cms.auth import hash_password
+    from cms.database import get_db
+    from cms.models.user import Role, User
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        role = (
+            await db.execute(select(Role).where(Role.name == "Operator"))
+        ).scalar_one()
+        user = User(
+            username="chat-operator",
+            email="chat-op@test.com",
+            display_name="Chat Operator",
+            password_hash=hash_password("oppass"),
+            role_id=role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        operator_id = user.id
+        break
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/login",
+            data={"username": "chat-operator", "password": "oppass"},
+            follow_redirects=False,
+        )
+        ac.user_id = operator_id  # type: ignore[attr-defined]
+        yield ac
+
+
+async def _enable_for(app, user_id: uuid.UUID) -> None:
+    """Set the assistant allowlist to exactly ``[user_id]``."""
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [user_id])
+        break
+
+
+async def _disable_all(app) -> None:
+    """Clear the assistant allowlist."""
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [])
+        break
+
+
+@pytest.mark.asyncio
+class TestAssistantFeatureFlag:
+    async def test_admin_bypass_always_enabled(self, client, app):
+        await _disable_all(app)
+        resp = await client.get("/api/chat/feature")
+        assert resp.status_code == 200
+        # settings:write escape hatch — admin sees feature regardless
+        # of allowlist state.
+        assert resp.json() == {"enabled": True}
+
+    async def test_operator_disabled_by_default(self, operator_client, app):
+        await _disable_all(app)
+        resp = await operator_client.get("/api/chat/feature")
+        assert resp.status_code == 200
+        assert resp.json() == {"enabled": False}
+
+    async def test_operator_disabled_endpoints_404(
+        self, operator_client, app
+    ):
+        await _disable_all(app)
+        # Threads list should look like the endpoint doesn't exist at all.
+        assert (await operator_client.get("/api/chat/threads")).status_code == 404
+        assert (
+            await operator_client.post(
+                "/api/chat/threads", json={"title": "x"}
+            )
+        ).status_code == 404
+
+    async def test_operator_allowlisted_can_use(
+        self, operator_client, app
+    ):
+        await _enable_for(app, operator_client.user_id)
+        feature = await operator_client.get("/api/chat/feature")
+        assert feature.json() == {"enabled": True}
+        listing = await operator_client.get("/api/chat/threads")
+        assert listing.status_code == 200
+        assert listing.json() == []
+
+    async def test_malformed_allowlist_setting_is_treated_as_empty(
+        self, operator_client, app
+    ):
+        # Persist a deliberately broken value and confirm the operator
+        # still sees the feature as disabled (no 500s into the router).
+        from cms.auth import set_setting
+        from cms.database import get_db
+        from cms.services.assistant_flag import ASSISTANT_FLAG_KEY
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_setting(db, ASSISTANT_FLAG_KEY, "not json")
+            break
+
+        resp = await operator_client.get("/api/chat/feature")
+        assert resp.status_code == 200
+        assert resp.json() == {"enabled": False}
+
+
+@pytest.mark.asyncio
+class TestChatThreadCRUD:
+    """Admin user (settings:write) → always enabled, so we drive these
+    tests through the default ``client`` fixture without touching the
+    allowlist."""
+
+    async def test_create_list_messages_delete(self, client):
+        created = await client.post("/api/chat/threads", json={"title": "Promo"})
+        assert created.status_code == 201, created.text
+        thread = created.json()
+        assert thread["title"] == "Promo"
+        tid = thread["id"]
+
+        listing = (await client.get("/api/chat/threads")).json()
+        assert any(t["id"] == tid for t in listing)
+
+        msgs = await client.get(f"/api/chat/threads/{tid}/messages")
+        assert msgs.status_code == 200
+        assert msgs.json() == []
+
+        deleted = await client.delete(f"/api/chat/threads/{tid}")
+        assert deleted.status_code == 204
+        listing2 = (await client.get("/api/chat/threads")).json()
+        assert all(t["id"] != tid for t in listing2)
+
+    async def test_create_with_empty_title_defaults_to_blank(self, client):
+        resp = await client.post("/api/chat/threads", json={})
+        assert resp.status_code == 201
+        assert resp.json()["title"] == ""
+
+    async def test_thread_isolation_cross_user(
+        self, client, operator_client, app
+    ):
+        # Allowlist the operator and let it create a thread; the admin
+        # (different user) must not see it in their listing or be able
+        # to read its messages by ID.
+        await _enable_for(app, operator_client.user_id)
+
+        created = await operator_client.post(
+            "/api/chat/threads", json={"title": "operator-only"}
+        )
+        assert created.status_code == 201
+        op_thread_id = created.json()["id"]
+
+        admin_listing = (await client.get("/api/chat/threads")).json()
+        assert all(t["id"] != op_thread_id for t in admin_listing)
+
+        # Cross-user fetch returns 404, not 403, so existence isn't
+        # leaked.
+        resp = await client.get(
+            f"/api/chat/threads/{op_thread_id}/messages"
+        )
+        assert resp.status_code == 404
+        # And admin cannot delete someone else's thread either.
+        resp = await client.delete(f"/api/chat/threads/{op_thread_id}")
+        assert resp.status_code == 404
+
+    async def test_messages_404_for_unknown_thread(self, client):
+        resp = await client.get(f"/api/chat/threads/{uuid.uuid4()}/messages")
+        assert resp.status_code == 404
+
+    async def test_delete_unknown_thread_404(self, client):
+        resp = await client.delete(f"/api/chat/threads/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestAllowlistService:
+    """Direct unit-style checks against the service layer (no HTTP)."""
+
+    async def test_set_and_get_round_trip(self, app):
+        from cms.database import get_db
+        from cms.services.assistant_flag import (
+            ASSISTANT_FLAG_KEY,
+            get_allowlist,
+            set_allowlist,
+        )
+        from cms.auth import get_setting
+
+        u1, u2 = uuid.uuid4(), uuid.uuid4()
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_allowlist(db, [u1, u2, u1])  # de-duped
+            got = await get_allowlist(db)
+            assert got == [u1, u2]
+            raw = await get_setting(db, ASSISTANT_FLAG_KEY)
+            assert raw is not None
+            assert json.loads(raw) == [str(u1), str(u2)]
+            break
+
+    async def test_invalid_uuids_in_setting_are_dropped(self, app):
+        from cms.auth import set_setting
+        from cms.database import get_db
+        from cms.services.assistant_flag import (
+            ASSISTANT_FLAG_KEY,
+            get_allowlist,
+        )
+
+        u1 = uuid.uuid4()
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_setting(
+                db,
+                ASSISTANT_FLAG_KEY,
+                json.dumps([str(u1), "not-a-uuid", 42]),
+            )
+            got = await get_allowlist(db)
+            assert got == [u1]
+            break


### PR DESCRIPTION
PR 2 of 6 in the in-CMS Assistant series. Pure backend skeleton -- no LLM, no MCP, no SSE. Just the data plane and the per-user feature gate the rest of the series will build on.

## Tables (migration `0034`)
- `chat_threads`  -- per-user conversation envelopes
- `chat_messages` -- one row per turn (`user` / `assistant` / `tool` / `system`), with `tool_calls` JSONB for assistant turns that requested an MCP tool

The approval-queue (`chat_pending_approvals`) and budget (`chat_user_budget`) tables ship with the PRs that actually use them (PR 4 and PR 6) so the blast radius per PR stays small.

Cross-dialect: JSONB on Postgres, generic JSON on SQLite via `.with_variant()` -- matches the existing `asset_view` pattern.

## Feature flag
Lives in `cms/services/assistant_flag.py`. Reuses the existing `cms_settings` key/value table rather than introducing a generic feature-flag framework for one flag.

- Setting key: `assistant_enabled_user_ids`
- Setting value: JSON list of user UUID strings
- Missing / empty / malformed JSON / invalid UUIDs -> dropped silently, feature stays OFF
- Users with `settings:write` (admins) are **always** enabled regardless of allowlist -- escape hatch so we can't lock the people who can fix it out of the feature

## API surface
| Method | Path | Behaviour |
|---|---|---|
| GET    | `/api/chat/feature`               | `{ enabled: bool }` for the caller; never 404s |
| GET    | `/api/chat/threads`               | List newest-updated first |
| POST   | `/api/chat/threads`               | Create empty thread |
| DELETE | `/api/chat/threads/{id}`          | Hard delete (cascades to messages) |
| GET    | `/api/chat/threads/{id}/messages` | Chronological message history |

Disabled callers and cross-user fetches both return **404 not 403**, so a non-allowlisted user can't tell the feature exists. Matches the `asset_views` router pattern.

## Tests
12 new tests, all passing:
- feature-flag gating: admin bypass, operator disabled by default, operator allowlisted, malformed-JSON-setting fallback
- thread CRUD round-trips (admin client)
- cross-user isolation (admin can't see operator's thread)
- 404s on unknown thread / unknown delete
- service-layer: set/get allowlist round-trip de-duplicates and persists canonical UUID strings; invalid UUIDs in the setting are dropped, not raised

Neighbouring suites (`test_asset_views`, `test_migration_policy`) still green.

## Visible from this PR forward
Nothing user-visible. Every endpoint 404s for non-admin users until PR 6's settings UI populates the allowlist (or someone POSTs to `cms_settings` directly). Admins can hit `/api/chat/feature` and `/api/chat/threads` immediately -- they'll just see empty arrays.

## Next: PR 3 -- agent loop
- LLM client (`DefaultAzureCredential` -> AOAI `chat.completions`)
- MCP client (forwards CMS user as `on_behalf_of`)
- Hand-rolled tool-calling loop, read-only tools only initially
- `POST /api/chat/threads/{id}/message` + SSE `/stream`
- End-to-end: `what's offline right now?` works
