### PR TITLE
feat(assistant): MCP tool-calling loop with read-only whitelist (PR 3b)

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -154,4 +154,9 @@ class Settings(SharedSettings):
     # through the daily budget in a single shot; PR 6 layers a real
     # budget cap on top of this.
     assistant_max_completion_tokens: int = 1024
+    # Hard cap on LLM ↔ MCP-tool round-trips per user turn.  Protects
+    # against a model that keeps requesting tools forever; once hit the
+    # agent injects a "(stopped: max tool iterations reached)" assistant
+    # message and returns.
+    assistant_max_tool_iterations: int = 10
 

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -40,6 +40,7 @@ from cms.services.assistant.llm_client import (
     AssistantUnavailableError,
     is_available as assistant_llm_available,
 )
+from cms.services.assistant.mcp_client import McpUnavailableError
 from cms.services.assistant_flag import assistant_enabled_for
 
 
@@ -224,5 +225,12 @@ async def post_message(
         # Defensive — assistant_llm_available() should have caught this,
         # but a race against config changes is theoretically possible.
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except McpUnavailableError as exc:
+        # The agent needs MCP for tool grounding; if the MCP backend is
+        # down we refuse rather than reply with an ungrounded answer.
+        raise HTTPException(
+            status_code=503,
+            detail=f"Assistant tool backend unavailable: {exc}",
+        ) from exc
 
     return ChatMessageOut.model_validate(assistant_row)

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -1,29 +1,40 @@
 """Assistant agent: orchestrates a single chat turn.
 
-PR 3a flow (non-streaming, no tools):
+PR 3b flow (non-streaming, MCP tool-calling loop):
 
 1. Caller posts a user message to ``POST /api/chat/threads/{id}/message``.
 2. :func:`run_user_turn` is invoked:
    a. Persists the user's :class:`ChatMessage`.
-   b. Loads the thread's existing messages (chronological).
-   c. Builds the OpenAI-format conversation: system prompt + history +
-      the new user turn.
-   d. Calls :meth:`LLMClient.complete`.
-   e. Persists the assistant :class:`ChatMessage` with the response and
-      token usage.
-   f. Auto-titles the thread if this was the first user turn and the
-      thread title is empty.
-   g. Bumps the thread's ``updated_at`` so it sorts to the top of the
+   b. Opens an :class:`AssistantMcpClient` (SSE handshake + MCP
+      ``initialize``) using the CMS service key + ``X-On-Behalf-Of:
+      <user.id>`` header so per-user RBAC is preserved.
+   c. Loads the thread's existing messages (chronological) and builds
+      the OpenAI-format conversation: system prompt + history + the
+      new user turn.
+   d. Loops up to ``assistant_max_tool_iterations`` times:
+        i. Call the LLM with the current ``messages`` + read-only
+           tool list.
+       ii. If the model returns no ``tool_calls``: persist a final
+           ``assistant`` row with the text and break out of the loop.
+      iii. Otherwise persist an ``assistant`` row that carries the
+           ``tool_calls`` (text content may be empty), then execute
+           each tool call against MCP, persist a ``tool`` row per
+           result, append everything to ``messages``, and loop again.
+   e. If the loop hits its cap without a clean answer, persist a final
+      ``assistant`` row with a "(stopped: max tool iterations reached)"
+      message so the user sees something.
+   f. Auto-title untitled threads from the first user prompt.
+   g. Bump ``thread.updated_at`` so it sorts to the top of the
       sidebar.
-3. The router serialises the assistant message and returns it.
 
 The agent owns the DB transaction boundary — the router doesn't have
 to think about it.  Token-budget enforcement and approval gating land
-in later PRs; this module's signature is shaped so that adding them
-won't require a router change.
+in later PRs; this module's signature is shaped so adding them won't
+require a router change.
 """
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -38,6 +49,11 @@ from cms.models.user import User
 from cms.services.assistant.llm_client import (
     CompletionResult,
     LLMClient,
+)
+from cms.services.assistant.mcp_client import (
+    AssistantMcpClient,
+    McpUnavailableError,
+    READ_ONLY_TOOLS,
 )
 from cms.services.assistant.prompts import build_system_prompt
 
@@ -61,9 +77,10 @@ def _history_to_openai_messages(
 ) -> list[dict[str, Any]]:
     """Convert persisted :class:`ChatMessage` rows to OpenAI format.
 
-    PR 3a only emits ``user`` / ``assistant`` turns — ``tool`` /
-    ``system`` rows from later PRs are preserved transparently so the
-    same helper can be used after PR 3b lands.
+    Preserves ``tool_calls`` on assistant turns and ``tool_call_id`` on
+    tool turns so an interrupted multi-step turn (e.g. server restart
+    between tool result and final answer) replays correctly on the
+    next call.
     """
     out: list[dict[str, Any]] = []
     for row in history:
@@ -76,6 +93,62 @@ def _history_to_openai_messages(
     return out
 
 
+def _parse_tool_arguments(raw: Any) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(args, error)``.  ``error`` is non-None on bad JSON."""
+    if raw is None or raw == "":
+        return {}, None
+    if isinstance(raw, dict):
+        return raw, None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        return None, f"invalid_json_arguments: {exc}"
+    if not isinstance(parsed, dict):
+        return None, "tool arguments must be a JSON object"
+    return parsed, None
+
+
+async def _execute_tool_call(
+    *,
+    mcp: AssistantMcpClient,
+    tool_call: dict[str, Any],
+) -> str:
+    """Run a single OpenAI ``tool_call`` against MCP, returning a string.
+
+    Never raises — failures are encoded as JSON ``{"error": ...}`` so
+    the LLM can see the failure and reason about it on the next turn.
+    """
+    fn = tool_call.get("function", {}) or {}
+    name = fn.get("name", "")
+    args, err = _parse_tool_arguments(fn.get("arguments"))
+    if err is not None:
+        return json.dumps({"error": "bad_arguments", "message": err})
+    if name not in READ_ONLY_TOOLS:
+        return json.dumps(
+            {
+                "error": "tool_not_allowed",
+                "message": (
+                    f"Tool '{name}' is not in the read-only whitelist. "
+                    "Write/mutating tools require an approval flow that "
+                    "isn't built yet (PR 4)."
+                ),
+            }
+        )
+    try:
+        return await mcp.call_tool(name, args or {})
+    except PermissionError as exc:
+        # Should be unreachable (whitelist check above) but defensive.
+        return json.dumps({"error": "tool_not_allowed", "message": str(exc)})
+    except Exception as exc:  # noqa: BLE001 — surface as tool result
+        logger.exception("assistant.tool.exec_failed tool=%s", name)
+        return json.dumps(
+            {
+                "error": "tool_execution_failed",
+                "message": f"{type(exc).__name__}: {exc}",
+            }
+        )
+
+
 async def run_user_turn(
     *,
     db: AsyncSession,
@@ -84,12 +157,15 @@ async def run_user_turn(
     thread: ChatThread,
     user_message: str,
     llm_client: LLMClient | None = None,
+    mcp_client: AssistantMcpClient | None = None,
 ) -> ChatMessage:
     """Run one user → assistant turn against ``thread``.
 
-    Returns the persisted assistant :class:`ChatMessage`.  Caller-supplied
-    ``llm_client`` is used if provided (tests inject a mock); otherwise
-    a fresh client is constructed and closed at the end of the call.
+    Returns the persisted assistant :class:`ChatMessage` that the caller
+    should serialize back to the HTTP client (the final text reply, not
+    an intermediate tool-call turn).  Caller-supplied ``llm_client`` /
+    ``mcp_client`` are used if provided (tests inject fakes); otherwise
+    fresh ones are constructed and closed at the end of the call.
     """
     user_message = user_message.strip()
     if not user_message:
@@ -105,8 +181,9 @@ async def run_user_turn(
     await db.flush()
 
     # 2. Reload the full history (now including the row we just added)
-    #    in chronological order.  Single round-trip; threads in PR 3a
-    #    are bounded by user typing speed so no pagination needed.
+    #    in chronological order.  Single round-trip; threads in Phase 1
+    #    are bounded by the token budget cap (PR 6) so no pagination
+    #    needed.
     rows = (
         await db.execute(
             select(ChatMessage)
@@ -121,47 +198,124 @@ async def run_user_turn(
     ]
     openai_messages.extend(_history_to_openai_messages(list(rows)))
 
-    # 4. Call the LLM, owning the client lifecycle if the caller didn't
-    #    inject one.
-    owns_client = llm_client is None
-    client = llm_client if llm_client is not None else LLMClient(settings)
-    try:
-        result: CompletionResult = await client.complete(openai_messages)
-    finally:
-        if owns_client:
-            await client.aclose()
-
-    # 5. Persist the assistant turn with token accounting.
-    assistant_row = ChatMessage(
-        thread_id=thread.id,
-        role="assistant",
-        content=result.content,
-        tokens_in=result.tokens_in,
-        tokens_out=result.tokens_out,
+    # 4. Open clients.  Both raise *Unavailable / construction errors
+    #    BEFORE we mutate the DB further, so the router can return 503
+    #    cleanly with only the user turn persisted (which is correct —
+    #    the user typed it, it should appear in history).
+    owns_llm = llm_client is None
+    llm = llm_client if llm_client is not None else LLMClient(settings)
+    owns_mcp = mcp_client is None
+    mcp = mcp_client if mcp_client is not None else AssistantMcpClient(
+        settings=settings, user=user
     )
-    db.add(assistant_row)
+    if owns_mcp:
+        await mcp.__aenter__()
 
-    # 6. Auto-title untitled threads from the first user prompt.  We
-    #    check that the only persisted user row is this one rather than
-    #    relying on `not thread.title`, because the user may have
-    #    cleared the title in the UI.
+    final_assistant_row: ChatMessage | None = None
+    try:
+        tools = await mcp.list_openai_tools()
+        max_iters = max(1, int(settings.assistant_max_tool_iterations))
+
+        for iteration in range(max_iters):
+            result: CompletionResult = await llm.complete(
+                openai_messages, tools=tools or None
+            )
+
+            if not result.tool_calls:
+                # Final answer turn — persist text + token accounting.
+                final_assistant_row = ChatMessage(
+                    thread_id=thread.id,
+                    role="assistant",
+                    content=result.content,
+                    tokens_in=result.tokens_in,
+                    tokens_out=result.tokens_out,
+                )
+                db.add(final_assistant_row)
+                openai_messages.append(
+                    {"role": "assistant", "content": result.content}
+                )
+                break
+
+            # Intermediate tool-call turn — persist with tool_calls.
+            tc_row = ChatMessage(
+                thread_id=thread.id,
+                role="assistant",
+                content=result.content or "",
+                tool_calls=result.tool_calls,
+                tokens_in=result.tokens_in,
+                tokens_out=result.tokens_out,
+            )
+            db.add(tc_row)
+            openai_messages.append(
+                {
+                    "role": "assistant",
+                    "content": result.content or "",
+                    "tool_calls": result.tool_calls,
+                }
+            )
+
+            # Execute each tool call and persist its result.
+            for tool_call in result.tool_calls:
+                tool_content = await _execute_tool_call(
+                    mcp=mcp, tool_call=tool_call
+                )
+                tool_row = ChatMessage(
+                    thread_id=thread.id,
+                    role="tool",
+                    content=tool_content,
+                    tool_call_id=tool_call.get("id"),
+                )
+                db.add(tool_row)
+                openai_messages.append(
+                    {
+                        "role": "tool",
+                        "content": tool_content,
+                        "tool_call_id": tool_call.get("id"),
+                    }
+                )
+            await db.flush()
+        else:
+            # Hit the iteration cap without a tool_calls-free response.
+            logger.warning(
+                "assistant.turn.max_iters_hit thread=%s user=%s cap=%d",
+                thread.id,
+                user.id,
+                max_iters,
+            )
+            final_assistant_row = ChatMessage(
+                thread_id=thread.id,
+                role="assistant",
+                content=(
+                    "(stopped: max tool iterations reached. The assistant "
+                    "kept requesting more tools without producing a final "
+                    "answer. Try rephrasing the request.)"
+                ),
+            )
+            db.add(final_assistant_row)
+    finally:
+        if owns_mcp:
+            await mcp.__aexit__(None, None, None)
+        if owns_llm:
+            await llm.aclose()
+
+    # 5. Auto-title untitled threads from the first user prompt.
     user_turn_count = sum(1 for r in rows if r.role == "user")
     if user_turn_count == 1 and not thread.title.strip():
         thread.title = _auto_title(user_message)
 
-    # 7. Bump `updated_at` so this thread sorts to the top of the
-    #    sidebar.  We set it explicitly rather than relying on
-    #    `onupdate=` because SQLAlchemy only fires an UPDATE when at
-    #    least one mapped attribute is actually dirty.
+    # 6. Bump `updated_at` so this thread sorts to the top of the
+    #    sidebar.  Set it explicitly because SQLAlchemy only fires an
+    #    UPDATE when at least one mapped attribute is actually dirty.
     thread.updated_at = datetime.now(timezone.utc)
     await db.flush()
     await db.commit()
-    await db.refresh(assistant_row)
+    assert final_assistant_row is not None  # always set by either branch
+    await db.refresh(final_assistant_row)
     logger.info(
         "assistant.turn.complete thread=%s user=%s in=%d out=%d",
         thread.id,
         user.id,
-        result.tokens_in,
-        result.tokens_out,
+        final_assistant_row.tokens_in,
+        final_assistant_row.tokens_out,
     )
-    return assistant_row
+    return final_assistant_row

--- a/cms/services/assistant/llm_client.py
+++ b/cms/services/assistant/llm_client.py
@@ -55,6 +55,11 @@ class CompletionResult:
     content: str
     tokens_in: int
     tokens_out: int
+    # When the model wanted to invoke one or more tools this turn the
+    # OpenAI ``tool_calls`` array is preserved verbatim (each entry
+    # already has ``id``, ``type``, ``function.name``,
+    # ``function.arguments``).  ``None`` for a plain text reply.
+    tool_calls: list[dict[str, Any]] | None = None
 
 
 def is_available(settings: Settings) -> bool:
@@ -100,12 +105,19 @@ class LLMClient:
         *,
         max_completion_tokens: int | None = None,
         temperature: float = 0.2,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
     ) -> CompletionResult:
         """Run a single non-streaming chat completion.
 
         ``messages`` is the OpenAI-format conversation (``{role, content}``
         dicts), pre-trimmed by the caller — this method does not enforce
         a context-window budget.
+
+        ``tools`` is the optional OpenAI tool schema list.  When supplied
+        the model may respond with ``tool_calls`` instead of (or in
+        addition to) text; both are returned on :class:`CompletionResult`
+        for the agent loop to act on.
 
         Returns the assembled assistant content and token usage.  If the
         API returns ``None`` for ``content`` (e.g. content-filter
@@ -118,28 +130,53 @@ class LLMClient:
             else self._settings.assistant_max_completion_tokens
         )
         logger.info(
-            "assistant.llm.request deployment=%s messages=%d max_tokens=%d",
+            "assistant.llm.request deployment=%s messages=%d max_tokens=%d tools=%d",
             self._settings.azure_openai_deployment,
             len(messages),
             max_tokens,
+            len(tools) if tools else 0,
         )
-        response = await self._client.chat.completions.create(
-            model=self._settings.azure_openai_deployment,
-            messages=messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
+        kwargs: dict[str, Any] = {
+            "model": self._settings.azure_openai_deployment,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if tools:
+            kwargs["tools"] = tools
+            if tool_choice is not None:
+                kwargs["tool_choice"] = tool_choice
+        response = await self._client.chat.completions.create(**kwargs)
         choice = response.choices[0]
         content = choice.message.content or ""
+        tool_calls: list[dict[str, Any]] | None = None
+        raw_tcs = getattr(choice.message, "tool_calls", None)
+        if raw_tcs:
+            tool_calls = []
+            for tc in raw_tcs:
+                tool_calls.append(
+                    {
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                )
         usage = response.usage
         tokens_in = getattr(usage, "prompt_tokens", 0) if usage else 0
         tokens_out = getattr(usage, "completion_tokens", 0) if usage else 0
         logger.info(
-            "assistant.llm.response finish=%s in=%d out=%d",
+            "assistant.llm.response finish=%s in=%d out=%d tool_calls=%d",
             choice.finish_reason,
             tokens_in,
             tokens_out,
+            len(tool_calls) if tool_calls else 0,
         )
         return CompletionResult(
-            content=content, tokens_in=tokens_in, tokens_out=tokens_out
+            content=content,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            tool_calls=tool_calls,
         )

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -1,0 +1,237 @@
+"""MCP client for the Assistant agent (PR 3b).
+
+Opens an SSE connection to the in-cluster MCP server using the same
+``agora_svc_*`` service key shared with the MCP container's
+``/reload-key`` path, plus an ``X-On-Behalf-Of: <user uuid>`` header so
+that per-user RBAC is preserved end-to-end (see PR #656).
+
+Design notes:
+
+* The agent owns one ``AssistantMcpClient`` instance per user turn, used
+  as an async context manager.  Setup cost is the SSE handshake + MCP
+  ``initialize`` round-trip — small, but enough that we don't pay it on
+  every tool call within a turn.
+* Only **read-only** tools are exposed to the LLM in Phase 1.  Writes
+  land in a later PR once the approval flow exists; until then, even if
+  the LLM hallucinates a write tool name we refuse it at the wrapper
+  before hitting MCP.  The whitelist is hand-curated against
+  :data:`mcp.server.TOOL_PERMISSIONS` so a new write tool doesn't
+  silently become callable just because it's exposed by MCP.
+* MCP unreachable is a hard failure, not a degrade — the agent loop
+  treats it the same as Azure OpenAI being down and surfaces a 503 to
+  the caller via :class:`McpUnavailableError`.  We don't want to give
+  the user a chatty answer with no tool grounding when the whole point
+  of the feature is the tool grounding.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any
+
+from cms.config import Settings
+from cms.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+class McpUnavailableError(RuntimeError):
+    """Raised when the MCP server cannot be reached or initialized.
+
+    The chat router converts this to ``503 Service Unavailable``.
+    """
+
+
+# Read-only tool whitelist — manually curated against
+# ``mcp/server.py::TOOL_PERMISSIONS``.  Includes every tool whose
+# required permission ends in ``:read`` plus the small set of
+# ``None``-permission tools that are read-only by construction.
+#
+# When ``mcp/server.py`` gains a new tool, it does NOT automatically
+# show up here — that's deliberate.  A human has to decide whether the
+# new tool is safe to expose to the LLM without approval, and add it
+# below.  PR 4 will replace this list with a "any tool, but writes
+# require approval" model.
+READ_ONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        # devices:read
+        "list_devices",
+        "get_device",
+        # groups:read
+        "list_groups",
+        # assets:read
+        "list_assets",
+        "get_asset",
+        "list_assets_paged",
+        "list_tags",
+        # schedules:read
+        "list_schedules",
+        "get_schedule",
+        # profiles:read
+        "list_profiles",
+        # logs:read
+        "get_device_logs",
+        # audit:read
+        "list_audit_events",
+        # None (any authenticated user)
+        "get_server_time",
+        "get_dashboard",
+        "list_asset_views",
+    }
+)
+
+
+def _read_service_key(path: str) -> str:
+    """Read the MCP service key off the shared volume.
+
+    Returns the raw ``agora_svc_*`` string.  Raises
+    :class:`McpUnavailableError` if the file is missing or empty — both
+    are fatal: there is no fallback authentication path.
+    """
+    try:
+        raw = Path(path).read_text().strip()
+    except OSError as exc:
+        raise McpUnavailableError(
+            f"MCP service key file is not readable at {path}: {exc}"
+        ) from exc
+    if not raw:
+        raise McpUnavailableError(
+            f"MCP service key file at {path} is empty (key not provisioned?)"
+        )
+    return raw
+
+
+class AssistantMcpClient:
+    """Async wrapper around ``mcp.client.sse.sse_client`` + ``ClientSession``.
+
+    Use as an async context manager — connection + initialize happen in
+    ``__aenter__``, teardown in ``__aexit__``.  Construction is cheap
+    (no I/O); all network work is deferred.
+    """
+
+    def __init__(self, *, settings: Settings, user: User) -> None:
+        self._settings = settings
+        self._user = user
+        self._stack = AsyncExitStack()
+        self._session: Any = None  # mcp.client.session.ClientSession
+
+    async def __aenter__(self) -> "AssistantMcpClient":
+        # Import inside __aenter__ so a broken ``mcp`` install doesn't
+        # take out import-time for the whole CMS process.
+        from mcp.client.session import ClientSession
+        from mcp.client.sse import sse_client
+
+        raw_key = _read_service_key(self._settings.service_key_path)
+        url = self._settings.mcp_server_url.rstrip("/") + "/sse"
+        headers = {
+            "Authorization": f"Bearer {raw_key}",
+            "X-On-Behalf-Of": str(self._user.id),
+        }
+        logger.info(
+            "assistant.mcp.connect url=%s user=%s",
+            url,
+            self._user.id,
+        )
+        try:
+            streams = await self._stack.enter_async_context(
+                sse_client(url, headers=headers)
+            )
+            # sse_client yields (read_stream, write_stream).  Newer SDK
+            # versions yield a 3-tuple including a write callback; we
+            # only need the first two.
+            read_stream, write_stream = streams[0], streams[1]
+            session = await self._stack.enter_async_context(
+                ClientSession(read_stream, write_stream)
+            )
+            await session.initialize()
+        except McpUnavailableError:
+            await self._stack.aclose()
+            raise
+        except Exception as exc:
+            await self._stack.aclose()
+            raise McpUnavailableError(
+                f"MCP connection failed: {type(exc).__name__}: {exc}"
+            ) from exc
+        self._session = session
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        try:
+            await self._stack.aclose()
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("assistant.mcp.close_failed")
+
+    async def list_openai_tools(self) -> list[dict[str, Any]]:
+        """Return MCP tools filtered to the read-only whitelist, in OpenAI format.
+
+        OpenAI's tool schema is:
+        ``{"type":"function", "function":{"name":..., "description":..., "parameters":{...}}}``
+        which maps cleanly from MCP's ``Tool.inputSchema`` JSON-Schema.
+        """
+        if self._session is None:  # pragma: no cover
+            raise RuntimeError("AssistantMcpClient not entered")
+        listing = await self._session.list_tools()
+        out: list[dict[str, Any]] = []
+        for tool in listing.tools:
+            if tool.name not in READ_ONLY_TOOLS:
+                continue
+            out.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": tool.inputSchema
+                        or {"type": "object", "properties": {}},
+                    },
+                }
+            )
+        logger.info(
+            "assistant.mcp.list_tools total=%d exposed=%d",
+            len(listing.tools),
+            len(out),
+        )
+        return out
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        """Invoke an MCP tool and return its result as a JSON-string.
+
+        Raises :class:`PermissionError` if ``name`` isn't in the
+        read-only whitelist — the agent loop catches this and turns it
+        into a synthetic tool-result the LLM can reason about.
+        """
+        if self._session is None:  # pragma: no cover
+            raise RuntimeError("AssistantMcpClient not entered")
+        if name not in READ_ONLY_TOOLS:
+            raise PermissionError(
+                f"Tool '{name}' is not in the read-only whitelist "
+                "(writes require approval; see PR 4)."
+            )
+        logger.info(
+            "assistant.mcp.call name=%s user=%s",
+            name,
+            self._user.id,
+        )
+        result = await self._session.call_tool(name, arguments)
+        # Prefer structuredContent if the server sent it.
+        if getattr(result, "structuredContent", None) is not None:
+            return json.dumps(result.structuredContent, default=str)
+        # Fall back to concatenated text blocks.
+        parts: list[str] = []
+        for block in result.content or []:
+            text = getattr(block, "text", None)
+            if text is not None:
+                parts.append(text)
+            else:
+                dump = (
+                    block.model_dump()
+                    if hasattr(block, "model_dump")
+                    else str(block)
+                )
+                parts.append(json.dumps(dump, default=str))
+        body = "\n".join(parts)
+        if getattr(result, "isError", False):
+            return json.dumps({"error": "tool_error", "message": body})
+        return body

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -31,6 +31,7 @@ class _FakeResult:
     content: str
     tokens_in: int
     tokens_out: int
+    tool_calls: list[dict] | None = None
 
 
 class FakeLLMClient:
@@ -38,23 +39,89 @@ class FakeLLMClient:
 
     Records the messages it was called with so tests can assert against
     the prompt construction without mocking the OpenAI SDK.
+
+    In PR 3b a single instance can also be scripted with a sequence of
+    canned responses (``replies=[...]``) to exercise the tool-calling
+    loop without an LLM.  Each call pops the next response; once the
+    sequence is exhausted further calls return the trailing ``reply``
+    string with no tool_calls.
     """
 
     last_instance: "FakeLLMClient | None" = None
 
-    def __init__(self, settings=None, *, reply: str = "stub reply"):
+    def __init__(
+        self,
+        settings=None,
+        *,
+        reply: str = "stub reply",
+        replies: list[_FakeResult] | None = None,
+    ):
         self.calls: list[list[dict]] = []
+        self.tools_seen: list[list[dict] | None] = []
         self.reply = reply
+        self._scripted: list[_FakeResult] = list(replies or [])
         self.closed = False
         FakeLLMClient.last_instance = self
 
-    async def complete(self, messages, *, max_completion_tokens=None,
-                       temperature: float = 0.2):
+    async def complete(
+        self,
+        messages,
+        *,
+        max_completion_tokens=None,
+        temperature: float = 0.2,
+        tools=None,
+        tool_choice=None,
+    ):
         self.calls.append(list(messages))
+        self.tools_seen.append(list(tools) if tools else None)
+        if self._scripted:
+            return self._scripted.pop(0)
         return _FakeResult(content=self.reply, tokens_in=42, tokens_out=17)
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class FakeMcpClient:
+    """In-memory MCP stand-in used by the agent loop tests.
+
+    Returns a fixed (small) tool list from ``list_openai_tools`` and a
+    queue of canned results from ``call_tool``.  Records every call for
+    assertions.
+    """
+
+    last_instance: "FakeMcpClient | None" = None
+
+    def __init__(
+        self,
+        *,
+        settings=None,
+        user=None,
+        tools: list[dict] | None = None,
+        results: dict[str, str] | None = None,
+    ):
+        self._tools = tools if tools is not None else []
+        self._results = dict(results or {})
+        self.calls: list[tuple[str, dict]] = []
+        self.opened = False
+        self.closed = False
+        FakeMcpClient.last_instance = self
+
+    async def __aenter__(self) -> "FakeMcpClient":
+        self.opened = True
+        return self
+
+    async def __aexit__(self, *a) -> None:
+        self.closed = True
+
+    async def list_openai_tools(self) -> list[dict]:
+        return list(self._tools)
+
+    async def call_tool(self, name: str, arguments: dict) -> str:
+        self.calls.append((name, dict(arguments)))
+        if name in self._results:
+            return self._results[name]
+        return f'{{"ok": true, "tool": "{name}"}}'
 
 
 @pytest_asyncio.fixture
@@ -62,7 +129,10 @@ async def patched_llm(app, monkeypatch):
     """Force Azure OpenAI to look configured AND patch the LLMClient class.
 
     Tests using this fixture get a single shared FakeLLMClient instance
-    that can be inspected via ``FakeLLMClient.last_instance``.
+    that can be inspected via ``FakeLLMClient.last_instance``.  The MCP
+    client is also patched with a no-tool ``FakeMcpClient`` so tests
+    that don't care about the tool loop see the same single-shot
+    behaviour they had in PR 3a.
     """
     from cms.auth import get_settings
     from cms.routers import chat as chat_router
@@ -76,10 +146,13 @@ async def patched_llm(app, monkeypatch):
     # different name as well as the module-level reference.
     monkeypatch.setattr(chat_router, "assistant_llm_available", lambda s: True)
     monkeypatch.setattr(agent_mod, "LLMClient", FakeLLMClient)
+    monkeypatch.setattr(agent_mod, "AssistantMcpClient", FakeMcpClient)
 
     FakeLLMClient.last_instance = None
+    FakeMcpClient.last_instance = None
     yield
     FakeLLMClient.last_instance = None
+    FakeMcpClient.last_instance = None
 
 
 async def _create_thread(client, title: str = "") -> str:
@@ -372,3 +445,428 @@ def test_llm_client_is_available_helper():
     s.azure_openai_endpoint = "https://x.openai.azure.com"
     s.azure_openai_deployment = "gpt"
     assert is_available(s) is True
+
+
+# ── PR 3b: MCP tool-calling loop ──────────────────────────────────────
+
+
+def _tool_call(name: str, arguments: dict, call_id: str = "call_1") -> dict:
+    """Build an OpenAI-format tool_call dict (mirrors what the SDK
+    serialises from a real Azure response)."""
+    import json as _json
+
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": _json.dumps(arguments)},
+    }
+
+
+@pytest_asyncio.fixture
+async def scripted_agent(app, monkeypatch):
+    """Patch the agent with a FakeLLMClient + FakeMcpClient pair the
+    test can pre-script before posting a message.
+
+    Differs from ``patched_llm`` in that it returns a builder the test
+    uses to set the scripted ``replies`` and ``results`` _before_ the
+    fakes are constructed (the agent constructs them per turn)."""
+    from cms.auth import get_settings
+    from cms.routers import chat as chat_router
+    from cms.services.assistant import agent as agent_mod
+
+    settings = app.dependency_overrides[get_settings]()
+    settings.azure_openai_endpoint = "https://fake.openai.azure.com"
+    settings.azure_openai_deployment = "gpt-4o-fake"
+    monkeypatch.setattr(chat_router, "assistant_llm_available", lambda s: True)
+
+    state = {
+        "llm_replies": [],
+        "llm_reply": "stub reply",
+        "mcp_tools": [],
+        "mcp_results": {},
+    }
+
+    class _ScriptedLLM(FakeLLMClient):
+        def __init__(self, settings=None):
+            super().__init__(
+                settings,
+                reply=state["llm_reply"],
+                replies=list(state["llm_replies"]),
+            )
+
+    class _ScriptedMcp(FakeMcpClient):
+        def __init__(self, *, settings=None, user=None):
+            super().__init__(
+                settings=settings,
+                user=user,
+                tools=list(state["mcp_tools"]),
+                results=dict(state["mcp_results"]),
+            )
+
+    monkeypatch.setattr(agent_mod, "LLMClient", _ScriptedLLM)
+    monkeypatch.setattr(agent_mod, "AssistantMcpClient", _ScriptedMcp)
+    FakeLLMClient.last_instance = None
+    FakeMcpClient.last_instance = None
+    yield state
+    FakeLLMClient.last_instance = None
+    FakeMcpClient.last_instance = None
+
+
+@pytest.mark.asyncio
+class TestToolLoop:
+    async def test_tool_definitions_passed_to_llm(self, client, scripted_agent):
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_devices",
+                    "description": "list devices",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "list devices"},
+        )
+        assert resp.status_code == 201, resp.text
+        # The first LLM call should have received the tool list.
+        first_tools = FakeLLMClient.last_instance.tools_seen[0]
+        assert first_tools is not None
+        assert first_tools[0]["function"]["name"] == "list_devices"
+
+    async def test_single_tool_call_then_final_answer(
+        self, client, scripted_agent, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_message import ChatMessage
+
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_devices",
+                    "description": "list devices",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        scripted_agent["mcp_results"] = {"list_devices": '[{"id":"d1"}]'}
+        scripted_agent["llm_replies"] = [
+            # Turn 1: request the tool.
+            _FakeResult(
+                content="",
+                tokens_in=10,
+                tokens_out=5,
+                tool_calls=[_tool_call("list_devices", {})],
+            ),
+            # Turn 2: produce final answer using the tool result.
+            _FakeResult(content="You have 1 device.", tokens_in=20, tokens_out=8),
+        ]
+
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "how many devices"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["role"] == "assistant"
+        assert body["content"] == "You have 1 device."
+
+        # MCP got the call.
+        assert FakeMcpClient.last_instance.calls == [("list_devices", {})]
+
+        # Persisted rows: user → assistant(tool_calls) → tool → assistant(final).
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            rows = (
+                await db.execute(
+                    select(ChatMessage)
+                    .where(ChatMessage.thread_id == uuid.UUID(tid))
+                    .order_by(ChatMessage.created_at, ChatMessage.id)
+                )
+            ).scalars().all()
+            assert [r.role for r in rows] == [
+                "user",
+                "assistant",
+                "tool",
+                "assistant",
+            ]
+            assert rows[1].tool_calls is not None
+            assert rows[1].tool_calls[0]["function"]["name"] == "list_devices"
+            assert rows[2].tool_call_id == "call_1"
+            assert rows[2].content == '[{"id":"d1"}]'
+            assert rows[3].content == "You have 1 device."
+            break
+
+    async def test_history_with_tool_turns_replays_on_second_turn(
+        self, client, scripted_agent
+    ):
+        # Turn 1: one tool call, then final answer.
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_server_time",
+                    "description": "time",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=1,
+                tokens_out=1,
+                tool_calls=[_tool_call("get_server_time", {})],
+            ),
+            _FakeResult(content="It is now.", tokens_in=1, tokens_out=1),
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "first"}
+        )
+
+        # Turn 2: scripted_agent rebuilds the LLM, no scripted replies →
+        # stub reply, no tool calls.  The point is the messages= list
+        # passed into the new LLM call must include the prior tool turn.
+        scripted_agent["llm_replies"] = []
+        scripted_agent["llm_reply"] = "second"
+        await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "second"}
+        )
+
+        messages = FakeLLMClient.last_instance.calls[0]
+        roles = [m["role"] for m in messages]
+        # system + user(first) + assistant(tool_calls) + tool + assistant(final) + user(second)
+        assert roles == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+            "user",
+        ]
+
+    async def test_write_tool_blocked_via_whitelist(
+        self, client, scripted_agent, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_message import ChatMessage
+
+        # MCP exposes only the read tool, but the LLM hallucinates a
+        # write call name.  The agent must refuse, persist a synthetic
+        # error tool result, and let the LLM continue.
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_server_time",
+                    "description": "time",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=1,
+                tokens_out=1,
+                tool_calls=[_tool_call("delete_device", {"id": "x"})],
+            ),
+            _FakeResult(content="I can't do that.", tokens_in=1, tokens_out=1),
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message",
+            json={"content": "delete dev x"},
+        )
+        assert resp.status_code == 201
+        # MCP should NOT have been called for the write.
+        assert FakeMcpClient.last_instance.calls == []
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            rows = (
+                await db.execute(
+                    select(ChatMessage)
+                    .where(ChatMessage.thread_id == uuid.UUID(tid))
+                    .order_by(ChatMessage.created_at, ChatMessage.id)
+                )
+            ).scalars().all()
+            tool_row = next(r for r in rows if r.role == "tool")
+            assert "tool_not_allowed" in tool_row.content
+            break
+
+    async def test_invalid_json_arguments_handled(self, client, scripted_agent):
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_devices",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        bad_call = {
+            "id": "call_x",
+            "type": "function",
+            "function": {"name": "list_devices", "arguments": "{not json"},
+        }
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=1,
+                tokens_out=1,
+                tool_calls=[bad_call],
+            ),
+            _FakeResult(content="ok", tokens_in=1, tokens_out=1),
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "hi"}
+        )
+        assert resp.status_code == 201
+        assert FakeMcpClient.last_instance.calls == []  # never reached MCP
+        # The error gets fed back to the LLM on turn 2.
+        second_call_msgs = FakeLLMClient.last_instance.calls[1]
+        tool_msg = next(m for m in second_call_msgs if m["role"] == "tool")
+        assert "bad_arguments" in tool_msg["content"]
+
+    async def test_max_iterations_returns_safe_message(
+        self, client, scripted_agent, app
+    ):
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_server_time",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        # Lower the cap so the test is fast.
+        settings = app.dependency_overrides[
+            __import__("cms.auth", fromlist=["get_settings"]).get_settings
+        ]()
+        settings.assistant_max_tool_iterations = 2
+
+        # Always returns a tool call → loop exhausts.
+        tc = _tool_call("get_server_time", {})
+        scripted_agent["llm_replies"] = [
+            _FakeResult(content="", tokens_in=1, tokens_out=1, tool_calls=[tc]),
+            _FakeResult(content="", tokens_in=1, tokens_out=1, tool_calls=[tc]),
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "loop forever"}
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "max tool iterations" in body["content"]
+
+    async def test_mcp_unavailable_returns_503(self, client, app, monkeypatch):
+        # LLM is configured, but the MCP client raises on enter.
+        from cms.auth import get_settings
+        from cms.routers import chat as chat_router
+        from cms.services.assistant import agent as agent_mod
+        from cms.services.assistant.mcp_client import McpUnavailableError
+
+        settings = app.dependency_overrides[get_settings]()
+        settings.azure_openai_endpoint = "https://fake.openai.azure.com"
+        settings.azure_openai_deployment = "gpt-4o-fake"
+        monkeypatch.setattr(
+            chat_router, "assistant_llm_available", lambda s: True
+        )
+        monkeypatch.setattr(agent_mod, "LLMClient", FakeLLMClient)
+
+        class _BrokenMcp:
+            def __init__(self, *, settings=None, user=None):
+                pass
+
+            async def __aenter__(self):
+                raise McpUnavailableError("simulated outage")
+
+            async def __aexit__(self, *a):
+                pass
+
+        monkeypatch.setattr(agent_mod, "AssistantMcpClient", _BrokenMcp)
+
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "hi"}
+        )
+        assert resp.status_code == 503
+        assert "tool backend" in resp.json()["detail"].lower()
+
+
+# ── PR 3b: MCP client unit tests ──────────────────────────────────────
+
+
+class TestReadOnlyWhitelist:
+    def test_known_read_tools_present(self):
+        from cms.services.assistant.mcp_client import READ_ONLY_TOOLS
+
+        for name in (
+            "list_devices",
+            "get_device",
+            "list_groups",
+            "list_assets",
+            "list_schedules",
+            "get_server_time",
+            "list_audit_events",
+        ):
+            assert name in READ_ONLY_TOOLS, name
+
+    def test_known_write_tools_excluded(self):
+        from cms.services.assistant.mcp_client import READ_ONLY_TOOLS
+
+        for name in (
+            "delete_device",
+            "adopt_device",
+            "reboot_device",
+            "create_group",
+            "delete_group",
+            "create_schedule",
+            "delete_schedule",
+            "play_now",
+            "factory_reset_device",
+            "set_device_password",
+        ):
+            assert name not in READ_ONLY_TOOLS, name
+
+
+def test_read_service_key_missing_file(tmp_path):
+    from cms.services.assistant.mcp_client import (
+        McpUnavailableError,
+        _read_service_key,
+    )
+
+    with pytest.raises(McpUnavailableError):
+        _read_service_key(str(tmp_path / "nope.key"))
+
+
+def test_read_service_key_empty_file(tmp_path):
+    from cms.services.assistant.mcp_client import (
+        McpUnavailableError,
+        _read_service_key,
+    )
+
+    p = tmp_path / "k"
+    p.write_text("   \n")
+    with pytest.raises(McpUnavailableError):
+        _read_service_key(str(p))
+
+
+def test_read_service_key_ok(tmp_path):
+    from cms.services.assistant.mcp_client import _read_service_key
+
+    p = tmp_path / "k"
+    p.write_text("agora_svc_deadbeef\n")
+    assert _read_service_key(str(p)) == "agora_svc_deadbeef"
+
+


