### PR TITLE
feat(assistant): non-streaming single-shot agent loop (PR 3a/6)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -140,3 +140,18 @@ class Settings(SharedSettings):
     github_issues_token: str | None = None
     github_issues_repo: str = "sslivins/agora-cms"
     github_issues_label: str = "user-reported"
+
+    # Assistant feature (Azure OpenAI).  Endpoint + deployment are
+    # injected by infra/modules/containerApps.bicep when the env opts
+    # into AOAI; if either is empty the runtime treats the Assistant
+    # as disabled (LLM client raises a clean RuntimeError that the
+    # router converts to a 503).  Auth is always managed-identity via
+    # DefaultAzureCredential — no API keys.
+    azure_openai_endpoint: str = ""
+    azure_openai_deployment: str = ""
+    azure_openai_api_version: str = "2024-10-21"
+    # Per-turn completion cap.  Keeps a runaway response from blowing
+    # through the daily budget in a single shot; PR 6 layers a real
+    # budget cap on top of this.
+    assistant_max_completion_tokens: int = 1024
+

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -30,9 +30,15 @@ from cms.models.chat_thread import ChatThread
 from cms.models.user import User
 from cms.schemas.chat import (
     AssistantFeatureStatus,
+    ChatMessageCreate,
     ChatMessageOut,
     ChatThreadCreate,
     ChatThreadOut,
+)
+from cms.services.assistant.agent import run_user_turn
+from cms.services.assistant.llm_client import (
+    AssistantUnavailableError,
+    is_available as assistant_llm_available,
 )
 from cms.services.assistant_flag import assistant_enabled_for
 
@@ -171,3 +177,52 @@ async def list_thread_messages(
         )
     ).scalars().all()
     return [ChatMessageOut.model_validate(m) for m in rows]
+
+
+# ── Chat turn (PR 3a: non-streaming, no tools) ────────────────────────
+# Posts a user message and runs a single LLM turn.  Returns the
+# assistant message synchronously — no streaming yet (that lands in
+# PR 3b alongside MCP tool calls).
+
+@router.post(
+    "/threads/{thread_id}/message",
+    response_model=ChatMessageOut,
+    status_code=201,
+)
+async def post_message(
+    thread_id: uuid.UUID,
+    payload: ChatMessageCreate,
+    user: User = Depends(_current_user),
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+):
+    """Send a user prompt and return the assistant's reply.
+
+    Returns 503 if the environment hasn't been wired up with Azure
+    OpenAI yet (allowlisted user but no LLM backend).  This is distinct
+    from the feature-flag 404 — the feature IS on for this user, but
+    the backend is missing.
+    """
+    await _require_feature(user, db)
+    thread = await _get_owned_thread(thread_id, user, db)
+
+    if not assistant_llm_available(settings):
+        raise HTTPException(
+            status_code=503,
+            detail="Assistant LLM backend is not configured in this environment.",
+        )
+
+    try:
+        assistant_row = await run_user_turn(
+            db=db,
+            settings=settings,
+            user=user,
+            thread=thread,
+            user_message=payload.content,
+        )
+    except AssistantUnavailableError as exc:
+        # Defensive — assistant_llm_available() should have caught this,
+        # but a race against config changes is theoretically possible.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return ChatMessageOut.model_validate(assistant_row)

--- a/cms/schemas/chat.py
+++ b/cms/schemas/chat.py
@@ -26,6 +26,17 @@ class ChatThreadCreate(BaseModel):
     title: str = Field(default="", max_length=200)
 
 
