### PR TITLE
feat(assistant): expose curated write tools via PR-4 approval flow

### DIFF
--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -56,9 +56,11 @@ from cms.services.assistant.llm_client import (
     LLMClient,
 )
 from cms.services.assistant.mcp_client import (
+    ALLOWED_TOOLS,
     AssistantMcpClient,
     McpUnavailableError,
     READ_ONLY_TOOLS,
+    WRITE_TOOLS,
 )
 from cms.services.assistant.prompts import build_system_prompt
 
@@ -129,13 +131,18 @@ async def _execute_tool_call(
     if err is not None:
         return json.dumps({"error": "bad_arguments", "message": err})
     if name not in READ_ONLY_TOOLS:
+        # Non-streaming agent path only invokes reads.  Write tools
+        # need the approval flow, which lives in the streaming agent.
+        # Tell the model so it doesn't keep retrying.
         return json.dumps(
             {
                 "error": "tool_not_allowed",
                 "message": (
-                    f"Tool '{name}' is not in the read-only whitelist. "
-                    "Write/mutating tools require an approval flow that "
-                    "isn't built yet (PR 4)."
+                    f"Tool '{name}' requires an approval click which "
+                    "isn't available in the non-streaming agent path. "
+                    "Try again over the SSE stream endpoint."
+                    if name in WRITE_TOOLS
+                    else f"Tool '{name}' is not exposed to the assistant."
                 ),
             }
         )
@@ -520,16 +527,56 @@ async def run_user_turn_streaming(
                     "arguments": fn.get("arguments", ""),
                 }
 
-                # PR 4: write-tool approval intercept.  Any tool name
-                # NOT in the read-only whitelist becomes an approval
-                # request instead of an MCP call.  We still persist a
+                # PR 4: write-tool approval intercept.  When the LLM
+                # picks a tool from WRITE_TOOLS we queue an approval
+                # request instead of calling MCP directly; the tool only
+                # runs after the user clicks Approve via the
+                # chat_approvals endpoint.  We still persist a
                 # placeholder ``role=tool`` row so the conversation
                 # history stays internally consistent (OpenAI rejects
                 # any assistant-with-tool_calls turn that isn't followed
                 # by matching tool rows on the next API call).  The
                 # approve / reject endpoint OVERWRITES this row's
                 # content with the real result once the user decides.
-                if tc_name and tc_name not in READ_ONLY_TOOLS:
+                #
+                # Anything outside the union of READ_ONLY_TOOLS and
+                # WRITE_TOOLS is treated as a hallucinated tool name
+                # and returned as a synthetic error so the LLM can
+                # recover (rather than queuing an approval the user
+                # would just have to reject).
+                if tc_name and tc_name not in ALLOWED_TOOLS:
+                    err = json.dumps(
+                        {
+                            "error": "tool_not_allowed",
+                            "message": (
+                                f"Tool '{tc_name}' is not exposed to "
+                                "the assistant."
+                            ),
+                        }
+                    )
+                    tool_row = ChatMessage(
+                        thread_id=thread.id,
+                        role="tool",
+                        content=err,
+                        tool_call_id=tc_id,
+                    )
+                    db.add(tool_row)
+                    await db.flush()
+                    openai_messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc_id,
+                            "content": err,
+                        }
+                    )
+                    yield {
+                        "type": "tool_result",
+                        "id": tc_id,
+                        "name": tc_name,
+                        "content": err,
+                    }
+                    continue
+                if tc_name and tc_name in WRITE_TOOLS:
                     parsed_args, parse_err = _parse_tool_arguments(
                         fn.get("arguments")
                     )

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -83,6 +83,70 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
 )
 
 
