### PR TITLE
feat(assistant): chat UI page (PR 5 of 6)

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -234,7 +234,14 @@ async def require_auth(
     user = await get_current_user(request, settings, db)
     request.state.user = user
 
-    # Force password change redirect for users that haven't completed setup.
+    # Stash the assistant allowlist check on request.state so the topbar
+    # template can conditionally render the Assistant tab without each
+    # page route having to look it up.  Cheap (single cms_settings read).
+    try:
+        from cms.services.assistant_flag import assistant_enabled_for
+        request.state.assistant_enabled = await assistant_enabled_for(db, user)
+    except Exception:
+        request.state.assistant_enabled = False
     # The exempt set is the minimum surface a half-setup user must reach to
     # finish: the HTML form, the JSON API that backs the same operation,
     # and logout (so they can bail out without being trapped).

--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -1,0 +1,503 @@
+// Assistant chat UI — vanilla JS + fetch streaming.
+//
+// We use fetch() rather than EventSource because EventSource is GET-only
+// and the backend's /stream endpoint takes the prompt as a POST body.
+// The stream wire format is plain SSE so we parse `event: ...\n\n` frames
+// off the byte stream ourselves.
+//
+// Event types from the backend agent (PR 3c + PR 4):
+//   token             text delta
+//   tool_call         { id, name, arguments }     — about to invoke
+//   tool_result       { id, name, content }       — read tool finished
+//   approval_request  { approval_id, name, arguments, tool_call_id }
+//   done              { message_id, tokens_in, tokens_out }
+//   error             { message }
+(function () {
+    "use strict";
+
+    const $app = document.getElementById("assistant-app");
+    const $unavailable = document.getElementById("assistant-unavailable");
+    const $threadList = document.getElementById("assistant-thread-list");
+    const $messages = document.getElementById("assistant-messages");
+    const $input = document.getElementById("assistant-input");
+    const $send = document.getElementById("assistant-send");
+    const $form = document.getElementById("assistant-composer");
+    const $newThread = document.getElementById("assistant-new-thread");
+
+    let state = {
+        threads: [],
+        activeThreadId: null,
+        sending: false,
+        // Map approval_id -> DOM node so we can flip cards on decision.
+        approvalCards: new Map(),
+    };
+
+    // ── Feature gate ─────────────────────────────────────────────────
+    async function probeFeature() {
+        try {
+            const r = await fetch("/api/chat/feature");
+            if (!r.ok) return false;
+            const j = await r.json();
+            return !!j.enabled;
+        } catch (e) { return false; }
+    }
+
+    // ── API helpers ──────────────────────────────────────────────────
+    async function apiGet(path) {
+        const r = await fetch(path);
+        if (!r.ok) throw new Error(`${path} → ${r.status}`);
+        return r.json();
+    }
+    async function apiPost(path, body) {
+        const r = await fetch(path, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body || {}),
+        });
+        if (!r.ok) {
+            const text = await r.text();
+            throw new Error(`${path} → ${r.status}: ${text}`);
+        }
+        return r.json();
+    }
+    async function apiDelete(path) {
+        const r = await fetch(path, { method: "DELETE" });
+        if (!r.ok && r.status !== 204) throw new Error(`${path} → ${r.status}`);
+    }
+
+    // ── Thread sidebar ───────────────────────────────────────────────
+    async function loadThreads() {
+        state.threads = await apiGet("/api/chat/threads");
+        renderThreads();
+    }
+    function renderThreads() {
+        $threadList.innerHTML = "";
+        if (!state.threads.length) {
+            const p = document.createElement("p");
+            p.className = "assistant-empty-state";
+            p.textContent = "No conversations yet.";
+            $threadList.appendChild(p);
+            return;
+        }
+        state.threads.forEach((t) => {
+            const row = document.createElement("div");
+            row.className = "assistant-thread";
+            if (t.id === state.activeThreadId) row.classList.add("active");
+            row.dataset.threadId = t.id;
+
+            const title = document.createElement("span");
+            title.className = "assistant-thread-title";
+            title.textContent = t.title || "(new conversation)";
+            row.appendChild(title);
+
+            const del = document.createElement("button");
+            del.className = "assistant-thread-delete";
+            del.title = "Delete thread";
+            del.textContent = "×";
+            del.addEventListener("click", async (ev) => {
+                ev.stopPropagation();
+                if (!confirm("Delete this conversation?")) return;
+                await apiDelete(`/api/chat/threads/${t.id}`);
+                if (state.activeThreadId === t.id) {
+                    state.activeThreadId = null;
+                    renderEmptyConversation();
+                }
+                await loadThreads();
+            });
+            row.appendChild(del);
+
+            row.addEventListener("click", () => selectThread(t.id));
+            $threadList.appendChild(row);
+        });
+    }
+
+    async function createThread() {
+        const created = await apiPost("/api/chat/threads", { title: "" });
+        await loadThreads();
+        await selectThread(created.id);
+        $input.focus();
+    }
+
+    async function selectThread(id) {
+        state.activeThreadId = id;
+        state.approvalCards.clear();
+        renderThreads();
+        await loadConversation(id);
+        $input.disabled = false;
+        $send.disabled = false;
+    }
+
+    function renderEmptyConversation() {
+        $messages.innerHTML = "";
+        const p = document.createElement("p");
+        p.className = "assistant-empty-state";
+        p.textContent = "Pick a thread or start a new one.";
+        $messages.appendChild(p);
+        $input.disabled = true;
+        $send.disabled = true;
+    }
+
+    // ── Conversation view ────────────────────────────────────────────
+    async function loadConversation(id) {
+        const data = await apiGet(`/api/chat/threads/${id}/messages`);
+        $messages.innerHTML = "";
+        const approvals = await loadApprovalIndex(id);
+        data.forEach((m) => appendMessage(m, approvals));
+        scrollToBottom();
+    }
+
+    async function loadApprovalIndex(threadId) {
+        // Fetch ALL approvals (any state) and map by tool_call_id so
+        // we can render the right card on placeholder tool rows.
+        try {
+            const list = await apiGet(
+                `/api/chat/threads/${threadId}/approvals?status=`
+            );
+            const idx = new Map();
+            list.forEach((a) => idx.set(a.tool_call_id, a));
+            return idx;
+        } catch (e) {
+            console.warn("approvals fetch failed", e);
+            return new Map();
+        }
+    }
+
+    function appendMessage(m, approvalIndex) {
+        // Tool rows that are placeholders (awaiting_approval) render
+        // as the approval card so the user can act on them on reload.
+        if (m.role === "tool") {
+            let parsed = null;
+            try { parsed = JSON.parse(m.content); } catch (e) {}
+            if (parsed && parsed.status === "awaiting_approval"
+                && approvalIndex && approvalIndex.has(m.tool_call_id)) {
+                const approval = approvalIndex.get(m.tool_call_id);
+                renderApprovalCard(approval);
+                return;
+            }
+            // A finished approval has the real result content — render
+            // the historical decision instead of the raw blob.
+            if (approvalIndex && approvalIndex.has(m.tool_call_id)) {
+                const approval = approvalIndex.get(m.tool_call_id);
+                if (approval.status === "approved" || approval.status === "rejected") {
+                    renderApprovalCard(approval);
+                    return;
+                }
+            }
+        }
+        const wrap = document.createElement("div");
+        wrap.className = `assistant-message ${m.role}`;
+        const bubble = document.createElement("div");
+        bubble.className = "assistant-message-bubble";
+
+        if (m.role === "assistant" && m.tool_calls && m.tool_calls.length) {
+            // Assistant turn that was a tool-call announcement.
+            const list = m.tool_calls
+                .map((tc) => `→ ${tc.function?.name || "?"}(${tc.function?.arguments || ""})`)
+                .join("\n");
+            bubble.textContent = m.content
+                ? `${m.content}\n\n${list}`
+                : list;
+        } else {
+            bubble.textContent = m.content || "";
+        }
+        wrap.appendChild(bubble);
+        $messages.appendChild(wrap);
+    }
+
+    // ── Approval card ────────────────────────────────────────────────
+    function renderApprovalCard(approval) {
+        const card = document.createElement("div");
+        card.className = "assistant-approval";
+        if (approval.status !== "pending") card.classList.add("decided");
+        card.dataset.approvalId = approval.id;
+
+        const h = document.createElement("h4");
+        h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
+        card.appendChild(h);
+
+        const args = document.createElement("pre");
+        args.className = "assistant-approval-args";
+        args.textContent = JSON.stringify(approval.tool_arguments, null, 2);
+        card.appendChild(args);
+
+        const actions = document.createElement("div");
+        actions.className = "assistant-approval-actions";
+        const approveBtn = document.createElement("button");
+        approveBtn.className = "btn-approve";
+        approveBtn.textContent = "Approve & run";
+        approveBtn.addEventListener("click", () => decideApproval(approval.id, "approve", card));
+        const rejectBtn = document.createElement("button");
+        rejectBtn.className = "btn-reject";
+        rejectBtn.textContent = "Reject";
+        rejectBtn.addEventListener("click", () => decideApproval(approval.id, "reject", card));
+        actions.appendChild(approveBtn);
+        actions.appendChild(rejectBtn);
+        card.appendChild(actions);
+
+        const decision = document.createElement("div");
+        decision.className = "assistant-approval-decision";
+        if (approval.status === "approved") decision.textContent = "✓ Approved";
+        else if (approval.status === "rejected") decision.textContent = "✗ Rejected";
+        else if (approval.status === "expired") decision.textContent = "⏳ Expired";
+        card.appendChild(decision);
+
+        $messages.appendChild(card);
+        state.approvalCards.set(approval.id, card);
+    }
+
+    async function decideApproval(approvalId, action, card) {
+        const note = action === "reject"
+            ? (prompt("Optional reason for rejecting:") || "")
+            : "";
+        const buttons = card.querySelectorAll("button");
+        buttons.forEach((b) => b.disabled = true);
+        try {
+            const result = await apiPost(
+                `/api/chat/approvals/${approvalId}/${action}`,
+                { note }
+            );
+            card.classList.add("decided");
+            const decision = card.querySelector(".assistant-approval-decision");
+            if (decision) {
+                decision.textContent = action === "approve"
+                    ? `✓ Approved — result attached to thread. Send a message to continue.`
+                    : `✗ Rejected${note ? " — " + note : ""}`;
+            }
+        } catch (e) {
+            alert(`Decision failed: ${e.message}`);
+            buttons.forEach((b) => b.disabled = false);
+        }
+    }
+
+    // ── Send + stream ────────────────────────────────────────────────
+    async function sendMessage(content) {
+        if (state.sending) return;
+        if (!state.activeThreadId) {
+            await createThread();
+        }
+        state.sending = true;
+        $send.disabled = true;
+        $input.disabled = true;
+
+        // Optimistic user-bubble render.
+        appendMessage({ role: "user", content }, null);
+        const indicator = document.createElement("div");
+        indicator.className = "assistant-streaming-indicator";
+        indicator.textContent = "Thinking ";
+        $messages.appendChild(indicator);
+        scrollToBottom();
+
+        let assistantBubble = null;
+        const ensureAssistantBubble = () => {
+            if (assistantBubble) return assistantBubble;
+            const wrap = document.createElement("div");
+            wrap.className = "assistant-message assistant";
+            const b = document.createElement("div");
+            b.className = "assistant-message-bubble";
+            wrap.appendChild(b);
+            $messages.insertBefore(wrap, indicator);
+            assistantBubble = b;
+            return b;
+        };
+
+        try {
+            const resp = await fetch(
+                `/api/chat/threads/${state.activeThreadId}/stream`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ content }),
+                }
+            );
+            if (!resp.ok) {
+                const errText = await resp.text();
+                throw new Error(`stream → ${resp.status}: ${errText}`);
+            }
+            await consumeSseStream(resp.body, (evt) => {
+                switch (evt.event) {
+                    case "token":
+                        ensureAssistantBubble().textContent += evt.data.text || "";
+                        scrollToBottom();
+                        break;
+                    case "tool_call": {
+                        const note = document.createElement("div");
+                        note.className = "assistant-tool-call";
+                        note.textContent = `→ calling ${evt.data.name}…`;
+                        $messages.insertBefore(note, indicator);
+                        scrollToBottom();
+                        break;
+                    }
+                    case "tool_result": {
+                        const note = document.createElement("div");
+                        note.className = "assistant-tool-call";
+                        note.textContent = `✓ ${evt.data.name} done`;
+                        $messages.insertBefore(note, indicator);
+                        scrollToBottom();
+                        break;
+                    }
+                    case "approval_request": {
+                        // Build a minimal ChatPendingApprovalOut-shaped object.
+                        const approval = {
+                            id: evt.data.approval_id,
+                            tool_call_id: evt.data.tool_call_id,
+                            tool_name: evt.data.name,
+                            tool_arguments: evt.data.arguments,
+                            status: "pending",
+                        };
+                        // Use a temporary card host BEFORE the indicator.
+                        const card = renderApprovalCardInline(approval, indicator);
+                        scrollToBottom();
+                        break;
+                    }
+                    case "done":
+                        break;
+                    case "error": {
+                        const e = document.createElement("div");
+                        e.className = "assistant-error";
+                        e.textContent = `Error: ${evt.data.message || "unknown"}`;
+                        $messages.insertBefore(e, indicator);
+                        scrollToBottom();
+                        break;
+                    }
+                }
+            });
+        } catch (e) {
+            const errBox = document.createElement("div");
+            errBox.className = "assistant-error";
+            errBox.textContent = `Request failed: ${e.message}`;
+            $messages.insertBefore(errBox, indicator);
+        } finally {
+            indicator.remove();
+            state.sending = false;
+            $send.disabled = false;
+            $input.disabled = false;
+            $input.focus();
+            // Refresh sidebar so the auto-title shows up on a new thread.
+            await loadThreads();
+        }
+    }
+
+    function renderApprovalCardInline(approval, anchorBefore) {
+        const card = document.createElement("div");
+        card.className = "assistant-approval";
+        card.dataset.approvalId = approval.id;
+
+        const h = document.createElement("h4");
+        h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
+        card.appendChild(h);
+
+        const args = document.createElement("pre");
+        args.className = "assistant-approval-args";
+        args.textContent = JSON.stringify(approval.tool_arguments, null, 2);
+        card.appendChild(args);
+
+        const actions = document.createElement("div");
+        actions.className = "assistant-approval-actions";
+        const approveBtn = document.createElement("button");
+        approveBtn.className = "btn-approve";
+        approveBtn.textContent = "Approve & run";
+        approveBtn.addEventListener("click", () => decideApproval(approval.id, "approve", card));
+        const rejectBtn = document.createElement("button");
+        rejectBtn.className = "btn-reject";
+        rejectBtn.textContent = "Reject";
+        rejectBtn.addEventListener("click", () => decideApproval(approval.id, "reject", card));
+        actions.appendChild(approveBtn);
+        actions.appendChild(rejectBtn);
+        card.appendChild(actions);
+
+        const decision = document.createElement("div");
+        decision.className = "assistant-approval-decision";
+        card.appendChild(decision);
+
+        if (anchorBefore && anchorBefore.parentNode) {
+            anchorBefore.parentNode.insertBefore(card, anchorBefore);
+        } else {
+            $messages.appendChild(card);
+        }
+        state.approvalCards.set(approval.id, card);
+        return card;
+    }
+
+    // ── SSE byte-stream parser ───────────────────────────────────────
+    async function consumeSseStream(stream, onEvent) {
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            // SSE frames are separated by a blank line. CRLF or LF.
+            let idx;
+            while ((idx = findFrameBoundary(buffer)) !== -1) {
+                const raw = buffer.slice(0, idx);
+                buffer = buffer.slice(idx).replace(/^(\r?\n){2}/, "");
+                const evt = parseFrame(raw);
+                if (evt) onEvent(evt);
+            }
+        }
+    }
+
+    function findFrameBoundary(buf) {
+        const a = buf.indexOf("\n\n");
+        const b = buf.indexOf("\r\n\r\n");
+        if (a === -1) return b;
+        if (b === -1) return a;
+        return Math.min(a, b);
+    }
+
+    function parseFrame(raw) {
+        let event = "message";
+        let data = "";
+        raw.split(/\r?\n/).forEach((line) => {
+            if (line.startsWith(":")) return; // comment / heartbeat
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) data += line.slice(5).trim();
+        });
+        if (!data) return null;
+        try { return { event, data: JSON.parse(data) }; }
+        catch (e) { return { event, data: { _raw: data } }; }
+    }
+
+    // ── Misc ─────────────────────────────────────────────────────────
+    function scrollToBottom() {
+        $messages.scrollTop = $messages.scrollHeight;
+    }
+
+    // ── Init ─────────────────────────────────────────────────────────
+    async function init() {
+        const enabled = await probeFeature();
+        if (!enabled) {
+            $unavailable.style.display = "";
+            $app.style.display = "none";
+            return;
+        }
+        $unavailable.style.display = "none";
+        $app.style.display = "";
+
+        await loadThreads();
+        renderEmptyConversation();
+
+        $newThread.addEventListener("click", () => createThread());
+        $form.addEventListener("submit", (ev) => {
+            ev.preventDefault();
+            const text = $input.value.trim();
+            if (!text || state.sending) return;
+            $input.value = "";
+            $input.style.height = "auto";
+            sendMessage(text);
+        });
+        $input.addEventListener("keydown", (ev) => {
+            if (ev.key === "Enter" && !ev.shiftKey) {
+                ev.preventDefault();
+                $form.requestSubmit();
+            }
+        });
+        $input.addEventListener("input", () => {
+            $input.style.height = "auto";
+            $input.style.height = Math.min($input.scrollHeight, 180) + "px";
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", init);
+})();

--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -96,7 +96,8 @@
             del.textContent = "×";
             del.addEventListener("click", async (ev) => {
                 ev.stopPropagation();
-                if (!confirm("Delete this conversation?")) return;
+                const ok = await showConfirm("Delete this conversation?");
+                if (!ok) return;
                 await apiDelete(`/api/chat/threads/${t.id}`);
                 if (state.activeThreadId === t.id) {
                     state.activeThreadId = null;
@@ -246,9 +247,13 @@
     }
 
     async function decideApproval(approvalId, action, card) {
-        const note = action === "reject"
-            ? (prompt("Optional reason for rejecting:") || "")
-            : "";
+        let note = "";
+        if (action === "reject") {
+            const entered = await showPrompt("Optional reason for rejecting:");
+            // Null = cancel — bail without sending the decision.
+            if (entered === null) return;
+            note = entered;
+        }
         const buttons = card.querySelectorAll("button");
         buttons.forEach((b) => b.disabled = true);
         try {
@@ -264,7 +269,7 @@
                     : `✗ Rejected${note ? " — " + note : ""}`;
             }
         } catch (e) {
-            alert(`Decision failed: ${e.message}`);
+            showToast(`Decision failed: ${e.message}`, "error");
             buttons.forEach((b) => b.disabled = false);
         }
     }

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -1,0 +1,310 @@
+{% extends "base.html" %}
+{% block title %}Assistant — Agora CMS{% endblock %}
+{% block content %}
+<style>
+/* ── Assistant layout ─────────────────────────────────────────── */
+.assistant-page {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 1rem;
+    height: calc(100vh - 200px);
+    min-height: 500px;
+}
+.assistant-sidebar {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+.assistant-sidebar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+}
+.assistant-sidebar-header h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+.assistant-thread-list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.assistant-thread {
+    padding: 0.5rem 0.6rem;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.88rem;
+    color: var(--text);
+    border: 1px solid transparent;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.4rem;
+}
+.assistant-thread:hover {
+    background: var(--surface-2, rgba(0,0,0,0.04));
+}
+.assistant-thread.active {
+    background: var(--accent-soft, rgba(78,140,255,0.12));
+    border-color: var(--accent, #4e8cff);
+}
+.assistant-thread-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.assistant-thread-delete {
+    opacity: 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.2rem;
+}
+.assistant-thread:hover .assistant-thread-delete {
+    opacity: 1;
+}
+.assistant-empty-state {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.assistant-main {
+    display: flex;
+    flex-direction: column;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+.assistant-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.assistant-message {
+    display: flex;
+    flex-direction: column;
+    max-width: 80%;
+    word-wrap: break-word;
+}
+.assistant-message.user {
+    align-self: flex-end;
+}
+.assistant-message.assistant, .assistant-message.tool {
+    align-self: flex-start;
+}
+.assistant-message-bubble {
+    padding: 0.6rem 0.85rem;
+    border-radius: 12px;
+    font-size: 0.92rem;
+    white-space: pre-wrap;
+}
+.assistant-message.user .assistant-message-bubble {
+    background: var(--accent, #4e8cff);
+    color: white;
+    border-bottom-right-radius: 4px;
+}
+.assistant-message.assistant .assistant-message-bubble {
+    background: var(--surface-2, rgba(0,0,0,0.05));
+    color: var(--text);
+    border-bottom-left-radius: 4px;
+}
+.assistant-message.tool .assistant-message-bubble {
+    background: rgba(120,120,120,0.08);
+    color: var(--text-muted);
+    font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+    font-size: 0.78rem;
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px dashed var(--border);
+}
+.assistant-message-meta {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin-top: 0.2rem;
+    padding: 0 0.2rem;
+}
+
+.assistant-tool-call {
+    align-self: flex-start;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 0.2rem 0.5rem;
+}
+
+/* Approval card */
+.assistant-approval {
+    align-self: stretch;
+    background: var(--warn-soft, #fff8e6);
+    border: 1px solid var(--warn, #d4a72c);
+    border-radius: 8px;
+    padding: 0.75rem;
+}
+.assistant-approval h4 {
+    margin: 0 0 0.4rem 0;
+    color: var(--warn-text, #8c6a00);
+    font-size: 0.9rem;
+}
+.assistant-approval-args {
+    font-family: ui-monospace, monospace;
+    font-size: 0.78rem;
+    background: rgba(0,0,0,0.04);
+    padding: 0.4rem 0.55rem;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    margin: 0.3rem 0;
+    max-height: 180px;
+    overflow-y: auto;
+}
+.assistant-approval-actions {
+    display: flex;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+}
+.assistant-approval-actions button {
+    padding: 0.3rem 0.8rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.assistant-approval-actions .btn-approve {
+    background: var(--accent, #4e8cff);
+    color: white;
+    border-color: var(--accent, #4e8cff);
+}
+.assistant-approval-actions .btn-reject {
+    background: white;
+    color: var(--danger, #c93434);
+    border-color: var(--danger, #c93434);
+}
+.assistant-approval.decided {
+    opacity: 0.65;
+}
+.assistant-approval.decided .assistant-approval-actions { display: none; }
+.assistant-approval-decision {
+    font-size: 0.78rem;
+    font-style: italic;
+    margin-top: 0.3rem;
+}
+
+.assistant-composer {
+    border-top: 1px solid var(--border);
+    padding: 0.6rem 0.75rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+.assistant-composer textarea {
+    flex: 1;
+    resize: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.6rem;
+    font-family: inherit;
+    font-size: 0.92rem;
+    min-height: 38px;
+    max-height: 180px;
+    background: var(--bg, white);
+    color: var(--text);
+}
+.assistant-composer button {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid var(--accent, #4e8cff);
+    background: var(--accent, #4e8cff);
+    color: white;
+    cursor: pointer;
+    font-weight: 500;
+}
+.assistant-composer button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.assistant-streaming-indicator {
+    align-self: flex-start;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    font-style: italic;
+    padding: 0.25rem 0.5rem;
+}
+.assistant-streaming-indicator::after {
+    content: "▍";
+    animation: assistant-blink 1s infinite;
+}
+@keyframes assistant-blink {
+    50% { opacity: 0; }
+}
+
+.assistant-error {
+    align-self: stretch;
+    background: var(--danger-soft, #fde6e6);
+    border: 1px solid var(--danger, #c93434);
+    border-radius: 6px;
+    padding: 0.5rem 0.7rem;
+    color: var(--danger-text, #8c1f1f);
+    font-size: 0.85rem;
+}
+
+#assistant-unavailable {
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-muted);
+}
+</style>
+
+<div id="assistant-app" style="display:none;">
+    <h1>Assistant <small style="font-weight:normal;color:var(--text-muted);font-size:0.85rem;">— preview</small></h1>
+    <div class="assistant-page">
+        <aside class="assistant-sidebar">
+            <div class="assistant-sidebar-header">
+                <h3>Threads</h3>
+                <button class="btn btn-sm" id="assistant-new-thread">+ New</button>
+            </div>
+            <div class="assistant-thread-list" id="assistant-thread-list">
+                <p class="assistant-empty-state">No conversations yet.</p>
+            </div>
+        </aside>
+        <section class="assistant-main">
+            <div class="assistant-messages" id="assistant-messages">
+                <p class="assistant-empty-state">Pick a thread or start a new one.</p>
+            </div>
+            <form class="assistant-composer" id="assistant-composer">
+                <textarea
+                    id="assistant-input"
+                    placeholder="Ask about devices, schedules, assets…  (Shift+Enter for newline)"
+                    rows="1"
+                    disabled></textarea>
+                <button type="submit" id="assistant-send" disabled>Send</button>
+            </form>
+        </section>
+    </div>
+</div>
+
+<div id="assistant-unavailable">
+    <p>The Assistant is not enabled for your account.</p>
+    <p style="font-size:0.85rem;">Ask an admin to add you to the allowlist in Settings.</p>
+</div>
+
+<script src="/static/assistant.js?v={{ static_version }}"></script>
+{% endblock %}

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -84,6 +84,9 @@
         {% if 'users:read' in user_perms %}
         <a href="/users" class="nav-tab {% if active_tab == 'users' %}active{% endif %}">Users</a>
         {% endif %}
+        {% if request.state.assistant_enabled is defined and request.state.assistant_enabled %}
+        <a href="/assistant" class="nav-tab {% if active_tab == 'assistant' %}active{% endif %}">Assistant</a>
+        {% endif %}
         </div>
         {% if request.state.user is defined and request.state.user %}
         <div class="header-status-lights">

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -905,6 +905,26 @@ async def dashboard(request: Request, db: AsyncSession = Depends(get_db)):
     })
 
 
+@router.get("/assistant", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
+async def assistant_page(request: Request, db: AsyncSession = Depends(get_db)):
+    """Render the Assistant chat UI.
+
+    Gated by the per-user allowlist: users not on the list get a 404
+    (matches the /api/chat/* endpoints, which return 404 so the feature
+    is invisible).  The client-side JS does its own /api/chat/feature
+    probe and renders a polite "not enabled" view when the user is off
+    the allowlist — this server-side gate is the belt-and-braces.
+    """
+    from fastapi import HTTPException
+    from cms.services.assistant_flag import assistant_enabled_for
+    user = getattr(request.state, "user", None)
+    if user is None or not await assistant_enabled_for(db, user):
+        raise HTTPException(status_code=404)
+    return templates.TemplateResponse(request, "assistant.html", {
+        "active_tab": "assistant",
+    })
+
+
 @router.get("/api/server-time", dependencies=[Depends(require_auth)])
 async def server_time_json(db: AsyncSession = Depends(get_db)):
     """Return the CMS server's configured timezone and current local time."""

--- a/tests/test_assistant_page.py
+++ b/tests/test_assistant_page.py
@@ -1,0 +1,65 @@
+"""Tests for the /assistant HTML page (PR 5).
+
+The endpoint is allowlist-gated: users not on the assistant allowlist
+get a 404 (same shape as the /api/chat/* endpoints).  Admins always
+pass via the existing escape hatch in assistant_enabled_for().
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _enable_for(app, user_id: uuid.UUID) -> None:
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [user_id])
+        break
+
+
+async def _disable_all(app) -> None:
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [])
+        break
+
+
+@pytest.mark.asyncio
+class TestAssistantPage:
+    async def test_admin_can_view(self, client):
+        resp = await client.get("/assistant")
+        assert resp.status_code == 200
+        body = resp.text
+        # Sanity-check the shell renders.
+        assert "assistant-app" in body
+        assert "/static/assistant.js" in body
+
+    async def test_operator_off_allowlist_gets_404(self, operator_client, app):
+        await _disable_all(app)
+        resp = await operator_client.get("/assistant")
+        assert resp.status_code == 404
+
+    async def test_operator_on_allowlist_can_view(self, operator_client, app):
+        await _enable_for(app, operator_client.user_id)
+        resp = await operator_client.get("/assistant")
+        assert resp.status_code == 200
+        assert "assistant-app" in resp.text
+
+    async def test_nav_tab_appears_when_enabled(self, operator_client, app):
+        # Pull any HTML page (dashboard) and confirm the nav link is
+        # only present when the feature is enabled for the user.
+        await _disable_all(app)
+        page = await operator_client.get("/")
+        assert page.status_code == 200
+        assert ">Assistant<" not in page.text
+
+        await _enable_for(app, operator_client.user_id)
+        page = await operator_client.get("/")
+        assert page.status_code == 200
+        assert ">Assistant<" in page.text


### PR DESCRIPTION
Adds the `/assistant` page that wires up the Assistant chat experience against the backend already shipped in PRs 2-4.

## What's in the UI

- **Thread sidebar** — lists the user's conversations, with `+ New` and per-row delete. Click to switch.
- **Message timeline** — renders user / assistant / tool rows; tool rows that are approval placeholders render as approval cards on history reload.
- **Composer** — Enter to send, Shift+Enter for newline; disabled while a stream is in flight.
- **Streaming** — uses `fetch()` + `ReadableStream` (not `EventSource`, because `/stream` is POST). Parses `token` / `tool_call` / `tool_result` / `approval_request` / `done` / `error` frames live.
- **Approval cards** — write-tool requests render an Approve / Reject card inline. Approve POSTs to `/api/chat/approvals/{id}/approve`; reject prompts for an optional note and POSTs to `/reject`.

## Server-side gating

- New `GET /assistant` route returns **404** for users not on the allowlist (matches the `/api/chat/*` shape — the feature is invisible to non-allowlisted users).
- `require_auth` now stashes `request.state.assistant_enabled` so the topbar nav-tab can render conditionally without every page route having to recompute it.
- Admins still pass via the existing `settings:write` escape hatch in `assistant_enabled_for`.

## Tests

4 new tests in `test_assistant_page.py`:
- admin can view the page
- operator off allowlist gets 404
- operator on allowlist gets 200
- nav tab appears/disappears with the allowlist flag

Full chat suite still green locally: **61 passed**.

## Out of scope (deferred)

- The approval flow currently INSERTS a new `role=tool` row alongside the placeholder rather than updating it. History reconstruction sees both rows. Will be cleaned up in PR 6 or a follow-up.
- Per-user budget UI + cap enforcement (PR 6).
- Admin allowlist multi-select picker in the Settings page (PR 6).

## Reviewing locally

Allowlist yourself, then visit `/assistant`:
\\\sh
# in a python shell with the CMS db handle
from cms.services.assistant_flag import set_allowlist
await set_allowlist(db, [my_user_uuid])
\\\

This is the **review checkpoint** — auto-merge intentionally NOT enabled. Please poke around and let me know.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>