+class ChatMessageCreate(BaseModel):
+    """Request body for ``POST /api/chat/threads/{id}/message``.
+
+    Single field — the user's prompt.  The agent loop is responsible
+    for persisting both the user turn AND the assistant turn; callers
+    just send the prompt and get back the assistant's reply.
+    """
+
+    content: str = Field(min_length=1, max_length=10_000)
+
+
 class ChatMessageOut(BaseModel):
     """A single message in a thread.
 

--- a/cms/services/assistant/__init__.py
+++ b/cms/services/assistant/__init__.py
@@ -1,0 +1,14 @@
+"""Assistant feature internals.
+
+The Assistant feature is split across several modules so each layer can
+be tested in isolation:
+
+* :mod:`cms.services.assistant.llm_client` — Azure OpenAI wrapper.
+* :mod:`cms.services.assistant.prompts`    — system-prompt builder.
+* :mod:`cms.services.assistant.agent`      — orchestration: persists
+  the user turn, calls the LLM, persists the assistant turn.
+
+PR 3a (this PR) ships a non-streaming, no-tools single-shot flow.
+PR 3b will add MCP tool calls + SSE streaming on top of the same
+interfaces.
+"""

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -1,0 +1,167 @@
+"""Assistant agent: orchestrates a single chat turn.
+
+PR 3a flow (non-streaming, no tools):
+
+1. Caller posts a user message to ``POST /api/chat/threads/{id}/message``.
+2. :func:`run_user_turn` is invoked:
+   a. Persists the user's :class:`ChatMessage`.
+   b. Loads the thread's existing messages (chronological).
+   c. Builds the OpenAI-format conversation: system prompt + history +
+      the new user turn.
+   d. Calls :meth:`LLMClient.complete`.
+   e. Persists the assistant :class:`ChatMessage` with the response and
+      token usage.
+   f. Auto-titles the thread if this was the first user turn and the
+      thread title is empty.
+   g. Bumps the thread's ``updated_at`` so it sorts to the top of the
+      sidebar.
+3. The router serialises the assistant message and returns it.
+
+The agent owns the DB transaction boundary — the router doesn't have
+to think about it.  Token-budget enforcement and approval gating land
+in later PRs; this module's signature is shaped so that adding them
+won't require a router change.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.config import Settings
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+from cms.services.assistant.llm_client import (
+    CompletionResult,
+    LLMClient,
+)
+from cms.services.assistant.prompts import build_system_prompt
+
+logger = logging.getLogger(__name__)
+
+# Max characters used for the auto-generated thread title.  The DB
+# column is 200 chars (ChatThread.title); 80 is a comfortable UI cap.
+_AUTO_TITLE_MAX = 80
+
+
+def _auto_title(user_message: str) -> str:
+    """Return a single-line truncated version of ``user_message``."""
+    flat = " ".join(user_message.split())
+    if len(flat) <= _AUTO_TITLE_MAX:
+        return flat
+    return flat[: _AUTO_TITLE_MAX - 1].rstrip() + "\u2026"  # ellipsis
+
+
+def _history_to_openai_messages(
+    history: list[ChatMessage],
+) -> list[dict[str, Any]]:
+    """Convert persisted :class:`ChatMessage` rows to OpenAI format.
+
+    PR 3a only emits ``user`` / ``assistant`` turns — ``tool`` /
+    ``system`` rows from later PRs are preserved transparently so the
+    same helper can be used after PR 3b lands.
+    """
+    out: list[dict[str, Any]] = []
+    for row in history:
+        msg: dict[str, Any] = {"role": row.role, "content": row.content}
+        if row.tool_calls:
+            msg["tool_calls"] = row.tool_calls
+        if row.tool_call_id:
+            msg["tool_call_id"] = row.tool_call_id
+        out.append(msg)
+    return out
+
+
+async def run_user_turn(
+    *,
+    db: AsyncSession,
+    settings: Settings,
+    user: User,
+    thread: ChatThread,
+    user_message: str,
+    llm_client: LLMClient | None = None,
+) -> ChatMessage:
+    """Run one user → assistant turn against ``thread``.
+
+    Returns the persisted assistant :class:`ChatMessage`.  Caller-supplied
+    ``llm_client`` is used if provided (tests inject a mock); otherwise
+    a fresh client is constructed and closed at the end of the call.
+    """
+    user_message = user_message.strip()
+    if not user_message:
+        raise ValueError("user_message must not be empty")
+
+    # 1. Persist the user turn first so it's visible in history even if
+    #    the LLM call later fails (the frontend's optimistic render
+    #    will reconcile to this row on the next poll).
+    user_row = ChatMessage(
+        thread_id=thread.id, role="user", content=user_message
+    )
+    db.add(user_row)
+    await db.flush()
+
+    # 2. Reload the full history (now including the row we just added)
+    #    in chronological order.  Single round-trip; threads in PR 3a
+    #    are bounded by user typing speed so no pagination needed.
+    rows = (
+        await db.execute(
+            select(ChatMessage)
+            .where(ChatMessage.thread_id == thread.id)
+            .order_by(ChatMessage.created_at, ChatMessage.id)
+        )
+    ).scalars().all()
+
+    # 3. Build the OpenAI-format payload.
+    openai_messages: list[dict[str, Any]] = [
+        {"role": "system", "content": build_system_prompt(user)},
+    ]
+    openai_messages.extend(_history_to_openai_messages(list(rows)))
+
+    # 4. Call the LLM, owning the client lifecycle if the caller didn't
+    #    inject one.
+    owns_client = llm_client is None
+    client = llm_client if llm_client is not None else LLMClient(settings)
+    try:
+        result: CompletionResult = await client.complete(openai_messages)
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    # 5. Persist the assistant turn with token accounting.
+    assistant_row = ChatMessage(
+        thread_id=thread.id,
+        role="assistant",
+        content=result.content,
+        tokens_in=result.tokens_in,
+        tokens_out=result.tokens_out,
+    )
+    db.add(assistant_row)
+
+    # 6. Auto-title untitled threads from the first user prompt.  We
+    #    check that the only persisted user row is this one rather than
+    #    relying on `not thread.title`, because the user may have
+    #    cleared the title in the UI.
+    user_turn_count = sum(1 for r in rows if r.role == "user")
+    if user_turn_count == 1 and not thread.title.strip():
+        thread.title = _auto_title(user_message)
+
+    # 7. Bump `updated_at` so this thread sorts to the top of the
+    #    sidebar.  We set it explicitly rather than relying on
+    #    `onupdate=` because SQLAlchemy only fires an UPDATE when at
+    #    least one mapped attribute is actually dirty.
+    thread.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    await db.commit()
+    await db.refresh(assistant_row)
+    logger.info(
+        "assistant.turn.complete thread=%s user=%s in=%d out=%d",
+        thread.id,
+        user.id,
+        result.tokens_in,
+        result.tokens_out,
+    )
+    return assistant_row

