### PR TITLE
feat(mcp): service-key + X-On-Behalf-Of auth for Assistant agent

### DIFF
--- a/cms/routers/mcp.py
+++ b/cms/routers/mcp.py
@@ -1,31 +1,91 @@
 """MCP server auth API — used by the MCP container to validate bearer tokens."""
 
+import uuid as _uuid
+
 from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from cms.auth import (
+    SERVICE_KEY_PREFIX,
     SETTING_MCP_ENABLED,
+    SETTING_MCP_SERVICE_KEY_HASH,
+    _hash_api_key,
     _resolve_user_from_api_key,
     compute_effective_permissions,
     get_setting,
 )
 from cms.database import get_db
+from cms.models.user import User
 
 router = APIRouter(prefix="/api/mcp")
+
+
+async def _resolve_on_behalf_of_user(
+    on_behalf_of: str, db: AsyncSession
+) -> User:
+    """Resolve ``X-On-Behalf-Of`` to an active :class:`User`.
+
+    Validates that ``on_behalf_of`` parses as a UUID, that the user
+    exists, and that the user is active.  Raises HTTPException with the
+    appropriate status on any failure — never returns ``None``.
+
+    The header is treated strictly as "which DB row to load" — the
+    caller's permissions come from that user's actual ``role``, NOT
+    from any claim in the header.  This means a compromised CMS could
+    impersonate any user (same blast radius as the existing service-key
+    auth path used by the MCP back-channel calls) but cannot forge
+    permissions a user doesn't have.
+    """
+    try:
+        user_id = _uuid.UUID(on_behalf_of)
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=400,
+            detail="X-On-Behalf-Of must be a valid user UUID",
+        )
+
+    result = await db.execute(
+        select(User).options(selectinload(User.role)).where(User.id == user_id)
+    )
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="On-behalf-of user not found")
+    if not user.is_active:
+        raise HTTPException(
+            status_code=403, detail="On-behalf-of user is disabled"
+        )
+    return user
 
 
 @router.get("/auth")
 async def verify_mcp_token(
     db: AsyncSession = Depends(get_db),
     authorization: str = Header(default=""),
+    x_on_behalf_of: str | None = Header(default=None),
 ):
-    """Validate a bearer token (user API key) and return user permissions.
+    """Validate a bearer token and return the resolved user's permissions.
 
