### PR TITLE
fix(assistant): record streaming token usage + resolve model name

### DIFF
--- a/cms/config.py
+++ b/cms/config.py
@@ -150,6 +150,14 @@ class Settings(SharedSettings):
     azure_openai_endpoint: str = ""
     azure_openai_deployment: str = ""
     azure_openai_api_version: str = "2024-10-21"
+    # Model behind the deployment.  Deployment names are user-chosen
+    # (we use "chat") and rarely contain the model name, so the pricing
+    # module can't reliably infer rates from the deployment string.
+    # Pass the model explicitly so /api/chat/usage shows real $$ and
+    # the right model label.  Keep in sync with the bicep
+    # ``azureOpenAIChatModel`` parameter; empty falls back to
+    # substring-matching on the deployment name.
+    azure_openai_model: str = "gpt-4o"
     # Per-turn completion cap.  Keeps a runaway response from blowing
     # through the daily budget in a single shot; PR 6 layers a real
     # budget cap on top of this.

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -137,10 +137,12 @@ async def get_assistant_usage(
     tokens_in, tokens_out = await get_user_today_usage_split(db, user)
     cap = await get_user_daily_cap(db, user)
     deployment = settings.azure_openai_deployment or ""
+    model_override = settings.azure_openai_model or ""
     usd = estimate_usd(
         deployment=deployment,
         tokens_in=tokens_in,
         tokens_out=tokens_out,
+        model_override=model_override,
     )
     return AssistantUsageOut(
         used_tokens=tokens_in + tokens_out,
@@ -149,7 +151,7 @@ async def get_assistant_usage(
         cap_tokens=cap,
         unlimited=cap < 0,
         used_usd_estimate=usd,
-        model=model_for_deployment(deployment),
+        model=model_for_deployment(deployment, model_override=model_override),
     )
 
 

--- a/cms/services/assistant/llm_client.py
+++ b/cms/services/assistant/llm_client.py
@@ -235,6 +235,16 @@ class LLMClient:
         response = await self._client.chat.completions.create(**kwargs)
         tokens_in = 0
         tokens_out = 0
+        finish_reason: str | None = None
+        # Azure OpenAI emits the final ``usage`` block in a *separate*
+        # chunk after the chunk that carries ``finish_reason``.  That
+        # usage chunk has ``choices == []``.  If we yield ``finish``
+        # the moment we see ``finish_reason`` we capture tokens_in/out
+        # as zeros and the agent then persists ``ChatMessage`` rows
+        # with 0/0 — which makes the per-user usage strip on the
+        # Assistant page read "0 tokens today" forever.  Defer the
+        # single ``finish`` yield to after the stream completes so it
+        # carries both the finish_reason and the real usage.
         async for chunk in response:
             usage = getattr(chunk, "usage", None)
             if usage is not None:
@@ -265,10 +275,11 @@ class LLMClient:
                             ),
                         }
             if getattr(choice, "finish_reason", None):
-                yield {
-                    "type": "finish",
-                    "reason": choice.finish_reason,
-                    "tokens_in": tokens_in,
-                    "tokens_out": tokens_out,
-                }
+                finish_reason = choice.finish_reason
+        yield {
+            "type": "finish",
+            "reason": finish_reason,
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+        }
 

--- a/cms/services/assistant/pricing.py
+++ b/cms/services/assistant/pricing.py
@@ -71,7 +71,11 @@ FALLBACK_RATES_USD_PER_M_TOKENS: Final[tuple[float, float]] = (0.15, 0.60)
 PRICE_TABLE_VERSION: Final[int] = 1
 
 
-def _resolve_model(deployment: str) -> tuple[str, tuple[float, float]]:
+def _resolve_model(
+    deployment: str,
+    *,
+    model_override: str = "",
+) -> tuple[str, tuple[float, float]]:
     """Match a deployment name to a price-table entry.
 
     Azure OpenAI deployments are user-named (e.g. ``cms-chat-prod``)
@@ -80,10 +84,22 @@ def _resolve_model(deployment: str) -> tuple[str, tuple[float, float]]:
     match so that ``gpt-4o-mini-2024-07-18`` and ``my-gpt-4o-mini-v2``
     both resolve correctly.
 
+    When ``model_override`` is supplied (e.g. from the
+    ``AGORA_CMS_AZURE_OPENAI_MODEL`` env var) and matches a known
+    price-table key, it wins regardless of the deployment string.
+    This lets operators deploy under a generic name like ``chat`` —
+    which doesn't contain any model substring — and still get
+    accurate USD estimates.
+
     Returns ``(matched_key_or_'unknown', rates)``.  Use the matched
     key when emitting telemetry / UI strings so the operator can see
     which entry was chosen.
     """