--- a/cms/services/assistant/llm_client.py
+++ b/cms/services/assistant/llm_client.py
@@ -1,0 +1,145 @@
+"""Azure OpenAI client wrapper.
+
+Thin async facade over the official ``openai`` SDK's ``AsyncAzureOpenAI``
+client.  Encapsulates:
+
+* Endpoint / deployment / api-version lookup from :class:`cms.config.Settings`.
+* Managed-identity authentication via :class:`azure.identity.DefaultAzureCredential`
+  + the ``cognitiveservices.azure.com/.default`` scope (matches the
+  ``Cognitive Services OpenAI User`` role granted to the CMS managed
+  identity by ``infra/main.bicep``).
+* "Feature available?" check — returns ``False`` when the endpoint or
+  deployment env var is empty so callers can degrade cleanly in envs
+  that haven't opted into Azure OpenAI.
+
+The client itself is intentionally stateless and **not** cached on the
+process — the underlying SDK keeps its own ``httpx`` connection pool and
+the credential object is cheap to construct.  If profiling later shows
+auth overhead we can memoise; for the single-shot PR 3a flow there's no
+point.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
+from openai import AsyncAzureOpenAI
+
+from cms.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+# AAD scope for Azure Cognitive Services data-plane.  See:
+# https://learn.microsoft.com/azure/ai-services/openai/how-to/managed-identity
+_AOAI_SCOPE = "https://cognitiveservices.azure.com/.default"
+
+
+class AssistantUnavailableError(RuntimeError):
+    """Raised when Azure OpenAI isn't configured in this environment.
+
+    The chat router catches this and converts it to ``503 Service
+    Unavailable`` so allowlisted users get a clear error message rather
+    than a 500.  This is distinct from the feature-flag gate, which
+    404s; here the feature IS enabled, the LLM backend just isn't
+    deployed.
+    """
+
+
+@dataclass
+class CompletionResult:
+    """Return value of :meth:`LLMClient.complete`."""
+
+    content: str
+    tokens_in: int
+    tokens_out: int
+
+
+def is_available(settings: Settings) -> bool:
+    """Return True iff Azure OpenAI is wired up in this environment."""
+    return bool(settings.azure_openai_endpoint and settings.azure_openai_deployment)
+
+
+class LLMClient:
+    """Async wrapper around :class:`openai.AsyncAzureOpenAI`."""
+
+    def __init__(self, settings: Settings) -> None:
+        if not is_available(settings):
+            raise AssistantUnavailableError(
+                "Azure OpenAI is not configured "
+                "(AGORA_CMS_AZURE_OPENAI_ENDPOINT / _DEPLOYMENT unset)."
+            )
+        self._settings = settings
+        # Per-instance credential — the openai SDK calls the token
+        # provider on every request, so reusing one credential lets
+        # MSAL cache hits short-circuit the AAD round-trip.
+        self._credential = DefaultAzureCredential()
+        token_provider = get_bearer_token_provider(self._credential, _AOAI_SCOPE)
+        self._client = AsyncAzureOpenAI(
+            azure_endpoint=settings.azure_openai_endpoint,
+            azure_ad_token_provider=token_provider,
+            api_version=settings.azure_openai_api_version,
+        )
+
+    async def aclose(self) -> None:
+        """Release the SDK's httpx pool and the AAD credential."""
+        await self._client.close()
+        await self._credential.close()
+
+    async def __aenter__(self) -> "LLMClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        max_completion_tokens: int | None = None,
+        temperature: float = 0.2,
+    ) -> CompletionResult:
+        """Run a single non-streaming chat completion.
+
+        ``messages`` is the OpenAI-format conversation (``{role, content}``
+        dicts), pre-trimmed by the caller — this method does not enforce
+        a context-window budget.
+
+        Returns the assembled assistant content and token usage.  If the
+        API returns ``None`` for ``content`` (e.g. content-filter
+        response) we substitute an empty string so the caller can still
+        persist the turn; the absence of content is recorded as-is.
+        """
+        max_tokens = (
+            max_completion_tokens
+            if max_completion_tokens is not None
+            else self._settings.assistant_max_completion_tokens
+        )
+        logger.info(
+            "assistant.llm.request deployment=%s messages=%d max_tokens=%d",
+            self._settings.azure_openai_deployment,
+            len(messages),
+            max_tokens,
+        )
+        response = await self._client.chat.completions.create(
+            model=self._settings.azure_openai_deployment,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        choice = response.choices[0]
+        content = choice.message.content or ""
+        usage = response.usage
+        tokens_in = getattr(usage, "prompt_tokens", 0) if usage else 0
+        tokens_out = getattr(usage, "completion_tokens", 0) if usage else 0
+        logger.info(
+            "assistant.llm.response finish=%s in=%d out=%d",
+            choice.finish_reason,
+            tokens_in,
+            tokens_out,
+        )
+        return CompletionResult(
+            content=content, tokens_in=tokens_in, tokens_out=tokens_out
+        )

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -1,0 +1,50 @@
+"""System-prompt builder for the Assistant feature.
+
+PR 3a uses a deliberately minimal system prompt — no tool descriptions,
+no schema dumps, just the role and a short list of conversational
+rules.  PR 3b will extend this with the MCP tool catalogue once the
+agent can actually invoke tools.
+
+The prompt is rebuilt fresh on every turn so context (current UTC
+time, the caller's display name) is always up to date.  It is NOT
+persisted to ``chat_messages`` — only user / assistant / tool turns
+are stored.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from cms.models.user import User
+
+
+SYSTEM_PROMPT_TEMPLATE = """\
+You are the Agora CMS Assistant, an in-app helper for operators of a
+digital-signage platform.  The signed-in operator is **{username}**
+({email}).  The current UTC time is {utc_now}.
+
+Guidelines:
+* Be concise.  Operators want answers, not essays.
+* You do not have access to any tools yet.  If the user asks you to
+  perform an action (create a schedule, modify a group, etc.), tell
+  them that feature is coming soon and offer to walk them through how
+  to do it in the UI.
+* Never invent device IDs, asset IDs, schedule IDs, or other data
+  about this deployment — you have no access to the database in this
+  release.
+* If the user asks who built you or how you work, you can say that
+  you are powered by Azure OpenAI and run inside the Agora CMS.
+"""
+
+
+def build_system_prompt(user: User, *, now: datetime | None = None) -> str:
+    """Render the system prompt for ``user``.
+
+    ``now`` is injected for deterministic testing; defaults to current
+    UTC time.
+    """
+    when = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M UTC")
+    return SYSTEM_PROMPT_TEMPLATE.format(
+        username=user.username,
+        email=user.email or "no email",
+        utc_now=when,
+    )

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1780,6 +1780,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/threads/{thread_id}/message:
+    post:
+      summary: Post Message
+      description: |-
+        Send a user prompt and return the assistant's reply.
+
+        Returns 503 if the environment hasn't been wired up with Azure
+        OpenAI yet (allowlisted user but no LLM backend).  This is distinct
+        from the feature-flag 404 — the feature IS on for this user, but
+        the backend is missing.
+      operationId: post_message_api_chat_threads__thread_id__message_post
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Thread Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatMessageCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatMessageOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/profiles:
     get:
       summary: List Profiles
@@ -4513,6 +4551,23 @@ components:
       required:
       - entries
       title: CatalogOut
+    ChatMessageCreate:
+      properties:
+        content:
+          type: string
+          maxLength: 10000
+          minLength: 1
+          title: Content
+      type: object
+      required:
+      - content
+      title: ChatMessageCreate
+      description: |-
+        Request body for ``POST /api/chat/threads/{id}/message``.
+
+        Single field — the user's prompt.  The agent loop is responsible
+        for persisting both the user turn AND the assistant turn; callers
+        just send the prompt and get back the assistant's reply.
     ChatMessageOut:
       properties:
         id:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,9 @@ azure-messaging-webpubsubservice>=1.2,<2.0
 # A no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset — see
 # cms/observability.py for the wiring.
 azure-monitor-opentelemetry>=1.6,<2.0
+
+# Azure OpenAI client for the Assistant feature (issue #5xx).
+# Used by cms/services/assistant/* to call the GPT-4o deployment
+# provisioned by infra/modules/azureOpenAI.bicep.  Auth via managed
+# identity (DefaultAzureCredential) — no API keys.
+openai>=1.50,<2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,3 +409,55 @@ async def unauthed_client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+
+
+@pytest_asyncio.fixture
+async def operator_client(app):
+    """Authenticated client for a non-admin Operator user.
+
+    Used by the Assistant chat tests (and any future tests that need a
+    user without ``settings:write``) to exercise role-gated paths.
+    The created user is unique per-test via UUID-suffixed username so
+    multiple parameterised tests can coexist.
+    """
+    import uuid as _uuid
+
+    from sqlalchemy import select
+
+    from cms.auth import hash_password
+    from cms.database import get_db
+    from cms.models.user import Role, User
+
+    suffix = _uuid.uuid4().hex[:8]
+    username = f"chat-operator-{suffix}"
+    password = "oppass"
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        role = (
+            await db.execute(select(Role).where(Role.name == "Operator"))
+        ).scalar_one()
+        user = User(
+            username=username,
+            email=f"{username}@test.com",
+            display_name="Chat Operator",
+            password_hash=hash_password(password),
+            role_id=role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        operator_id = user.id
+        break
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=False,
+        )
+        ac.user_id = operator_id  # type: ignore[attr-defined]
+        yield ac

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,0 +1,374 @@
+"""Tests for the Assistant agent loop (PR 3a — non-streaming, no tools).
+
+Covers:
+* ``POST /api/chat/threads/{id}/message`` round-trip with a stubbed LLM
+  client so we don't depend on Azure OpenAI in CI.
+* 503 fallback when the LLM backend isn't configured.
+* Persistence of both user and assistant turns, with token accounting.
+* Auto-titling of empty threads from the first user prompt.
+* ``updated_at`` bump so the thread sorts to the top after a turn.
+* Direct unit-level checks against
+  :func:`cms.services.assistant.agent.run_user_turn` to lock the
+  conversation construction down without going through HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+
+# ── Fakes ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResult:
+    content: str
+    tokens_in: int
+    tokens_out: int
+
+
+class FakeLLMClient:
+    """Stand-in for :class:`cms.services.assistant.llm_client.LLMClient`.
+
+    Records the messages it was called with so tests can assert against
+    the prompt construction without mocking the OpenAI SDK.
+    """
+
+    last_instance: "FakeLLMClient | None" = None
+
+    def __init__(self, settings=None, *, reply: str = "stub reply"):
+        self.calls: list[list[dict]] = []
+        self.reply = reply
+        self.closed = False
+        FakeLLMClient.last_instance = self
+
+    async def complete(self, messages, *, max_completion_tokens=None,
+                       temperature: float = 0.2):
+        self.calls.append(list(messages))
+        return _FakeResult(content=self.reply, tokens_in=42, tokens_out=17)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest_asyncio.fixture
+async def patched_llm(app, monkeypatch):
+    """Force Azure OpenAI to look configured AND patch the LLMClient class.
+
+    Tests using this fixture get a single shared FakeLLMClient instance
+    that can be inspected via ``FakeLLMClient.last_instance``.
+    """
+    from cms.auth import get_settings
+    from cms.routers import chat as chat_router
+    from cms.services.assistant import agent as agent_mod
+
+    settings = app.dependency_overrides[get_settings]()
+    settings.azure_openai_endpoint = "https://fake.openai.azure.com"
+    settings.azure_openai_deployment = "gpt-4o-fake"
+
+    # Patch the `is_available` symbol the router imported under a
+    # different name as well as the module-level reference.
+    monkeypatch.setattr(chat_router, "assistant_llm_available", lambda s: True)
+    monkeypatch.setattr(agent_mod, "LLMClient", FakeLLMClient)
+
+    FakeLLMClient.last_instance = None
+    yield
+    FakeLLMClient.last_instance = None
+
+
+async def _create_thread(client, title: str = "") -> str:
+    resp = await client.post("/api/chat/threads", json={"title": title})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# ── HTTP-level tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestPostMessageHTTP:
+    async def test_round_trip_persists_user_and_assistant(
+        self, client, patched_llm
+    ):
+        tid = await _create_thread(client, title="Promo planning")
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["role"] == "assistant"
+        assert body["content"] == "stub reply"
+        assert body["thread_id"] == tid
+
+        # Both user and assistant rows now visible in /messages.
+        listing = (await client.get(
+            f"/api/chat/threads/{tid}/messages"
+        )).json()
+        assert [m["role"] for m in listing] == ["user", "assistant"]
+        assert listing[0]["content"] == "Hello"
+        assert listing[1]["content"] == "stub reply"
+
+    async def test_503_when_llm_not_configured(self, client):
+        # No patched_llm — settings have empty endpoint/deployment.
+        tid = await _create_thread(client)
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 503
+
+    async def test_cross_user_thread_404s(
+        self, client, operator_client, app, patched_llm
+    ):
+        # Allowlist the operator so its create call succeeds, then have
+        # admin try to post a message to the operator's thread.
+        from cms.services.assistant_flag import set_allowlist
+        from cms.database import get_db
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_allowlist(db, [operator_client.user_id])
+            break
+
+        created = await operator_client.post(
+            "/api/chat/threads", json={"title": "ops"}
+        )
+        op_tid = created.json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{op_tid}/message",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 404
+
+    async def test_empty_content_rejected(self, client, patched_llm):
+        tid = await _create_thread(client)
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": ""},
+        )
+        assert resp.status_code == 422
+
+    async def test_unknown_thread_404(self, client, patched_llm):
+        resp = await client.post(
+            f"/api/chat/threads/{uuid.uuid4()}/message",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 404
+
+    async def test_feature_flag_gates_message_endpoint(
+        self, operator_client, app, patched_llm
+    ):
+        # Operator with no allowlist entry should see a 404 on the
+        # message endpoint just like the rest of the surface.
+        from cms.services.assistant_flag import set_allowlist
+        from cms.database import get_db
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_allowlist(db, [])
+            break
+
+        resp = await operator_client.post(
+            f"/api/chat/threads/{uuid.uuid4()}/message",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 404
+
+
+# ── Service-level tests ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAgentService:
+    async def test_auto_titles_empty_thread_from_first_prompt(
+        self, client, patched_llm, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_thread import ChatThread
+
+        tid = await _create_thread(client, title="")
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Schedule the promo for Saturday"},
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            t = (await db.execute(
+                select(ChatThread).where(ChatThread.id == uuid.UUID(tid))
+            )).scalar_one()
+            assert t.title == "Schedule the promo for Saturday"
+            break
+
+    async def test_does_not_retitle_existing_title(
+        self, client, patched_llm, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_thread import ChatThread
+
+        tid = await _create_thread(client, title="My Title")
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "different prompt"},
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            t = (await db.execute(
+                select(ChatThread).where(ChatThread.id == uuid.UUID(tid))
+            )).scalar_one()
+            assert t.title == "My Title"
+            break
+
+    async def test_token_usage_persisted_on_assistant_turn(
+        self, client, patched_llm, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_message import ChatMessage
+
+        tid = await _create_thread(client)
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Hello"},
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            rows = (await db.execute(
+                select(ChatMessage)
+                .where(ChatMessage.thread_id == uuid.UUID(tid))
+                .order_by(ChatMessage.created_at)
+            )).scalars().all()
+            assert rows[0].role == "user"
+            assert rows[0].tokens_in == 0  # user turns don't accumulate
+            assert rows[1].role == "assistant"
+            assert rows[1].tokens_in == 42
+            assert rows[1].tokens_out == 17
+            break
+
+    async def test_system_prompt_included_in_llm_call(
+        self, client, patched_llm
+    ):
+        tid = await _create_thread(client)
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Hello"},
+        )
+        call = FakeLLMClient.last_instance.calls[0]
+        # First message must be the system prompt; subsequent the user
+        # turn we just posted.
+        assert call[0]["role"] == "system"
+        assert "Agora CMS Assistant" in call[0]["content"]
+        assert call[-1]["role"] == "user"
+        assert call[-1]["content"] == "Hello"
+
+    async def test_history_replayed_on_subsequent_turn(
+        self, client, patched_llm
+    ):
+        tid = await _create_thread(client)
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "First"},
+        )
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "Second"},
+        )
+        last_call = FakeLLMClient.last_instance.calls[-1]
+        roles = [m["role"] for m in last_call]
+        # system + user + assistant (from turn 1) + user (turn 2)
+        assert roles == ["system", "user", "assistant", "user"]
+        assert last_call[1]["content"] == "First"
+        assert last_call[2]["content"] == "stub reply"
+        assert last_call[3]["content"] == "Second"
+
+    async def test_updated_at_bumps_on_turn(
+        self, client, patched_llm, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_thread import ChatThread
+
+        tid = await _create_thread(client)
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            t1 = (await db.execute(
+                select(ChatThread).where(ChatThread.id == uuid.UUID(tid))
+            )).scalar_one()
+            before = t1.updated_at
+            break
+
+        # Sleep a hair so we can detect the bump even on coarse clocks.
+        import asyncio
+        await asyncio.sleep(0.01)
+
+        await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "trigger"},
+        )
+
+        async for db in factory():
+            t2 = (await db.execute(
+                select(ChatThread).where(ChatThread.id == uuid.UUID(tid))
+            )).scalar_one()
+            assert t2.updated_at > before
+            break
+
+
+# ── Prompt builder unit tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_user_identity_and_time(app):
+    from datetime import datetime, timezone
+    from cms.database import get_db
+    from cms.models.user import User
+    from cms.services.assistant.prompts import build_system_prompt
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        admin = (await db.execute(
+            select(User).where(User.username == "admin")
+        )).scalar_one()
+        prompt = build_system_prompt(
+            admin,
+            now=datetime(2026, 5, 28, 20, 0, 0, tzinfo=timezone.utc),
+        )
+        assert "admin" in prompt
+        assert "2026-05-28 20:00 UTC" in prompt
+        assert "Agora CMS Assistant" in prompt
+        break
+
+
+def test_llm_client_unavailable_raises(monkeypatch):
+    from cms.config import Settings
+    from cms.services.assistant.llm_client import (
+        AssistantUnavailableError,
+        LLMClient,
+    )
+
+    s = Settings(
+        database_url="sqlite:///x",
+        secret_key="x",
+        azure_openai_endpoint="",
+        azure_openai_deployment="",
+    )
+    with pytest.raises(AssistantUnavailableError):
+        LLMClient(s)
+
+
+def test_llm_client_is_available_helper():
+    from cms.config import Settings
+    from cms.services.assistant.llm_client import is_available
+
+    s = Settings(database_url="sqlite:///x", secret_key="x")
+    assert is_available(s) is False
+    s.azure_openai_endpoint = "https://x.openai.azure.com"
+    s.azure_openai_deployment = "gpt"
+    assert is_available(s) is True

