### PR TITLE
feat(assistant): write-tool approval flow (PR 4)

### DIFF
--- a/alembic/versions/0035_chat_pending_approvals.py
+++ b/alembic/versions/0035_chat_pending_approvals.py
@@ -1,0 +1,122 @@
+"""Alembic migration 0035 — chat pending approvals table (PR 4 of 6).
+
+Adds the queue the assistant uses to gate **write** MCP tools.  When
+the LLM proposes a write tool (i.e. anything *not* in
+:data:`cms.services.assistant.mcp_client.READ_ONLY_TOOLS`) the agent
+loop inserts a row here in state ``pending`` and emits an
+``approval_request`` event to the user instead of calling MCP.  The
+user then approves or rejects via the chat router; on approve the
+agent loop persists the tool result and the conversation continues on
+the user's next turn.  On reject we synthesise a tool-result message
+that tells the LLM the user declined.
+
+Row lifecycle:
+
+* ``pending``   — awaiting user decision (default state).
+* ``approved``  — user clicked Approve; row stays for audit.
+* ``rejected``  — user clicked Reject; row stays for audit.
+* ``expired``   — TTL elapsed before any decision (job-driven; not
+                  enforced in PR 4, but the column reserves the state).
+
+Revision ID: 0035
+Revises: 0034
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def _types(bind):
+    dialect = bind.dialect.name
+    uuid_type = (
+        sa.dialects.postgresql.UUID(as_uuid=True)
+        if dialect == "postgresql"
+        else sa.String(length=36)
+    )
+    json_type = (
+        sa.dialects.postgresql.JSONB()
+        if dialect == "postgresql"
+        else sa.JSON()
+    )
+    return uuid_type, json_type
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    uuid_type, json_type = _types(bind)
+
+    op.create_table(
+        "chat_pending_approvals",
+        sa.Column("id", uuid_type, nullable=False),
+        sa.Column(
+            "thread_id",
+            uuid_type,
+            sa.ForeignKey("chat_threads.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # The assistant turn (assistant role, tool_calls set) that
+        # proposed this write; nullable because the row is created
+        # before that assistant row is committed on some paths.
+        sa.Column(
+            "proposed_by_message_id",
+            uuid_type,
+            sa.ForeignKey("chat_messages.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("tool_name", sa.String(length=100), nullable=False),
+        sa.Column("tool_call_id", sa.String(length=100), nullable=False),
+        sa.Column("tool_arguments", json_type, nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        # The MCP tool result captured on approve (for audit / replay);
+        # null until the approve endpoint runs the tool.
+        sa.Column("result_content", sa.Text(), nullable=True),
+        # Free-form decision context (e.g. "rejected via UI",
+        # "auto-approved by admin allowlist") — optional.
+        sa.Column("decision_note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "decided_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_chat_pending_approvals_thread_id",
+        "chat_pending_approvals",
+        ["thread_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_chat_pending_approvals_status",
+        "chat_pending_approvals",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0035 is not supported")

--- a/cms/main.py
+++ b/cms/main.py
@@ -832,6 +832,7 @@ from cms.routers.schedules import router as schedules_router  # noqa: E402
 from cms.routers.tags import router as tags_router  # noqa: E402
 from cms.routers.asset_views import router as asset_views_router  # noqa: E402
 from cms.routers.chat import router as chat_router  # noqa: E402
+from cms.routers.chat_approvals import router as chat_approvals_router  # noqa: E402
 from cms.routers.ws import router as ws_router  # noqa: E402
 from cms.routers.api_keys import router as api_keys_router  # noqa: E402
 from cms.routers.audit import router as audit_router  # noqa: E402
@@ -855,6 +856,7 @@ app.include_router(schedules_router)
 app.include_router(tags_router)
 app.include_router(asset_views_router)
 app.include_router(chat_router)
+app.include_router(chat_approvals_router)
 app.include_router(profiles_router)
 app.include_router(logs_router)
 app.include_router(cms_logs_router)

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -23,6 +23,7 @@ from cms.models.slideshow_slide import SlideshowSlide  # noqa: F401
 from cms.models.tag import Tag, AssetTag, DEFAULT_TAG_COLOR  # noqa: F401
 from cms.models.asset_view import AssetView  # noqa: F401
 from cms.models.chat_message import ChatMessage  # noqa: F401
+from cms.models.chat_pending_approval import ChatPendingApproval  # noqa: F401
 from cms.models.chat_thread import ChatThread  # noqa: F401
 from cms.models.user import Role, User, UserGroup  # noqa: F401
 

--- a/cms/models/chat_pending_approval.py
+++ b/cms/models/chat_pending_approval.py
@@ -1,0 +1,87 @@
+"""Chat assistant: pending write-tool approvals (PR 4 of 6).
+
+When the agent loop sees the LLM propose a write tool (anything not
+in :data:`cms.services.assistant.mcp_client.READ_ONLY_TOOLS`) it
+inserts a row here in state ``pending`` instead of executing the
+tool, then yields an ``approval_request`` SSE event so the UI can
+render an Approve/Reject card.
+
+Decisions are terminal — once a row is ``approved`` / ``rejected``
+it stays for audit.  Replay of the conversation history after the
+fact uses ``result_content`` to reconstruct the tool turn the LLM
+saw (or the synthetic "user declined" turn on reject).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from cms.database import Base
+
+
+# Match the chat_messages convention — JSONB on Postgres, plain JSON
+# on SQLite (test matrix).
+_JSON_TYPE = JSON().with_variant(JSONB(), "postgresql")
+
+
+# Terminal status values.  Kept as plain strings (not an enum) so
+# Alembic migrations stay portable across SQLite (tests) and Postgres
+# (prod) without needing CREATE TYPE / DROP TYPE plumbing.
+STATUS_PENDING = "pending"
+STATUS_APPROVED = "approved"
+STATUS_REJECTED = "rejected"
+STATUS_EXPIRED = "expired"
+
+
+class ChatPendingApproval(Base):
+    __tablename__ = "chat_pending_approvals"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    thread_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_threads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    proposed_by_message_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_messages.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    tool_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    tool_call_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    tool_arguments: Mapped[dict[str, Any]] = mapped_column(
+        _JSON_TYPE, nullable=False
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=STATUS_PENDING,
+        server_default=STATUS_PENDING,
+        index=True,
+    )
+    result_content: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    decision_note: Mapped[str | None] = mapped_column(Text(), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.current_timestamp(),
+    )
+    decided_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/cms/routers/chat_approvals.py
+++ b/cms/routers/chat_approvals.py
@@ -1,0 +1,290 @@
+"""Assistant chat: write-tool approval endpoints (PR 4 of 6).
+
+This router lives alongside :mod:`cms.routers.chat` rather than inside
+it because the approval flow is its own surface — distinct lifecycle,
+distinct schemas, distinct invariants.  Keeping it in a separate
+module also makes the auth / feature-gate plumbing easier to test in
+isolation.
+
+Endpoints
+---------
+
+* ``GET    /api/chat/threads/{tid}/approvals`` — list pending approvals.
+* ``GET    /api/chat/approvals/{aid}``         — fetch one (any state).
+* ``POST   /api/chat/approvals/{aid}/approve`` — execute the tool, then
+  persist a ``role=tool`` ChatMessage so the LLM can reason about it
+  on the user's next turn.  Marks the approval row ``approved``.
+* ``POST   /api/chat/approvals/{aid}/reject``  — synthesise a tool
+  result that tells the LLM the user declined, persist it as a
+  ``role=tool`` ChatMessage, mark the approval row ``rejected``.
+
+The chat router emits an ``approval_request`` SSE event with the
+approval row's ``id`` whenever the streaming agent loop hits a write
+tool; the UI uses that id to call the endpoints here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_current_user, get_settings, require_auth
+from cms.config import Settings
+from cms.database import get_db
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_pending_approval import (
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    STATUS_REJECTED,
+    ChatPendingApproval,
+)
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+from cms.schemas.chat import ChatApprovalDecision, ChatPendingApprovalOut
+from cms.services.assistant.mcp_client import (
+    AssistantMcpClient,
+    McpUnavailableError,
+)
+from cms.services.assistant_flag import assistant_enabled_for
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/api/chat", dependencies=[Depends(require_auth)])
+
+
+async def _current_user(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    return await get_current_user(request, settings, db)
+
+
+async def _require_feature(user: User, db: AsyncSession) -> None:
+    """Mirror ``cms.routers.chat._require_feature``."""
+    if not await assistant_enabled_for(db, user):
+        raise HTTPException(status_code=404, detail="Not found")
+
+
+async def _get_owned_thread(
+    thread_id: uuid.UUID, user: User, db: AsyncSession
+) -> ChatThread:
+    thread = (
+        await db.execute(select(ChatThread).where(ChatThread.id == thread_id))
+    ).scalar_one_or_none()
+    if not thread or thread.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    return thread
+
+
+async def _get_owned_approval(
+    approval_id: uuid.UUID, user: User, db: AsyncSession
+) -> tuple[ChatPendingApproval, ChatThread]:
+    """Fetch the approval row + its parent thread.
+
+    404 (not 403) if the row doesn't exist OR the parent thread isn't
+    owned by ``user`` — same leak-prevention pattern as the rest of
+    the chat router.
+    """
+    row = (
+        await db.execute(
+            select(ChatPendingApproval).where(
+                ChatPendingApproval.id == approval_id
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Approval not found")
+    thread = await _get_owned_thread(row.thread_id, user, db)
+    return row, thread
+
+
+def _ensure_pending(row: ChatPendingApproval) -> None:
+    if row.status != STATUS_PENDING:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Approval already {row.status!r}; decisions are terminal.",
+        )
+
+
+# ── Listing / fetch ───────────────────────────────────────────────────
+
+
+@router.get(
+    "/threads/{thread_id}/approvals",
+    response_model=List[ChatPendingApprovalOut],
+)
+async def list_thread_approvals(
+    thread_id: uuid.UUID,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+    status: str | None = None,
+):
+    """List approval rows for ``thread_id``.
+
+    Defaults to ``status=pending`` so the UI's "needs your attention"
+    badge has a cheap query.  Pass ``status=`` (empty) to fetch every
+    state for the audit timeline.
+    """
+    await _require_feature(user, db)
+    await _get_owned_thread(thread_id, user, db)
+
+    stmt = select(ChatPendingApproval).where(
+        ChatPendingApproval.thread_id == thread_id
+    )
+    effective_status = STATUS_PENDING if status is None else status
+    if effective_status:
+        stmt = stmt.where(ChatPendingApproval.status == effective_status)
+    stmt = stmt.order_by(ChatPendingApproval.created_at)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [ChatPendingApprovalOut.model_validate(r) for r in rows]
+
+
+@router.get(
+    "/approvals/{approval_id}",
+    response_model=ChatPendingApprovalOut,
+)
+async def get_approval(
+    approval_id: uuid.UUID,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _require_feature(user, db)
+    row, _ = await _get_owned_approval(approval_id, user, db)
+    return ChatPendingApprovalOut.model_validate(row)
+
+
+# ── Decide ────────────────────────────────────────────────────────────
+
+
+def _result_message(
+    thread_id: uuid.UUID, tool_call_id: str, content: str
+) -> ChatMessage:
+    """Build the synthetic ``role=tool`` ChatMessage the agent loop
+    would have produced if the tool had been called normally."""
+    return ChatMessage(
+        thread_id=thread_id,
+        role="tool",
+        tool_call_id=tool_call_id,
+        content=content,
+    )
+
+
+@router.post(
+    "/approvals/{approval_id}/approve",
+    response_model=ChatPendingApprovalOut,
+)
+async def approve_approval(
+    approval_id: uuid.UUID,
+    payload: ChatApprovalDecision | None = None,
+    user: User = Depends(_current_user),
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+):
+    """Execute the proposed write tool via MCP and persist the result.
+
+    On success the agent loop's next turn (i.e. when the user types
+    again) sees a ``role=tool`` history row and can carry on as if the
+    tool had run normally.  No in-flight stream is resumed — keeping
+    "approve" decoupled from a live SSE connection avoids a whole
+    class of reconnect / orphan-generator failure modes.
+    """
+    await _require_feature(user, db)
+    row, _thread = await _get_owned_approval(approval_id, user, db)
+    _ensure_pending(row)
+
+    arguments = dict(row.tool_arguments or {})
+    try:
+        async with AssistantMcpClient(settings=settings, user=user) as mcp:
+            # bypass_whitelist=True is the whole reason this path
+            # exists — the read-only whitelist exists to defend against
+            # the LLM running writes WITHOUT a human in the loop.  Here
+            # the human just clicked Approve.
+            result_text = await mcp.call_tool(
+                row.tool_name, arguments, bypass_whitelist=True
+            )
+    except McpUnavailableError as exc:
+        # The row stays ``pending`` so the user can retry.
+        raise HTTPException(
+            status_code=503,
+            detail=f"Assistant tool backend unavailable: {exc}",
+        ) from exc
+    except Exception as exc:
+        # Tool execution failed — record the failure as a tool-result
+        # the LLM can reason about, but mark the row approved (the
+        # user did approve; MCP just returned an error).  This matches
+        # how the non-approval path handles tool errors.
+        logger.exception(
+            "assistant.approve.tool_failed name=%s user=%s",
+            row.tool_name,
+            user.id,
+        )
+        result_text = json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+
+    db.add(_result_message(row.thread_id, row.tool_call_id, result_text))
+    row.status = STATUS_APPROVED
+    row.result_content = result_text
+    row.decision_note = (payload.note if payload else None) or None
+    row.decided_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(row)
+    logger.info(
+        "assistant.approve.ok approval=%s tool=%s user=%s",
+        row.id,
+        row.tool_name,
+        user.id,
+    )
+    return ChatPendingApprovalOut.model_validate(row)
+
+
+@router.post(
+    "/approvals/{approval_id}/reject",
+    response_model=ChatPendingApprovalOut,
+)
+async def reject_approval(
+    approval_id: uuid.UUID,
+    payload: ChatApprovalDecision | None = None,
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Decline the proposed write tool and tell the LLM the user said no.
+
+    We still persist a ``role=tool`` row so the conversation history
+    is internally consistent (every ``tool_calls`` assistant turn must
+    have matching ``tool`` rows for the OpenAI API to accept the
+    history on the next turn).  The content is a structured JSON blob
+    so the LLM can reliably detect the rejection.
+    """
+    await _require_feature(user, db)
+    row, _thread = await _get_owned_approval(approval_id, user, db)
+    _ensure_pending(row)
+
+    note = (payload.note if payload else None) or None
+    rejection_payload: dict[str, object] = {
+        "rejected": True,
+        "reason": note or "User declined to approve this action.",
+    }
+    result_text = json.dumps(rejection_payload)
+
+    db.add(_result_message(row.thread_id, row.tool_call_id, result_text))
+    row.status = STATUS_REJECTED
+    row.result_content = result_text
+    row.decision_note = note
+    row.decided_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(row)
+    logger.info(
+        "assistant.reject.ok approval=%s tool=%s user=%s",
+        row.id,
+        row.tool_name,
+        user.id,
+    )
+    return ChatPendingApprovalOut.model_validate(row)

