### PR TITLE
Assistant PR 6a: per-user daily token budget + approval row cleanup

### DIFF
--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -39,6 +39,7 @@ from cms.schemas.chat import (
     ChatThreadOut,
 )
 from cms.services.assistant.agent import run_user_turn, run_user_turn_streaming
+from cms.services.assistant.budget import BudgetExceededError, check_budget
 from cms.services.assistant.llm_client import (
     AssistantUnavailableError,
     is_available as assistant_llm_available,
@@ -212,6 +213,19 @@ async def post_message(
     await _require_feature(user, db)
     thread = await _get_owned_thread(thread_id, user, db)
 
+    try:
+        await check_budget(db, user)
+    except BudgetExceededError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "Daily token cap reached.",
+                "daily_cap": exc.daily_cap,
+                "used": exc.used,
+            },
+            headers={"Retry-After": "3600"},
+        ) from exc
+
     if not assistant_llm_available(settings):
         raise HTTPException(
             status_code=503,
@@ -226,6 +240,16 @@ async def post_message(
             thread=thread,
             user_message=payload.content,
         )
+    except BudgetExceededError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "Daily token cap reached.",
+                "daily_cap": exc.daily_cap,
+                "used": exc.used,
+            },
+            headers={"Retry-After": "3600"},
+        ) from exc
     except AssistantUnavailableError as exc:
         # Defensive — assistant_llm_available() should have caught this,
         # but a race against config changes is theoretically possible.
