### PR TITLE
fix(assistant): add missing mcp Python SDK to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,11 @@ azure-monitor-opentelemetry>=1.6,<2.0
 # provisioned by infra/modules/azureOpenAI.bicep.  Auth via managed
 # identity (DefaultAzureCredential) — no API keys.
 openai>=1.50,<2.0
+# MCP Python SDK — client side, used by cms/services/assistant/mcp_client.py
+# to call into the agora-cms-mcp container over SSE.  Same major version
+# as the MCP server pin in mcp/requirements.txt to avoid wire-protocol
+# drift between client and server.
+mcp>=1.0.0,<2.0
 # Server-Sent Events response helper for the chat-assistant streaming
 # endpoint (cms/routers/chat.py).  Pinned to a recent stable; the
 # library is tiny and stable.


### PR DESCRIPTION
## Why

Assistant chat on Goodwill dev fails with:

```
ModuleNotFoundError: No module named 'mcp'
```

the first time a prompt actually hits the MCP tool path. The CMS imports
the `mcp` Python SDK in `cms/services/assistant/mcp_client.py`, but the
import is deferred inside `__aenter__`, so the app starts cleanly and the
test suite (which uses FakeMcpClient via monkeypatch) never exercises the
real import — masking the missing dep at CI time.

## What

Add `mcp>=1.0.0,<2.0` to `requirements.txt`, matching the pin on the
server side (`mcp/requirements.txt: mcp[cli]>=1.0.0`).