### PR TITLE
feat(assistant): show per-user token usage + USD estimate on Assistant page

### DIFF
--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -33,18 +33,25 @@ from cms.models.chat_thread import ChatThread
 from cms.models.user import User
 from cms.schemas.chat import (
     AssistantFeatureStatus,
+    AssistantUsageOut,
     ChatMessageCreate,
     ChatMessageOut,
     ChatThreadCreate,
     ChatThreadOut,
 )
 from cms.services.assistant.agent import run_user_turn, run_user_turn_streaming
-from cms.services.assistant.budget import BudgetExceededError, check_budget
+from cms.services.assistant.budget import (
+    BudgetExceededError,
+    check_budget,
+    get_user_daily_cap,
+    get_user_today_usage_split,
+)
 from cms.services.assistant.llm_client import (
     AssistantUnavailableError,
     is_available as assistant_llm_available,
 )
 from cms.services.assistant.mcp_client import McpUnavailableError
+from cms.services.assistant.pricing import estimate_usd, model_for_deployment
 from cms.services.assistant_flag import assistant_enabled_for
 
 logger = logging.getLogger(__name__)
@@ -106,6 +113,44 @@ async def get_feature_status(
 ):
     """Report whether the caller has the Assistant feature enabled."""
     return AssistantFeatureStatus(enabled=await assistant_enabled_for(db, user))
