### PR TITLE
feat(assistant): teach LLM to ask before inventing write-tool params

### DIFF
--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -35,6 +35,17 @@ Guidelines:
   go ahead and call it (do not refuse) — confirm the key parameters
   first if they're ambiguous, then make the call and tell the user
   to look for the approval card.
+* **Never invent parameters for write tools.**  Do not silently fill
+  in priority, loop_count, days_of_week, end_date, end_time, or any
+  other optional field that the user did not explicitly state.  If
+  an optional field is missing, either omit it (the API will use its
+  default) or ASK the user before calling — do not guess on their
+  behalf.  When in doubt, briefly restate the parameters you're
+  about to send ("I'll create a schedule called X for asset Y,
+  starting at Z, no end date, no loop — sound right?") and wait for
+  confirmation before the tool call.  The approval card shows the
+  literal args, so a user surprised by your defaults will reject
+  the call — better to ask first.
 * Truly destructive or security-sensitive actions are intentionally
   not exposed (deleting devices, factory reset, setting device
   passwords, toggling SSH or the local API).  If asked to do one of

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -427,6 +427,21 @@ async def create_schedule(
 
     Assigns an asset to play on a device group during a time window.
 
+    CLARIFY BEFORE CALLING (LLM behaviour):
+    Do not invent values for optional fields.  In particular, if the
+    user did NOT explicitly mention:
+      - end_time / loop_count → omit both for an open-ended slot;
+        DO NOT pick a loop_count like 5 to "make it short".
+      - end_date → omit it (open-ended).  Do not copy start_date.
+      - days_of_week → omit it (= every day).  Do not pick today's
+        weekday on your own.
+      - priority → omit it (defaults to 0).  Never pick 10 or any
+        other non-zero value without being asked.
+    If the request is ambiguous (e.g. "show this for a bit"), ASK the
+    user rather than guessing — the approval card shows the literal
+    args you chose, and a user who sees an unexpected loop_count or
+    priority will reject the call.
+
     IMPORTANT — loop_count vs end_time:
     When loop_count is set, end_time is IGNORED and overridden to
     start_time + (loop_count × asset_duration). This creates a narrow
@@ -493,6 +508,14 @@ async def update_schedule(
 ) -> str:
     """Update an existing schedule. Only provided fields are changed.
 
+    CLARIFY BEFORE CALLING (LLM behaviour):
+    Pass ONLY the fields the user explicitly asked to change.  Do not
+    re-send every field with its current value — anything you pass
+    will be written, which means an off-by-one (e.g. "fix the start
+    time" → also resending priority: 5 when it was actually 0) will
+    silently overwrite unrelated config.  Read the schedule first
+    with get_schedule if you need to know its current values.
+
     Args:
         schedule_id: UUID of the schedule to update.
         name: New display name.
@@ -541,6 +564,13 @@ async def play_now(
 ) -> str:
     """Immediately play an asset on a device group. Creates a high-priority schedule
     for today with an all-day time window so playback starts right away.
+
+    PREFER THIS over create_schedule for ad-hoc / "just for now" / "show
+    this for a bit" requests — the user almost certainly wants playback
+    starting immediately on the current day, not a recurring schedule
+    with a guessed loop_count, end_time, or priority.  Use create_schedule
+    only when the user explicitly wants a recurring or future-dated
+    schedule.
 
     When done, call end_schedule_now with the returned schedule ID to stop
     playback, or delete_schedule to remove it entirely.


### PR DESCRIPTION
User reported: assistant created a schedule and silently invented `loop_count: 5`, `priority: 10`, `days_of_week: [Saturday]`, `end_date == start_date` -- none of which were asked for. The approval card shows the literal args so it can be rejected, but better to never guess in the first place.

Two-pronged fix that stacks:

**1. System prompt** (broad lever, applies to every write tool)
Adds a 'Never invent parameters for write tools' rule with an explicit list of fields not to make up, and tells the LLM to restate ambiguous args before calling.

**2. MCP tool descriptions** (per-tool surgical lever, read every turn alongside the schema)
- `create_schedule`: enumerates exactly which fields to omit rather than guess, and calls out the specific bad defaults to avoid (`loop_count: 5`, `priority: 10`, today's weekday).
- `play_now`: 'PREFER THIS over create_schedule for ad-hoc / show-this-for-a-bit requests' -- the right answer to today's prompt would have been `play_now`, not a custom `create_schedule`.
- `update_schedule`: only pass fields the user asked to change.

39 chat-agent + MCP-status tests still pass.