### PR TITLE
fix(assistant): make approval card readable (contrast + key/value args)

### DIFF
--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -229,6 +229,62 @@
     }
 
     // ── Approval card ────────────────────────────────────────────────
+    function renderApprovalArgs(parent, toolArgs) {
+        // Render the tool's arguments as a readable key/value list
+        // instead of a raw JSON blob.  Most write tools take a flat
+        // bag of scalars (name, start_time, asset_id, …); arrays and
+        // nested objects collapse to a one-line pretty-printed form.
+        const wrap = document.createElement("div");
+        wrap.className = "assistant-approval-args";
+        const entries = toolArgs && typeof toolArgs === "object"
+            ? Object.entries(toolArgs)
+            : [];
+        if (entries.length === 0) {
+            const empty = document.createElement("span");
+            empty.className = "empty";
+            empty.textContent = "(no arguments)";
+            wrap.appendChild(empty);
+            parent.appendChild(wrap);
+            return;
+        }
+        const dl = document.createElement("dl");
+        for (const [key, value] of entries) {
+            const dt = document.createElement("dt");
+            dt.textContent = key;
+            const dd = document.createElement("dd");
+            const { text, multiline } = formatApprovalValue(value);
+            dd.textContent = text;
+            if (multiline) dd.classList.add("is-multiline");
+            dl.appendChild(dt);
+            dl.appendChild(dd);
+        }
+        wrap.appendChild(dl);
+        parent.appendChild(wrap);
+    }
+
+    function formatApprovalValue(v) {
+        if (v === null || v === undefined) return { text: "—", multiline: false };
+        if (typeof v === "boolean") return { text: v ? "yes" : "no", multiline: false };
+        if (typeof v === "number" || typeof v === "string") {
+            const s = String(v);
+            return { text: s, multiline: s.includes("\n") };
+        }
+        if (Array.isArray(v)) {
+            // Short arrays of scalars → "a, b, c"; everything else → JSON.
+            const allScalar = v.every(
+                (x) => x === null || ["string", "number", "boolean"].includes(typeof x)
+            );
+            if (allScalar && v.length <= 12) {
+                return { text: v.length === 0 ? "(none)" : v.join(", "), multiline: false };
+            }
+            const j = JSON.stringify(v, null, 2);
+            return { text: j, multiline: true };
+        }
+        // Object — pretty print on multiple lines.
+        const j = JSON.stringify(v, null, 2);
+        return { text: j, multiline: true };
+    }
+
     function renderApprovalCard(approval) {
         const card = document.createElement("div");
         card.className = "assistant-approval";
@@ -239,10 +295,7 @@
         h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
         card.appendChild(h);
 
-        const args = document.createElement("pre");
-        args.className = "assistant-approval-args";
-        args.textContent = JSON.stringify(approval.tool_arguments, null, 2);
-        card.appendChild(args);
+        renderApprovalArgs(card, approval.tool_arguments);
 
         const actions = document.createElement("div");
         actions.className = "assistant-approval-actions";
@@ -416,10 +469,7 @@
         h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
         card.appendChild(h);
 
-        const args = document.createElement("pre");
-        args.className = "assistant-approval-args";
-        args.textContent = JSON.stringify(approval.tool_arguments, null, 2);
-        card.appendChild(args);
+        renderApprovalArgs(card, approval.tool_arguments);
 
         const actions = document.createElement("div");
         actions.className = "assistant-approval-actions";

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -241,6 +241,11 @@
     border: 1px solid var(--warn, #d4a72c);
     border-radius: 8px;
     padding: 0.75rem;
+    /* Pin readable text colour rather than inheriting from whatever the
+       surrounding theme decides — the soft-yellow background is fixed,
+       so dark text is always the right choice (including in dark mode,
+       where the inherited colour would otherwise be near-white). */
+    color: #2a2a2a;
 }
 .assistant-approval h4 {
     margin: 0 0 0.4rem 0;
@@ -248,15 +253,39 @@
     font-size: 0.9rem;
 }
 .assistant-approval-args {
+    font-size: 0.82rem;
+    background: rgba(0,0,0,0.04);
+    padding: 0.5rem 0.65rem;
+    border-radius: 4px;
+    margin: 0.3rem 0;
+    max-height: 220px;
+    overflow-y: auto;
+    color: #2a2a2a;
+}
+.assistant-approval-args dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 0.6rem;
+    row-gap: 0.2rem;
+}
+.assistant-approval-args dt {
+    color: #6b6b6b;
+    font-weight: 500;
+    white-space: nowrap;
+}
+.assistant-approval-args dd {
+    margin: 0;
+    word-break: break-word;
     font-family: ui-monospace, monospace;
     font-size: 0.78rem;
-    background: rgba(0,0,0,0.04);
-    padding: 0.4rem 0.55rem;
-    border-radius: 4px;
+}
+.assistant-approval-args dd.is-multiline {
     white-space: pre-wrap;
-    margin: 0.3rem 0;
-    max-height: 180px;
-    overflow-y: auto;
+}
+.assistant-approval-args .empty {
+    color: #6b6b6b;
+    font-style: italic;
 }
 .assistant-approval-actions {
     display: flex;


### PR DESCRIPTION
Two UX nits on the write-tool approval card that landed in #670:

1. **Low contrast.** The card has a fixed soft-yellow background but text colour inherited from the page theme -- in dark mode that's near-white, making the args essentially invisible. Pin the card's text to dark grey.
2. **Raw JSON wasn't user-friendly.** Replaced the `<pre>` + `JSON.stringify` with a two-column key/value grid (label → value). Scalars render inline; short scalar arrays become `a, b, c`; nested objects fall back to pretty-printed JSON.

Shared `renderApprovalArgs()` helper used by both the live-stream and historical-reload card builders. 4 assistant-page tests still pass.