--- a/tests/test_chat_threads.py
+++ b/tests/test_chat_threads.py
@@ -11,51 +11,7 @@ import json
 import uuid
 
 import pytest
-import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
-
-
-@pytest_asyncio.fixture
-async def operator_client(app):
-    """Authenticated client for a non-admin Operator user.
-
-    Used to exercise the allowlist gate: operators have no
-    ``settings:write`` so the admin escape hatch doesn't apply.
-    """
-    from cms.auth import hash_password
-    from cms.database import get_db
-    from cms.models.user import Role, User
-
-    factory = app.dependency_overrides[get_db]
-    async for db in factory():
-        role = (
-            await db.execute(select(Role).where(Role.name == "Operator"))
-        ).scalar_one()
-        user = User(
-            username="chat-operator",
-            email="chat-op@test.com",
-            display_name="Chat Operator",
-            password_hash=hash_password("oppass"),
-            role_id=role.id,
-            is_active=True,
-            must_change_password=False,
-        )
-        db.add(user)
-        await db.commit()
-        await db.refresh(user)
-        operator_id = user.id
-        break
-
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        await ac.post(
-            "/login",
-            data={"username": "chat-operator", "password": "oppass"},
-            follow_redirects=False,
-        )
-        ac.user_id = operator_id  # type: ignore[attr-defined]
-        yield ac
 
 
 async def _enable_for(app, user_id: uuid.UUID) -> None:


### PR DESCRIPTION
Adds the LLM-backed chat turn endpoint that powers the Assistant sidebar.

**Scope is intentionally narrow** — single-shot completion with NO tools and NO streaming. PR 3b will layer MCP tool calls and SSE on top of these same interfaces.

### What's new

- `cms/services/assistant/llm_client.py` — async wrapper around `openai.AsyncAzureOpenAI`, authenticated via `DefaultAzureCredential` against the `cognitiveservices.azure.com/.default` scope (matches the `Cognitive Services OpenAI User` role granted to the CMS managed identity in PR #653).
- `cms/services/assistant/prompts.py` — system-prompt builder. Rebuilt fresh each turn (UTC time + user identity); never persisted.
- `cms/services/assistant/agent.py` — orchestrates one turn: persist user row → replay history → call LLM → persist assistant row with token accounting → auto-title untitled threads → bump `updated_at`.
- `POST /api/chat/threads/{id}/message` endpoint — returns the assistant `ChatMessage` synchronously. Returns 404 on cross-user threads (no existence leak), 503 when allowlisted but the LLM backend isn't deployed.
- Settings: `azure_openai_endpoint` / `_deployment` / `_api_version` / `assistant_max_completion_tokens` (env-driven via `AGORA_CMS_*` prefix wired up in PR #653's `containerApps.bicep`).
- 13 new tests using a `FakeLLMClient` injected via monkeypatch — no Azure dependency in CI.

### Notes

- The `operator_client` fixture moved from `test_chat_threads.py` to `tests/conftest.py` and its username is now UUID-suffixed for parallelisation safety.
- `openai>=1.50,<2.0` added to `requirements.txt`.
- `docs/openapi.yaml` regenerated (+1 path, +1 schema).

### Verification

- 13/13 agent tests pass locally.
- 12/12 prior chat-threads tests still pass.
- openapi.yaml in sync (no drift).
- No new alembic migrations (no model changes in this PR).