+    if model_override:
+        ovr = model_override.lower()
+        rates = PRICE_TABLE_USD_PER_M_TOKENS.get(ovr)
+        if rates is not None:
+            return ovr, rates
     if not deployment:
         return "unknown", FALLBACK_RATES_USD_PER_M_TOKENS
     dep = deployment.lower()
@@ -101,24 +117,34 @@ def estimate_usd(
     deployment: str,
     tokens_in: int,
     tokens_out: int,
+    model_override: str = "",
 ) -> float:
     """Return an estimated cost in USD for the given token counts.
 
     The math is trivially ``(in * in_rate + out * out_rate) / 1e6``.
     Negative inputs are clamped to zero so a corrupt row in the
     summing query can't yield a negative cost.
+
+    ``model_override`` short-circuits the deployment-name heuristic
+    when the operator has configured ``AGORA_CMS_AZURE_OPENAI_MODEL``
+    (recommended; deployment names like ``chat`` don't contain a
+    model substring and would otherwise fall through to the fallback
+    rate).
     """
     tokens_in = max(0, int(tokens_in))
     tokens_out = max(0, int(tokens_out))
-    _key, (in_rate, out_rate) = _resolve_model(deployment)
+    _key, (in_rate, out_rate) = _resolve_model(
+        deployment, model_override=model_override
+    )
     return (tokens_in * in_rate + tokens_out * out_rate) / 1_000_000.0
 
 
-def model_for_deployment(deployment: str) -> str:
+def model_for_deployment(deployment: str, *, model_override: str = "") -> str:
     """Return the matched price-table model key (or ``"unknown"``).
 
     Useful for the ``/api/chat/usage`` payload so the UI can show
-    operators which rate row was applied to their numbers.
+    operators which rate row was applied to their numbers.  Honors
+    ``model_override`` for the same reason ``estimate_usd`` does.
     """
-    key, _ = _resolve_model(deployment)
+    key, _ = _resolve_model(deployment, model_override=model_override)
     return key

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -284,6 +284,7 @@ module containerApps 'modules/containerApps.bicep' = {
     // CMS treats empty endpoint as "feature disabled" at runtime.
     azureOpenAIEndpoint: deployAzureOpenAI ? azureOpenAI.outputs.endpoint : ''
     azureOpenAIDeployment: deployAzureOpenAI ? azureOpenAI.outputs.deploymentName : ''
+    azureOpenAIModel: deployAzureOpenAI ? azureOpenAIChatModel : ''
   }
 }
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -69,6 +69,9 @@ param azureOpenAIEndpoint string = ''
 @description('Azure OpenAI deployment name to use for chat completions (matches the deployment provisioned in azureOpenAI.bicep, default "chat"). Empty when the Assistant feature is not deployed in this environment.')
 param azureOpenAIDeployment string = ''
 
+@description('Model name behind the chat deployment (e.g. "gpt-4o"). Pricing/telemetry use this to label the model and compute USD; deployment names like "chat" do not contain a model substring so the runtime cannot infer it. Empty when the Assistant feature is not deployed in this environment.')
+param azureOpenAIModel string = ''
+
 // ── Blue/green deploy controls (Multiple revision mode) ──
 @description('Revision suffix for the CMS Container App. Each deploy MUST pass a unique value (e.g. "v1-12-34") so a brand-new revision is created at 0% traffic. The workflow flips traffic to it after smoke probes pass.')
 param cmsRevisionSuffix string = ''
@@ -327,6 +330,14 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'AGORA_CMS_AZURE_OPENAI_DEPLOYMENT'
               value: azureOpenAIDeployment