+# Write/mutating tools exposed to the assistant.  Each one is gated by
+# the PR-4 approval flow: when the LLM calls one of these, the agent
+# loop intercepts, persists a ``ChatPendingApproval`` row, and emits
+# an ``approval_request`` SSE event so the UI can render an
+# Approve / Reject card.  The tool only runs after the user clicks
+# Approve, and it runs with ``bypass_whitelist=True`` from the
+# chat_approvals router.
+#
+# Truly destructive or security-sensitive operations are deliberately
+# left off this list and remain UI-only.  Add a tool here only after
+# confirming that a malicious-prompt-induced invocation, intercepted
+# by approval, would still be obviously wrong to the human reviewer
+# (i.e. the tool's name + arguments make its impact clear).
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        # devices — onboarding / lifecycle (NOT delete, factory-reset,
+        # set-password, ssh/local-api toggles)
+        "adopt_device",
+        "update_device",
+        "reboot_device",
+        "check_device_updates",
+        "upgrade_device",
+        # groups
+        "create_group",
+        "update_group",
+        "delete_group",
+        # assets (non-destructive + delete; webpage assets are user-authored)
+        "create_webpage_asset",
+        "update_asset",
+        "delete_asset",
+        "share_asset",
+        "unshare_asset",
+        "toggle_asset_global",
+        "recapture_stream",
+        # tags
+        "create_tag",
+        "update_tag",
+        "delete_tag",
+        # schedules
+        "create_schedule",
+        "update_schedule",
+        "delete_schedule",
+        "play_now",
+        "end_schedule_now",
+        # profiles
+        "create_profile",
+        "update_profile",
+        "copy_profile",
+        "enable_profile",
+        "disable_profile",
+        "reset_profile",
+        "delete_profile",
+        # asset views (per-user saved filters; low-risk)
+        "create_asset_view",
+        "update_asset_view",
+        "delete_asset_view",
+    }
+)
+
+# Combined set used both for tool exposure and for the approval gate
+# in :class:`cms.services.assistant.agent`.
+ALLOWED_TOOLS: frozenset[str] = READ_ONLY_TOOLS | WRITE_TOOLS
+
+
 def _read_service_key(settings: Settings) -> str:
     """Read the MCP service key.
 
@@ -197,14 +261,26 @@ class AssistantMcpClient:
         listing = await self._session.list_tools()
         out: list[dict[str, Any]] = []
         for tool in listing.tools:
-            if tool.name not in READ_ONLY_TOOLS:
+            if tool.name not in ALLOWED_TOOLS:
                 continue
+            description = tool.description or ""
+            if tool.name in WRITE_TOOLS:
+                # Surface the approval contract in the description the
+                # LLM sees so it can set expectations with the user
+                # ("I'll create that schedule — you'll see an approve
+                # button") rather than promising instant execution.
+                description = (
+                    f"{description}\n\n"
+                    "[Note: this is a write tool — calling it will queue "
+                    "an approval request that the user must explicitly "
+                    "click Approve on before it runs.]"
+                ).strip()
             out.append(
                 {
                     "type": "function",
                     "function": {
                         "name": tool.name,
-                        "description": tool.description or "",
+                        "description": description,
                         "parameters": tool.inputSchema
                         or {"type": "object", "properties": {}},
                     },
@@ -243,7 +319,18 @@ class AssistantMcpClient:
         if not bypass_whitelist and name not in READ_ONLY_TOOLS:
             raise PermissionError(
                 f"Tool '{name}' is not in the read-only whitelist "
-                "(writes require approval; see PR 4)."
+                "(writes require approval)."
+            )
+        if bypass_whitelist and name not in ALLOWED_TOOLS:
+            # Defence in depth: the approval router calls us with
+            # bypass=True only after a human clicked Approve, but we
+            # must still refuse anything outside the explicit
+            # WRITE_TOOLS allowlist so a hallucinated or out-of-scope
+            # tool name can't slip through just because someone hit
+            # the button on the card.
+            raise PermissionError(
+                f"Tool '{name}' is not in the assistant's allowlist "
+                "(read or write)."
             )
         logger.info(
             "assistant.mcp.call name=%s user=%s bypass=%s",

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -25,10 +25,21 @@ Guidelines:
   this deployment — counts, names, statuses, recent activity — call
   the appropriate tool instead of guessing or asking them to look
   in the UI.  Prefer one well-targeted tool call over many.
-* Write/mutating actions (create schedule, modify group, reboot
-  device, etc.) are not yet exposed.  If the user asks for one, tell
-  them that capability is coming soon and offer to walk them through
-  how to do it in the UI.
+* You ALSO have write tools for routine CRUD on schedules, groups,
+  assets, tags, profiles, asset views, and a few device lifecycle
+  actions (adopt, update, reboot, check/apply updates).  Every write
+  tool is gated by an approval click — when you call one, the UI
+  shows the user an Approve / Reject card with the exact arguments
+  and the tool only runs after they approve.  So when a user asks
+  you to create / update / delete something covered by these tools,
+  go ahead and call it (do not refuse) — confirm the key parameters
+  first if they're ambiguous, then make the call and tell the user
+  to look for the approval card.
+* Truly destructive or security-sensitive actions are intentionally
+  not exposed (deleting devices, factory reset, setting device
+  passwords, toggling SSH or the local API).  If asked to do one of
+  these, explain it isn't available through the assistant and walk
+  them through the UI.
 * Never invent device IDs, asset IDs, schedule IDs, or other data —
   always source them from a tool result before referring to them.
 * If a tool call fails or returns nothing, say so plainly rather

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1149,12 +1149,12 @@ class TestStreamingApprovalIntercept:
             ChatPendingApproval,
         )
 
-        # ``delete_device`` is intentionally NOT in READ_ONLY_TOOLS.
+        # ``update_device`` is intentionally in WRITE_TOOLS (approval required).
         scripted_agent["mcp_tools"] = [
             {
                 "type": "function",
                 "function": {
-                    "name": "delete_device",
+                    "name": "update_device",
                     "description": "delete a device",
                     "parameters": {"type": "object", "properties": {}},
                 },
@@ -1166,7 +1166,7 @@ class TestStreamingApprovalIntercept:
                 tokens_in=12,
                 tokens_out=4,
                 tool_calls=[
-                    _tool_call("delete_device", {"id": "dev-1"})
+                    _tool_call("update_device", {"id": "dev-1"})
                 ],
             ),
             # Should NOT be consumed — the loop must stop on the
@@ -1191,7 +1191,7 @@ class TestStreamingApprovalIntercept:
         import json as _json
 
         ar = _json.loads(frames[1][1])
-        assert ar["name"] == "delete_device"
+        assert ar["name"] == "update_device"
         assert ar["arguments"] == {"id": "dev-1"}
         assert "approval_id" in ar
 
@@ -1206,7 +1206,7 @@ class TestStreamingApprovalIntercept:
                 )
             ).scalars().all()
             assert len(rows) == 1
-            assert rows[0].tool_name == "delete_device"
+            assert rows[0].tool_name == "update_device"
             assert rows[0].status == STATUS_PENDING
             assert rows[0].tool_arguments == {"id": "dev-1"}
 
@@ -1223,7 +1223,7 @@ class TestStreamingApprovalIntercept:
             assert roles == ["user", "assistant", "tool", "assistant"]
             placeholder = _json.loads(msgs[2].content)
             assert placeholder["status"] == "awaiting_approval"
-            assert placeholder["tool"] == "delete_device"
+            assert placeholder["tool"] == "update_device"
             # Final assistant message explains the pause.
             assert "awaiting your approval" in msgs[3].content
             break
@@ -1251,7 +1251,7 @@ class TestStreamingApprovalIntercept:
             {
                 "type": "function",
                 "function": {
-                    "name": "delete_device",
+                    "name": "update_device",
                     "description": "",
                     "parameters": {"type": "object", "properties": {}},
                 },
@@ -1276,7 +1276,7 @@ class TestStreamingApprovalIntercept:
                         "id": "call_write",
                         "type": "function",
                         "function": {
-                            "name": "delete_device",
+                            "name": "update_device",
                             "arguments": '{"id": "dev-1"}',
                         },
                     },
@@ -1316,7 +1316,7 @@ class TestStreamingApprovalIntercept:
                 )
             ).scalars().all()
             assert len(approvals) == 1
-            assert approvals[0].tool_name == "delete_device"
+            assert approvals[0].tool_name == "update_device"
             break
 
 


### PR DESCRIPTION
PR-4 (#659) shipped the approval intercept but list_openai_tools() still only advertised the read-only set, so the LLM would politely refuse anything mutating and tell the user to open the UI.

This wires up the write path:

- New `WRITE_TOOLS` frozenset covering routine CRUD on schedules, groups, assets, tags, profiles, asset views, plus device lifecycle ops (adopt, update, reboot, check/upgrade updates).
- Destructive ops stay deliberately unexposed: `delete_device`, `factory_reset_device`, `set_device_password`, `toggle_device_ssh`, `toggle_device_local_api` -- those still require the CMS UI.
- `ALLOWED_TOOLS = READ_ONLY_TOOLS | WRITE_TOOLS`; `list_openai_tools()` iterates this and appends a note to each write-tool description so the LLM tells the user up-front that the action will be approved before running.
- Streaming intercept now branches on `WRITE_TOOLS` explicitly and rejects hallucinated tool names (not in `ALLOWED_TOOLS`) with a synthetic `tool_result` error -- the model can recover instead of queuing an approval the user would just have to reject.
- `call_tool()` defense-in-depth: even with `bypass_whitelist=True` we re-check the name is in `ALLOWED_TOOLS`, so a hallucinated name that slips into an approval payload can't execute.
- System prompt rewritten to describe both tool sets, the approval click contract, and what's deliberately excluded.

Tests: existing streaming-intercept tests switched from `delete_device` (now excluded) to `update_device`. 62 chat tests pass.