### PR TITLE
fix(assistant): read MCP service key from Key Vault when no shared volume

### DIFF
--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -83,24 +83,46 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
 )
 
 
-def _read_service_key(path: str) -> str:
-    """Read the MCP service key off the shared volume.
+def _read_service_key(settings: Settings) -> str:
+    """Read the MCP service key.
 
-    Returns the raw ``agora_svc_*`` string.  Raises
-    :class:`McpUnavailableError` if the file is missing or empty — both
-    are fatal: there is no fallback authentication path.
+    In local/Docker-Compose deployments CMS and MCP share a volume and
+    the key lives at ``settings.service_key_path``. In Azure Container
+    Apps there's no shared volume, so the key is exchanged via Key
+    Vault (see ``cms.keyvault.write_key_to_keyvault``).
+
+    Tries the local file first; if it's missing or empty and
+    ``azure_keyvault_uri`` is configured, falls back to Key Vault.
+    Raises :class:`McpUnavailableError` if neither path yields a key.
     """
+    file_err: str | None = None
     try:
-        raw = Path(path).read_text().strip()
-    except OSError as exc:
-        raise McpUnavailableError(
-            f"MCP service key file is not readable at {path}: {exc}"
-        ) from exc
-    if not raw:
-        raise McpUnavailableError(
-            f"MCP service key file at {path} is empty (key not provisioned?)"
+        raw = Path(settings.service_key_path).read_text().strip()
+        if raw:
+            return raw
+        file_err = (
+            f"MCP service key file at {settings.service_key_path} is "
+            "empty (key not provisioned?)"
         )
-    return raw
+    except OSError as exc:
+        file_err = (
+            f"MCP service key file is not readable at "
+            f"{settings.service_key_path}: {exc}"
+        )
+
+    if settings.azure_keyvault_uri:
+        from cms.keyvault import read_key_from_keyvault
+
+        kv_key = read_key_from_keyvault(settings.azure_keyvault_uri).strip()
+        if kv_key:
+            return kv_key
+        raise McpUnavailableError(
+            f"MCP service key not available: {file_err}; Key Vault "
+            f"{settings.azure_keyvault_uri} returned empty value for "
+            "'mcp-service-key' (key not provisioned?)"
+        )
+
+    raise McpUnavailableError(file_err or "MCP service key not available")
 
 
 class AssistantMcpClient:
@@ -123,7 +145,7 @@ class AssistantMcpClient:
         from mcp.client.session import ClientSession
         from mcp.client.sse import sse_client
 
-        raw_key = _read_service_key(self._settings.service_key_path)
+        raw_key = _read_service_key(self._settings)
         url = self._settings.mcp_server_url.rstrip("/") + "/sse"
         headers = {
             "Authorization": f"Bearer {raw_key}",

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -881,16 +881,19 @@ class TestReadOnlyWhitelist:
 
 
 def test_read_service_key_missing_file(tmp_path):
+    from cms.config import Settings
     from cms.services.assistant.mcp_client import (
         McpUnavailableError,
         _read_service_key,
     )
 
+    s = Settings(service_key_path=str(tmp_path / "nope.key"))
     with pytest.raises(McpUnavailableError):
-        _read_service_key(str(tmp_path / "nope.key"))
+        _read_service_key(s)
 
 
 def test_read_service_key_empty_file(tmp_path):
+    from cms.config import Settings
     from cms.services.assistant.mcp_client import (
         McpUnavailableError,
         _read_service_key,
@@ -898,16 +901,57 @@ def test_read_service_key_empty_file(tmp_path):
 
     p = tmp_path / "k"
     p.write_text("   \n")
+    s = Settings(service_key_path=str(p))
     with pytest.raises(McpUnavailableError):
-        _read_service_key(str(p))
+        _read_service_key(s)
 
 
 def test_read_service_key_ok(tmp_path):
+    from cms.config import Settings
     from cms.services.assistant.mcp_client import _read_service_key
 
     p = tmp_path / "k"
     p.write_text("agora_svc_deadbeef\n")
-    assert _read_service_key(str(p)) == "agora_svc_deadbeef"
+    s = Settings(service_key_path=str(p))
+    assert _read_service_key(s) == "agora_svc_deadbeef"
+
+
+def test_read_service_key_keyvault_fallback(tmp_path, monkeypatch):
+    """When the local file is missing but Key Vault is configured,
+    fall back to reading the key from KV (the Azure Container Apps
+    deployment shape — no shared volume between CMS and MCP)."""
+    from cms.config import Settings
+    from cms.services.assistant.mcp_client import _read_service_key
+
+    monkeypatch.setattr(
+        "cms.keyvault.read_key_from_keyvault",
+        lambda uri: "agora_svc_fromkv",
+    )
+    s = Settings(
+        service_key_path=str(tmp_path / "nope.key"),
+        azure_keyvault_uri="https://example-kv.vault.azure.net",
+    )
+    assert _read_service_key(s) == "agora_svc_fromkv"
+
+
+def test_read_service_key_keyvault_empty_raises(tmp_path, monkeypatch):
+    """Both file missing and KV returning empty → McpUnavailableError."""
+    from cms.config import Settings
+    from cms.services.assistant.mcp_client import (
+        McpUnavailableError,
+        _read_service_key,
+    )
+
+    monkeypatch.setattr(
+        "cms.keyvault.read_key_from_keyvault",
+        lambda uri: "",
+    )
+    s = Settings(
+        service_key_path=str(tmp_path / "nope.key"),
+        azure_keyvault_uri="https://example-kv.vault.azure.net",
+    )
+    with pytest.raises(McpUnavailableError):
+        _read_service_key(s)
 
 
 # ── PR 3c: SSE streaming endpoint ─────────────────────────────────────


### PR DESCRIPTION
## Why

Assistant chat on Goodwill dev fails with:

```
Assistant tool backend unavailable: MCP service key file is not readable at /shared/mcp-service.key: [Errno 2] No such file or directory: '/shared/mcp-service.key'
```

`cms/services/assistant/mcp_client._read_service_key` only ever tries the
local file at `settings.service_key_path` (default `/shared/mcp-service.key`).
In Azure Container Apps the CMS and MCP run as **separate apps with no shared
volume** — the rest of the CMS already exchanges the key via Key Vault
(`cms/keyvault.py`, secret name `mcp-service-key`; see
`docs/security/secret-rotation.md`) and the MCP server reads it from KV
(`mcp/server.py:799`). The assistant's client just didn't know to fall back.

## What

Update `_read_service_key` to accept the full `Settings`:

1. Try the local file first (Docker-Compose / dev path unchanged).
2. If the file is missing/empty AND `settings.azure_keyvault_uri` is set,
   call `cms.keyvault.read_key_from_keyvault` for the `mcp-service-key`
   secret.
3. If neither yields a key, raise `McpUnavailableError` with both
   failure reasons in the message.

## Tests

- 2 new tests: `test_read_service_key_keyvault_fallback`, `test_read_service_key_keyvault_empty_raises`
- 3 existing `_read_service_key` tests updated for the new signature
- Full `tests/test_chat_agent.py`: **36 passed**

## Verification after deploy

Open the Assistant on Goodwill dev and send a prompt that needs a tool
(e.g. "list devices"). It should succeed instead of returning the
"MCP service key file is not readable" error.