+            }
+            {
+              // Pricing / usage display reads this so /api/chat/usage
+              // can report real USD and the model label.  Deployment
+              // names are operator-chosen ("chat") and don't contain
+              // a model substring, so the runtime can't infer it.
+              name: 'AGORA_CMS_AZURE_OPENAI_MODEL'
+              value: azureOpenAIModel
             }
             {
               // Tag every emitted record so we can distinguish prod from

--- a/tests/test_chat_usage.py
+++ b/tests/test_chat_usage.py
@@ -128,6 +128,57 @@ class TestEstimateUsd:
         assert model_for_deployment("") == "unknown"
 
 
+class TestModelOverride:
+    """The ``model_override`` arg is the fix for deployments whose
+    *name* doesn't embed the model (e.g. our bicep names the AOAI
+    deployment ``chat``, so the substring matcher would return
+    ``"unknown"`` and the USD estimate would always be 0)."""
+
+    def test_override_wins_over_unknown_deployment(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, rates = _resolve_model("chat", model_override="gpt-4o")
+        assert key == "gpt-4o"
+        # gpt-4o rates: 2.50 / 10.00 per million
+        assert rates == (2.50, 10.00)
+
+    def test_override_case_insensitive(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, _ = _resolve_model("chat", model_override="GPT-4O")
+        assert key == "gpt-4o"
+
+    def test_unknown_override_falls_back_to_deployment_match(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, _ = _resolve_model("cms-gpt-4o-mini", model_override="madeup")
+        assert key == "gpt-4o-mini"
+
+    def test_estimate_usd_uses_override(self):
+        from cms.services.assistant.pricing import estimate_usd
+
+        cost = estimate_usd(
+            deployment="chat",
+            tokens_in=1_000_000,
+            tokens_out=1_000_000,
+            model_override="gpt-4o",
+        )
+        assert cost == pytest.approx(12.50)
+
+    def test_model_for_deployment_uses_override(self):
+        from cms.services.assistant.pricing import model_for_deployment
+
+        assert (
+            model_for_deployment("chat", model_override="gpt-4o") == "gpt-4o"
+        )
+
+    def test_empty_override_keeps_substring_behaviour(self):
+        from cms.services.assistant.pricing import _resolve_model
+
+        key, _ = _resolve_model("cms-gpt-4o-mini", model_override="")
+        assert key == "gpt-4o-mini"
+
+
 # ── Endpoint tests ────────────────────────────────────────────────────
 
 

--- a/tests/test_llm_client_stream.py
+++ b/tests/test_llm_client_stream.py
@@ -1,0 +1,135 @@
+"""Regression test for the streaming-usage capture in :class:`LLMClient`.
+
+Azure OpenAI emits the final ``usage`` block in a chunk *after* the
+chunk that carries ``finish_reason``.  An earlier bug yielded the
+``finish`` event inline (with tokens=0) when ``finish_reason`` showed
+up, then skipped the later usage-only chunk because ``choices == []``.
+The net effect: every streamed turn persisted ``tokens_in/out = 0``
+and the per-user usage strip on the Assistant page always read
+"0 tokens".
+
+This test pins the corrected behaviour: a single ``finish`` event is
+yielded after the stream ends, carrying both the reason and the real
+token counts.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from cms.services.assistant.llm_client import LLMClient
+
+
+class _FakeChatCompletions:
+    """Minimal stand-in for ``client.chat.completions``."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = chunks
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.last_kwargs = kwargs
+
+        async def _iter():
+            for c in self._chunks:
+                yield c
+
+        return _iter()
+
+
+def _make_chunk(
+    *,
+    content: str | None = None,
+    finish_reason: str | None = None,
+    usage: tuple[int, int] | None = None,
+) -> SimpleNamespace:
+    """Build a chunk shaped like ``openai.types.chat.ChatCompletionChunk``.
+
+    ``usage`` is a ``(prompt_tokens, completion_tokens)`` tuple; when
+    set we emit a usage-only chunk with ``choices=[]`` to mimic AOAI's
+    real stream-termination pattern.
+    """
+    if usage is not None:
+        return SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=usage[0], completion_tokens=usage[1]),
+        )
+    delta = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def _make_client(chunks: list[Any]) -> LLMClient:
+    """Construct an ``LLMClient`` without touching real Azure auth."""
+    client = object.__new__(LLMClient)  # bypass __init__
+    client._settings = SimpleNamespace(
+        azure_openai_deployment="chat",
+        assistant_max_completion_tokens=512,
+    )
+    fake = SimpleNamespace(chat=SimpleNamespace(completions=_FakeChatCompletions(chunks)))
+    client._client = fake
+    return client
+
+
+@pytest.mark.asyncio
+async def test_stream_captures_usage_from_trailing_chunk():
+    """The canonical AOAI sequence: content → finish-reason → usage-only.
+
+    The fix must defer the single ``finish`` yield until after the
+    stream ends so it carries the real tokens_in/out.
+    """
+    chunks = [
+        _make_chunk(content="Hello"),
+        _make_chunk(content=" world"),
+        _make_chunk(finish_reason="stop"),
+        _make_chunk(usage=(42, 17)),
+    ]
+    client = _make_client(chunks)
+    events = [ev async for ev in client.stream(messages=[{"role": "user", "content": "hi"}])]
+
+    finishes = [e for e in events if e["type"] == "finish"]
+    assert len(finishes) == 1, f"expected exactly one finish event, got {events!r}"
+    finish = finishes[0]
+    assert finish["reason"] == "stop"
+    assert finish["tokens_in"] == 42
+    assert finish["tokens_out"] == 17
+
+    texts = [e["text"] for e in events if e["type"] == "content"]
+    assert "".join(texts) == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_stream_finish_without_usage_yields_zero_tokens():
+    """Older API versions / non-streaming-usage paths still terminate
+    cleanly — we just report zeros instead of dropping the event."""
+    chunks = [
+        _make_chunk(content="hi"),
+        _make_chunk(finish_reason="stop"),
+    ]
+    client = _make_client(chunks)
+    events = [ev async for ev in client.stream(messages=[{"role": "user", "content": "hi"}])]
+
+    finishes = [e for e in events if e["type"] == "finish"]
+    assert len(finishes) == 1
+    assert finishes[0]["reason"] == "stop"
+    assert finishes[0]["tokens_in"] == 0
+    assert finishes[0]["tokens_out"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_usage_with_zero_completion_does_not_clobber_prompt():
+    """Guard against the ``or`` short-circuit losing a real value when
+    the other side of the usage tuple is zero."""
+    chunks = [
+        _make_chunk(content="x"),
+        _make_chunk(finish_reason="stop"),
+        _make_chunk(usage=(15, 0)),
+    ]
+    client = _make_client(chunks)
+    events = [ev async for ev in client.stream(messages=[{"role": "user", "content": "hi"}])]
+    finish = next(e for e in events if e["type"] == "finish")
+    assert finish["tokens_in"] == 15
+    assert finish["tokens_out"] == 0


### PR DESCRIPTION
Two related bugs in the per-user usage strip:

1. **Streaming token capture** — `LLMClient.stream` yielded the `finish` event inline when `finish_reason` arrived, before AOAI's trailing usage-only chunk (the one with `choices=[]` and `usage={prompt_tokens, completion_tokens}`). Result: every streamed turn persisted `tokens_in/out = 0`. Fix: capture `finish_reason` in a local during the loop, yield one `finish` event after the stream ends carrying the real token counts.

2. **Model resolution** — `pricing._resolve_model` inferred the model from a substring match on the deployment name. Our bicep names the AOAI deployment `chat`, which contains no model substring, so `/api/chat/usage` always reported `model='unknown'` and `used_usd_estimate=0`. Fix: new `azure_openai_model` setting (plumbed through bicep) takes precedence over the substring heuristic; default `gpt-4o` matches the bicep `azureOpenAIChatModel` default.

### Tests
- `tests/test_llm_client_stream.py` (new) — pins AOAI's chunk-sequence contract: content -> finish-reason -> usage-only. Includes a regression test for the `or`-short-circuit risk where a real `0` on one side of the usage tuple could clobber the other.
- `tests/test_chat_usage.py::TestModelOverride` — covers the override path end-to-end (override wins, case-insensitive, unknown-override fallback, empty-override preserves substring behavior).

### Notes
- Historical 0-token rows stay 0 — only affects rows written post-deploy.
- Bicep change is mechanical (one param, one env var) and follows the existing pattern for `azureOpenAIDeployment`.