### PR TITLE
feat(assistant): stream chat turns over SSE (PR 3c)

### DIFF
--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -15,12 +15,15 @@ escape hatch.
 
 from __future__ import annotations
 
+import json
+import logging
 import uuid
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette.sse import EventSourceResponse
 
 from cms.auth import get_current_user, get_settings, require_auth
 from cms.config import Settings
@@ -35,13 +38,15 @@ from cms.schemas.chat import (
     ChatThreadCreate,
     ChatThreadOut,
 )
-from cms.services.assistant.agent import run_user_turn
+from cms.services.assistant.agent import run_user_turn, run_user_turn_streaming
 from cms.services.assistant.llm_client import (
     AssistantUnavailableError,
     is_available as assistant_llm_available,
 )
 from cms.services.assistant.mcp_client import McpUnavailableError
 from cms.services.assistant_flag import assistant_enabled_for
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter(prefix="/api/chat", dependencies=[Depends(require_auth)])
@@ -234,3 +239,97 @@ async def post_message(
         ) from exc
 
     return ChatMessageOut.model_validate(assistant_row)
+
+
+# ── Streaming chat turn (PR 3c) ──────────────────────────────────────
+# Same agent loop as POST /message above, but the response is an SSE
+# stream so the UI can render tokens / tool-call progress as they
+# happen instead of waiting for the whole turn.
+
+
+def _format_sse_error(message: str) -> dict[str, str]:
+    """sse-starlette dict-shape for a terminal error frame."""
+    return {"event": "error", "data": json.dumps({"message": message})}
+
+
+async def _stream_agent_events(
+    *,
+    db: AsyncSession,
+    settings: Settings,
+    user: User,
+    thread: ChatThread,
+    content: str,
+):
+    """Adapt :func:`run_user_turn_streaming` events into sse-starlette
+    ``{event, data}`` dicts.
+
+    Catches the two known *Unavailable* errors and emits a final
+    ``error`` event instead of letting them propagate — the SSE
+    connection is already open at this point so an HTTP 503 wouldn't
+    actually reach the client.
+    """
+    try:
+        async for evt in run_user_turn_streaming(
+            db=db,
+            settings=settings,
+            user=user,
+            thread=thread,
+            user_message=content,
+        ):
+            yield {"event": evt["type"], "data": json.dumps(evt)}
+    except AssistantUnavailableError as exc:
+        logger.warning("assistant.stream.llm_unavailable: %s", exc)
+        yield _format_sse_error(f"Assistant LLM unavailable: {exc}")
+    except McpUnavailableError as exc:
+        logger.warning("assistant.stream.mcp_unavailable: %s", exc)
+        yield _format_sse_error(f"Assistant tool backend unavailable: {exc}")
+    except Exception as exc:  # noqa: BLE001 — last-resort error frame
+        logger.exception("assistant.stream.unexpected_error")
+        yield _format_sse_error(f"{type(exc).__name__}: {exc}")
+
+
+@router.post("/threads/{thread_id}/stream")
+async def post_message_stream(
+    thread_id: uuid.UUID,
+    payload: ChatMessageCreate,
+    user: User = Depends(_current_user),
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+):
+    """Send a user prompt and stream the assistant's reply as SSE.
+
+    The response is an ``EventSourceResponse`` with these event types
+    (each ``data`` is JSON):
+
+    * ``token`` — assistant text chunk.
+    * ``tool_call`` — model is about to invoke a tool.
+    * ``tool_result`` — tool finished, result attached.
+    * ``done`` — turn complete (carries final ``message_id``).
+    * ``error`` — fatal error; the stream terminates after this frame.
+
+    LLM-unavailable / MCP-unavailable are surfaced as ``error`` frames
+    once the SSE handshake has succeeded.  Pre-stream failures (feature
+    flag, thread ownership, LLM config missing) still return HTTP
+    4xx/5xx the normal way before any event is sent.
+    """
+    await _require_feature(user, db)
+    thread = await _get_owned_thread(thread_id, user, db)
+
+    if not assistant_llm_available(settings):
+        raise HTTPException(
+            status_code=503,
+            detail="Assistant LLM backend is not configured in this environment.",
+        )
+
+    return EventSourceResponse(
+        _stream_agent_events(
+            db=db,
+            settings=settings,
+            user=user,
+            thread=thread,
+            content=payload.content,
+        ),
+        # ``ping`` keeps intermediate proxies (Container Apps front-door,
+        # browsers) from closing the connection during long LLM waits.
+        ping=15,
+    )

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from typing import Any
 
