### PR TITLE
Assistant PR 6b: admin Settings UI + telemetry counters (FINAL)

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -833,6 +833,7 @@ from cms.routers.tags import router as tags_router  # noqa: E402
 from cms.routers.asset_views import router as asset_views_router  # noqa: E402
 from cms.routers.chat import router as chat_router  # noqa: E402
 from cms.routers.chat_approvals import router as chat_approvals_router  # noqa: E402
+from cms.routers.assistant_settings import router as assistant_settings_router  # noqa: E402
 from cms.routers.ws import router as ws_router  # noqa: E402
 from cms.routers.api_keys import router as api_keys_router  # noqa: E402
 from cms.routers.audit import router as audit_router  # noqa: E402
@@ -857,6 +858,7 @@ app.include_router(tags_router)
 app.include_router(asset_views_router)
 app.include_router(chat_router)
 app.include_router(chat_approvals_router)
+app.include_router(assistant_settings_router)
 app.include_router(profiles_router)
 app.include_router(logs_router)
 app.include_router(cms_logs_router)

--- a/cms/metrics.py
+++ b/cms/metrics.py
@@ -223,3 +223,53 @@ presence_heartbeat_late_total: Final = _meter.create_counter(
 # Attribute key for the lease-loop name on presence counters.
 
 ATTR_LOOP_NAME: Final[str] = "loop_name"
+
+
+# ── Assistant (in-CMS LLM chat) ──────────────────────────────────────
+#
+# Three counters drive the App Insights view of Assistant adoption
+# and guardrails:
+#
+#   * agora.assistant.message_sent  — every successfully completed
+#     user turn (i.e. the LLM returned an answer).  Dimension:
+#     ``streaming`` ("true"/"false").  Forms the denominator for
+#     "approval rate" and "budget-exceeded rate" derived metrics.
+#
+#   * agora.assistant.budget_exceeded — fired inside
+#     ``services.assistant.budget.check_budget`` when a user is at
+#     or over their cap.  No dimensions; per-user attribution
+#     happens through the audit log.
+#
+#   * agora.assistant.approval_decided — increments when an admin
+#     approves or rejects a queued write tool.  Dimension:
+#     ``decision`` ("approve" / "reject").
+
+assistant_message_sent_total: Final = _meter.create_counter(
+    "agora.assistant.message_sent",
+    description=(
+        "User-initiated Assistant turns that completed successfully "
+        "(i.e. the LLM produced a reply).  Dimension: ``streaming`` "
+        "distinguishes /message from /stream callers."
+    ),
+)
+
+assistant_budget_exceeded_total: Final = _meter.create_counter(
+    "agora.assistant.budget_exceeded",
+    description=(
+        "Assistant turns refused because the user is at or over "
+        "their daily token cap.  Incremented in check_budget before "
+        "the BudgetExceededError is raised."
+    ),
+)
+
+assistant_approval_decided_total: Final = _meter.create_counter(
+    "agora.assistant.approval_decided",
+    description=(
+        "Write-tool approval decisions.  Dimension: ``decision`` "
+        "(``approve`` or ``reject``)."
+    ),
+)
+
+
+ATTR_STREAMING: Final[str] = "streaming"
+ATTR_DECISION: Final[str] = "decision"

--- a/cms/routers/assistant_settings.py
+++ b/cms/routers/assistant_settings.py
@@ -1,0 +1,250 @@
+"""Admin API for the in-CMS Assistant settings (PR 6b of 6).
+
+Three endpoints, all gated on ``settings:write``:
+
+* ``GET  /api/settings/assistant`` — full state for the admin UI:
+  current allowlist UUIDs, global default cap, per-user override map,
+  and a catalog of active users (id + display label) so the UI can
+  render checkboxes / select menus without a second round-trip.
+
+* ``PUT  /api/settings/assistant/allowlist`` — replace the allowlist
+  with the supplied list of user UUIDs.
+
+* ``PUT  /api/settings/assistant/budget`` — set the global default
+  cap and replace the per-user override map.
+
+Both writes audit-log with a stable ``settings.assistant.*`` action
+prefix so the audit log is filterable.
+
+This module owns no schema — it reads/writes via the existing
+``assistant_flag`` and ``assistant.budget`` services, which are the
+authoritative homes for the underlying ``cms_settings`` keys.  The
+admin UI is therefore the only consumer of these endpoints; the
+runtime path (chat router, agent loop) still goes through the
+service layer directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from cms.services.audit_service import audit_log
+from cms.auth import require_permission
+from cms.database import get_db
+from cms.models.user import User
+from cms.services.assistant.budget import (
+    DEFAULT_DAILY_TOKEN_CAP,
+    get_default_cap,
+    get_overrides,
+    set_default_cap,
+    set_user_override,
+    clear_user_override,
+)
+from cms.services.assistant_flag import get_allowlist, set_allowlist
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/api/settings/assistant", tags=["assistant-settings"])
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+class AssistantUserCatalogEntry(BaseModel):
+    id: uuid.UUID
+    username: str
+    display_name: str | None = None
+    email: str | None = None
+
+
+class AssistantSettingsOut(BaseModel):
+    allowlist: list[uuid.UUID]
+    default_cap: int
+    overrides: dict[str, int]
+    default_cap_fallback: int = Field(
+        default=DEFAULT_DAILY_TOKEN_CAP,
+        description=(
+            "The compiled-in fallback cap used when no global cap is "
+            "configured.  Returned so the UI can show it as the "
+            "placeholder."
+        ),
+    )
+    users: list[AssistantUserCatalogEntry]
+
+
+class AssistantAllowlistIn(BaseModel):
+    user_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
+class AssistantBudgetIn(BaseModel):
+    default_cap: int
+    overrides: dict[str, int] = Field(default_factory=dict)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+async def _load_user_catalog(db: AsyncSession) -> list[AssistantUserCatalogEntry]:
+    """All active users, sorted by display label, for the admin UI."""
+    rows = (
+        await db.execute(
+            select(User)
+            .where(User.is_active == True)  # noqa: E712
+            .order_by(User.username)
+        )
+    ).scalars().all()
+    return [
+        AssistantUserCatalogEntry(
+            id=u.id,
+            username=u.username,
+            display_name=u.display_name,
+            email=u.email,
+        )
+        for u in rows
+    ]
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=AssistantSettingsOut)
+async def get_assistant_settings(
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission("settings:write")),
+) -> AssistantSettingsOut:
+    allowlist = await get_allowlist(db)
+    default_cap = await get_default_cap(db)
+    overrides_map = await get_overrides(db)
+    users = await _load_user_catalog(db)
+    return AssistantSettingsOut(
+        allowlist=allowlist,
+        default_cap=default_cap,
+        overrides={str(k): v for k, v in overrides_map.items()},
+        users=users,
+    )
+
+
+@router.put("/allowlist", response_model=AssistantSettingsOut)
+async def put_assistant_allowlist(
+    payload: AssistantAllowlistIn,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission("settings:write")),
+) -> AssistantSettingsOut:
+    # Validate every UUID resolves to an actual active user — silently
+    # dropping unknown ids would mask UI bugs; refusing the whole call
+    # is the more honest behaviour.
+    if payload.user_ids:
+        known_ids = {
+            u.id
+            for u in (
+                await db.execute(
+                    select(User).where(User.id.in_(payload.user_ids))
+                )
+            ).scalars().all()
+        }
+        unknown = [str(uid) for uid in payload.user_ids if uid not in known_ids]
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": "Allowlist contains unknown user_ids.",
+                    "unknown_user_ids": unknown,
+                },
+            )
+
+    await set_allowlist(db, payload.user_ids)
+    await audit_log(
+        db,
+        user=_user,
+        action="settings.assistant.allowlist.update",
+        resource_type="settings",
+        description=f"Updated Assistant allowlist ({len(payload.user_ids)} users)",
+        details={"user_ids": [str(uid) for uid in payload.user_ids]},
+        request=request,
+    )
+    await db.commit()
+    return await get_assistant_settings(db=db, _user=_user)
+
+
+@router.put("/budget", response_model=AssistantSettingsOut)
+async def put_assistant_budget(
+    payload: AssistantBudgetIn,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission("settings:write")),
+) -> AssistantSettingsOut:
+    # Validate override keys parse as UUIDs of known active users.
+    parsed_overrides: dict[uuid.UUID, int] = {}
+    bad_keys: list[str] = []
+    for k, v in payload.overrides.items():
+        try:
+            parsed_overrides[uuid.UUID(k)] = int(v)
+        except (ValueError, TypeError):
+            bad_keys.append(k)
+    if bad_keys:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "Override map has invalid entries.",
+                "invalid_keys": bad_keys,
+            },
+        )
+    if parsed_overrides:
+        known_ids = {
+            u.id
+            for u in (
+                await db.execute(
+                    select(User).where(User.id.in_(list(parsed_overrides.keys())))
+                )
+            ).scalars().all()
+        }
+        unknown = [str(uid) for uid in parsed_overrides if uid not in known_ids]
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": "Override map references unknown user_ids.",
+                    "unknown_user_ids": unknown,
+                },
+            )
+
+    await set_default_cap(db, payload.default_cap)
+
+    # Reconcile the override map: anything in current-but-not-incoming
+    # gets cleared so the UI can edit overrides additively or
+    # subtractively in one round-trip.
+    current = await get_overrides(db)
+    incoming_ids = set(parsed_overrides.keys())
+    for uid in list(current.keys()):
+        if uid not in incoming_ids:
+            await clear_user_override(db, uid)
+    for uid, cap in parsed_overrides.items():
+        await set_user_override(db, uid, cap)
+
+    await audit_log(
+        db,
+        user=_user,
+        action="settings.assistant.budget.update",
+        resource_type="settings",
+        description=(
+            f"Updated Assistant budget (default_cap={payload.default_cap}, "
+            f"overrides={len(parsed_overrides)})"
+        ),
+        details={
+            "default_cap": payload.default_cap,
+            "overrides": {str(uid): cap for uid, cap in parsed_overrides.items()},
+        },
+        request=request,
+    )
+    await db.commit()
+    return await get_assistant_settings(db=db, _user=_user)

--- a/cms/routers/chat_approvals.py
+++ b/cms/routers/chat_approvals.py
@@ -286,6 +286,16 @@ async def approve_approval(
         row.tool_name,
         user.id,
     )
+    try:
+        from cms.metrics import (
+            ATTR_DECISION,
+            assistant_approval_decided_total,
+        )
+        assistant_approval_decided_total.add(1, {ATTR_DECISION: "approve"})
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "assistant.approval_decided metric emit failed", exc_info=True
+        )
     return ChatPendingApprovalOut.model_validate(row)
 
 
@@ -331,4 +341,14 @@ async def reject_approval(
         row.tool_name,
         user.id,
     )
+    try:
+        from cms.metrics import (
+            ATTR_DECISION,
+            assistant_approval_decided_total,
+        )
+        assistant_approval_decided_total.add(1, {ATTR_DECISION: "reject"})
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "assistant.approval_decided metric emit failed", exc_info=True
+        )
     return ChatPendingApprovalOut.model_validate(row)

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -330,6 +330,14 @@ async def run_user_turn(
         final_assistant_row.tokens_in,
         final_assistant_row.tokens_out,
     )
+    try:
+        from cms.metrics import (
+            ATTR_STREAMING,
+            assistant_message_sent_total,
+        )
+        assistant_message_sent_total.add(1, {ATTR_STREAMING: "false"})
+    except Exception:  # noqa: BLE001 - telemetry must never break the turn
+        logger.debug("assistant.message_sent metric emit failed", exc_info=True)
     return final_assistant_row
 
 
@@ -663,6 +671,14 @@ async def run_user_turn_streaming(
         final_row.tokens_in,
         final_row.tokens_out,
     )
+    try:
+        from cms.metrics import (
+            ATTR_STREAMING,
+            assistant_message_sent_total,
+        )
+        assistant_message_sent_total.add(1, {ATTR_STREAMING: "true"})
+    except Exception:  # noqa: BLE001 - telemetry must never break the turn
+        logger.debug("assistant.message_sent metric emit failed", exc_info=True)
     yield {
         "type": "done",
         "message_id": str(final_row.id),

--- a/cms/services/assistant/budget.py
+++ b/cms/services/assistant/budget.py
@@ -201,5 +201,12 @@ async def check_budget(
         )
         return used, cap
     if used >= cap:
+        try:
+            from cms.metrics import assistant_budget_exceeded_total
+            assistant_budget_exceeded_total.add(1)
+        except Exception:  # noqa: BLE001 - telemetry must never block enforcement
+            logger.debug(
+                "assistant.budget_exceeded metric emit failed", exc_info=True
+            )
         raise BudgetExceededError(daily_cap=cap, used=used)
     return used, cap

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -659,4 +659,189 @@ async function saveAlertSettings() {
 })();
 </script>
 
-{% endblock %}
+    {% if 'settings:write' in user_perms %}
+    <div class="card" id="assistant-card">
+        <h2>Assistant</h2>
+        <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
+            Controls the in-CMS Assistant (chat + tool grounding via MCP). The
+            feature is gated by a per-user allowlist; admins always have access.
+            Daily token caps protect against runaway LLM spend.
+        </p>
+
+        <h3 style="margin-top: 1rem;">Allowlist</h3>
+        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+            Users who can see and use the Assistant. Admins (anyone with
+            <code>settings:write</code>) always have access regardless of this list.
+        </p>
+        <div id="assistant-allowlist" style="max-height: 240px; overflow-y: auto; border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
+            <span class="text-muted">Loading…</span>
+        </div>
+        <button type="button" class="btn btn-primary" id="assistant-save-allowlist">Save allowlist</button>
+
+        <h3 style="margin-top: 1.5rem;">Daily token budget</h3>
+        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+            Cap on tokens (input + output) per user per UTC day. Negative = unlimited.
+            Zero = blocked. Defaults to <span id="assistant-cap-fallback">50000</span> when nothing is configured.
+        </p>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="assistant-default-cap">Global default (tokens/day)</label>
+                <input type="number" id="assistant-default-cap" min="-1" value="" style="max-width: 200px;">
+            </div>
+        </div>
+
+        <h4 style="margin-top: 1rem;">Per-user overrides</h4>
+        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+            Override the global cap for individual allowlisted users. Leave the cap
+            blank to remove an override (the user will fall back to the global default).
+        </p>
+        <div id="assistant-overrides" style="border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
+            <span class="text-muted">Loading…</span>
+        </div>
+        <button type="button" class="btn btn-primary" id="assistant-save-budget" style="margin-top: 0.5rem;">Save budget</button>
+    </div>
+
+    <script>
+    (function () {
+        const allowlistDiv = document.getElementById("assistant-allowlist");
+        const overridesDiv = document.getElementById("assistant-overrides");
+        const defaultCapInput = document.getElementById("assistant-default-cap");
+        const fallbackSpan = document.getElementById("assistant-cap-fallback");
+
+        let state = {users: [], allowlist: [], default_cap: 0, overrides: {}};
+
+        function userLabel(u) {
+            const name = u.display_name || u.username;
+            return u.email ? `${name} (${u.email})` : name;
+        }
+
+        function renderAllowlist() {
+            const allowSet = new Set(state.allowlist.map(String));
+            allowlistDiv.innerHTML = "";
+            state.users.forEach(u => {
+                const label = document.createElement("label");
+                label.style.cssText = "display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer;";
+                const cb = document.createElement("input");
+                cb.type = "checkbox";
+                cb.value = u.id;
+                cb.checked = allowSet.has(String(u.id));
+                cb.style.cssText = "width: auto; margin: 0;";
+                cb.dataset.userId = u.id;
+                cb.addEventListener("change", renderOverrides);
+                label.appendChild(cb);
+                const span = document.createElement("span");
+                span.textContent = userLabel(u);
+                label.appendChild(span);
+                allowlistDiv.appendChild(label);
+            });
+        }
+
+        function currentAllowlist() {
+            return Array.from(allowlistDiv.querySelectorAll("input[type=checkbox]:checked"))
+                .map(cb => cb.dataset.userId);
+        }
+
+        function renderOverrides() {
+            const allowed = new Set(currentAllowlist());
+            overridesDiv.innerHTML = "";
+            const visible = state.users.filter(u => allowed.has(String(u.id)));
+            if (visible.length === 0) {
+                const p = document.createElement("p");
+                p.className = "text-muted";
+                p.style.margin = "0";
+                p.textContent = "No allowlisted users — toggle some above to add per-user overrides.";
+                overridesDiv.appendChild(p);
+                return;
+            }
+            visible.forEach(u => {
+                const row = document.createElement("div");
+                row.style.cssText = "display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0;";
+                const lbl = document.createElement("span");
+                lbl.textContent = userLabel(u);
+                lbl.style.cssText = "flex: 1;";
+                const input = document.createElement("input");
+                input.type = "number";
+                input.min = "-1";
+                input.placeholder = "(use default)";
+                input.style.cssText = "max-width: 150px;";
+                input.dataset.userId = u.id;
+                const ovr = state.overrides[String(u.id)];
+                if (ovr !== undefined) input.value = ovr;
+                row.appendChild(lbl);
+                row.appendChild(input);
+                overridesDiv.appendChild(row);
+            });
+        }
+
+        async function loadState() {
+            try {
+                const resp = await fetch("/api/settings/assistant");
+                if (!resp.ok) throw new Error("Failed to load assistant settings");
+                state = await resp.json();
+                defaultCapInput.value = state.default_cap;
+                if (state.default_cap_fallback != null) {
+                    fallbackSpan.textContent = state.default_cap_fallback;
+                }
+                renderAllowlist();
+                renderOverrides();
+            } catch (err) {
+                allowlistDiv.innerHTML = `<span class="text-muted">${err.message || "Load failed"}</span>`;
+            }
+        }
+
+        document.getElementById("assistant-save-allowlist").addEventListener("click", async () => {
+            const user_ids = currentAllowlist();
+            try {
+                const resp = await fetch("/api/settings/assistant/allowlist", {
+                    method: "PUT",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({user_ids}),
+                });
+                if (!resp.ok) {
+                    const data = await resp.json().catch(() => ({}));
+                    throw new Error((data.detail && data.detail.message) || data.detail || "Save failed");
+                }
+                state = await resp.json();
+                showToast(`Allowlist saved (${user_ids.length} users)`);
+                renderOverrides();
+            } catch (err) {
+                showToast(err.message || "Failed to save allowlist", true);
+            }
+        });
+
+        document.getElementById("assistant-save-budget").addEventListener("click", async () => {
+            const default_cap = parseInt(defaultCapInput.value, 10);
+            if (Number.isNaN(default_cap)) {
+                showToast("Default cap must be a number", true);
+                return;
+            }
+            const overrides = {};
+            overridesDiv.querySelectorAll("input[type=number]").forEach(input => {
+                const v = input.value.trim();
+                if (v === "") return;
+                const n = parseInt(v, 10);
+                if (!Number.isNaN(n)) overrides[input.dataset.userId] = n;
+            });
+            try {
+                const resp = await fetch("/api/settings/assistant/budget", {
+                    method: "PUT",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({default_cap, overrides}),
+                });
+                if (!resp.ok) {
+                    const data = await resp.json().catch(() => ({}));
+                    throw new Error((data.detail && data.detail.message) || data.detail || "Save failed");
+                }
+                state = await resp.json();
+                showToast("Budget saved");
+            } catch (err) {
+                showToast(err.message || "Failed to save budget", true);
+            }
+        });
+
+        loadState();
+    })();
+    </script>
+    {% endif %}
+
+    {% endblock %}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2013,6 +2013,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/settings/assistant:
+    get:
+      tags:
+      - assistant-settings
+      summary: Get Assistant Settings
+      operationId: get_assistant_settings_api_settings_assistant_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantSettingsOut'
+  /api/settings/assistant/allowlist:
+    put:
+      tags:
+      - assistant-settings
+      summary: Put Assistant Allowlist
+      operationId: put_assistant_allowlist_api_settings_assistant_allowlist_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssistantAllowlistIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/settings/assistant/budget:
+    put:
+      tags:
+      - assistant-settings
+      summary: Put Assistant Budget
+      operationId: put_assistant_budget_api_settings_assistant_budget_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssistantBudgetIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/profiles:
     get:
       summary: List Profiles
@@ -4469,6 +4532,30 @@ components:
       type: object
       title: AssetViewPatch
       description: Request body for ``PATCH /api/asset-views/{id}``. All fields optional.
+    AssistantAllowlistIn:
+      properties:
+        user_ids:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: User Ids
+      type: object
+      title: AssistantAllowlistIn
+    AssistantBudgetIn:
+      properties:
+        default_cap:
+          type: integer
+          title: Default Cap
+        overrides:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Overrides
+      type: object
+      required:
+      - default_cap
+      title: AssistantBudgetIn
     AssistantFeatureStatus:
       properties:
         enabled:
@@ -4483,6 +4570,64 @@ components:
 
         Lets the frontend decide whether to render the Assistant tab without
         needing to probe a 404 from another endpoint.
+    AssistantSettingsOut:
+      properties:
+        allowlist:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Allowlist
+        default_cap:
+          type: integer
+          title: Default Cap
+        overrides:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Overrides
+        default_cap_fallback:
+          type: integer
+          title: Default Cap Fallback
+          description: The compiled-in fallback cap used when no global cap is configured.  Returned so the UI can show it
+            as the placeholder.
+          default: 50000
+        users:
+          items:
+            $ref: '#/components/schemas/AssistantUserCatalogEntry'
+          type: array
+          title: Users
+      type: object
+      required:
+      - allowlist
+      - default_cap
+      - overrides
+      - users
+      title: AssistantSettingsOut
+    AssistantUserCatalogEntry:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        username:
+          type: string
+          title: Username
+        display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Display Name
+        email:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Email
+      type: object
+      required:
+      - id
+      - username
+      title: AssistantUserCatalogEntry
     AuditLogRead:
       properties:
         id:
@@ -6690,6 +6835,7 @@ servers:
 security:
 - sessionCookie: []
 tags:
+- name: assistant-settings
 - name: bootstrap
   description: First-contact registration / adoption endpoints used during device onboarding.
 - name: devices (device-originated)

--- a/tests/test_assistant_settings_api.py
+++ b/tests/test_assistant_settings_api.py
@@ -1,0 +1,274 @@
+"""Tests for the admin Assistant settings API (PR 6b).
+
+Covers ``GET /api/settings/assistant`` and the two PUT endpoints that
+the admin Settings UI uses.  Verifies RBAC (admin vs. operator),
+input validation (unknown user_ids, malformed override keys), and
+the reconciliation semantics of the budget PUT (incoming map is the
+source of truth — overrides not in the body get cleared).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from cms.auth import hash_password
+from cms.models.user import Role, User
+from cms.services.assistant.budget import (
+    BUDGET_CAP_KEY,
+    BUDGET_OVERRIDES_KEY,
+    DEFAULT_DAILY_TOKEN_CAP,
+    get_default_cap,
+    get_overrides,
+    set_default_cap,
+    set_user_override,
+)
+from cms.services.assistant_flag import (
+    ASSISTANT_FLAG_KEY,
+    get_allowlist,
+    set_allowlist,
+)
+
+
+@pytest_asyncio.fixture
+async def operator_client(app):
+    """A logged-in Operator client — lacks settings:write."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        role = (
+            await db.execute(select(Role).where(Role.name == "Operator"))
+        ).scalar_one()
+        user = User(
+            username="asst-op",
+            email="asst-op@test.com",
+            display_name="Asst Op",
+            password_hash=hash_password("pw"),
+            role_id=role.id,
+            is_active=True,
+            must_change_password=False,
+        )
+        db.add(user)
+        await db.commit()
+        break
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/login",
+            data={"username": "asst-op", "password": "pw"},
+            follow_redirects=False,
+        )
+        yield ac
+
+
+async def _admin_user(db):
+    return (
+        await db.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+
+
+async def _make_extra_user(db, *, username="alice"):
+    role = (
+        await db.execute(select(Role).where(Role.name == "Operator"))
+    ).scalar_one()
+    u = User(
+        username=username,
+        email=f"{username}@test.com",
+        display_name=username.title(),
+        password_hash=hash_password("pw"),
+        role_id=role.id,
+        is_active=True,
+        must_change_password=False,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+class TestAssistantSettingsGet:
+    @pytest.mark.asyncio
+    async def test_default_state_returns_empty_allowlist_and_default_cap(
+        self, client
+    ):
+        resp = await client.get("/api/settings/assistant")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["allowlist"] == []
+        assert data["default_cap"] == DEFAULT_DAILY_TOKEN_CAP
+        assert data["overrides"] == {}
+        assert data["default_cap_fallback"] == DEFAULT_DAILY_TOKEN_CAP
+        assert isinstance(data["users"], list)
+        # admin user always present
+        usernames = [u["username"] for u in data["users"]]
+        assert "admin" in usernames
+
+    @pytest.mark.asyncio
+    async def test_returns_persisted_state(self, client, db_session):
+        admin = await _admin_user(db_session)
+        await set_allowlist(db_session, [admin.id])
+        await set_default_cap(db_session, 12345)
+        await set_user_override(db_session, admin.id, 99)
+        await db_session.commit()
+
+        resp = await client.get("/api/settings/assistant")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["allowlist"] == [str(admin.id)]
+        assert data["default_cap"] == 12345
+        assert data["overrides"] == {str(admin.id): 99}
+
+    @pytest.mark.asyncio
+    async def test_operator_forbidden(self, operator_client):
+        resp = await operator_client.get("/api/settings/assistant")
+        assert resp.status_code == 403
+
+
+class TestAssistantAllowlistPut:
+    @pytest.mark.asyncio
+    async def test_admin_save_allowlist(self, client, db_session):
+        admin = await _admin_user(db_session)
+        alice = await _make_extra_user(db_session, username="alice")
+
+        resp = await client.put(
+            "/api/settings/assistant/allowlist",
+            json={"user_ids": [str(admin.id), str(alice.id)]},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert set(data["allowlist"]) == {str(admin.id), str(alice.id)}
+
+        stored = await get_allowlist(db_session)
+        assert set(stored) == {admin.id, alice.id}
+
+    @pytest.mark.asyncio
+    async def test_empty_list_clears_allowlist(self, client, db_session):
+        admin = await _admin_user(db_session)
+        await set_allowlist(db_session, [admin.id])
+        await db_session.commit()
+
+        resp = await client.put(
+            "/api/settings/assistant/allowlist",
+            json={"user_ids": []},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["allowlist"] == []
+        assert await get_allowlist(db_session) == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_id_rejected(self, client):
+        bogus = str(uuid.uuid4())
+        resp = await client.put(
+            "/api/settings/assistant/allowlist",
+            json={"user_ids": [bogus]},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "unknown_user_ids" in body["detail"]
+        assert bogus in body["detail"]["unknown_user_ids"]
+
+    @pytest.mark.asyncio
+    async def test_operator_forbidden(self, operator_client):
+        resp = await operator_client.put(
+            "/api/settings/assistant/allowlist", json={"user_ids": []}
+        )
+        assert resp.status_code == 403
+
+
+class TestAssistantBudgetPut:
+    @pytest.mark.asyncio
+    async def test_admin_save_default_cap(self, client, db_session):
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={"default_cap": 25000, "overrides": {}},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["default_cap"] == 25000
+        assert await get_default_cap(db_session) == 25000
+
+    @pytest.mark.asyncio
+    async def test_admin_save_overrides_and_default(self, client, db_session):
+        admin = await _admin_user(db_session)
+        alice = await _make_extra_user(db_session, username="ovr-alice")
+
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={
+                "default_cap": 10000,
+                "overrides": {str(admin.id): 5000, str(alice.id): 0},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["default_cap"] == 10000
+        assert data["overrides"] == {str(admin.id): 5000, str(alice.id): 0}
+
+        stored = await get_overrides(db_session)
+        assert stored[admin.id] == 5000
+        assert stored[alice.id] == 0
+
+    @pytest.mark.asyncio
+    async def test_overrides_reconciled_on_save(self, client, db_session):
+        """Overrides not present in the PUT body get cleared."""
+        admin = await _admin_user(db_session)
+        alice = await _make_extra_user(db_session, username="rec-alice")
+
+        await set_user_override(db_session, admin.id, 1000)
+        await set_user_override(db_session, alice.id, 2000)
+        await db_session.commit()
+
+        # Send a PUT that includes ONLY admin's override.
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={"default_cap": 50000, "overrides": {str(admin.id): 7777}},
+        )
+        assert resp.status_code == 200
+        stored = await get_overrides(db_session)
+        assert stored == {admin.id: 7777}
+        assert alice.id not in stored
+
+    @pytest.mark.asyncio
+    async def test_negative_cap_allowed(self, client, db_session):
+        """Negative = unlimited; the API must not reject it."""
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={"default_cap": -1, "overrides": {}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["default_cap"] == -1
+
+    @pytest.mark.asyncio
+    async def test_override_with_invalid_uuid_key_rejected(self, client):
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={
+                "default_cap": 5000,
+                "overrides": {"not-a-uuid": 100},
+            },
+        )
+        assert resp.status_code == 400
+        assert "invalid_keys" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_override_for_unknown_user_rejected(self, client):
+        bogus = str(uuid.uuid4())
+        resp = await client.put(
+            "/api/settings/assistant/budget",
+            json={"default_cap": 5000, "overrides": {bogus: 1}},
+        )
+        assert resp.status_code == 400
+        assert "unknown_user_ids" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_operator_forbidden(self, operator_client):
+        resp = await operator_client.put(
+            "/api/settings/assistant/budget",
+            json={"default_cap": 1000, "overrides": {}},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
Final scope item of the in-CMS Assistant rollout. Adds the admin UI for the things PR 6a made configurable (allowlist + budget) and wires up App Insights telemetry counters.

## What

**API** (`cms/routers/assistant_settings.py`, all gated on `settings:write`)
- `GET  /api/settings/assistant` — returns `{allowlist, default_cap, overrides, default_cap_fallback, users[]}`. The `users` catalog is included so the UI doesn't need a second round-trip to render checkboxes.
- `PUT /api/settings/assistant/allowlist` — replaces the allowlist. Validates every UUID resolves to an active user; 400 `unknown_user_ids` if any don't.
- `PUT /api/settings/assistant/budget` — sets the global default cap AND reconciles the override map. Overrides not present in the body are cleared, so the UI can add/remove in one round-trip. Validates override keys.

**UI** (`cms/templates/settings.html`)
- New `Assistant` card at the bottom of /settings (gated on `settings:write`).
- Allowlist: scrollable user checkbox list, `Save allowlist` button.
- Budget: numeric input for global default + dynamic per-user override grid that auto-populates from the current allowlist.

**Telemetry** (`cms/metrics.py` + emit sites)
- `agora.assistant.message_sent` (dim: `streaming=true|false`) — every successfully completed user turn.
- `agora.assistant.budget_exceeded` — fired inside `check_budget` before raising.
- `agora.assistant.approval_decided` (dim: `decision=approve|reject`) — at the end of the approve/reject endpoints.

All emits are wrapped in `try/except` so telemetry failures can't break a request.

## Tests
- `tests/test_assistant_settings_api.py` — 14 new tests (default state, persisted state, save+roundtrip for both endpoints, override reconciliation, negative cap allowed, invalid UUID rejected, unknown user rejected, operator forbidden on all three).
- Wider chat suite (chat_agent + chat_threads + assistant_page + chat_budget + chat_approvals + assistant_settings_api + alert_settings_api): **95 passing**.

## Review notes
- No migration.
- Plays nicely with PR 6a's defense-in-depth budget enforcement.
- This PR is intentionally **not** auto-merged — UI change, request from previous turn was to land it for your review.