@@ -314,6 +338,23 @@ async def post_message_stream(
     """
     await _require_feature(user, db)
     thread = await _get_owned_thread(thread_id, user, db)
+
+    # Budget pre-check.  Runs BEFORE EventSourceResponse so a user
+    # over their cap gets a clean 429 instead of a half-open SSE
+    # stream that immediately emits an error frame.  The agent re-
+    # checks internally as a belt-and-braces safety net.
+    try:
+        await check_budget(db, user)
+    except BudgetExceededError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "Daily token cap reached.",
+                "daily_cap": exc.daily_cap,
+                "used": exc.used,
+            },
+            headers={"Retry-After": "3600"},
+        ) from exc
 
     if not assistant_llm_available(settings):
         raise HTTPException(

--- a/cms/routers/chat_approvals.py
+++ b/cms/routers/chat_approvals.py
@@ -165,11 +165,55 @@ async def get_approval(
 # ── Decide ────────────────────────────────────────────────────────────
 
 
+async def _upsert_tool_result(
+    db: AsyncSession,
+    thread_id: uuid.UUID,
+    tool_call_id: str,
+    content: str,
+) -> None:
+    """Write the tool result for ``tool_call_id`` into the thread.
+
+    The streaming agent persists a *placeholder* ``role=tool`` row at
+    the moment a write tool is intercepted so the OpenAI conversation
+    history stays internally consistent (every ``tool_calls`` assistant
+    turn must have a matching ``role=tool`` row).  When the human
+    later approves or rejects, we UPDATE that placeholder in place
+    rather than INSERTing a duplicate — otherwise the next turn's
+    history would carry two rows with the same ``tool_call_id``,
+    which is a wire-protocol violation OpenAI may or may not reject
+    silently.
+
+    If no placeholder exists (legacy data, or an approval created by
+    the non-streaming path that didn't go through the intercept), we
+    INSERT a fresh row — the upsert is idempotent on first call.
+    """
+    existing = (
+        await db.execute(
+            select(ChatMessage)
+            .where(ChatMessage.thread_id == thread_id)
+            .where(ChatMessage.tool_call_id == tool_call_id)
+            .where(ChatMessage.role == "tool")
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.content = content
+        return
+    db.add(
+        ChatMessage(
+            thread_id=thread_id,
+            role="tool",
+            tool_call_id=tool_call_id,
+            content=content,
+        )
+    )
+
+
 def _result_message(
     thread_id: uuid.UUID, tool_call_id: str, content: str
 ) -> ChatMessage:
-    """Build the synthetic ``role=tool`` ChatMessage the agent loop
-    would have produced if the tool had been called normally."""
+    """Legacy synchronous helper, kept for callers that still INSERT
+    a fresh row.  Prefer :func:`_upsert_tool_result` which handles
+    the placeholder-update case from the streaming approval flow."""
     return ChatMessage(
         thread_id=thread_id,
         role="tool",
@@ -229,7 +273,7 @@ async def approve_approval(
         )
         result_text = json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
-    db.add(_result_message(row.thread_id, row.tool_call_id, result_text))
+    await _upsert_tool_result(db, row.thread_id, row.tool_call_id, result_text)
     row.status = STATUS_APPROVED
     row.result_content = result_text
     row.decision_note = (payload.note if payload else None) or None
@@ -274,7 +318,7 @@ async def reject_approval(
     }
     result_text = json.dumps(rejection_payload)
 
-    db.add(_result_message(row.thread_id, row.tool_call_id, result_text))
+    await _upsert_tool_result(db, row.thread_id, row.tool_call_id, result_text)
     row.status = STATUS_REJECTED
     row.result_content = result_text
     row.decision_note = note

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -176,6 +176,13 @@ async def run_user_turn(
     if not user_message:
         raise ValueError("user_message must not be empty")
 
+    # 0. Daily-cap check.  Done BEFORE persisting the user row so a
+    #    user who is at the cap doesn't accumulate empty turns; the
+    #    router converts BudgetExceededError into a 429 with the
+    #    cap details and the user sees a friendly message.
+    from cms.services.assistant.budget import check_budget
+    await check_budget(db, user)
+
     # 1. Persist the user turn first so it's visible in history even if
     #    the LLM call later fails (the frontend's optimistic render
     #    will reconcile to this row on the next poll).
@@ -388,6 +395,13 @@ async def run_user_turn_streaming(
     user_message = user_message.strip()
     if not user_message:
         raise ValueError("user_message must not be empty")
+
+    # 0. Daily-cap check (same as run_user_turn).  Raised before any
+    #    DB mutation so the router can surface 429 BEFORE the SSE
+    #    handshake — the user never sees a half-open stream that
+    #    immediately errors out.
+    from cms.services.assistant.budget import check_budget
+    await check_budget(db, user)
 
     # 1. Persist the user turn first.
     user_row = ChatMessage(

--- a/cms/services/assistant/budget.py
+++ b/cms/services/assistant/budget.py
@@ -1,0 +1,205 @@
+"""Per-user daily token budget for the Assistant.
+
+Tracks LLM token usage by *summing* ``ChatMessage.tokens_in`` +
+``tokens_out`` across the user's threads since the start of the
+current UTC day.  No separate counter table is required because the
+authoritative per-turn token counts are already persisted on each
+assistant message (recorded from the OpenAI completion ``usage`` reply).
+
+Configuration uses the existing ``cms_settings`` key/value store:
+
+* ``assistant_daily_token_cap`` — integer, global default in tokens
+  per UTC day per user.  Missing or unparseable → ``DEFAULT_DAILY_TOKEN_CAP``.
+* ``assistant_daily_token_cap_overrides`` — JSON object mapping
+  ``{user_id_str: int}`` for per-user overrides.  A user listed here
+  uses their override; everyone else uses the global default.  A
+  ``0`` cap means "blocked, even though allowlisted" (useful for
+  temporarily revoking access without rewriting the allowlist).
+  A negative cap is treated as **unlimited** (escape hatch for the
+  admin running diagnostics; logged at INFO when invoked).
+
+Enforcement is invoked from :func:`agent.run_user_turn` and
+:func:`agent.run_user_turn_streaming` *before* any LLM call is made.
+A :class:`BudgetExceededError` carries the cap and current usage so
+the router can build a useful 429 response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, time, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import get_setting, set_setting
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+
+
+logger = logging.getLogger(__name__)
+
+
+# Default cap when nothing is configured.  50k tokens/day at the
+# AOAI gpt-4o-mini blended rate (~$0.15/M in + $0.60/M out) is well
+# under $0.05/day per user — safe Phase-1 ceiling that lets us see
+# real usage before any admin has to touch a setting.
+DEFAULT_DAILY_TOKEN_CAP: int = 50_000
+
+BUDGET_CAP_KEY = "assistant_daily_token_cap"
+BUDGET_OVERRIDES_KEY = "assistant_daily_token_cap_overrides"
+
+
+class BudgetExceededError(Exception):
+    """Raised when a user has hit their daily token cap for the day.
+
+    Attributes:
+        daily_cap: The cap that was in effect for this user.
+        used:      Tokens already consumed today before this turn.
+    """
+
+    def __init__(self, *, daily_cap: int, used: int) -> None:
+        self.daily_cap = daily_cap
+        self.used = used
+        super().__init__(
+            f"Daily token cap reached ({used}/{daily_cap})."
+        )
+
+
+# ── Settings accessors ────────────────────────────────────────────────
+
+
+async def get_default_cap(db: AsyncSession) -> int:
+    """Return the configured global cap, falling back to the default."""
+    raw = await get_setting(db, BUDGET_CAP_KEY)
+    if raw is None or raw == "":
+        return DEFAULT_DAILY_TOKEN_CAP
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "assistant_daily_token_cap=%r is not an int; falling back to default",
+            raw,
+        )
+        return DEFAULT_DAILY_TOKEN_CAP
+
+
+async def set_default_cap(db: AsyncSession, cap: int) -> None:
+    """Persist the global default cap (admin-only)."""
+    await set_setting(db, BUDGET_CAP_KEY, str(int(cap)))
+
+
+async def _load_overrides(db: AsyncSession) -> dict[uuid.UUID, int]:
+    raw = await get_setting(db, BUDGET_OVERRIDES_KEY)
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(
+            "%s contains invalid JSON; treating as empty", BUDGET_OVERRIDES_KEY
+        )
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[uuid.UUID, int] = {}
+    for k, v in data.items():
+        try:
+            out[uuid.UUID(str(k))] = int(v)
+        except (TypeError, ValueError):
+            logger.warning(
+                "skipping override entry %r=%r (invalid uuid or int)", k, v
+            )
+    return out
+
+
+async def get_overrides(db: AsyncSession) -> dict[uuid.UUID, int]:
+    """Return the per-user override map (admin UI uses this directly)."""
+    return await _load_overrides(db)
+
+
+async def set_user_override(
+    db: AsyncSession, user_id: uuid.UUID, cap: int
+) -> None:
+    """Set an override for a single user (does not touch others)."""
+    overrides = await _load_overrides(db)
+    overrides[user_id] = int(cap)
+    serialised = {str(uid): int(c) for uid, c in overrides.items()}
+    await set_setting(db, BUDGET_OVERRIDES_KEY, json.dumps(serialised))
+
+
+async def clear_user_override(db: AsyncSession, user_id: uuid.UUID) -> None:
+    """Remove an override; the user reverts to the global default."""
+    overrides = await _load_overrides(db)
+    if overrides.pop(user_id, None) is None:
+        return
+    serialised = {str(uid): int(c) for uid, c in overrides.items()}
+    await set_setting(db, BUDGET_OVERRIDES_KEY, json.dumps(serialised))
+
+
+# ── Lookups ───────────────────────────────────────────────────────────
+
+
+async def get_user_daily_cap(db: AsyncSession, user: User) -> int:
+    """Return the cap that applies to ``user`` today."""
+    overrides = await _load_overrides(db)
+    if user.id in overrides:
+        return overrides[user.id]
+    return await get_default_cap(db)
+
+
+def _utc_day_start(now: datetime | None = None) -> datetime:
+    """Return midnight UTC of the current (or provided) instant."""
+    now = now or datetime.now(timezone.utc)
+    return datetime.combine(now.date(), time.min, tzinfo=timezone.utc)
+
+
+async def get_user_today_usage(
+    db: AsyncSession, user: User, *, now: datetime | None = None
+) -> int:
+    """Sum ``tokens_in + tokens_out`` for ``user``'s assistant turns today.
+
+    Threads are scoped by ``ChatThread.user_id`` so we don't double-count
+    if a thread is later transferred / inherited.  System and tool rows
+    have ``tokens_in/out`` = 0 by construction so they contribute
+    nothing; the implementation just adds the whole column.
+    """
+    day_start = _utc_day_start(now)
+    stmt = (
+        select(
+            func.coalesce(func.sum(ChatMessage.tokens_in), 0)
+            + func.coalesce(func.sum(ChatMessage.tokens_out), 0)
+        )
+        .select_from(ChatMessage)
+        .join(ChatThread, ChatThread.id == ChatMessage.thread_id)
+        .where(ChatThread.user_id == user.id)
+        .where(ChatMessage.created_at >= day_start)
+    )
+    total = (await db.execute(stmt)).scalar()
+    return int(total or 0)
+
+
+async def check_budget(
+    db: AsyncSession, user: User, *, now: datetime | None = None
+) -> tuple[int, int]:
+    """Raise :class:`BudgetExceededError` if the user is at/over their cap.
+
+    Returns ``(used, cap)`` on success so the caller can attach the
+    pair to a log line / telemetry event.
+
+    A negative cap is treated as unlimited (admin escape hatch);
+    we log INFO so the audit trail still records the use of it.
+    """
+    cap = await get_user_daily_cap(db, user)
+    used = await get_user_today_usage(db, user, now=now)
+    if cap < 0:
+        logger.info(
+            "assistant.budget.unlimited user=%s used=%d", user.id, used
+        )
+        return used, cap
+    if used >= cap:
+        raise BudgetExceededError(daily_cap=cap, used=used)
+    return used, cap

--- a/tests/test_chat_approvals.py
+++ b/tests/test_chat_approvals.py
@@ -307,3 +307,98 @@ class TestRejectEndpoint:
         await client.post(f"/api/chat/approvals/{aid}/approve")
         resp = await client.post(f"/api/chat/approvals/{aid}/reject")
         assert resp.status_code == 409
+
+
+# ── Placeholder upsert (PR 6) ────────────────────────────────────────
+
+
+async def _insert_placeholder_tool_row(
+    app, thread_id: uuid.UUID, tool_call_id: str
+) -> uuid.UUID:
+    """Insert a `role=tool` placeholder row that the streaming agent
+    would have written when it intercepted a write tool.  Returns the
+    row id so the test can assert it was UPDATED (not replaced)."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    row_id: uuid.UUID | None = None
+    async for db in factory():
+        row = ChatMessage(
+            thread_id=thread_id,
+            role="tool",
+            tool_call_id=tool_call_id,
+            content=json.dumps({"status": "awaiting_approval"}),
+        )
+        db.add(row)
+        await db.commit()
+        await db.refresh(row)
+        row_id = row.id
+        break
+    assert row_id is not None
+    return row_id
+
+
+@pytest.mark.asyncio
+class TestApprovalResultUpsert:
+    """The approve / reject paths must UPDATE the placeholder tool row
+    in place rather than INSERT a duplicate — otherwise the next turn's
+    history would carry two rows with the same `tool_call_id`."""
+
+    async def test_approve_updates_placeholder_in_place(
+        self, client, app, patched_approve_mcp
+    ):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+        # Find the approval's tool_call_id and pre-seed the placeholder.
+        approval = await client.get(f"/api/chat/approvals/{aid}")
+        tc_id = approval.json()["tool_call_id"]
+        placeholder_id = await _insert_placeholder_tool_row(app, tid, tc_id)
+        patched_approve_mcp.result = '{"deleted": "dev-1"}'
+
+        resp = await client.post(f"/api/chat/approvals/{aid}/approve")
+        assert resp.status_code == 200
+
+        messages = await _fetch_thread_messages(app, tid)
+        tool_msgs = [m for m in messages if m.tool_call_id == tc_id]
+        assert len(tool_msgs) == 1, (
+            "expected exactly one tool row per tool_call_id after approve"
+        )
+        assert tool_msgs[0].id == placeholder_id
+        assert tool_msgs[0].content == '{"deleted": "dev-1"}'
+
+    async def test_reject_updates_placeholder_in_place(self, client, app):
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+        approval = await client.get(f"/api/chat/approvals/{aid}")
+        tc_id = approval.json()["tool_call_id"]
+        placeholder_id = await _insert_placeholder_tool_row(app, tid, tc_id)
+
+        resp = await client.post(
+            f"/api/chat/approvals/{aid}/reject", json={"note": "nope"}
+        )
+        assert resp.status_code == 200
+
+        messages = await _fetch_thread_messages(app, tid)
+        tool_msgs = [m for m in messages if m.tool_call_id == tc_id]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].id == placeholder_id
+        body = json.loads(tool_msgs[0].content)
+        assert body["rejected"] is True
+        assert "nope" in body["reason"]
+
+    async def test_approve_inserts_when_no_placeholder_exists(
+        self, client, app, patched_approve_mcp
+    ):
+        # Backward-compat: if no placeholder is pre-seeded (legacy /
+        # non-streaming origin path) the upsert falls back to INSERT.
+        tid = await _create_thread(client)
+        aid = await _new_approval(app, tid)
+        patched_approve_mcp.result = '{"ok": true}'
+
+        resp = await client.post(f"/api/chat/approvals/{aid}/approve")
+        assert resp.status_code == 200
+
+        messages = await _fetch_thread_messages(app, tid)
+        tool_msgs = [m for m in messages if m.role == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].content == '{"ok": true}'

--- a/tests/test_chat_budget.py
+++ b/tests/test_chat_budget.py
@@ -1,0 +1,249 @@
+"""Tests for the Assistant per-user daily token budget (PR 6 of 6).
+
+Covers the standalone service layer + the router-level 429 surface:
+
+* Default cap is honoured when nothing is configured.
+* Per-user override beats the default.
+* Negative cap means "unlimited".
+* `check_budget` raises `BudgetExceededError` at/above the cap.
+* `/message` and `/stream` both return 429 with the cap details when
+  the user is over.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _create_thread(client, title: str = "") -> uuid.UUID:
+    resp = await client.post("/api/chat/threads", json={"title": title})
+    assert resp.status_code == 201, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _seed_usage(app, thread_id: uuid.UUID, tokens_in: int, tokens_out: int) -> None:
+    """Persist a synthetic assistant message with the given token counts
+    so the budget query has something to sum."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        db.add(
+            ChatMessage(
+                thread_id=thread_id,
+                role="assistant",
+                content="(synthetic)",
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+            )
+        )
+        await db.commit()
+        break
+
+
+async def _seed_old_usage(
+    app, thread_id: uuid.UUID, tokens_in: int, tokens_out: int
+) -> None:
+    """Same as `_seed_usage` but back-dates the row by 2 days so we can
+    confirm it's excluded from today's window."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        row = ChatMessage(
+            thread_id=thread_id,
+            role="assistant",
+            content="(synthetic-old)",
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+        db.add(row)
+        await db.flush()
+        row.created_at = datetime.now(timezone.utc) - timedelta(days=2)
+        await db.commit()
+        break
+
+
+async def _admin_user(db):
+    return (
+        await db.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+
+
+# ── Service layer ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestBudgetService:
+    async def test_default_cap_when_unset(self, app):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            DEFAULT_DAILY_TOKEN_CAP,
+            get_default_cap,
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            cap = await get_default_cap(db)
+            assert cap == DEFAULT_DAILY_TOKEN_CAP
+            break
+
+    async def test_set_and_get_default_cap(self, app):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            get_default_cap,
+            set_default_cap,
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, 9000)
+            assert await get_default_cap(db) == 9000
+            break
+
+    async def test_user_override_beats_default(self, app):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            get_user_daily_cap,
+            set_default_cap,
+            set_user_override,
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, 100)
+            user = await _admin_user(db)
+            await set_user_override(db, user.id, 5000)
+            assert await get_user_daily_cap(db, user) == 5000
+            break
+
+    async def test_today_usage_sums_only_todays_rows(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import get_user_today_usage
+
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 100, 200)
+        await _seed_old_usage(app, tid, 999, 999)  # 2 days ago — excluded
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            user = await _admin_user(db)
+            used = await get_user_today_usage(db, user)
+            assert used == 300
+            break
+
+    async def test_check_budget_raises_at_cap(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            BudgetExceededError,
+            check_budget,
+            set_default_cap,
+        )
+
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 500, 500)
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, 1000)
+            user = await _admin_user(db)
+            with pytest.raises(BudgetExceededError) as ei:
+                await check_budget(db, user)
+            assert ei.value.daily_cap == 1000
+            assert ei.value.used == 1000
+            break
+
+    async def test_negative_cap_is_unlimited(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            check_budget,
+            set_user_override,
+        )
+
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 100_000, 100_000)
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            user = await _admin_user(db)
+            await set_user_override(db, user.id, -1)
+            used, cap = await check_budget(db, user)
+            assert used == 200_000
+            assert cap == -1
+            break
+
+    async def test_clear_user_override_reverts_to_default(self, app):
+        from cms.database import get_db
+        from cms.services.assistant.budget import (
+            clear_user_override,
+            get_user_daily_cap,
+            set_default_cap,
+            set_user_override,
+        )
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            user = await _admin_user(db)
+            await set_default_cap(db, 7777)
+            await set_user_override(db, user.id, 100)
+            assert await get_user_daily_cap(db, user) == 100
+            await clear_user_override(db, user.id)
+            assert await get_user_daily_cap(db, user) == 7777
+            break
+
+
+# ── Router-level 429 enforcement ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestBudget429:
+    async def test_message_returns_429_when_over_cap(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import set_default_cap
+
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 1, 1)
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, 1)  # forces 2/1 over
+            break
+
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/message", json={"content": "hi"}
+        )
+        assert resp.status_code == 429, resp.text
+        detail = resp.json()["detail"]
+        assert detail["daily_cap"] == 1
+        assert detail["used"] == 2
+        assert resp.headers.get("retry-after") == "3600"
+
+    async def test_stream_returns_429_before_handshake(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import set_default_cap
+
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 50, 50)
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, 10)
+            break
+
+        resp = await client.post(
+            f"/api/chat/threads/{tid}/stream", json={"content": "hi"}
+        )
+        assert resp.status_code == 429, resp.text
+        detail = resp.json()["detail"]
+        assert detail["daily_cap"] == 10
+        assert detail["used"] == 100
+


