### PR TITLE
fix(assistant): friendly names on approval cards

### DIFF
--- a/alembic/versions/0036_approval_display_arguments.py
+++ b/alembic/versions/0036_approval_display_arguments.py
@@ -1,0 +1,51 @@
+"""Alembic migration 0036 — friendly-name snapshot for approval cards.
+
+Adds ``display_arguments`` (JSONB on Postgres, JSON on SQLite) to
+``chat_pending_approvals``.  See
+:mod:`cms.services.assistant.approval_display` for the resolver that
+populates it.
+
+The column is nullable on purpose:
+
+* **Read-tool turns** never create an approval row, so the column is
+  irrelevant for them.
+* **Legacy rows** (anything written before this migration ran) stay
+  NULL — the frontend already had to handle that case (since the
+  resolver may also return an empty mapping if no IDs in the args
+  could be resolved).
+* **Resolver failures** (transient DB hiccup, unknown ID schema)
+  store NULL rather than blocking the approval card.
+
+Revision ID: 0036
+Revises: 0035
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+
+def _json_type(bind):
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        return sa.dialects.postgresql.JSONB()
+    return sa.JSON()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    op.add_column(
+        "chat_pending_approvals",
+        sa.Column("display_arguments", _json_type(bind), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0036 is not supported")

--- a/cms/models/chat_pending_approval.py
+++ b/cms/models/chat_pending_approval.py
@@ -62,6 +62,15 @@ class ChatPendingApproval(Base):
     tool_arguments: Mapped[dict[str, Any]] = mapped_column(
         _JSON_TYPE, nullable=False
     )
+    # Snapshot of human-readable values for any UUID-shaped args we
+    # could resolve at write time (see ``approval_display``).  NULL on
+    # read-tool turns and on legacy rows written before this column
+    # existed; the frontend treats a missing key as "render the raw
+    # UUID".  Snapshotting keeps the approval card stable even if a
+    # device / asset is renamed between propose and approve.
+    display_arguments: Mapped[dict[str, Any] | None] = mapped_column(
+        _JSON_TYPE, nullable=True
+    )
 
     status: Mapped[str] = mapped_column(
         String(20),

--- a/cms/schemas/chat.py
+++ b/cms/schemas/chat.py
@@ -115,6 +115,11 @@ class ChatPendingApprovalOut(BaseModel):
     tool_name: str
     tool_call_id: str
     tool_arguments: dict[str, Any]
+    # Optional snapshot of friendly names for UUID-shaped arg keys
+    # (e.g. ``{"device_id": "Pi100"}``).  NULL on legacy rows and on
+    # read-tool turns; missing keys mean "show the raw UUID".  See
+    # ``cms.services.assistant.approval_display`` for the resolver.
+    display_arguments: Optional[dict[str, Any]] = None
     status: str
     result_content: Optional[str] = None
     decision_note: Optional[str] = None

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -51,6 +51,7 @@ from cms.models.chat_pending_approval import (
 )
 from cms.models.chat_thread import ChatThread
 from cms.models.user import User
+from cms.services.assistant.approval_display import resolve_friendly_names
 from cms.services.assistant.llm_client import (
     CompletionResult,
     LLMClient,
@@ -585,12 +586,17 @@ async def run_user_turn_streaming(
                         if parse_err is None
                         else {"_unparsed_arguments": fn.get("arguments")}
                     )
+                    display_args = await resolve_friendly_names(
+                        db, approval_args
+                    )
+                    display_args_for_persist = display_args or None
                     approval = ChatPendingApproval(
                         thread_id=thread.id,
                         proposed_by_message_id=tc_row.id,
                         tool_name=tc_name,
                         tool_call_id=tc_id,
                         tool_arguments=approval_args,
+                        display_arguments=display_args_for_persist,
                         status=STATUS_PENDING,
                     )
                     db.add(approval)
@@ -623,6 +629,7 @@ async def run_user_turn_streaming(
                             "id": str(approval.id),
                             "tool": tc_name,
                             "arguments": approval_args,
+                            "display_arguments": display_args_for_persist,
                             "tool_call_id": tc_id,
                         }
                     )
@@ -632,6 +639,7 @@ async def run_user_turn_streaming(
                         "tool_call_id": tc_id,
                         "name": tc_name,
                         "arguments": approval_args,
+                        "display_arguments": display_args_for_persist,
                     }
                     continue
 

--- a/cms/services/assistant/approval_display.py
+++ b/cms/services/assistant/approval_display.py
@@ -1,0 +1,258 @@
+"""Friendly-name resolver for assistant approval cards.
+
+The MCP write-tool schemas take UUID arguments (``device_id``,
+``default_asset_id``, …) which makes total sense for the LLM ↔ MCP
+boundary but renders as opaque hex blobs in the human approval card.
+This module produces a parallel ``display_arguments`` dict that maps
+the same keys to human-recognisable strings (device name, asset
+display-name, …) so the UI can show ``Pi100`` instead of
+``af06ad30-0c1e-45fe-a41c-f6b271396ded``.
+
+Design notes
+------------
+
+* **Snapshot at write time.** The resolver runs once when the
+  ``ChatPendingApproval`` row is created, and the result is persisted
+  on the row.  That means the user sees the friendly names that were
+  current *when they were asked to approve* — even if the device is
+  later renamed or the asset is deleted before they click Approve.
+
+* **Silent fallback on miss.** Unknown keys (anything not in the
+  registry), unparseable UUIDs, and IDs that don't resolve to a row
+  are all silently omitted from the output.  The frontend treats a
+  missing key as "show the raw UUID" so the user is never blocked.
+
+* **Registry-driven.** Adding a new ID-shaped arg key is a single
+  line in :data:`_SINGLE_REGISTRY` / :data:`_PLURAL_REGISTRY`.  No
+  changes required in the agent or the router.
+
+* **Batched queries.** All IDs for the same model are collected and
+  fetched in one ``WHERE id IN (...)`` query.  A worst-case approval
+  with ten ``device_ids`` + three ``asset_ids`` issues two SELECTs,
+  not thirteen.
+
+* **No visibility filter.** The action originates from the user who
+  is currently being asked to approve it — by construction the agent
+  loop already had on-behalf-of-them access to look these IDs up
+  (it's how the LLM produced the arguments in the first place).  So
+  resolving the names here doesn't leak anything the user couldn't
+  see on a normal page load.  If that invariant ever changes (e.g.
+  shared threads), this is the place to add a per-user gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Iterable, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.models.asset_view import AssetView
+from cms.models.device import Device, DeviceGroup
+from cms.models.device_profile import DeviceProfile
+from cms.models.schedule import Schedule
+from cms.models.tag import Tag
+from shared.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+
+# (Model, attribute-chain) — the first attribute in the chain that
+# evaluates to a non-empty string wins.  Multi-attr chains exist for
+# assets because ``display_name`` is user-editable and may be null on
+# legacy rows; fall back to ``original_filename`` (set when we
+# converted e.g. HEIC→JPG) and ultimately the on-disk filename.
+_AssetChain = (Asset, ("display_name", "original_filename", "filename"))
+
+_SINGLE_REGISTRY: dict[str, tuple[type, tuple[str, ...]]] = {
+    "device_id": (Device, ("name",)),
+    "asset_id": _AssetChain,
+    "default_asset_id": _AssetChain,
+    "source_asset_id": _AssetChain,
+    "group_id": (DeviceGroup, ("name",)),
+    "tag_id": (Tag, ("name",)),
+    "schedule_id": (Schedule, ("name",)),
+    "profile_id": (DeviceProfile, ("name",)),
+    "asset_view_id": (AssetView, ("name",)),
+    "view_id": (AssetView, ("name",)),
+}
+
+_PLURAL_REGISTRY: dict[str, tuple[type, tuple[str, ...]]] = {
+    "device_ids": (Device, ("name",)),
+    "member_device_ids": (Device, ("name",)),
+    "asset_ids": _AssetChain,
+    "group_ids": (DeviceGroup, ("name",)),
+    "member_group_ids": (DeviceGroup, ("name",)),
+    "tag_ids": (Tag, ("name",)),
+    "schedule_ids": (Schedule, ("name",)),
+}
+
+
+def _coerce_id(raw: Any) -> str | uuid.UUID | None:
+    """Best-effort coercion to an ID we can put into a WHERE id IN (...)
+    clause.  Returns ``None`` for anything obviously non-id-shaped.
+
+    We deliberately don't force UUID parsing: ``Device.id`` is a plain
+    ``String(64)`` (Pi serial), while the rest of the catalog uses
+    ``UUID``.  SQLAlchemy handles the column-type coercion downstream
+    for both shapes, so the registry can stay homogeneous.
+    """
+    if isinstance(raw, uuid.UUID):
+        return raw
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s or len(s) > 64:
+        return None
+    # Prefer a real UUID when the string parses as one — SQLAlchemy's
+    # UUID column binder requires uuid.UUID, not a plain string.  Plain
+    # strings (Pi serials in Device.id) are returned as-is.
+    try:
+        return uuid.UUID(s)
+    except (ValueError, AttributeError):
+        return s
+
+
+def _first_nonempty(row: Any, attr_chain: tuple[str, ...]) -> str | None:
+    """Return the first attribute in ``attr_chain`` that is set on
+    ``row`` and is a non-empty string."""
+    for attr in attr_chain:
+        val = getattr(row, attr, None)
+        if val is None:
+            continue
+        text = str(val).strip()
+        if text:
+            return text
+    return None
+
+
+async def _bulk_load(
+    db: AsyncSession,
+    model: type,
+    ids: Iterable[Any],
+) -> dict[Any, Any]:
+    """Return ``{id: row}`` for the given model + ids in one query.
+
+    Missing rows are simply absent from the output dict.  ``ids`` may
+    be a mix of ``str`` and :class:`uuid.UUID` — SQLAlchemy coerces to
+    the column type on the way out.
+    """
+    seen: list[Any] = []
+    dedup: set[str] = set()
+    for i in ids:
+        key = str(i)
+        if key in dedup:
+            continue
+        dedup.add(key)
+        seen.append(i)
+    if not seen:
+        return {}
+    stmt = select(model).where(model.id.in_(seen))  # type: ignore[attr-defined]
+    result = await db.execute(stmt)
+    return {str(row.id): row for row in result.scalars().all()}
+
+
+async def resolve_friendly_names(
+    db: AsyncSession,
+    tool_arguments: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a ``display_arguments`` mapping for ``tool_arguments``.
+
+    Returns a dict containing only the keys that successfully resolved
+    to a human-readable name.  An empty dict is returned (not ``None``)
+    if nothing resolves — the caller decides whether to persist an
+    empty dict or ``None``; this keeps the type consistent for tests.
+
+    Plural keys (``..._ids``) resolve to a *list of names* in the
+    original list order.  IDs that don't resolve produce ``None`` at
+    that position so the list length matches the input — the frontend
+    then knows to render the raw UUID for that slot.
+    """
+    if not tool_arguments:
+        return {}
+
+    # Pass 1 — collect everything we need to fetch, grouped by model.
+    needed_by_model: dict[type, list[Any]] = {}
+    plan_single: list[tuple[str, Any, type, tuple[str, ...]]] = []
+    plan_plural: list[
+        tuple[str, list[Any], type, tuple[str, ...]]
+    ] = []
+
+    def _track(model: type, raw_id: Any) -> None:
+        bucket = needed_by_model.setdefault(model, [])
+        if not any(str(existing) == str(raw_id) for existing in bucket):
+            bucket.append(raw_id)
+
+    for key, raw in tool_arguments.items():
+        if key in _SINGLE_REGISTRY:
+            model, attrs = _SINGLE_REGISTRY[key]
+            parsed = _coerce_id(raw)
+            if parsed is None:
+                continue
+            _track(model, parsed)
+            plan_single.append((key, parsed, model, attrs))
+        elif key in _PLURAL_REGISTRY and isinstance(raw, list):
+            model, attrs = _PLURAL_REGISTRY[key]
+            parsed_list: list[Any] = []
+            for item in raw:
+                pid = _coerce_id(item)
+                parsed_list.append(pid)
+                if pid is not None:
+                    _track(model, pid)
+            if any(p is not None for p in parsed_list):
+                plan_plural.append((key, parsed_list, model, attrs))
+
+    if not plan_single and not plan_plural:
+        return {}
+
+    # Pass 2 — one bulk SELECT per model, swallow lookup errors so a
+    # transient DB hiccup never blocks the approval card from being
+    # shown at all (worst case: the user sees raw UUIDs, same as
+    # before this feature existed).
+    loaded: dict[type, dict[Any, Any]] = {}
+    for model, ids in needed_by_model.items():
+        try:
+            loaded[model] = await _bulk_load(db, model, ids)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "approval_display.bulk_load_failed model=%s",
+                getattr(model, "__name__", repr(model)),
+                exc_info=True,
+            )
+            loaded[model] = {}
+
+    # Pass 3 — build the output.
+    display: dict[str, Any] = {}
+    for key, pid, model, attrs in plan_single:
+        row = loaded.get(model, {}).get(str(pid))
+        if row is None:
+            continue
+        name = _first_nonempty(row, attrs)
+        if name:
+            display[key] = name
+
+    for key, parsed_list, model, attrs in plan_plural:
+        rows = loaded.get(model, {})
+        names: list[str | None] = []
+        any_resolved = False
+        for pid in parsed_list:
+            if pid is None:
+                names.append(None)
+                continue
+            row = rows.get(str(pid))
+            if row is None:
+                names.append(None)
+                continue
+            name = _first_nonempty(row, attrs)
+            names.append(name)
+            if name:
+                any_resolved = True
+        if any_resolved:
+            display[key] = names
+
+    return display
+
+
+__all__ = ["resolve_friendly_names"]

--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -9,7 +9,7 @@
 //   token             text delta
 //   tool_call         { id, name, arguments }     — about to invoke
 //   tool_result       { id, name, content }       — read tool finished
-//   approval_request  { approval_id, name, arguments, tool_call_id }
+//   approval_request  { approval_id, name, arguments, display_arguments, tool_call_id }
 //   done              { message_id, tokens_in, tokens_out }
 //   error             { message }
 (function () {
@@ -229,11 +229,19 @@
     }
 
     // ── Approval card ────────────────────────────────────────────────
-    function renderApprovalArgs(parent, toolArgs) {
+    function renderApprovalArgs(parent, toolArgs, displayArgs) {
         // Render the tool's arguments as a readable key/value list
         // instead of a raw JSON blob.  Most write tools take a flat
         // bag of scalars (name, start_time, asset_id, …); arrays and
         // nested objects collapse to a one-line pretty-printed form.
+        //
+        // ``displayArgs`` is the optional friendly-name snapshot
+        // produced server-side at write time (see
+        // ``cms.services.assistant.approval_display``).  When the
+        // backend resolves a UUID-shaped key to a name we render the
+        // friendly name as the primary value and demote the raw UUID
+        // to a small grey subscript so the audit trail is still
+        // visible.
         const wrap = document.createElement("div");
         wrap.className = "assistant-approval-args";
         const entries = toolArgs && typeof toolArgs === "object"
@@ -248,18 +256,74 @@
             return;
         }
         const dl = document.createElement("dl");
+        const display = (displayArgs && typeof displayArgs === "object")
+            ? displayArgs
+            : null;
         for (const [key, value] of entries) {
             const dt = document.createElement("dt");
             dt.textContent = key;
             const dd = document.createElement("dd");
-            const { text, multiline } = formatApprovalValue(value);
-            dd.textContent = text;
-            if (multiline) dd.classList.add("is-multiline");
+            const friendly = display ? display[key] : undefined;
+            if (renderFriendlyValue(dd, value, friendly)) {
+                dd.classList.add("has-friendly");
+            } else {
+                const { text, multiline } = formatApprovalValue(value);
+                dd.textContent = text;
+                if (multiline) dd.classList.add("is-multiline");
+            }
             dl.appendChild(dt);
             dl.appendChild(dd);
         }
         wrap.appendChild(dl);
         parent.appendChild(wrap);
+    }
+
+    function renderFriendlyValue(dd, raw, friendly) {
+        // Single ID → "Pi100  (af06ad30-…)"
+        if (typeof friendly === "string" && friendly.trim()) {
+            const name = document.createElement("span");
+            name.className = "approval-friendly";
+            name.textContent = friendly;
+            dd.appendChild(name);
+            if (typeof raw === "string" && raw && raw !== friendly) {
+                dd.appendChild(document.createTextNode(" "));
+                const uuid = document.createElement("span");
+                uuid.className = "approval-uuid";
+                uuid.textContent = raw;
+                dd.appendChild(uuid);
+            }
+            return true;
+        }
+        // Plural IDs → name list, with raw UUID under each unresolved slot.
+        if (Array.isArray(friendly) && Array.isArray(raw)) {
+            if (friendly.length === 0) return false;
+            const ul = document.createElement("ul");
+            ul.className = "approval-friendly-list";
+            for (let i = 0; i < raw.length; i++) {
+                const item = document.createElement("li");
+                const name = friendly[i];
+                const rawId = raw[i];
+                if (typeof name === "string" && name.trim()) {
+                    const nameSpan = document.createElement("span");
+                    nameSpan.className = "approval-friendly";
+                    nameSpan.textContent = name;
+                    item.appendChild(nameSpan);
+                    if (typeof rawId === "string" && rawId && rawId !== name) {
+                        item.appendChild(document.createTextNode(" "));
+                        const uuid = document.createElement("span");
+                        uuid.className = "approval-uuid";
+                        uuid.textContent = rawId;
+                        item.appendChild(uuid);
+                    }
+                } else {
+                    item.textContent = rawId == null ? "—" : String(rawId);
+                }
+                ul.appendChild(item);
+            }
+            dd.appendChild(ul);
+            return true;
+        }
+        return false;
     }
 
     function formatApprovalValue(v) {
@@ -295,7 +359,7 @@
         h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
         card.appendChild(h);
 
-        renderApprovalArgs(card, approval.tool_arguments);
+        renderApprovalArgs(card, approval.tool_arguments, approval.display_arguments);
 
         const actions = document.createElement("div");
         actions.className = "assistant-approval-actions";
@@ -425,6 +489,7 @@
                             tool_call_id: evt.data.tool_call_id,
                             tool_name: evt.data.name,
                             tool_arguments: evt.data.arguments,
+                            display_arguments: evt.data.display_arguments,
                             status: "pending",
                         };
                         // Use a temporary card host BEFORE the indicator.
@@ -473,7 +538,7 @@
         h.textContent = `⚠ Approval needed — ${approval.tool_name}`;
         card.appendChild(h);
 
-        renderApprovalArgs(card, approval.tool_arguments);
+        renderApprovalArgs(card, approval.tool_arguments, approval.display_arguments);
 
         const actions = document.createElement("div");
         actions.className = "assistant-approval-actions";

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -291,6 +291,27 @@
     color: #6b6b6b;
     font-style: italic;
 }
+.assistant-approval-args dd .approval-friendly {
+    font-family: var(--font-body, system-ui, sans-serif);
+    font-size: 0.85rem;
+    color: #1a1a1a;
+    font-weight: 500;
+}
+.assistant-approval-args dd .approval-uuid {
+    font-family: ui-monospace, monospace;
+    font-size: 0.68rem;
+    color: #8a8a8a;
+    margin-left: 0.15rem;
+}
+.assistant-approval-args dd ul.approval-friendly-list {
+    margin: 0;
+    padding-left: 0.9rem;
+    list-style: disc;
+}
+.assistant-approval-args dd ul.approval-friendly-list li {
+    margin: 0;
+    padding: 0;
+}
 .assistant-approval-actions {
     display: flex;
     gap: 0.4rem;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5093,6 +5093,12 @@ components:
           additionalProperties: true
           type: object
           title: Tool Arguments
+        display_arguments:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Display Arguments
         status:
           type: string
           title: Status

--- a/tests/test_approval_display.py
+++ b/tests/test_approval_display.py
@@ -1,0 +1,141 @@
+"""Tests for the approval-card friendly-name resolver.
+
+See ``cms/services/assistant/approval_display.py``.
+"""
+
+import uuid
+
+import pytest
+
+from cms.models.asset import Asset
+from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.services.assistant.approval_display import resolve_friendly_names
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _device(db, did="pi-100", name="Pi100", group_id=None):
+    d = Device(id=did, name=name, status=DeviceStatus.ADOPTED, group_id=group_id)
+    db.add(d)
+    await db.commit()
+    return d
+
+
+async def _group(db, name="Lobby"):
+    g = DeviceGroup(name=name, description="")
+    db.add(g)
+    await db.commit()
+    await db.refresh(g)
+    return g
+
+
+async def _asset(db, **fields):
+    defaults = dict(
+        id=uuid.uuid4(),
+        filename="x.png",
+        original_filename="x.png",
+        asset_type="image",
+        size_bytes=10,
+    )
+    defaults.update(fields)
+    a = Asset(**defaults)
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSingleResolution:
+    async def test_device_resolves(self, db_session):
+        await _device(db_session, did="pi-100", name="Pi100")
+        out = await resolve_friendly_names(db_session, {"device_id": "pi-100"})
+        assert out == {"device_id": "Pi100"}
+
+    async def test_group_resolves(self, db_session):
+        g = await _group(db_session, name="Lobby")
+        out = await resolve_friendly_names(db_session, {"group_id": str(g.id)})
+        assert out == {"group_id": "Lobby"}
+
+    async def test_asset_display_name_wins(self, db_session):
+        a = await _asset(db_session, display_name="Promo", original_filename="raw.mp4", filename="abc.mp4")
+        out = await resolve_friendly_names(db_session, {"default_asset_id": str(a.id)})
+        assert out == {"default_asset_id": "Promo"}
+
+    async def test_asset_falls_back_to_original_filename(self, db_session):
+        a = await _asset(db_session, display_name=None, original_filename="raw.mp4", filename="abc.mp4")
+        out = await resolve_friendly_names(db_session, {"asset_id": str(a.id)})
+        assert out == {"asset_id": "raw.mp4"}
+
+    async def test_asset_falls_back_to_filename(self, db_session):
+        a = await _asset(db_session, display_name=None, original_filename=None, filename="abc.mp4")
+        out = await resolve_friendly_names(db_session, {"asset_id": str(a.id)})
+        assert out == {"asset_id": "abc.mp4"}
+
+
+class TestPluralResolution:
+    async def test_device_list_resolves(self, db_session):
+        await _device(db_session, did="pi-a", name="Lobby-A")
+        await _device(db_session, did="pi-b", name="Lobby-B")
+        out = await resolve_friendly_names(
+            db_session, {"device_ids": ["pi-a", "pi-b"]}
+        )
+        assert out == {"device_ids": ["Lobby-A", "Lobby-B"]}
+
+    async def test_plural_with_partial_miss(self, db_session):
+        await _device(db_session, did="pi-a", name="Lobby-A")
+        out = await resolve_friendly_names(
+            db_session, {"device_ids": ["pi-a", "pi-missing"]}
+        )
+        assert out == {"device_ids": ["Lobby-A", None]}
+
+    async def test_plural_all_miss_skipped(self, db_session):
+        out = await resolve_friendly_names(
+            db_session, {"device_ids": ["pi-missing-1", "pi-missing-2"]}
+        )
+        assert out == {}
+
+
+class TestSkipping:
+    async def test_unknown_key_ignored(self, db_session):
+        out = await resolve_friendly_names(
+            db_session, {"random_field": "whatever", "other": 42}
+        )
+        assert out == {}
+
+    async def test_missing_row_skipped(self, db_session):
+        out = await resolve_friendly_names(
+            db_session, {"device_id": "does-not-exist"}
+        )
+        assert out == {}
+
+    async def test_malformed_input_skipped(self, db_session):
+        out = await resolve_friendly_names(
+            db_session, {"device_id": 12345, "group_id": ["not", "a", "uuid"]}
+        )
+        assert out == {}
+
+    async def test_empty_input(self, db_session):
+        assert await resolve_friendly_names(db_session, {}) == {}
+        assert await resolve_friendly_names(db_session, None) == {}  # type: ignore[arg-type]
+
+    async def test_mixed_resolves_some_skips_others(self, db_session):
+        await _device(db_session, did="pi-100", name="Pi100")
+        out = await resolve_friendly_names(
+            db_session,
+            {
+                "device_id": "pi-100",
+                "asset_id": "not-real-uuid-but-string",
+                "junk": "ignored",
+            },
+        )
+        # device resolves; asset_id has no matching row → skipped.
+        assert out == {"device_id": "Pi100"}


### PR DESCRIPTION
Approval cards rendered raw UUIDs for `device_id` / `asset_id` / `group_id` / etc., which the user has no way to recognize.  Fix renders the friendly name (`Device.name`, `Asset.display_name` fallback chain, `DeviceGroup.name`, ...) as the main value and shows the raw UUID as a small grey monospace subscript so the technical identifier is still recoverable.

## Approach (Option B, the right way)

- New `cms/services/assistant/approval_display.py` registry maps tool-arg keys to `(Model, attr-chain)` tuples and does one bulk SELECT per model.
- New `display_arguments JSONB NULL` column on `chat_pending_approvals` (alembic 0036).  **Snapshotted at write time** so the friendly name persists even if the underlying row is later renamed or deleted.
- Streaming agent calls `resolve_friendly_names()` and writes the result into both the DB row and the SSE `approval_request` event payload.
- `ChatPendingApprovalOut` schema exposes the new field, so the `GET /api/chat/approvals/{id}` endpoint also surfaces it.
- `assistant.js` `renderApprovalArgs()` takes the `displayArgs` map and renders friendly + UUID-subscript.  Handles single-id and list-of-ids shapes; unresolved slots fall back to raw UUID.

## Tests

- 13 new tests in `tests/test_approval_display.py` — device, group, asset fallback chain (display_name -> original_filename -> filename), plurals with partial-miss, unknown-key skip, malformed-input skip, empty input.
- Full chat suite green locally (81 passed in test_chat_approvals + test_chat_agent + test_chat_usage + test_approval_display).