@@ -319,3 +320,245 @@ async def run_user_turn(
         final_assistant_row.tokens_out,
     )
     return final_assistant_row
+
+
+# ── Streaming variant (PR 3c) ─────────────────────────────────────────
+
+
+def _assemble_tool_calls(
+    by_index: dict[int, dict[str, Any]],
+) -> list[dict[str, Any]] | None:
+    """Convert accumulated streaming tool-call fragments to OpenAI shape.
+
+    Returns ``None`` when no fragments were seen.  Empty-name fragments
+    are dropped (defensive against partial Azure responses).
+    """
+    if not by_index:
+        return None
+    out: list[dict[str, Any]] = []
+    for idx in sorted(by_index.keys()):
+        tc = by_index[idx]
+        if not tc.get("name"):
+            continue
+        out.append(
+            {
+                "id": tc.get("id") or f"call_{idx}",
+                "type": "function",
+                "function": {
+                    "name": tc["name"],
+                    "arguments": tc.get("arguments", ""),
+                },
+            }
+        )
+    return out or None
+
+
+async def run_user_turn_streaming(
+    *,
+    db: AsyncSession,
+    settings: Settings,
+    user: User,
+    thread: ChatThread,
+    user_message: str,
+    llm_client: LLMClient | None = None,
+    mcp_client: AssistantMcpClient | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """Streaming counterpart of :func:`run_user_turn`.
+
+    Yields event dicts the SSE endpoint serialises to the client:
+
+    * ``{"type": "token", "text": str}`` — assistant text chunk.
+    * ``{"type": "tool_call", "id", "name", "arguments"}`` — tool invocation
+      starting (after the LLM finished requesting it).
+    * ``{"type": "tool_result", "id", "name", "content"}`` — tool result.
+    * ``{"type": "done", "message_id", "tokens_in", "tokens_out"}`` —
+      final answer turn complete.
+    * ``{"type": "error", "message"}`` — fatal error; the generator
+      raises after yielding (caller turns it into the SSE error frame
+      and disconnects).
+
+    Persistence rules mirror :func:`run_user_turn`: every assistant /
+    tool turn is written to the DB as it happens so an interrupted
+    stream still leaves a coherent thread.
+    """
+    user_message = user_message.strip()
+    if not user_message:
+        raise ValueError("user_message must not be empty")
+
+    # 1. Persist the user turn first.
+    user_row = ChatMessage(
+        thread_id=thread.id, role="user", content=user_message
+    )
+    db.add(user_row)
+    await db.flush()
+
+    rows = (
+        await db.execute(
+            select(ChatMessage)
+            .where(ChatMessage.thread_id == thread.id)
+            .order_by(ChatMessage.created_at, ChatMessage.id)
+        )
+    ).scalars().all()
+
+    openai_messages: list[dict[str, Any]] = [
+        {"role": "system", "content": build_system_prompt(user)},
+    ]
+    openai_messages.extend(_history_to_openai_messages(list(rows)))
+
+    owns_llm = llm_client is None
+    llm = llm_client if llm_client is not None else LLMClient(settings)
+    owns_mcp = mcp_client is None
+    mcp = mcp_client if mcp_client is not None else AssistantMcpClient(
+        settings=settings, user=user
+    )
+    if owns_mcp:
+        await mcp.__aenter__()
+
+    final_row: ChatMessage | None = None
+    try:
+        tools = await mcp.list_openai_tools()
+        max_iters = max(1, int(settings.assistant_max_tool_iterations))
+
+        for iteration in range(max_iters):
+            full_content: list[str] = []
+            tc_by_idx: dict[int, dict[str, Any]] = {}
+            tokens_in = 0
+            tokens_out = 0
+
+            async for delta in llm.stream(
+                openai_messages, tools=tools or None
+            ):
+                dtype = delta.get("type")
+                if dtype == "content":
+                    full_content.append(delta["text"])
+                    yield {"type": "token", "text": delta["text"]}
+                elif dtype == "tool_call_delta":
+                    idx = delta.get("index", 0)
+                    slot = tc_by_idx.setdefault(
+                        idx, {"id": None, "name": "", "arguments": ""}
+                    )
+                    if delta.get("id"):
+                        slot["id"] = delta["id"]
+                    if delta.get("name"):
+                        slot["name"] = (slot["name"] or "") + delta["name"]
+                    if delta.get("arguments_delta"):
+                        slot["arguments"] += delta["arguments_delta"]
+                elif dtype == "finish":
+                    tokens_in = delta.get("tokens_in", 0) or tokens_in
+                    tokens_out = delta.get("tokens_out", 0) or tokens_out
+
+            content = "".join(full_content)
+            tool_calls = _assemble_tool_calls(tc_by_idx)
+
+            if not tool_calls:
+                final_row = ChatMessage(
+                    thread_id=thread.id,
+                    role="assistant",
+                    content=content,
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                )
+                db.add(final_row)
+                openai_messages.append(
+                    {"role": "assistant", "content": content}
+                )
+                break
+
+            tc_row = ChatMessage(
+                thread_id=thread.id,
+                role="assistant",
+                content=content,
+                tool_calls=tool_calls,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+            )
+            db.add(tc_row)
+            await db.flush()
+            openai_messages.append(
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": tool_calls,
+                }
+            )
+
+            for tool_call in tool_calls:
+                fn = tool_call.get("function", {}) or {}
+                yield {
+                    "type": "tool_call",
+                    "id": tool_call.get("id"),
+                    "name": fn.get("name"),
+                    "arguments": fn.get("arguments", ""),
+                }
+                tool_content = await _execute_tool_call(
+                    mcp=mcp, tool_call=tool_call
+                )
+                tool_row = ChatMessage(
+                    thread_id=thread.id,
+                    role="tool",
+                    content=tool_content,
+                    tool_call_id=tool_call.get("id"),
+                )
+                db.add(tool_row)
+                await db.flush()
+                openai_messages.append(
+                    {
+                        "role": "tool",
+                        "content": tool_content,
+                        "tool_call_id": tool_call.get("id"),
+                    }
+                )
+                yield {
+                    "type": "tool_result",
+                    "id": tool_call.get("id"),
+                    "name": fn.get("name"),
+                    "content": tool_content,
+                }
+        else:
+            logger.warning(
+                "assistant.stream.max_iters_hit thread=%s user=%s cap=%d",
+                thread.id,
+                user.id,
+                max_iters,
+            )
+            final_row = ChatMessage(
+                thread_id=thread.id,
+                role="assistant",
+                content=(
+                    "(stopped: max tool iterations reached. The assistant "
+                    "kept requesting more tools without producing a final "
+                    "answer. Try rephrasing the request.)"
+                ),
+            )
+            db.add(final_row)
+    finally:
+        if owns_mcp:
+            await mcp.__aexit__(None, None, None)
+        if owns_llm:
+            await llm.aclose()
+
+    # Auto-title + updated_at + commit.
+    user_turn_count = sum(1 for r in rows if r.role == "user")
+    if user_turn_count == 1 and not thread.title.strip():
+        thread.title = _auto_title(user_message)
+    thread.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    await db.commit()
+    assert final_row is not None
+    await db.refresh(final_row)
+    logger.info(
+        "assistant.stream.complete thread=%s user=%s in=%d out=%d",
+        thread.id,
+        user.id,
+        final_row.tokens_in,
+        final_row.tokens_out,
+    )
+    yield {
+        "type": "done",
+        "message_id": str(final_row.id),
+        "tokens_in": final_row.tokens_in,
+        "tokens_out": final_row.tokens_out,
+    }
+
+
+

