### PR TITLE
fix(assistant): tell LLM it has read-only MCP tools available

### DIFF
--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -1,10 +1,5 @@
 """System-prompt builder for the Assistant feature.
 
-PR 3a uses a deliberately minimal system prompt — no tool descriptions,
-no schema dumps, just the role and a short list of conversational
-rules.  PR 3b will extend this with the MCP tool catalogue once the
-agent can actually invoke tools.
-
 The prompt is rebuilt fresh on every turn so context (current UTC
 time, the caller's display name) is always up to date.  It is NOT
 persisted to ``chat_messages`` — only user / assistant / tool turns
@@ -24,13 +19,20 @@ digital-signage platform.  The signed-in operator is **{username}**
 
 Guidelines:
 * Be concise.  Operators want answers, not essays.
-* You do not have access to any tools yet.  If the user asks you to
-  perform an action (create a schedule, modify a group, etc.), tell
-  them that feature is coming soon and offer to walk them through how
-  to do it in the UI.
-* Never invent device IDs, asset IDs, schedule IDs, or other data
-  about this deployment — you have no access to the database in this
-  release.
+* You have read-only access to this deployment via MCP tools
+  (e.g. ``list_devices``, ``list_schedules``, ``list_assets``,
+  ``get_device_logs``).  When the user asks a factual question about
+  this deployment — counts, names, statuses, recent activity — call
+  the appropriate tool instead of guessing or asking them to look
+  in the UI.  Prefer one well-targeted tool call over many.
+* Write/mutating actions (create schedule, modify group, reboot
+  device, etc.) are not yet exposed.  If the user asks for one, tell
+  them that capability is coming soon and offer to walk them through
+  how to do it in the UI.
+* Never invent device IDs, asset IDs, schedule IDs, or other data —
+  always source them from a tool result before referring to them.
+* If a tool call fails or returns nothing, say so plainly rather
+  than fabricating a plausible answer.
 * If the user asks who built you or how you work, you can say that
   you are powered by Azure OpenAI and run inside the Agora CMS.
 """


### PR DESCRIPTION
The system prompt was a PR-3a leftover that still told the model `You do not have access to any tools yet` and `you have no access to the database`, even though PR #657 wired up the MCP read-only tool catalog (`list_devices`, `list_schedules`, etc.) and PR #658 streams it on every turn.

Result: asking 'how many schedules do we have?' got a redirect to the UI instead of a `list_schedules` call.

Updates the prompt to describe the read-only tool catalog and encourage tool use for factual questions, while keeping the 'don't invent IDs' guardrail (now grounded in 'source them from tool results').

All 36 `test_chat_agent.py` tests pass.