--- a/cms/schemas/chat.py
+++ b/cms/schemas/chat.py
@@ -65,3 +65,42 @@ class AssistantFeatureStatus(BaseModel):
     """
 
     enabled: bool
+
+
+# ── PR 4: write-tool approval flow ────────────────────────────────────
+
+
+class ChatPendingApprovalOut(BaseModel):
+    """A pending write-tool approval as returned by the API.
+
+    Surfaces the proposed tool name + arguments so the UI can render an
+    Approve / Reject card with the same detail level it would use for a
+    completed tool call.  ``status`` lets the UI hide already-decided
+    rows from the pending list without a separate filter param.
+    """
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    thread_id: uuid.UUID
+    proposed_by_message_id: Optional[uuid.UUID] = None
+    tool_name: str
+    tool_call_id: str
+    tool_arguments: dict[str, Any]
+    status: str
+    result_content: Optional[str] = None
+    decision_note: Optional[str] = None
+    created_at: datetime
+    decided_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+
+
+class ChatApprovalDecision(BaseModel):
+    """Request body for ``POST /api/chat/approvals/{id}/{approve|reject}``.
+
+    ``note`` is an optional free-form audit string.  We don't enforce
+    it on either path — UIs may collect a reason on reject and leave
+    it blank on approve.
+    """
+
+    note: Optional[str] = Field(default=None, max_length=500)

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -45,6 +45,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.config import Settings
 from cms.models.chat_message import ChatMessage
+from cms.models.chat_pending_approval import (
+    STATUS_PENDING,
+    ChatPendingApproval,
+)
 from cms.models.chat_thread import ChatThread
 from cms.models.user import User
 from cms.services.assistant.llm_client import (
@@ -424,6 +428,7 @@ async def run_user_turn_streaming(
             tc_by_idx: dict[int, dict[str, Any]] = {}
             tokens_in = 0
             tokens_out = 0
+            pending_approvals: list[dict[str, Any]] = []
 
             async for delta in llm.stream(
                 openai_messages, tools=tools or None
@@ -484,12 +489,83 @@ async def run_user_turn_streaming(
 
             for tool_call in tool_calls:
                 fn = tool_call.get("function", {}) or {}
+                tc_name = fn.get("name") or ""
+                tc_id = tool_call.get("id") or ""
                 yield {
                     "type": "tool_call",
-                    "id": tool_call.get("id"),
-                    "name": fn.get("name"),
+                    "id": tc_id,
+                    "name": tc_name,
                     "arguments": fn.get("arguments", ""),
                 }
+
+                # PR 4: write-tool approval intercept.  Any tool name
+                # NOT in the read-only whitelist becomes an approval
+                # request instead of an MCP call.  We still persist a
+                # placeholder ``role=tool`` row so the conversation
+                # history stays internally consistent (OpenAI rejects
+                # any assistant-with-tool_calls turn that isn't followed
+                # by matching tool rows on the next API call).  The
+                # approve / reject endpoint OVERWRITES this row's
+                # content with the real result once the user decides.
+                if tc_name and tc_name not in READ_ONLY_TOOLS:
+                    parsed_args, parse_err = _parse_tool_arguments(
+                        fn.get("arguments")
+                    )
+                    approval_args = (
+                        parsed_args
+                        if parse_err is None
+                        else {"_unparsed_arguments": fn.get("arguments")}
+                    )
+                    approval = ChatPendingApproval(
+                        thread_id=thread.id,
+                        proposed_by_message_id=tc_row.id,
+                        tool_name=tc_name,
+                        tool_call_id=tc_id,
+                        tool_arguments=approval_args,
+                        status=STATUS_PENDING,
+                    )
+                    db.add(approval)
+                    await db.flush()
+
+                    placeholder = json.dumps(
+                        {
+                            "status": "awaiting_approval",
+                            "approval_id": str(approval.id),
+                            "tool": tc_name,
+                        }
+                    )
+                    tool_row = ChatMessage(
+                        thread_id=thread.id,
+                        role="tool",
+                        content=placeholder,
+                        tool_call_id=tc_id,
+                    )
+                    db.add(tool_row)
+                    await db.flush()
+                    openai_messages.append(
+                        {
+                            "role": "tool",
+                            "content": placeholder,
+                            "tool_call_id": tc_id,
+                        }
+                    )
+                    pending_approvals.append(
+                        {
+                            "id": str(approval.id),
+                            "tool": tc_name,
+                            "arguments": approval_args,
+                            "tool_call_id": tc_id,
+                        }
+                    )
+                    yield {
+                        "type": "approval_request",
+                        "approval_id": str(approval.id),
+                        "tool_call_id": tc_id,
+                        "name": tc_name,
+                        "arguments": approval_args,
+                    }
+                    continue
+
                 tool_content = await _execute_tool_call(
                     mcp=mcp, tool_call=tool_call
                 )
@@ -497,7 +573,7 @@ async def run_user_turn_streaming(
                     thread_id=thread.id,
                     role="tool",
                     content=tool_content,
-                    tool_call_id=tool_call.get("id"),
+                    tool_call_id=tc_id,
                 )
                 db.add(tool_row)
                 await db.flush()
@@ -505,15 +581,35 @@ async def run_user_turn_streaming(
                     {
                         "role": "tool",
                         "content": tool_content,
-                        "tool_call_id": tool_call.get("id"),
+                        "tool_call_id": tc_id,
                     }
                 )
                 yield {
                     "type": "tool_result",
-                    "id": tool_call.get("id"),
-                    "name": fn.get("name"),
+                    "id": tc_id,
+                    "name": tc_name,
                     "content": tool_content,
                 }
+
+            # PR 4: if any tool call in this batch was deferred to the
+            # approval queue, stop the agent loop here.  The user has
+            # to decide before any more LLM iterations make sense; the
+            # conversation resumes when the user sends their next
+            # message (which sees the placeholder tool rows + the
+            # decided approval state via the approve/reject endpoint).
+            if pending_approvals:
+                final_row = ChatMessage(
+                    thread_id=thread.id,
+                    role="assistant",
+                    content=(
+                        "(awaiting your approval before continuing — "
+                        f"{len(pending_approvals)} action"
+                        f"{'s' if len(pending_approvals) != 1 else ''} "
+                        "queued)"
+                    ),
+                )
+                db.add(final_row)
+                break
         else:
             logger.warning(
                 "assistant.stream.max_iters_hit thread=%s user=%s cap=%d",

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -195,24 +195,39 @@ class AssistantMcpClient:
         )
         return out
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        bypass_whitelist: bool = False,
+    ) -> str:
         """Invoke an MCP tool and return its result as a JSON-string.
 
         Raises :class:`PermissionError` if ``name`` isn't in the
         read-only whitelist — the agent loop catches this and turns it
         into a synthetic tool-result the LLM can reason about.