-    Called by the MCP server on each incoming connection.
-    The bearer token must be a valid user API key (``agora_...``) with
-    ``key_type="mcp"``.  API-type keys are rejected.
-    Returns the user's display name, role, and effective permissions
-    (user role ∩ MCP role ceiling).
+    Called by the MCP server's ``BearerAuthMiddleware`` on every
+    incoming connection.  Supports two authentication modes:
+
+    1. **Personal MCP key** (existing path).  The bearer token is a
+       ``key_type="mcp"`` API key owned by a user; the response carries
+       that user's effective permissions.
+
+    2. **Service key + X-On-Behalf-Of** (new — used by the in-process
+       Assistant agent).  The bearer is the CMS-issued MCP service key
+       (``agora_svc_...``) AND the ``X-On-Behalf-Of`` header carries
+       the UUID of the user the request is acting for.  The response
+       carries THAT user's effective permissions — never a synthetic
+       "service" permission set.  This lets the CMS act as a trusted
+       proxy without duplicating per-user secrets while keeping the
+       per-tool permission gating identical to mode (1).
+
+    Both modes share the same ``compute_effective_permissions`` path
+    (user role ∩ MCP role ceiling).  No new privileged permission set
+    is introduced.
     """
     token = authorization.removeprefix("Bearer ").strip()
     if not token:
@@ -35,6 +95,28 @@ async def verify_mcp_token(
     if enabled != "true":
         raise HTTPException(status_code=403, detail="MCP server is disabled")
 
+    # ── Mode 2: service key + X-On-Behalf-Of ──────────────────────────
+    if token.startswith(SERVICE_KEY_PREFIX):
+        service_key_hash = await get_setting(db, SETTING_MCP_SERVICE_KEY_HASH)
+        if not service_key_hash or _hash_api_key(token) != service_key_hash:
+            raise HTTPException(status_code=401, detail="Invalid service key")
+        if not x_on_behalf_of:
+            raise HTTPException(
+                status_code=400,
+                detail="Service-key auth requires the X-On-Behalf-Of header.",
+            )
+        user = await _resolve_on_behalf_of_user(x_on_behalf_of, db)
+        permissions = await compute_effective_permissions(user, "mcp", db)
+        return {
+            "valid": True,
+            "user": user.display_name or user.email or user.username,
+            "role": user.role.name if user.role else None,
+            "key_type": "service",
+            "on_behalf_of": str(user.id),
+            "permissions": permissions,
+        }
+
+    # ── Mode 1: personal MCP key (existing path) ──────────────────────
     result = await _resolve_user_from_api_key(token, db)
     if result is None:
         raise HTTPException(status_code=401, detail="Invalid API key")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2229,13 +2229,27 @@ paths:
     get:
       summary: Verify Mcp Token
       description: |-
-        Validate a bearer token (user API key) and return user permissions.
+        Validate a bearer token and return the resolved user's permissions.
 
-        Called by the MCP server on each incoming connection.
-        The bearer token must be a valid user API key (``agora_...``) with
-        ``key_type="mcp"``.  API-type keys are rejected.
-        Returns the user's display name, role, and effective permissions
-        (user role ∩ MCP role ceiling).
+        Called by the MCP server's ``BearerAuthMiddleware`` on every
+        incoming connection.  Supports two authentication modes:
+
+        1. **Personal MCP key** (existing path).  The bearer token is a
+           ``key_type="mcp"`` API key owned by a user; the response carries
+           that user's effective permissions.
+
+        2. **Service key + X-On-Behalf-Of** (new — used by the in-process
+           Assistant agent).  The bearer is the CMS-issued MCP service key
+           (``agora_svc_...``) AND the ``X-On-Behalf-Of`` header carries
+           the UUID of the user the request is acting for.  The response
+           carries THAT user's effective permissions — never a synthetic
+           "service" permission set.  This lets the CMS act as a trusted
+           proxy without duplicating per-user secrets while keeping the
+           per-tool permission gating identical to mode (1).
+
+        Both modes share the same ``compute_effective_permissions`` path
+        (user role ∩ MCP role ceiling).  No new privileged permission set
+        is introduced.
       operationId: verify_mcp_token_api_mcp_auth_get
       parameters:
       - name: authorization
@@ -2245,6 +2259,14 @@ paths:
           type: string
           default: ''
           title: Authorization
+      - name: x-on-behalf-of
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-On-Behalf-Of
       responses:
         '200':
           description: Successful Response

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1309,11 +1309,22 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # Extract raw key from "Bearer <key>"
         raw_key = token.removeprefix("Bearer ").strip()
 
+        # Forward X-On-Behalf-Of unchanged.  When the CMS Assistant
+        # calls MCP, it sends the service key as bearer AND this header
+        # to identify which user the request is acting for; the CMS
+        # auth endpoint validates the pairing and returns that user's
+        # permissions.  For personal-MCP-key auth this header is unset
+        # and harmlessly omitted.
+        on_behalf_of = request.headers.get("x-on-behalf-of", "")
+        forwarded_headers = {"Authorization": token}
+        if on_behalf_of:
+            forwarded_headers["X-On-Behalf-Of"] = on_behalf_of
+
         try:
             async with httpx.AsyncClient(timeout=5.0) as http:
                 resp = await http.get(
                     f"{CMS_BASE_URL}/api/mcp/auth",
-                    headers={"Authorization": token},
+                    headers=forwarded_headers,
                 )
                 if resp.status_code != 200:
                     detail = resp.json().get("detail", "Access denied")
@@ -1330,16 +1341,19 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                 status_code=503,
             )
 
-        # Store user context for MCP tools
+        # Store user context for MCP tools.  For service-key auth the
+        # CMS echoes the resolved user via ``on_behalf_of``; for
+        # personal-key auth it carries the key owner's display name.
         _ctx_api_key.set(raw_key)
         _ctx_permissions.set(auth_data.get("permissions", []))
         _ctx_user_name.set(auth_data.get("user", "unknown"))
 
         logger.info(
-            "Authenticated MCP user: %s (role: %s, %d permissions)",
+            "Authenticated MCP user: %s (role: %s, %d permissions, auth=%s)",
             auth_data.get("user"),
             auth_data.get("role"),
             len(auth_data.get("permissions", [])),
+            auth_data.get("key_type", "mcp"),
         )
 
         return await call_next(request)

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -149,6 +149,193 @@ class TestMcpAuth:
 
 
 @pytest.mark.asyncio
+class TestMcpAuthOnBehalfOf:
+    """Service-key + X-On-Behalf-Of auth path (used by the Assistant agent).
+
+    Mode 2 from the docstring on verify_mcp_token:  the CMS sends its
+    own service key as the bearer AND identifies the target user via
+    the X-On-Behalf-Of header.  The endpoint must return that user's
+    permissions — never any synthetic "service" permission set — and
+    must reject the request if the service key is wrong, the header
+    is missing or malformed, or the named user doesn't exist / is
+    disabled.
+    """
+
+    async def _seed_service_key(self, db_session):
+        """Install a known service key hash and return the raw key."""
+        from cms.auth import (
+            SETTING_MCP_SERVICE_KEY_HASH,
+            SERVICE_KEY_PREFIX,
+        )
+        raw = SERVICE_KEY_PREFIX + "test_service_key_value_1234567890"
+        await set_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH,
+                          _hash_api_key(raw))
+        return raw
+
+    async def _create_operator_user(self, db_session):
+        from sqlalchemy import select
+        from cms.auth import hash_password
+        from cms.models.user import Role, User
+
+        role = (await db_session.execute(
+            select(Role).where(Role.name == "Operator")
+        )).scalar_one()
+        user = User(
+            username="op-on-behalf-of",
+            email="op-obo@test.com",
+            display_name="Op OBO",
+            password_hash=hash_password("x"),
+            role_id=role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    async def test_service_key_with_admin_obo_returns_admin_perms(
+        self, client, db_session
+    ):
+        from sqlalchemy import select
+        from cms.models.user import User
+
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        admin = (await db_session.execute(
+            select(User).where(User.username == "admin")
+        )).scalar_one()
+
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": str(admin.id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["valid"] is True
+        assert data["key_type"] == "service"
+        assert data["on_behalf_of"] == str(admin.id)
+        # Admin gets all permissions
+        assert "devices:read" in data["permissions"]
+        assert "users:write" in data["permissions"]
+
+    async def test_service_key_with_operator_obo_returns_operator_perms(
+        self, client, db_session
+    ):
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        op = await self._create_operator_user(db_session)
+
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": str(op.id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # Operator does NOT have admin-only permissions even when the
+        # request comes via the trusted CMS service key.
+        assert "users:write" not in data["permissions"]
+        assert "roles:write" not in data["permissions"]
+        # But still has the basic read permissions Operator role has.
+        assert "devices:read" in data["permissions"]
+
+    async def test_service_key_without_obo_header_rejected(
+        self, client, db_session
+    ):
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={"Authorization": f"Bearer {service_key}"},
+        )
+        assert resp.status_code == 400
+        assert "X-On-Behalf-Of" in resp.json()["detail"]
+
+    async def test_wrong_service_key_rejected(self, client, db_session):
+        from cms.auth import SERVICE_KEY_PREFIX
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        await self._seed_service_key(db_session)  # plant the correct hash
+        wrong = SERVICE_KEY_PREFIX + "definitely_not_the_real_one_nope"
+        import uuid
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {wrong}",
+                "X-On-Behalf-Of": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 401
+
+    async def test_obo_with_non_uuid_rejected(self, client, db_session):
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": "not-a-uuid",
+            },
+        )
+        assert resp.status_code == 400
+
+    async def test_obo_with_unknown_user_404s(self, client, db_session):
+        import uuid
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 404
+
+    async def test_obo_with_disabled_user_403s(self, client, db_session):
+        await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+        service_key = await self._seed_service_key(db_session)
+        op = await self._create_operator_user(db_session)
+        op.is_active = False
+        await db_session.commit()
+
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": str(op.id),
+            },
+        )
+        assert resp.status_code == 403
+
+    async def test_mcp_disabled_blocks_service_key_path(
+        self, client, db_session
+    ):
+        from sqlalchemy import select
+        from cms.models.user import User
+
+        # MCP off — even valid service-key + OBO should 403.
+        await set_setting(db_session, SETTING_MCP_ENABLED, "false")
+        service_key = await self._seed_service_key(db_session)
+        admin = (await db_session.execute(
+            select(User).where(User.username == "admin")
+        )).scalar_one()
+        resp = await client.get(
+            "/api/mcp/auth",
+            headers={
+                "Authorization": f"Bearer {service_key}",
+                "X-On-Behalf-Of": str(admin.id),
+            },
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
 class TestMcpSettings:
     """Test the MCP settings UI endpoints."""
 


### PR DESCRIPTION
Adds a second auth mode to `/api/mcp/auth` and the MCP server's `BearerAuthMiddleware` so the in-CMS Assistant agent can call MCP on behalf of the logged-in user without a personal MCP API key.`r`n`r`n**Mode 1 (unchanged)**: `Authorization: Bearer <personal mcp key>`.`r`n**Mode 2 (new)**: `Authorization: Bearer agora_svc_...` + `X-On-Behalf-Of: <user uuid>` → returns that user's effective MCP permissions.`r`n`r`nPer-user RBAC is preserved: `compute_effective_permissions(user, 'mcp', db)` runs unchanged, so Operator-on-behalf-of does NOT get admin perms.`r`n`r`n8 new tests in `TestMcpAuthOnBehalfOf` cover happy + sad paths (wrong key, missing header, non-UUID, unknown user, disabled user, MCP disabled). 20/20 tests pass locally.