### PR TITLE
fix(setup-wizard): provision MCP service key when enabling MCP

### DIFF
--- a/cms/ui.py
+++ b/cms/ui.py
@@ -602,7 +602,25 @@ async def setup_mcp(
         details={"enabled": bool(enabled)},
         request=request,
     )
+
+    service_key: str | None = None
+    if enabled:
+        # Auto-provision the MCP service key the same way the post-setup
+        # Settings → MCP toggle does. Without this the wizard leaves the
+        # MCP server unable to authenticate any CMS callbacks because no
+        # key was ever generated, hashed, or written to the shared volume
+        # / Key Vault.
+        existing = await get_setting(db, SETTING_MCP_SERVICE_KEY_HASH)
+        if not existing:
+            raw_key, _prefix = await provision_service_key(
+                db, settings.service_key_path, keyvault_uri=settings.azure_keyvault_uri
+            )
+            await _notify_mcp_reload(settings)
+            service_key = raw_key
+
     await db.commit()
+    if service_key is not None:
+        return {"status": "ok", "service_key": service_key}
     return {"status": "ok"}
 
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -11,6 +11,7 @@ from cms.auth import (
     SETTING_SMTP_HOST,
     SETTING_TIMEZONE,
     SETTING_MCP_ENABLED,
+    SETTING_MCP_SERVICE_KEY_HASH,
     get_setting,
     set_setting,
 )
@@ -305,6 +306,50 @@ async def test_mcp_save(setup_client, db_session):
     assert resp.status_code == 200
     val = await get_setting(db_session, SETTING_MCP_ENABLED)
     assert val == "true"
+
+
+@pytest.mark.asyncio
+async def test_mcp_enable_provisions_service_key(setup_client, db_session):
+    """Enabling MCP in the wizard must provision the service key.
+
+    Regression guard for the bug where /setup/mcp only flipped the
+    enabled flag without ever calling provision_service_key. That left
+    fresh deployments with mcp_enabled=true but no key hash in the DB
+    and no secret in Key Vault, so the MCP server had nothing to
+    authenticate against.
+    """
+    resp = await setup_client.post("/setup/mcp", json={"enabled": True})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("service_key"), "wizard should return the freshly minted key"
+
+    key_hash = await get_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH)
+    assert key_hash, "service key hash should be persisted in settings"
+
+
+@pytest.mark.asyncio
+async def test_mcp_disable_does_not_provision(setup_client, db_session):
+    """Disabling MCP in the wizard must not mint a key."""
+    resp = await setup_client.post("/setup/mcp", json={"enabled": False})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "service_key" not in body
+    key_hash = await get_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH)
+    assert not key_hash
+
+
+@pytest.mark.asyncio
+async def test_mcp_enable_is_idempotent_when_key_exists(setup_client, db_session):
+    """If a hash already exists, /setup/mcp must not rotate the key."""
+    await set_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH, "preexisting-hash")
+    await db_session.commit()
+
+    resp = await setup_client.post("/setup/mcp", json={"enabled": True})
+    assert resp.status_code == 200
+    assert "service_key" not in resp.json()
+
+    key_hash = await get_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH)
+    assert key_hash == "preexisting-hash"
 
 
 # ── Completion ──


### PR DESCRIPTION
## Problem

The setup wizard's MCP step (POST /setup/mcp) only flips SETTING_MCP_ENABLED without ever calling provision_service_key. The post-setup Settings → MCP toggle path DOES provision. As a result, any fresh deployment that enables MCP via the wizard ends up with:

- mcp_enabled = true in DB
- no mcp_service_key_hash in DB
- no mcp-service-key secret in Key Vault
- no key on the (long-gone in ACA) shared-volume file

…meaning the MCP server has nothing to authenticate any CMS callback against. UI shows MCP enabled, reality is MCP is broken.

Discovered while debugging Goodwill prod: prod was set up via the wizard after the KV-exchange code shipped (2026-04-13) but agoragw-vault has no mcp-service-key. Workaround was to go to Settings → MCP → toggle off → toggle on to fire the toggle-path provisioning.

## Fix

Mirror the toggle path in the wizard: if enabling, and no hash is present, call provision_service_key(..., keyvault_uri=settings.azure_keyvault_uri) and ping MCP to reload. Idempotent — if a hash already exists, leave it alone.

## Tests

Three new regression tests in tests/test_setup_wizard.py:
- test_mcp_enable_provisions_service_key — wizard returns the freshly minted key and persists the hash
- test_mcp_disable_does_not_provision — disable path doesn't mint a key
- test_mcp_enable_is_idempotent_when_key_exists — pre-existing hash isn't rotated

All 25 tests in test_setup_wizard.py pass locally.