+
+
+@router.get("/usage", response_model=AssistantUsageOut)
+async def get_assistant_usage(
+    user: User = Depends(_current_user),
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    """Return the caller's current-day token usage + cap + USD estimate.
+
+    Gated on the same feature flag as the rest of ``/api/chat/*`` so
+    non-allowlisted users get a 404 (consistent with the rule that the
+    feature shouldn't even appear to exist for them).
+
+    The USD figure is an **estimate** based on the configured AOAI
+    deployment's matched model row in
+    :data:`cms.services.assistant.pricing.PRICE_TABLE_USD_PER_M_TOKENS`.
+    Actual Azure billing can differ (EA discounts, cached-input rates,
+    etc.) — the UI labels it as "estimated" for that reason.
+    """
+    await _require_feature(user, db)
+    tokens_in, tokens_out = await get_user_today_usage_split(db, user)
+    cap = await get_user_daily_cap(db, user)
+    deployment = settings.azure_openai_deployment or ""
+    usd = estimate_usd(
+        deployment=deployment,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+    )
+    return AssistantUsageOut(
+        used_tokens=tokens_in + tokens_out,
+        used_tokens_in=tokens_in,
+        used_tokens_out=tokens_out,
+        cap_tokens=cap,
+        unlimited=cap < 0,
+        used_usd_estimate=usd,
+        model=model_for_deployment(deployment),
+    )
 
 
 # ── Thread CRUD ───────────────────────────────────────────────────────

--- a/cms/schemas/chat.py
+++ b/cms/schemas/chat.py
@@ -67,6 +67,34 @@ class AssistantFeatureStatus(BaseModel):
     enabled: bool
 
 
+class AssistantUsageOut(BaseModel):
+    """Response body for ``GET /api/chat/usage``.
+
+    Lightweight snapshot of the caller's per-UTC-day token consumption
+    so the in-page usage strip can show "Today: 1,240 / 50,000 tok •
+    ~$0.0015" without the UI doing any pricing math.
+
+    ``cap_tokens`` is the cap that applies to *this* user (per-user
+    override beats the global default).  A negative cap means the
+    user has been granted unlimited use by an admin; ``unlimited`` is
+    surfaced as a discrete bool so the UI can hide the "of 50k"
+    fraction in that case.
+
+    ``model`` is the matched price-table key (e.g. ``"gpt-4o-mini"``)
+    or the string ``"unknown"`` if the configured AOAI deployment name
+    doesn't match any entry — surface it so the operator can spot a
+    mis-tagged deployment that's making the cost estimate suspect.
+    """
+
+    used_tokens: int
+    used_tokens_in: int
+    used_tokens_out: int
+    cap_tokens: int
+    unlimited: bool
+    used_usd_estimate: float
+    model: str
+
+
 # ── PR 4: write-tool approval flow ────────────────────────────────────
 
 

--- a/cms/services/assistant/budget.py
+++ b/cms/services/assistant/budget.py
@@ -182,6 +182,30 @@ async def get_user_today_usage(
     return int(total or 0)
 
 
+async def get_user_today_usage_split(
+    db: AsyncSession, user: User, *, now: datetime | None = None
+) -> tuple[int, int]:
+    """Return ``(tokens_in, tokens_out)`` for ``user``'s turns today.
+
+    Same scoping as :func:`get_user_today_usage`; split for callers
+    (e.g. the in-page usage strip) that want to feed input/output
+    counts into a $/M pricing table.
+    """
+    day_start = _utc_day_start(now)
+    stmt = (
+        select(
+            func.coalesce(func.sum(ChatMessage.tokens_in), 0),
+            func.coalesce(func.sum(ChatMessage.tokens_out), 0),
+        )
+        .select_from(ChatMessage)
+        .join(ChatThread, ChatThread.id == ChatMessage.thread_id)
+        .where(ChatThread.user_id == user.id)
+        .where(ChatMessage.created_at >= day_start)
+    )
+    row = (await db.execute(stmt)).one()
+    return int(row[0] or 0), int(row[1] or 0)
+
+
 async def check_budget(
     db: AsyncSession, user: User, *, now: datetime | None = None
 ) -> tuple[int, int]:

--- a/cms/services/assistant/pricing.py
+++ b/cms/services/assistant/pricing.py
@@ -1,0 +1,124 @@
+"""Token-to-USD estimation for the Assistant.
+
+The per-user daily token cap (:mod:`cms.services.assistant.budget`) is
+denominated in tokens because that's what the Azure OpenAI API returns
+deterministically.  Operators (and end users, via the in-page usage
+strip) generally think in dollars, so this module maintains a small
+lookup table of ``(input_$/1M-tokens, output_$/1M-tokens)`` for the
+Azure OpenAI models we actually deploy, plus a fallback for any model
+that isn't in the table.
+
+These rates are **list prices** taken from the Azure OpenAI pricing
+page (or OpenAI's, where Azure mirrors them).  They are estimates:
+
+* Discounts from EA / committed-use don't apply here.
+* Cached input tokens are billed at a different rate in some models
+  — we don't have visibility into the cache hit rate, so we use the
+  full input rate.
+* Tool / function tokens are billed at the input rate (correct).
+
+The fallback rate matches gpt-4o-mini (the cheapest modern small
+model).  This may under-report cost if the unknown deployment is
+actually a frontier model, but it avoids scaring users with phantom
+$$$ when the deployment name simply doesn't follow our convention.
+See :data:`FALLBACK_RATES_USD_PER_M_TOKENS`.
+
+To update rates after a price change:
+
+* Edit :data:`PRICE_TABLE_USD_PER_M_TOKENS`.
+* Bump :data:`PRICE_TABLE_VERSION` so any cached UI strings refresh.
+* The deployment-name → model-key heuristic in :func:`_resolve_model`
+  is intentionally loose; the matcher prefers the longest substring
+  match so ``gpt-4o-mini-2024-07-18`` resolves to ``gpt-4o-mini``
+  rather than ``gpt-4o``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Rates are USD per 1,000,000 tokens, ``(input, output)``.
+#
+# Sources (as of 2025-Q2):
+#   * https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+#   * https://openai.com/api/pricing/
+#
+# Keep keys lowercase; matching is case-insensitive.
+PRICE_TABLE_USD_PER_M_TOKENS: Final[dict[str, tuple[float, float]]] = {
+    # GPT-4o family
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4o-mini": (0.15, 0.60),
+    # GPT-4 turbo / classic
+    "gpt-4-turbo": (10.00, 30.00),
+    "gpt-4": (30.00, 60.00),
+    # GPT-3.5
+    "gpt-35-turbo": (0.50, 1.50),
+    "gpt-3.5-turbo": (0.50, 1.50),
+    # o1 / o3 reasoning models
+    "o1": (15.00, 60.00),
+    "o1-mini": (3.00, 12.00),
+    "o3-mini": (1.10, 4.40),
+    "o4-mini": (1.10, 4.40),
+}
+
+# Fallback when the configured deployment doesn't match anything above.
+# We pick gpt-4o-mini's rate as a conservative-but-not-doom default:
+# small enough that we don't scare users with phantom $$$, but if it
+# turns out the deployment is gpt-4o the under-report is at worst ~16×.
+FALLBACK_RATES_USD_PER_M_TOKENS: Final[tuple[float, float]] = (0.15, 0.60)
+
+# Bump on rate-table edits so the UI can cache-bust if needed.
+PRICE_TABLE_VERSION: Final[int] = 1
+
+
+def _resolve_model(deployment: str) -> tuple[str, tuple[float, float]]:
+    """Match a deployment name to a price-table entry.
+
+    Azure OpenAI deployments are user-named (e.g. ``cms-chat-prod``)
+    but the *model* the deployment points at is typically embedded in
+    the name (e.g. ``cms-gpt-4o-mini``).  We do a longest-substring
+    match so that ``gpt-4o-mini-2024-07-18`` and ``my-gpt-4o-mini-v2``
+    both resolve correctly.
+
+    Returns ``(matched_key_or_'unknown', rates)``.  Use the matched
+    key when emitting telemetry / UI strings so the operator can see
+    which entry was chosen.
+    """
+    if not deployment:
+        return "unknown", FALLBACK_RATES_USD_PER_M_TOKENS
+    dep = deployment.lower()
+    best_key: str | None = None
+    for key in PRICE_TABLE_USD_PER_M_TOKENS:
+        if key in dep and (best_key is None or len(key) > len(best_key)):
+            best_key = key
+    if best_key is None:
+        return "unknown", FALLBACK_RATES_USD_PER_M_TOKENS
+    return best_key, PRICE_TABLE_USD_PER_M_TOKENS[best_key]
+
+
+def estimate_usd(
+    *,
+    deployment: str,
+    tokens_in: int,
+    tokens_out: int,
+) -> float:
+    """Return an estimated cost in USD for the given token counts.
+
+    The math is trivially ``(in * in_rate + out * out_rate) / 1e6``.
+    Negative inputs are clamped to zero so a corrupt row in the
+    summing query can't yield a negative cost.
+    """
+    tokens_in = max(0, int(tokens_in))
+    tokens_out = max(0, int(tokens_out))
+    _key, (in_rate, out_rate) = _resolve_model(deployment)
+    return (tokens_in * in_rate + tokens_out * out_rate) / 1_000_000.0
+
+
+def model_for_deployment(deployment: str) -> str:
+    """Return the matched price-table model key (or ``"unknown"``).
+
+    Useful for the ``/api/chat/usage`` payload so the UI can show
+    operators which rate row was applied to their numbers.
+    """
+    key, _ = _resolve_model(deployment)
+    return key

--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -457,6 +457,10 @@
             $input.focus();
             // Refresh sidebar so the auto-title shows up on a new thread.
             await loadThreads();
+            // Refresh the usage strip so tokens-burned + $ estimate update
+            // immediately after a turn completes (even partial / errored
+            // turns can have token counts recorded).
+            refreshUsage();
         }
     }
 
@@ -544,6 +548,66 @@
         $messages.scrollTop = $messages.scrollHeight;
     }
 
+    // ── Per-user usage strip ─────────────────────────────────────────
+    // Refreshed on init and after every turn completes.  Failures are
+    // swallowed: the strip is informational, not critical, and we'd
+    // rather hide it than block the assistant on a transient 5xx.
+    const $usage = document.getElementById("assistant-usage");
+    const $usageText = document.getElementById("assistant-usage-text");
+    const $usageFill = document.getElementById("assistant-usage-fill");
+
+    function formatTokens(n) {
+        // Compact form for the strip — keeps "1,240 / 50,000" readable.
+        return Number(n || 0).toLocaleString();
+    }
+    function formatUsd(n) {
+        const v = Number(n || 0);
+        // Sub-cent: 4 decimals so $0.0015 isn't reported as $0.00.
+        if (v < 0.01) return `$${v.toFixed(4)}`;
+        if (v < 1) return `$${v.toFixed(3)}`;
+        return `$${v.toFixed(2)}`;
+    }
+    async function refreshUsage() {
+        if (!$usage) return;
+        try {
+            const r = await fetch("/api/chat/usage");
+            if (!r.ok) {
+                $usage.style.display = "none";
+                return;
+            }
+            const u = await r.json();
+            const used = u.used_tokens || 0;
+            const cap = u.cap_tokens || 0;
+            const usd = formatUsd(u.used_usd_estimate);
+            if (u.unlimited) {
+                $usage.dataset.unlimited = "true";
+                $usageText.textContent =
+                    `Today: ${formatTokens(used)} tok • ~${usd} (no cap)`;
+                $usageFill.style.width = "0%";
+            } else if (cap === 0) {
+                // Admin-paused user.  Keep the strip but make it obvious.
+                $usage.dataset.unlimited = "false";
+                $usageText.textContent =
+                    `Today: ${formatTokens(used)} tok • ~${usd} (cap 0 — disabled)`;
+                $usageFill.style.width = "100%";
+                $usageFill.classList.remove("warn");
+                $usageFill.classList.add("danger");
+            } else {
+                $usage.dataset.unlimited = "false";
+                const pct = Math.min(100, (used / cap) * 100);
+                $usageText.textContent =
+                    `Today: ${formatTokens(used)} / ${formatTokens(cap)} tok • ~${usd}`;
+                $usageFill.style.width = pct.toFixed(1) + "%";
+                $usageFill.classList.remove("warn", "danger");
+                if (pct >= 90) $usageFill.classList.add("danger");
+                else if (pct >= 70) $usageFill.classList.add("warn");
+            }
+            $usage.style.display = "";
+        } catch (e) {
+            $usage.style.display = "none";
+        }
+    }
+
     // ── Init ─────────────────────────────────────────────────────────
     async function init() {
         const enabled = await probeFeature();
@@ -557,6 +621,7 @@
 
         await loadThreads();
         renderEmptyConversation();
+        refreshUsage();
 
         $newThread.addEventListener("click", () => createThread());
         $form.addEventListener("submit", (ev) => {

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -353,6 +353,52 @@
     cursor: not-allowed;
 }
 
+/* ── Per-user usage strip (PR: usage display) ─────────────────────
+   Sits below the composer, in the right-hand column only.  Token +
+   USD figures are refreshed after every turn completes; the bar fill
+   tracks ``used / cap`` so users can see at a glance how close they
+   are to their daily ceiling. */
+.assistant-usage {
+    border-top: 1px solid var(--border);
+    padding: 0.4rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.assistant-usage-text {
+    white-space: nowrap;
+}
+.assistant-usage-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--surface-2, rgba(0,0,0,0.06));
+    border-radius: 3px;
+    overflow: hidden;
+    min-width: 60px;
+}
+.assistant-usage-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--accent, #4e8cff);
+    transition: width 0.3s ease, background-color 0.3s ease;
+}
+.assistant-usage-fill.warn {
+    background: var(--warning, #e6a817);
+}
+.assistant-usage-fill.danger {
+    background: var(--danger, #c93434);
+}
+.assistant-usage[data-unlimited="true"] .assistant-usage-bar {
+    display: none;
+}
+.assistant-usage .assistant-usage-hint {
+    cursor: help;
+    border-bottom: 1px dotted var(--text-muted);
+}
+
 .assistant-streaming-indicator {
     align-self: flex-start;
     color: var(--text-muted);
@@ -409,6 +455,14 @@
                     disabled></textarea>
                 <button type="submit" id="assistant-send" disabled>Send</button>
             </form>
+            <div class="assistant-usage" id="assistant-usage" style="display:none;">
+                <span class="assistant-usage-text" id="assistant-usage-text">Today: …</span>
+                <div class="assistant-usage-bar" aria-hidden="true">
+                    <div class="assistant-usage-fill" id="assistant-usage-fill"></div>
+                </div>
+                <span class="assistant-usage-hint" id="assistant-usage-hint"
+                      title="USD figure is an estimate based on the configured Azure OpenAI model's list price. Actual billing may differ slightly.">est.</span>
+            </div>
         </section>
     </div>
 </div>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -659,50 +659,50 @@ async function saveAlertSettings() {
 })();
 </script>
 
-    {% if 'settings:write' in user_perms %}
-    <div class="card" id="assistant-card">
-        <h2>Assistant</h2>
-        <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
-            Controls the in-CMS Assistant (chat + tool grounding via MCP). The
-            feature is gated by a per-user allowlist; admins always have access.
-            Daily token caps protect against runaway LLM spend.
-        </p>
+{% if 'settings:write' in user_perms %}
+<div class="card" id="assistant-card">
+    <h2>Assistant</h2>
+    <p class="text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
+        Controls the in-CMS Assistant (chat + tool grounding via MCP). The
+        feature is gated by a per-user allowlist; admins always have access.
+        Daily token caps protect against runaway LLM spend.
+    </p>
 
-        <h3 style="margin-top: 1rem;">Allowlist</h3>
-        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
-            Users who can see and use the Assistant. Admins (anyone with
-            <code>settings:write</code>) always have access regardless of this list.
-        </p>
-        <div id="assistant-allowlist" style="max-height: 240px; overflow-y: auto; border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
-            <span class="text-muted">Loading…</span>
-        </div>
-        <button type="button" class="btn btn-primary" id="assistant-save-allowlist">Save allowlist</button>
+    <h3 style="margin-top: 1rem;">Allowlist</h3>
+    <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+        Users who can see and use the Assistant. Admins (anyone with
+        <code>settings:write</code>) always have access regardless of this list.
+    </p>
+    <div id="assistant-allowlist" style="max-height: 240px; overflow-y: auto; border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
+        <span class="text-muted">Loading…</span>
+    </div>
+    <button type="button" class="btn btn-primary" id="assistant-save-allowlist">Save allowlist</button>
 
-        <h3 style="margin-top: 1.5rem;">Daily token budget</h3>
-        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
-            Cap on tokens (input + output) per user per UTC day. Negative = unlimited.
-            Zero = blocked. Defaults to <span id="assistant-cap-fallback">50000</span> when nothing is configured.
-        </p>
-        <div class="form-row">
-            <div class="form-group">
-                <label for="assistant-default-cap">Global default (tokens/day)</label>
-                <input type="number" id="assistant-default-cap" min="-1" value="" style="max-width: 200px;">
-            </div>
+    <h3 style="margin-top: 1.5rem;">Daily token budget</h3>
+    <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+        Cap on tokens (input + output) per user per UTC day. Negative = unlimited.
+        Zero = blocked. Defaults to <span id="assistant-cap-fallback">50000</span> when nothing is configured.
+    </p>
+    <div class="form-row">
+        <div class="form-group">
+            <label for="assistant-default-cap">Global default (tokens/day)</label>
+            <input type="number" id="assistant-default-cap" min="-1" value="" style="max-width: 200px;">
         </div>
-
-        <h4 style="margin-top: 1rem;">Per-user overrides</h4>
-        <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
-            Override the global cap for individual allowlisted users. Leave the cap
-            blank to remove an override (the user will fall back to the global default).
-        </p>
-        <div id="assistant-overrides" style="border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
-            <span class="text-muted">Loading…</span>
-        </div>
-        <button type="button" class="btn btn-primary" id="assistant-save-budget" style="margin-top: 0.5rem;">Save budget</button>
     </div>
 
-    <script>
-    (function () {
+    <h4 style="margin-top: 1rem;">Per-user overrides</h4>
+    <p class="text-muted" style="font-size: 0.8rem; margin: 0.25rem 0 0.5rem;">
+        Override the global cap for individual allowlisted users. Leave the cap
+        blank to remove an override (the user will fall back to the global default).
+    </p>
+    <div id="assistant-overrides" style="border: 1px solid var(--border); border-radius: 4px; padding: 0.5rem; margin-bottom: 0.5rem;">
+        <span class="text-muted">Loading…</span>
+    </div>
+    <button type="button" class="btn btn-primary" id="assistant-save-budget" style="margin-top: 0.5rem;">Save budget</button>
+</div>
+
+<script>
+(function () {
         const allowlistDiv = document.getElementById("assistant-allowlist");
         const overridesDiv = document.getElementById("assistant-overrides");
         const defaultCapInput = document.getElementById("assistant-default-cap");
@@ -842,6 +842,6 @@ async function saveAlertSettings() {
         loadState();
     })();
     </script>
-    {% endif %}
+{% endif %}
 
-    {% endblock %}
+{% endblock %}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1682,6 +1682,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssistantFeatureStatus'
+  /api/chat/usage:
+    get:
+      summary: Get Assistant Usage
+      description: |-
+        Return the caller's current-day token usage + cap + USD estimate.
+
+        Gated on the same feature flag as the rest of ``/api/chat/*`` so
+        non-allowlisted users get a 404 (consistent with the rule that the
+        feature shouldn't even appear to exist for them).
+
+        The USD figure is an **estimate** based on the configured AOAI
+        deployment's matched model row in
+        :data:`cms.services.assistant.pricing.PRICE_TABLE_USD_PER_M_TOKENS`.
+        Actual Azure billing can differ (EA discounts, cached-input rates,
+        etc.) — the UI labels it as "estimated" for that reason.
+      operationId: get_assistant_usage_api_chat_usage_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantUsageOut'
   /api/chat/threads:
     get:
       summary: List Threads
@@ -4604,6 +4627,56 @@ components:
       - overrides
       - users
       title: AssistantSettingsOut
+    AssistantUsageOut:
+      properties:
+        used_tokens:
+          type: integer
+          title: Used Tokens
+        used_tokens_in:
+          type: integer
+          title: Used Tokens In
+        used_tokens_out:
+          type: integer
+          title: Used Tokens Out
+        cap_tokens:
+          type: integer
+          title: Cap Tokens
+        unlimited:
+          type: boolean
+          title: Unlimited
+        used_usd_estimate:
+          type: number
+          title: Used Usd Estimate
+        model:
+          type: string
+          title: Model
+      type: object
+      required:
+      - used_tokens
+      - used_tokens_in
+      - used_tokens_out
+      - cap_tokens
+      - unlimited
+      - used_usd_estimate
+      - model
+      title: AssistantUsageOut
+      description: |-
+        Response body for ``GET /api/chat/usage``.
+
+        Lightweight snapshot of the caller's per-UTC-day token consumption
+        so the in-page usage strip can show "Today: 1,240 / 50,000 tok •
+        ~$0.0015" without the UI doing any pricing math.
+
+        ``cap_tokens`` is the cap that applies to *this* user (per-user
+        override beats the global default).  A negative cap means the
+        user has been granted unlimited use by an admin; ``unlimited`` is
+        surfaced as a discrete bool so the UI can hide the "of 50k"
+        fraction in that case.
+
+        ``model`` is the matched price-table key (e.g. ``"gpt-4o-mini"``)
+        or the string ``"unknown"`` if the configured AOAI deployment name
+        doesn't match any entry — surface it so the operator can spot a
+        mis-tagged deployment that's making the cost estimate suspect.
     AssistantUserCatalogEntry:
       properties:
         id:

--- a/tests/test_chat_usage.py
+++ b/tests/test_chat_usage.py
@@ -1,0 +1,178 @@
+"""Tests for the Assistant per-user usage display.
+
+Covers two layers:
+
+* The pure pricing helper (:mod:`cms.services.assistant.pricing`) —
+  deployment-name resolution, USD math, fallback behaviour, and the
+  defensive clamp for corrupt token counts.
+* The ``GET /api/chat/usage`` endpoint — surfaces tokens + USD for the
+  caller's UTC day, gated on the Assistant feature flag.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.chat_message import ChatMessage
+from cms.models.chat_thread import ChatThread
+from cms.models.user import User
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _create_thread(client, title: str = "") -> uuid.UUID:
+    resp = await client.post("/api/chat/threads", json={"title": title})
+    assert resp.status_code == 201, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _seed_usage(app, thread_id: uuid.UUID, tokens_in: int, tokens_out: int) -> None:
+    """Persist a synthetic assistant message so the usage query has
+    something to sum."""
+    from cms.database import get_db
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        db.add(
+            ChatMessage(
+                thread_id=thread_id,
+                role="assistant",
+                content="(synthetic)",
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+            )
+        )
+        await db.commit()
+        break
+
+
+# ── Pricing unit tests ────────────────────────────────────────────────
+
+
+class TestPricingResolver:
+    def test_exact_match_gpt_4o_mini(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, (in_rate, out_rate) = _resolve_model("gpt-4o-mini")
+        assert key == "gpt-4o-mini"
+        assert (in_rate, out_rate) == (0.15, 0.60)
+
+    def test_longest_substring_wins(self):
+        """A deployment named ``cms-gpt-4o-mini-2024-07-18`` must
+        resolve to ``gpt-4o-mini``, not the shorter ``gpt-4o``."""
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, _ = _resolve_model("cms-gpt-4o-mini-2024-07-18")
+        assert key == "gpt-4o-mini"
+
+    def test_unknown_deployment_uses_fallback(self):
+        from cms.services.assistant.pricing import (
+            FALLBACK_RATES_USD_PER_M_TOKENS,
+            _resolve_model,
+        )
+
+        key, rates = _resolve_model("totally-custom-name")
+        assert key == "unknown"
+        assert rates == FALLBACK_RATES_USD_PER_M_TOKENS
+
+    def test_empty_deployment_uses_fallback(self):
+        from cms.services.assistant.pricing import (
+            FALLBACK_RATES_USD_PER_M_TOKENS,
+            _resolve_model,
+        )
+
+        key, rates = _resolve_model("")
+        assert key == "unknown"
+        assert rates == FALLBACK_RATES_USD_PER_M_TOKENS
+
+    def test_case_insensitive_match(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, _ = _resolve_model("CMS-GPT-4O-MINI")
+        assert key == "gpt-4o-mini"
+
+
+class TestEstimateUsd:
+    def test_math_matches_table(self):
+        from cms.services.assistant.pricing import estimate_usd
+
+        # gpt-4o: 2.50 / 10.00 per million.
+        # 1M input + 1M output → 2.50 + 10.00 = 12.50
+        cost = estimate_usd(
+            deployment="gpt-4o", tokens_in=1_000_000, tokens_out=1_000_000
+        )
+        assert cost == pytest.approx(12.50)
+
+    def test_negative_token_counts_clamped(self):
+        from cms.services.assistant.pricing import estimate_usd
+
+        assert (
+            estimate_usd(deployment="gpt-4o", tokens_in=-5, tokens_out=-5)
+            == 0.0
+        )
+
+    def test_zero_tokens_returns_zero(self):
+        from cms.services.assistant.pricing import estimate_usd
+
+        assert estimate_usd(deployment="gpt-4o", tokens_in=0, tokens_out=0) == 0.0
+
+    def test_model_for_deployment_passthrough(self):
+        from cms.services.assistant.pricing import model_for_deployment
+
+        assert model_for_deployment("cms-gpt-4o-mini") == "gpt-4o-mini"
+        assert model_for_deployment("weird-deployment") == "unknown"
+        assert model_for_deployment("") == "unknown"
+
+
+# ── Endpoint tests ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestUsageEndpoint:
+    async def test_zero_for_fresh_user(self, client):
+        resp = await client.get("/api/chat/usage")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["used_tokens"] == 0
+        assert body["used_tokens_in"] == 0
+        assert body["used_tokens_out"] == 0
+        assert body["used_usd_estimate"] == 0.0
+        assert body["cap_tokens"] > 0  # default cap applies
+        assert body["unlimited"] is False
+        # The deployment configured for tests may not match our table —
+        # just assert the field exists and is a string.
+        assert isinstance(body["model"], str)
+
+    async def test_sums_todays_tokens(self, app, client):
+        tid = await _create_thread(client)
+        await _seed_usage(app, tid, 1234, 5678)
+
+        resp = await client.get("/api/chat/usage")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["used_tokens_in"] == 1234
+        assert body["used_tokens_out"] == 5678
+        assert body["used_tokens"] == 1234 + 5678
+        # USD must be > 0 once tokens are non-zero, regardless of
+        # whether the deployment matched the table (fallback rates
+        # are also non-zero).
+        assert body["used_usd_estimate"] > 0.0
+
+    async def test_unlimited_flag_when_cap_negative(self, app, client):
+        from cms.database import get_db
+        from cms.services.assistant.budget import set_default_cap
+
+        factory = app.dependency_overrides[get_db]
+        async for db in factory():
+            await set_default_cap(db, -1)
+            break
+
+        resp = await client.get("/api/chat/usage")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["unlimited"] is True
+        assert body["cap_tokens"] == -1


### PR DESCRIPTION
Adds a footer strip below the Assistant composer that surfaces the caller's UTC-day token usage, the configured cap, and a USD estimate based on the configured Azure OpenAI deployment. Refreshes on page load and after every assistant turn.

Also normalises the indentation of the Settings page Assistant card block — speculative fix for a reported h2 font-size discrepancy on that card vs. peer cards (e.g. `Download Logs`). Static markup looked identical to me, so the root cause is unconfirmed; will verify visually post-deploy.

## What you'll see

- New strip below the chat composer: `Today: 1,240 / 50,000 tok • ~+'$'+