### PR TITLE
fix(assistant): tab visible on Settings; composer pinned without scroll

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -275,6 +275,16 @@ def require_permission(*perms: str):
     ) -> User:
         user = await get_current_user(request, settings, db)
         request.state.user = user
+        # Mirror require_auth: stash the assistant allowlist flag so the
+        # topbar's "Assistant" tab still renders on permission-gated
+        # pages (e.g. /settings, which uses require_permission, not
+        # require_auth).  Without this, the tab disappears the moment
+        # you visit Settings even though the user is allowlisted.
+        try:
+            from cms.services.assistant_flag import assistant_enabled_for
+            request.state.assistant_enabled = await assistant_enabled_for(db, user)
+        except Exception:
+            request.state.assistant_enabled = False
         if user.role is None:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No role assigned")
         for perm in perms:

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -3,12 +3,29 @@
 {% block content %}
 <style>
 /* ── Assistant layout ─────────────────────────────────────────── */
+#assistant-app {
+    display: flex;
+    flex-direction: column;
+    /* Reserve room for the topbar (header + nav tabs + status lights
+       row + page padding).  Using viewport height anchors the
+       composer to the bottom of the window so the user never has to
+       scroll the page to reach it. */
+    height: calc(100vh - 150px);
+    min-height: 500px;
+}
+#assistant-app > h1 {
+    margin: 0 0 0.6rem 0;
+    flex-shrink: 0;
+}
 .assistant-page {
+    flex: 1;
     display: grid;
     grid-template-columns: 280px 1fr;
     gap: 1rem;
-    height: calc(100vh - 200px);
-    min-height: 500px;
+    /* Required so the grid children can shrink below their content
+       size — otherwise the messages area grows and pushes the
+       composer off-screen. */
+    min-height: 0;
 }
 .assistant-sidebar {
     background: var(--surface);
@@ -90,6 +107,7 @@
     border: 1px solid var(--border);
     border-radius: 8px;
     overflow: hidden;
+    min-height: 0;
 }
 .assistant-messages {
     flex: 1;


### PR DESCRIPTION
Two small UI nits.

**1. Assistant tab disappears on /settings.** Topbar's Assistant link is gated on `request.state.assistant_enabled`, which `require_auth` sets but `require_permission` did not. Settings (and any other permission-gated page) therefore dropped the tab even for allowlisted users. Mirror the same lookup in `require_permission`.

**2. Composer required scrolling on /assistant.** `.assistant-page` used `height: calc(100vh - 200px)` but did not account for the page's own `<h1>` above the grid, so the composer slipped below the fold on shorter viewports. Restructure: `#assistant-app` becomes a viewport-anchored flex column (`100vh - 150px`, covering real chrome) with the h1 fixed-size and the grid taking `flex: 1`; add `min-height: 0` to the grid and `.assistant-main` so the messages list shrinks instead of pushing the composer down.

41 `test_auth` + `test_assistant_page` + `test_assistant_settings_api` tests pass locally.