### PR DESCRIPTION
Extends the chat agent from PR 3a (single-shot) into a real multi-iteration LLM ↔ MCP tool-calling loop.`r`n`r`n**What landed**`r`n- `cms/services/assistant/mcp_client.py` - SSE-based MCP client that authenticates with the CMS service key + `X-On-Behalf-Of: <user.id>` (the auth path shipped in PR #656).`r`n- `READ_ONLY_TOOLS` whitelist - hand-curated against `mcp/server.py::TOOL_PERMISSIONS`. Only `:read`-permission tools + the `None`-permission read tools are exposed; writes are refused at the wrapper with a synthetic tool result the LLM can reason about (real approval flow lands in PR 4).`r`n- `cms/services/assistant/agent.py` - tool-calling loop. Persists `assistant`(`tool_calls`) and `tool` rows so an interrupted multi-step turn replays cleanly on the next call. Caps at `assistant_max_tool_iterations` (default 10) with a safe "max iterations reached" message.`r`n- `cms/routers/chat.py` - 503 if MCP unreachable (`McpUnavailableError`).`r`n- `cms/services/assistant/llm_client.py` - `complete(tools=...)` overload + `tool_calls` on `CompletionResult`.`r`n`r`n**Tests**`r`n- 12 new tests covering: tool definitions reach the LLM, single-call round-trip, multi-turn history replay with tool turns, write-tool refused via whitelist, invalid JSON arguments, max-iterations cap, MCP unavailable → 503, read-only whitelist contents, service-key file reader.`r`n- 27/27 chat_agent tests pass locally. 59/59 chat + MCP auth tests pass.