### PR TITLE
Fix approval resolver poisoning outer tx on UUID-shaped Pi IDs

### DIFF
--- a/cms/services/assistant/approval_display.py
+++ b/cms/services/assistant/approval_display.py
@@ -47,7 +47,9 @@ import uuid
 from typing import Any, Iterable, Mapping
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.types import Uuid as SA_Uuid
 
 from cms.models.asset_view import AssetView
 from cms.models.device import Device, DeviceGroup
@@ -57,6 +59,24 @@ from cms.models.tag import Tag
 from shared.models.asset import Asset
 
 logger = logging.getLogger(__name__)
+
+
+def _id_column_is_uuid(model: type) -> bool:
+    """True if ``model.id`` is a UUID-typed column.
+
+    The catalog is heterogeneous: ``Device.id`` is ``String(64)`` (Pi
+    serial), while the rest use UUID.  We use this to bind the right
+    Python type — passing a ``uuid.UUID`` to a varchar column or a
+    plain ``str`` to a UUID column will type-mismatch and **abort the
+    outer Postgres transaction** (asyncpg behaviour), poisoning every
+    subsequent statement in the same session including the actual
+    approval INSERT.  See ``_bulk_load``.
+    """
+    try:
+        col_type = model.__table__.c.id.type  # type: ignore[attr-defined]
+    except AttributeError:
+        return False
+    return isinstance(col_type, (PG_UUID, SA_Uuid))
 
 
 # (Model, attribute-chain) — the first attribute in the chain that
@@ -135,23 +155,43 @@ async def _bulk_load(
 ) -> dict[Any, Any]:
     """Return ``{id: row}`` for the given model + ids in one query.
 
+    Wrapped in a SAVEPOINT (``begin_nested``) so that a type-mismatch
+    or any other DB error during the friendly-name lookup can ONLY
+    poison the savepoint, never the outer transaction that's about to
+    insert the ``ChatPendingApproval`` row.
+
     Missing rows are simply absent from the output dict.  ``ids`` may
-    be a mix of ``str`` and :class:`uuid.UUID` — SQLAlchemy coerces to
-    the column type on the way out.
+    be a mix of ``str`` and :class:`uuid.UUID`; we normalise them to
+    match the model's id column type before binding so asyncpg doesn't
+    type-mismatch and abort the surrounding transaction.
     """
     seen: list[Any] = []
     dedup: set[str] = set()
+    use_uuid = _id_column_is_uuid(model)
     for i in ids:
         key = str(i)
         if key in dedup:
             continue
         dedup.add(key)
-        seen.append(i)
+        if use_uuid:
+            if isinstance(i, uuid.UUID):
+                seen.append(i)
+            else:
+                try:
+                    seen.append(uuid.UUID(str(i)))
+                except (ValueError, AttributeError):
+                    # Caller already coerced; non-UUID strings against
+                    # a UUID column would type-mismatch.  Skip silently.
+                    continue
+        else:
+            seen.append(str(i))
     if not seen:
         return {}
     stmt = select(model).where(model.id.in_(seen))  # type: ignore[attr-defined]
-    result = await db.execute(stmt)
-    return {str(row.id): row for row in result.scalars().all()}
+    async with db.begin_nested():
+        result = await db.execute(stmt)
+        rows = result.scalars().all()
+    return {str(row.id): row for row in rows}
 
 
 async def resolve_friendly_names(

--- a/tests/test_approval_display.py
+++ b/tests/test_approval_display.py
@@ -139,3 +139,47 @@ class TestSkipping:
         )
         # device resolves; asset_id has no matching row → skipped.
         assert out == {"device_id": "Pi100"}
+
+    async def test_device_with_uuid_shaped_string_id(self, db_session):
+        """Regression for prod bug: Device.id is String(64) but a Pi
+        serial that happens to look UUID-shaped used to be coerced to
+        uuid.UUID and bound against the varchar column, type-mismatching
+        and aborting the outer transaction.
+        """
+        uuid_shaped = "af06ad30-0c1e-45fe-a41c-f6b271396ded"
+        await _device(db_session, did=uuid_shaped, name="UUIDShapedPi")
+        out = await resolve_friendly_names(
+            db_session, {"device_id": uuid_shaped}
+        )
+        assert out == {"device_id": "UUIDShapedPi"}
+
+    async def test_resolver_failure_does_not_poison_transaction(self, db_session):
+        """If a SELECT inside the resolver errors, the outer transaction
+        must remain usable. We simulate by monkey-patching
+        ``db.execute`` for a single call, then prove the session can
+        still run further queries.
+        """
+        from cms.services.assistant.approval_display import _bulk_load
+
+        original_execute = db_session.execute
+        calls = {"n": 0}
+
+        async def boom(stmt, *a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated DB hiccup")
+            return await original_execute(stmt, *a, **kw)
+
+        db_session.execute = boom  # type: ignore[assignment]
+        with pytest.raises(RuntimeError):
+            await _bulk_load(db_session, Device, ["pi-100"])
+        db_session.execute = original_execute  # type: ignore[assignment]
+
+        # Outer transaction must still be usable — the SAVEPOINT
+        # absorbed the error.  Prove it by running a follow-up query.
+        await _device(db_session, did="pi-after-boom", name="AfterBoom")
+        out = await resolve_friendly_names(
+            db_session, {"device_id": "pi-after-boom"}
+        )
+        assert out == {"device_id": "AfterBoom"}
+


### PR DESCRIPTION
Hotfix for production error introduced by #678.`n`n## Symptom`n`n``
inFailedSQLTransactionError: current transaction is aborted, commands ignored until end of transaction block`n[INSERT INTO chat_pending_approvals ...]`n``
`n## Root cause`n`n`_coerce_id()` greedily parses UUID-shaped strings as `uuid.UUID`. That's correct for the 6 catalog models with `UUID(as_uuid=True)` PKs, but `Device.id` is `String(64)` (Pi serial). Real Pi serials happen to be UUID-shaped, so `_bulk_load` issued `WHERE Device.id IN (UUID(...))` against a varchar column. Postgres rejects `character varying = uuid` and asyncpg aborts the outer transaction. The caller's `try/except` swallows the Python exception but the tx stays poisoned, so the next statement (the approval INSERT) fails.`n`n## Fix`n`n- `_bulk_load` now inspects `model.__table__.c.id.type` and coerces ids to match — `uuid.UUID` for UUID columns, `str` for String columns.`n- The resolver SELECT is wrapped in `async with db.begin_nested():` so any future per-id type mismatch poisons only a SAVEPOINT, not the outer transaction.`n`n## Tests`n`n- All 13 existing resolver tests still pass.`n- New regression: Device with UUID-shaped String(64) PK (the prod shape that broke).`n- New regression: simulated `_bulk_load` failure proving the outer tx remains usable afterward.`n- Full chat suite (test_approval_display + test_chat_approvals + test_chat_agent + test_chat_usage): **83 passed**.`n`nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>