+
+        ``bypass_whitelist=True`` is the **explicit** opt-out used by
+        the PR 4 approval flow: when the user has clicked Approve on a
+        pending write-tool approval, the chat_approvals router runs
+        the tool with the whitelist disabled.  The whitelist exists to
+        prevent the LLM running writes without a human in the loop;
+        the approval click IS that human in the loop.  Never set this
+        flag without an approved :class:`ChatPendingApproval` row.
         """
         if self._session is None:  # pragma: no cover
             raise RuntimeError("AssistantMcpClient not entered")
-        if name not in READ_ONLY_TOOLS:
+        if not bypass_whitelist and name not in READ_ONLY_TOOLS:
             raise PermissionError(
                 f"Tool '{name}' is not in the read-only whitelist "
                 "(writes require approval; see PR 4)."
             )
         logger.info(
-            "assistant.mcp.call name=%s user=%s",
+            "assistant.mcp.call name=%s user=%s bypass=%s",
             name,
             self._user.id,
+            bypass_whitelist,
         )
         result = await self._session.call_tool(name, arguments)
         # Prefer structuredContent if the server sent it.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1864,6 +1864,155 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/threads/{thread_id}/approvals:
+    get:
+      summary: List Thread Approvals
+      description: |-
+        List approval rows for ``thread_id``.
+
+        Defaults to ``status=pending`` so the UI's "needs your attention"
+        badge has a cheap query.  Pass ``status=`` (empty) to fetch every
+        state for the audit timeline.
+      operationId: list_thread_approvals_api_chat_threads__thread_id__approvals_get
+      parameters:
+      - name: thread_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Thread Id
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChatPendingApprovalOut'
+                title: Response List Thread Approvals Api Chat Threads  Thread Id  Approvals Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/approvals/{approval_id}:
+    get:
+      summary: Get Approval
+      operationId: get_approval_api_chat_approvals__approval_id__get
+      parameters:
+      - name: approval_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Approval Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatPendingApprovalOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/approvals/{approval_id}/approve:
+    post:
+      summary: Approve Approval
+      description: |-
+        Execute the proposed write tool via MCP and persist the result.
+
+        On success the agent loop's next turn (i.e. when the user types
+        again) sees a ``role=tool`` history row and can carry on as if the
+        tool had run normally.  No in-flight stream is resumed — keeping
+        "approve" decoupled from a live SSE connection avoids a whole
+        class of reconnect / orphan-generator failure modes.
+      operationId: approve_approval_api_chat_approvals__approval_id__approve_post
+      parameters:
+      - name: approval_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Approval Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/ChatApprovalDecision'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatPendingApprovalOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/chat/approvals/{approval_id}/reject:
+    post:
+      summary: Reject Approval
+      description: |-
+        Decline the proposed write tool and tell the LLM the user said no.
+
+        We still persist a ``role=tool`` row so the conversation history
+        is internally consistent (every ``tool_calls`` assistant turn must
+        have matching ``tool`` rows for the OpenAI API to accept the
+        history on the next turn).  The content is a structured JSON blob
+        so the LLM can reliably detect the rejection.
+      operationId: reject_approval_api_chat_approvals__approval_id__reject_post
+      parameters:
+      - name: approval_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Approval Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/ChatApprovalDecision'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatPendingApprovalOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/profiles:
     get:
       summary: List Profiles
@@ -4619,6 +4768,22 @@ components:
       required:
       - entries
       title: CatalogOut
+    ChatApprovalDecision:
+      properties:
+        note:
+          anyOf:
+          - type: string
+            maxLength: 500
+          - type: 'null'
+          title: Note
+      type: object
+      title: ChatApprovalDecision
+      description: |-
+        Request body for ``POST /api/chat/approvals/{id}/{approve|reject}``.
+
+        ``note`` is an optional free-form audit string.  We don't enforce
+        it on either path — UIs may collect a reason on reject and leave
+        it blank on approve.
     ChatMessageCreate:
       properties:
         content:
@@ -4684,6 +4849,78 @@ components:
         the frontend needs them to render the tool-call timeline (and, in
         PR 4, the approval cards).  ``tokens_in`` / ``tokens_out`` are NOT
         surfaced; the budget badge reads from ``/api/chat/budget`` instead.
+    ChatPendingApprovalOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        thread_id:
+          type: string
+          format: uuid
+          title: Thread Id
+        proposed_by_message_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Proposed By Message Id
+        tool_name:
+          type: string
+          title: Tool Name
+        tool_call_id:
+          type: string
+          title: Tool Call Id
+        tool_arguments:
+          additionalProperties: true
+          type: object
+          title: Tool Arguments
+        status:
+          type: string
+          title: Status
+        result_content:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Result Content
+        decision_note:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Decision Note
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        decided_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Decided At
+        expires_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Expires At
+      type: object
+      required:
+      - id
+      - thread_id
+      - tool_name
+      - tool_call_id
+      - tool_arguments
+      - status
+      - created_at
+      title: ChatPendingApprovalOut
+      description: |-
+        A pending write-tool approval as returned by the API.
+
+        Surfaces the proposed tool name + arguments so the UI can render an
+        Approve / Reject card with the same detail level it would use for a
+        completed tool call.  ``status`` lets the UI hide already-decided
+        rows from the pending list without a separate filter param.
     ChatThreadCreate:
       properties:
         title:

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1090,4 +1090,191 @@ class TestStreamingEndpoint:
         assert "simulated outage" in err_frame
 
 
+# ── PR 4: streaming approval intercept ────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestStreamingApprovalIntercept:
+    async def test_write_tool_yields_approval_request_and_stops(
+        self, client, scripted_agent, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_message import ChatMessage
+        from cms.models.chat_pending_approval import (
+            STATUS_PENDING,
+            ChatPendingApproval,
+        )
+
+        # ``delete_device`` is intentionally NOT in READ_ONLY_TOOLS.
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "delete_device",
+                    "description": "delete a device",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=12,
+                tokens_out=4,
+                tool_calls=[
+                    _tool_call("delete_device", {"id": "dev-1"})
+                ],
+            ),
+            # Should NOT be consumed — the loop must stop on the
+            # approval intercept and not call the LLM again.
+            _FakeResult(content="should not appear", tokens_in=0, tokens_out=0),
+        ]
+
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "delete it"},
+        ) as resp:
+            assert resp.status_code == 200
+            body = await resp.aread()
+
+        frames = _parse_sse(body.decode())
+        events = [name for name, _ in frames]
+        # tool_call → approval_request (no tool_result) → done.
+        assert events == ["tool_call", "approval_request", "done"]
+
+        import json as _json
+
+        ar = _json.loads(frames[1][1])
+        assert ar["name"] == "delete_device"
+        assert ar["arguments"] == {"id": "dev-1"}
+        assert "approval_id" in ar
+
+        # An approval row was created.
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            rows = (
+                await db.execute(
+                    select(ChatPendingApproval).where(
+                        ChatPendingApproval.thread_id == uuid.UUID(tid)
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].tool_name == "delete_device"
+            assert rows[0].status == STATUS_PENDING
+            assert rows[0].tool_arguments == {"id": "dev-1"}
+
+            # Placeholder ``role=tool`` message persisted so OpenAI
+            # history stays consistent on the next turn.
+            msgs = (
+                await db.execute(
+                    select(ChatMessage)
+                    .where(ChatMessage.thread_id == uuid.UUID(tid))
+                    .order_by(ChatMessage.created_at, ChatMessage.id)
+                )
+            ).scalars().all()
+            roles = [m.role for m in msgs]
+            assert roles == ["user", "assistant", "tool", "assistant"]
+            placeholder = _json.loads(msgs[2].content)
+            assert placeholder["status"] == "awaiting_approval"
+            assert placeholder["tool"] == "delete_device"
+            # Final assistant message explains the pause.
+            assert "awaiting your approval" in msgs[3].content
+            break
+
+        # Only one LLM call was made — the loop stopped on the
+        # approval intercept and didn't iterate again.
+        assert FakeLLMClient.last_instance is not None
+        assert len(FakeLLMClient.last_instance.calls) == 1
+
+    async def test_read_tool_alongside_write_intercepts_only_write(
+        self, client, scripted_agent, app
+    ):
+        from cms.database import get_db
+        from cms.models.chat_pending_approval import ChatPendingApproval
+
+        scripted_agent["mcp_tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_devices",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "delete_device",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+        scripted_agent["mcp_results"] = {"list_devices": "[]"}
+        scripted_agent["llm_replies"] = [
+            _FakeResult(
+                content="",
+                tokens_in=8,
+                tokens_out=3,
+                tool_calls=[
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {
+                            "name": "list_devices",
+                            "arguments": "{}",
+                        },
+                    },
+                    {
+                        "id": "call_write",
+                        "type": "function",
+                        "function": {
+                            "name": "delete_device",
+                            "arguments": '{"id": "dev-1"}',
+                        },
+                    },
+                ],
+            )
+        ]
+
+        tid = (await client.post("/api/chat/threads", json={"title": ""})).json()["id"]
+        async with client.stream(
+            "POST",
+            f"/api/chat/threads/{tid}/stream",
+            json={"content": "list then delete"},
+        ) as resp:
+            assert resp.status_code == 200
+            body = await resp.aread()
+
+        frames = _parse_sse(body.decode())
+        events = [name for name, _ in frames]
+        # Read tool executes normally; write tool becomes approval.
+        # Order: tool_call(read) → tool_result(read) → tool_call(write)
+        # → approval_request(write) → done.
+        assert events == [
+            "tool_call",
+            "tool_result",
+            "tool_call",
+            "approval_request",
+            "done",
+        ]
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            approvals = (
+                await db.execute(
+                    select(ChatPendingApproval).where(
+                        ChatPendingApproval.thread_id == uuid.UUID(tid)
+                    )
+                )
+            ).scalars().all()
+            assert len(approvals) == 1
+            assert approvals[0].tool_name == "delete_device"
+            break
+
+
+
 

--- a/tests/test_chat_approvals.py
+++ b/tests/test_chat_approvals.py
@@ -1,0 +1,309 @@
+"""Tests for the Assistant write-tool approval endpoints (PR 4 of 6).
+
+Covers the standalone :mod:`cms.routers.chat_approvals` surface:
+
+* List endpoint (default ``pending`` filter, plus all-states).
+* Approve endpoint runs MCP with ``bypass_whitelist=True``, persists a
+  ``role=tool`` ChatMessage, marks the row ``approved``.
+* Approve endpoint is a 503 when MCP is down (and leaves the row
+  pending so the user can retry).
+* Approve endpoint records tool-execution errors as a tool-result
+  message AND still marks the row approved (matches the way the
+  agent loop handles tool errors).
+* Reject endpoint persists a synthetic ``role=tool`` rejection blob
+  and marks the row ``rejected``.
+* Both decision endpoints reject double-decisions with 409.
+* Cross-user / cross-thread access returns 404 (no leakage).
+* Feature flag gating returns 404 to non-allowlisted users.
+
+The agent-side write-tool intercept (which actually creates these
+``ChatPendingApproval`` rows) lands separately on top of PR 3c; this
+test file focuses on the decision surface only and creates the
+approval rows directly.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_pending_approval import (
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    STATUS_REJECTED,
+    ChatPendingApproval,
+)
+from cms.models.chat_thread import ChatThread
+
+
+# ── Fake MCP for the approve path ─────────────────────────────────────
+
+
+class _ApproveFakeMcp:
+    """Records call_tool args + returns a canned result.
+
+    Set ``raise_on_enter`` to raise ``McpUnavailableError`` from
+    ``__aenter__`` (i.e. the backend is down).  Set ``raise_on_call``
+    to raise a generic exception from ``call_tool``.
+    """
+
+    instances: list["_ApproveFakeMcp"] = []
+    result: str = '{"ok": true}'
+    raise_on_enter: bool = False
+    raise_on_call: bool = False
+
+    def __init__(self, *, settings=None, user=None):
+        self.settings = settings
+        self.user = user
+        self.calls: list[tuple[str, dict, bool]] = []
+        _ApproveFakeMcp.instances.append(self)
+
+    async def __aenter__(self):
+        if _ApproveFakeMcp.raise_on_enter:
+            from cms.services.assistant.mcp_client import McpUnavailableError
+
+            raise McpUnavailableError("simulated outage")
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def call_tool(self, name, arguments, *, bypass_whitelist=False):
+        self.calls.append((name, dict(arguments), bypass_whitelist))
+        if _ApproveFakeMcp.raise_on_call:
+            raise RuntimeError("tool blew up")
+        return _ApproveFakeMcp.result
+
+
+@pytest_asyncio.fixture
+async def patched_approve_mcp(monkeypatch):
+    """Patch the MCP client used by the approvals router."""
+    from cms.routers import chat_approvals as router_mod
+
+    _ApproveFakeMcp.instances = []
+    _ApproveFakeMcp.result = '{"ok": true}'
+    _ApproveFakeMcp.raise_on_enter = False
+    _ApproveFakeMcp.raise_on_call = False
+    monkeypatch.setattr(router_mod, "AssistantMcpClient", _ApproveFakeMcp)
+    yield _ApproveFakeMcp
+    _ApproveFakeMcp.instances = []
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _create_thread(client, title: str = "") -> uuid.UUID:
+    resp = await client.post("/api/chat/threads", json={"title": title})
+    assert resp.status_code == 201, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _new_approval(
+    app,
+    thread_id: uuid.UUID,
+    *,
+    tool_name: str = "delete_device",
+    tool_args: dict | None = None,
+    status: str = STATUS_PENDING,
+) -> uuid.UUID:
+    """Insert a ``ChatPendingApproval`` row directly via the app's DB
+    factory.  Returns the new row's id."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    row_id: uuid.UUID | None = None
+    async for db in factory():
+        row = ChatPendingApproval(
+            thread_id=thread_id,
+            tool_name=tool_name,
+            tool_call_id=f"call_{uuid.uuid4().hex[:8]}",
+            tool_arguments=tool_args or {"id": "dev-1"},
+            status=status,
+        )
+        db.add(row)
+        await db.commit()
+        await db.refresh(row)
+        row_id = row.id
+        break
+    assert row_id is not None
+    return row_id
+
+
+async def _fetch_thread_messages(app, thread_id: uuid.UUID) -> list[ChatMessage]:
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        rows = (
+            await db.execute(
+                select(ChatMessage)
+                .where(ChatMessage.thread_id == thread_id)
+                .order_by(ChatMessage.created_at, ChatMessage.id)
+            )
+        ).scalars().all()
+        return list(rows)
+    return []
+
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestListApprovals:
+    async def test_default_returns_only_pending(self, client, app):
+        tid = await _create_thread(client)
+        pending_id = await _new_approval(app, tid, status=STATUS_PENDING)
+        await _new_approval(app, tid, status=STATUS_APPROVED)
+        await _new_approval(app, tid, status=STATUS_REJECTED)
+
+        resp = await client.get(f"/api/chat/threads/{tid}/approvals")
+        assert resp.status_code == 200, resp.text
+        ids = [r["id"] for r in resp.json()]
+        assert ids == [str(pending_id)]
+
+    async def test_status_empty_returns_all(self, client, app):
+        tid = await _create_thread(client)
+        await _new_approval(app, tid, status=STATUS_PENDING)
+        await _new_approval(app, tid, status=STATUS_APPROVED)
+
+        resp = await client.get(
+            f"/api/chat/threads/{tid}/approvals", params={"status": ""}
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    async def test_cross_user_thread_is_404(
+        self, client, unauthed_client, app
+    ):
+        tid = await _create_thread(client)
+        await _new_approval(app, tid)
+        # Unauthed_client has no session — should 401 from require_auth
+        # OR 404 from feature gate; either way it's not 200.
+        resp = await unauthed_client.get(f"/api/chat/threads/{tid}/approvals")
+        assert resp.status_code in (401, 404)
+
+
+@pytest.mark.asyncio
+class TestApproveEndpoint:
+    async def test_approve_runs_tool_and_persists_result(
+        self, client, app, patched_approve_mcp
+    ):
+        tid = await _create_thread(client)
+        aid = await _new_approval(
+            app, tid, tool_name="delete_device", tool_args={"id": "dev-1"}
+        )
+        patched_approve_mcp.result = '{"deleted": "dev-1"}'
+
+        resp = await client.post(
+            f"/api/chat/approvals/{aid}/approve", json={"note": "go"}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == STATUS_APPROVED
+        assert body["result_content"] == '{"deleted": "dev-1"}'
+        assert body["decision_note"] == "go"
+        assert body["decided_at"] is not None
+
+        # MCP got called with bypass_whitelist=True.
+        assert len(patched_approve_mcp.instances) == 1
+        mcp = patched_approve_mcp.instances[0]
+        assert mcp.calls == [("delete_device", {"id": "dev-1"}, True)]
+
+        # A role=tool ChatMessage was persisted on the thread.
+        messages = await _fetch_thread_messages(app, tid)
+        tool_msgs = [m for m in messages if m.role == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].content == '{"deleted": "dev-1"}'
+
+    async def test_approve_503_when_mcp_unavailable_leaves_row_pending(
+        self, client, app, patched_approve_mcp
+    ):
+        _ApproveFakeMcp.raise_on_enter = True
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+
+        resp = await client.post(f"/api/chat/approvals/{aid}/approve")
+        assert resp.status_code == 503
+        # Re-fetch — should still be pending.
+        get_resp = await client.get(f"/api/chat/approvals/{aid}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["status"] == STATUS_PENDING
+
+    async def test_approve_records_tool_error_as_result(
+        self, client, app, patched_approve_mcp
+    ):
+        _ApproveFakeMcp.raise_on_call = True
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+
+        resp = await client.post(f"/api/chat/approvals/{aid}/approve")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == STATUS_APPROVED
+        result = json.loads(body["result_content"])
+        assert "error" in result
+        assert "tool blew up" in result["error"]
+        # And the synthetic tool message landed.
+        messages = await _fetch_thread_messages(app, tid)
+        assert any(m.role == "tool" for m in messages)
+
+    async def test_approve_twice_is_409(self, client, app, patched_approve_mcp):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+        await client.post(f"/api/chat/approvals/{aid}/approve")
+        resp = await client.post(f"/api/chat/approvals/{aid}/approve")
+        assert resp.status_code == 409
+
+    async def test_approve_unknown_is_404(self, client, patched_approve_mcp):
+        resp = await client.post(
+            f"/api/chat/approvals/{uuid.uuid4()}/approve"
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestRejectEndpoint:
+    async def test_reject_persists_synthetic_tool_message(self, client, app):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid, tool_name="delete_device")
+
+        resp = await client.post(
+            f"/api/chat/approvals/{aid}/reject", json={"note": "too risky"}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == STATUS_REJECTED
+        assert body["decision_note"] == "too risky"
+        payload = json.loads(body["result_content"])
+        assert payload["rejected"] is True
+        assert payload["reason"] == "too risky"
+
+        # Synthetic role=tool message landed.
+        messages = await _fetch_thread_messages(app, tid)
+        tool_msgs = [m for m in messages if m.role == "tool"]
+        assert len(tool_msgs) == 1
+        assert json.loads(tool_msgs[0].content)["rejected"] is True
+
+    async def test_reject_without_note_uses_default_reason(self, client, app):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+
+        resp = await client.post(f"/api/chat/approvals/{aid}/reject")
+        assert resp.status_code == 200
+        payload = json.loads(resp.json()["result_content"])
+        assert "declined" in payload["reason"].lower()
+
+    async def test_reject_after_approve_is_409(
+        self, client, app, patched_approve_mcp
+    ):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+        await client.post(f"/api/chat/approvals/{aid}/approve")
+        resp = await client.post(f"/api/chat/approvals/{aid}/reject")
+        assert resp.status_code == 409


### PR DESCRIPTION
When the streaming agent loop sees the LLM propose a non-whitelisted (write) MCP tool, it now creates a `ChatPendingApproval` row, emits an `approval_request` SSE event, persists a placeholder `role=tool` message so the OpenAI history stays internally consistent, and stops the loop. The user approves or rejects via two new endpoints, which execute (or synthesise the rejection of) the tool and persist the real result in place of the placeholder so the user's next message resumes the conversation with a coherent history.

### New surface

* `GET    /api/chat/threads/{tid}/approvals` (defaults to pending)
* `GET    /api/chat/approvals/{aid}`
* `POST   /api/chat/approvals/{aid}/approve`
* `POST   /api/chat/approvals/{aid}/reject`
* New SSE event `approval_request` from the streaming endpoint.

### Data plane

* Alembic `0035` + new `chat_pending_approvals` table (status, tool_name, tool_arguments JSONB, result_content, decided_at, expires_at).
* `cms/services/assistant/mcp_client.call_tool` gets `bypass_whitelist=True` used only by the approve path.

### Tests

* 11 new router tests in `test_chat_approvals.py` (list filter, approve/reject happy path, 503 leaves row pending, tool-execution error captured, double-decision 409, unknown 404).
* 2 new streaming-intercept tests in `test_chat_agent.py` (write tool alone, read+write batch).
* 57 chat-related tests green.

The legacy non-streaming `POST /message` keeps the existing refusal behaviour; the UI uses `POST /stream` exclusively.

Part of the assistant rollout (PR 5 = frontend).