### PR DESCRIPTION
Backend half of PR 6 (admin Settings UI lands in PR 6b).

## What

**Daily token budget (new `cms/services/assistant/budget.py`)**
- Sums today's `tokens_in + tokens_out` from `chat_message` per user vs a configured cap.
- Config lives in `cms_settings` (no new table):
  - `assistant_daily_token_cap` — global default int, defaults to 50,000.
  - `assistant_daily_token_cap_overrides` — JSON `{user_id_str: int}`.
- Negative cap = unlimited (escape hatch). Zero = explicit block.
- Wired into `run_user_turn` AND `run_user_turn_streaming` (defense in depth) and into `POST /api/chat/threads/{id}/message` + `/stream` — the latter pre-EventSourceResponse so over-cap users get a clean 429, not a half-open SSE.
- Budget check runs before the LLM-availability check so enforcement works even in environments without AOAI configured.

**Approval row cleanup**
- `_upsert_tool_result` in `chat_approvals.py` UPDATEs the placeholder `role=tool` row that the streaming agent persisted (keyed by `tool_call_id`) instead of INSERTing a sibling. Falls back to INSERT if no placeholder exists.

## Why no new table

The plan originally called for a `chat_user_budget` table; in practice the existing `ChatMessage.tokens_in/out` columns give us everything we need for a today-scoped sum, and `cms_settings` already holds the assistant allowlist. Keeps PR 6a migration-free; PR 6b adds the admin UI.

## Open question for reviewers

Should admins bypass budgets? Current behavior: no — the allowlist has an admin bypass but the budget does not. The negative-cap-as-unlimited override is the current escape hatch. Happy to add an admin bypass if preferred.

## Tests

23 new/updated (9 budget service + 2 HTTP 429 + 3 approval upsert + 9 pre-existing approval). Full chat suite: 73 passing.