--- a/cms/services/assistant/llm_client.py
+++ b/cms/services/assistant/llm_client.py
@@ -21,6 +21,7 @@ point.
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -180,3 +181,94 @@ class LLMClient:
             tokens_out=tokens_out,
             tool_calls=tool_calls,
         )
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        max_completion_tokens: int | None = None,
+        temperature: float = 0.2,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Streaming counterpart of :meth:`complete`.
+
+        Yields delta dicts in one of these shapes:
+
+        * ``{"type": "content", "text": str}`` — assistant text chunk.
+        * ``{"type": "tool_call_delta", "index": int, "id": str|None,
+              "name": str|None, "arguments_delta": str|None}`` — partial
+          tool-call (OpenAI streams ``function.arguments`` as JSON
+          fragments).
+        * ``{"type": "finish", "reason": str, "tokens_in": int,
+              "tokens_out": int}`` — final terminator; ``tokens_*`` are
+          0 when usage wasn't reported.
+
+        The caller is responsible for accumulating tool_call fragments
+        across deltas and joining content chunks.
+        """
+        max_tokens = (
+            max_completion_tokens
+            if max_completion_tokens is not None
+            else self._settings.assistant_max_completion_tokens
+        )
+        kwargs: dict[str, Any] = {
+            "model": self._settings.azure_openai_deployment,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": True,
+            # Asks Azure OpenAI to emit a final chunk with .usage; the
+            # SDK silently ignores it on older API versions.
+            "stream_options": {"include_usage": True},
+        }
+        if tools:
+            kwargs["tools"] = tools
+            if tool_choice is not None:
+                kwargs["tool_choice"] = tool_choice
+        logger.info(
+            "assistant.llm.stream_request deployment=%s messages=%d tools=%d",
+            self._settings.azure_openai_deployment,
+            len(messages),
+            len(tools) if tools else 0,
+        )
+        response = await self._client.chat.completions.create(**kwargs)
+        tokens_in = 0
+        tokens_out = 0
+        async for chunk in response:
+            usage = getattr(chunk, "usage", None)
+            if usage is not None:
+                tokens_in = getattr(usage, "prompt_tokens", 0) or tokens_in
+                tokens_out = (
+                    getattr(usage, "completion_tokens", 0) or tokens_out
+                )
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            choice = choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is not None:
+                content = getattr(delta, "content", None)
+                if content:
+                    yield {"type": "content", "text": content}
+                raw_tcs = getattr(delta, "tool_calls", None)
+                if raw_tcs:
+                    for tc in raw_tcs:
+                        fn = getattr(tc, "function", None)
+                        yield {
+                            "type": "tool_call_delta",
+                            "index": getattr(tc, "index", 0),
+                            "id": getattr(tc, "id", None),
+                            "name": getattr(fn, "name", None) if fn else None,
+                            "arguments_delta": (
+                                getattr(fn, "arguments", None) if fn else None
+                            ),
+                        }
+            if getattr(choice, "finish_reason", None):
+                yield {
+                    "type": "finish",
+                    "reason": choice.finish_reason,
+                    "tokens_in": tokens_in,
+                    "tokens_out": tokens_out,
+                }
+

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1818,6 +1818,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/threads/{thread_id}/stream:
+    post:
+      summary: Post Message Stream
+      description: |-
+        Send a user prompt and stream the assistant's reply as SSE.
+
+        The response is an ``EventSourceResponse`` with these event types
+        (each ``data`` is JSON):
+
+        * ``token`` — assistant text chunk.
+        * ``tool_call`` — model is about to invoke a tool.
+        * ``tool_result`` — tool finished, result attached.
+        * ``done`` — turn complete (carries final ``message_id``).
+        * ``error`` — fatal error; the stream terminates after this frame.
+
+        LLM-unavailable / MCP-unavailable are surfaced as ``error`` frames
+        once the SSE handshake has succeeded.  Pre-stream failures (feature
+        flag, thread ownership, LLM config missing) still return HTTP
+        4xx/5xx the normal way before any event is sent.
+      operationId: post_message_stream_api_chat_threads__thread_id__stream_post
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Thread Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatMessageCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/profiles:
     get:
       summary: List Profiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,7 @@ azure-monitor-opentelemetry>=1.6,<2.0
 # provisioned by infra/modules/azureOpenAI.bicep.  Auth via managed
 # identity (DefaultAzureCredential) — no API keys.
 openai>=1.50,<2.0
+# Server-Sent Events response helper for the chat-assistant streaming
+# endpoint (cms/routers/chat.py).  Pinned to a recent stable; the
+# library is tiny and stable.
+sse-starlette>=2.1,<4.0

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -78,6 +78,46 @@ class FakeLLMClient:
             return self._scripted.pop(0)
         return _FakeResult(content=self.reply, tokens_in=42, tokens_out=17)
 
+    async def stream(
+        self,
+        messages,
+        *,
+        max_completion_tokens=None,
+        temperature: float = 0.2,
+        tools=None,
+        tool_choice=None,
+    ):
+        """Adapt a scripted ``_FakeResult`` into the streaming delta
+        shape ``LLMClient.stream`` yields.  One call = one
+        ``_FakeResult`` worth of deltas (one content chunk if the
+        reply is text, one tool_call_delta per tool call if any,
+        then a ``finish``)."""
+        self.calls.append(list(messages))
+        self.tools_seen.append(list(tools) if tools else None)
+        result = (
+            self._scripted.pop(0)
+            if self._scripted
+            else _FakeResult(content=self.reply, tokens_in=42, tokens_out=17)
+        )
+        if result.content:
+            yield {"type": "content", "text": result.content}
+        if result.tool_calls:
+            for idx, tc in enumerate(result.tool_calls):
+                fn = tc.get("function", {})
+                yield {
+                    "type": "tool_call_delta",
+                    "index": idx,
+                    "id": tc.get("id"),
+                    "name": fn.get("name"),
+                    "arguments_delta": fn.get("arguments", ""),
+                }
+        yield {
+            "type": "finish",
+            "reason": "tool_calls" if result.tool_calls else "stop",
+            "tokens_in": result.tokens_in,
+            "tokens_out": result.tokens_out,
+        }
+
     async def aclose(self) -> None:
         self.closed = True
 
@@ -868,5 +908,186 @@ def test_read_service_key_ok(tmp_path):
     p = tmp_path / "k"
     p.write_text("agora_svc_deadbeef\n")
     assert _read_service_key(str(p)) == "agora_svc_deadbeef"
+
+
+# ── PR 3c: SSE streaming endpoint ─────────────────────────────────────
+
+
+def _parse_sse(text: str) -> list[tuple[str, str]]:
+    """Return ``[(event_name, data_json), ...]`` from an SSE blob.
+
+    Only handles the subset the agent emits — a sequence of frames of
+    the form ``event: foo\\ndata: {...}\\n\\n``.  Heartbeat ping frames
+    sent by ``sse-starlette`` (``: ping\\n\\n``) are skipped.
+    """
+    frames: list[tuple[str, str]] = []
+    # SSE frames use ``\r\n`` line endings; normalise first.
+    normalised = text.replace("\r\n", "\n")
+    for raw in normalised.split("\n\n"):
+        block = raw.strip()
+        if not block or block.startswith(":"):
+            continue
+        event = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                event = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data = line[len("data:"):].strip()
+        if event is not None and data is not None:
+            frames.append((event, data))
+    return frames
+
+
+@pytest.mark.asyncio
+class TestStreamingEndpoint:
+    async def test_text_only_stream_yields_token_and_done(
+        self, client, scripted_agent
+    ):
+        scripted_agent["mcp_tools"] = []
+        scripted_agent["llm_replies"] = [
+            _FakeResult(content="Hello world", tokens_in=3, tokens_out=2)
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "hi"},
+        ) as resp:
+            assert resp.status_code == 200
+            body = await resp.aread()
+        text = body.decode()
+        frames = _parse_sse(text)
+        events = [name for name, _ in frames]
+        assert events == ["token", "done"]
+        import json as _json
+
+        assert _json.loads(frames[0][1])["text"] == "Hello world"
+        done = _json.loads(frames[-1][1])
+        assert done["tokens_in"] == 3
+        assert done["tokens_out"] == 2
+        assert "message_id" in done
+
+    async def test_stream_with_tool_call_then_final_answer(
+        self, client, scripted_agent, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_message import ChatMessage
+
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_devices",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        scripted_agent["mcp_results"] = {"list_devices": '[{"id":"d1"}]'}
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=10,
+                tokens_out=5,
+                tool_calls=[_tool_call("list_devices", {})],
+            ),
+            _FakeResult(content="One device.", tokens_in=20, tokens_out=8),
+        ]
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "how many"},
+        ) as resp:
+            assert resp.status_code == 200
+            body = await resp.aread()
+        frames = _parse_sse(body.decode())
+        events = [name for name, _ in frames]
+        # The streaming agent emits tool_call → tool_result → (final
+        # text) token(s) → done.  No assistant token frame for the
+        # intermediate empty-content tool-call turn.
+        assert events == ["tool_call", "tool_result", "token", "done"]
+
+        # Persisted rows: user, assistant(tool_calls), tool, assistant(final).
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            rows = (
+                await db.execute(
+                    select(ChatMessage)
+                    .where(ChatMessage.thread_id == uuid.UUID(tid))
+                    .order_by(ChatMessage.created_at, ChatMessage.id)
+                )
+            ).scalars().all()
+            assert [r.role for r in rows] == [
+                "user",
+                "assistant",
+                "tool",
+                "assistant",
+            ]
+            assert rows[3].content == "One device."
+            break
+
+    async def test_stream_503_when_llm_not_configured(self, client):
+        # No patched_llm fixture — settings have empty endpoint.
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "hi"},
+        ) as resp:
+            assert resp.status_code == 503
+
+    async def test_stream_404_on_unknown_thread(self, client, scripted_agent):
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{uuid.uuid4()}/stream",
+            json={"content": "hi"},
+        ) as resp:
+            assert resp.status_code == 404
+
+    async def test_stream_emits_error_event_on_mcp_failure(
+        self, client, app, monkeypatch
+    ):
+        from cms.auth import get_settings
+        from cms.routers import chat as chat_router
+        from cms.services.assistant import agent as agent_mod
+        from cms.services.assistant.mcp_client import McpUnavailableError
+
+        settings = app.dependency_overrides[get_settings]()
+        settings.azure_openai_endpoint = "https://fake.openai.azure.com"
+        settings.azure_openai_deployment = "gpt-4o-fake"
+        monkeypatch.setattr(
+            chat_router, "assistant_llm_available", lambda s: True
+        )
+        monkeypatch.setattr(agent_mod, "LLMClient", FakeLLMClient)
+
+        class _BrokenMcp:
+            def __init__(self, *, settings=None, user=None):
+                pass
+
+            async def __aenter__(self):
+                raise McpUnavailableError("simulated outage")
+
+            async def __aexit__(self, *a):
+                pass
+
+        monkeypatch.setattr(agent_mod, "AssistantMcpClient", _BrokenMcp)
+
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "hi"},
+        ) as resp:
+            # Handshake succeeds (LLM looks configured); the failure is
+            # surfaced as an error frame.
+            assert resp.status_code == 200
+            body = await resp.aread()
+        frames = _parse_sse(body.decode())
+        assert any(name == "error" for name, _ in frames)
+        err_frame = next(d for name, d in frames if name == "error")
+        assert "simulated outage" in err_frame
+
 
 


### PR DESCRIPTION
Adds POST /api/chat/threads/{id}/stream — an SSE endpoint that streams an assistant turn (tokens, tool calls, tool results, done) instead of buffering until the model finishes. Same tool-calling loop and persistence rules as POST /message; rows are written mid-stream so dropped connections still leave the thread coherent.

* New `LLMClient.stream()` yielding content / tool_call_delta / finish deltas (with `stream_options.include_usage` so the terminal chunk carries token counts).
* New `run_user_turn_streaming()` async generator yielding `token` / `tool_call` / `tool_result` / `done` events. Reuses `_execute_tool_call`, `_history_to_openai_messages`, `_auto_title`.
* SSE router endpoint catches MCP- and LLM-unavailable errors that happen mid-stream and emits a terminal `error` frame (pre-stream failures still return 4xx/5xx).
* 5 new tests covering text-only, tool loop persistence, 503 when LLM unconfigured, 404 on unknown thread, and the post-handshake MCP-unavailable error frame. 32 chat tests green.
* Drift: regenerated `docs/openapi.yaml` for the new endpoint.

The existing non-streaming `POST /message` endpoint stays in place as a fallback.

Part of the assistant rollout (PRs 1–4 backend, PR 5 frontend).