### PR TITLE
feat(infra): opt goodwill prod into the assistant feature

### DIFF
--- a/infra/parameters/goodwill.bicepparam
+++ b/infra/parameters/goodwill.bicepparam
@@ -39,6 +39,22 @@ param location = 'westus2'
 param postgresAdminLogin = 'agoraadmin'
 param cmsAdminUsername = 'admin'
 
+// Opt this environment into the Assistant feature backend.
+// Phase 1 (dev pilot) validated the budget caps + approval UX on
+// agoragwdev between 2026-05-29 and 2026-05-31; prod opts in here.
+//
+// AOAI account is pinned to westus (NOT the prod RG region of westus2)
+// because westus2 has zero standard gpt-4o TPM quota at the time of
+// writing, while westus has 970 units of headroom on a 1000 limit
+// (dev account uses 30). Cross-region AOAI is supported — the CMS
+// container app calls AOAI by FQDN, not via VNet, so colocating dev
+// + prod AOAI in westus simplifies quota tracking too.
+param deployAzureOpenAI = true
+param azureOpenAIRegion = 'westus'
+param azureOpenAIChatModel = 'gpt-4o'
+param azureOpenAIChatModelVersion = '2024-11-20'
+param azureOpenAIChatCapacity = 30
+
 // Secure params — passed via CLI or the deploy-goodwill workflow,
 // never commit values:
 // param postgresAdminPassword = '<set-via-cli>'


### PR DESCRIPTION
## Summary

Mirrors the assistant-feature opt-in already live in goodwill-dev (since #653, 2026-05-29) into the prod parameter file. Adds 5 lines to `infra/parameters/goodwill.bicepparam`:

`\\\`ini
param deployAzureOpenAI = true
param azureOpenAIRegion = 'westus'
param azureOpenAIChatModel = 'gpt-4o'
param azureOpenAIChatModelVersion = '2024-11-20'
param azureOpenAIChatCapacity = 30
`\\\`

## Why westus, not the prod RG region (westus2)

`az cognitiveservices usage list -l westus2` shows only `OpenAI.FineTuned.Deployments` — **standard `gpt-4o` TPM quota in westus2 is effectively zero**. westus has 970 units of 1000 free (dev uses 30; prod will use another 30 of the same 1000-unit pool). eastus2 + westus3 are also viable but westus colocates with dev, simplifying quota tracking.

Cross-region is fine — CMS calls AOAI by FQDN, not via VNet.

## What this does NOT do

- Does **not** enable the feature for any user. `assistant_enabled_user_ids` in prod's `cms_settings` is still empty.
- Does **not** create or grant any RBAC. The 3 role assignments (CMS MI -> AOAI, CMS MI -> KV, MCP MI -> KV) gate on `deployRoleAssignments=true`, which only works if the deploying principal has UAA on the RG. Today:
  - The GH Actions SP has Contributor only on `agoragw-cms-rg`. Its UAA grant is blocked by the calling user's ABAC condition (verified 2026-05-31).
  - Workaround for the first prod deploy: operator runs bicep from their laptop. Their RG-Owner-with-ABAC role allows the 3 specific data-plane grants (`Cognitive Services OpenAI User`, `Key Vault Secrets Officer`, `Key Vault Secrets User`). Probed and confirmed today.
  - Long-term fix (sub-level Owner action, separate task): grant the SP UAA on the RG so the workflow can land RBAC unattended.

## Follow-up PR

A second PR (queued, branch `feat/goodwill-prod-assistant-automation`) will fold the manual rollout steps from `docs/security/assistant-prod-rollout.md` into bicep deploymentScripts:
- Auto-seed `mcp-service-key` to KV (idempotent).
- AOAI RBAC propagation burn-in (60–90 s post-deploy hammer).
- Bicepparam-driven `assistant_enabled_user_ids` + `assistant_monthly_budget_usd` seeding.

That PR comes after this one to keep the diff scoped and reviewable.

## Test plan

- `az bicep build-params --file infra/parameters/goodwill.bicepparam --stdout` — passes (the only errors are the expected `adminPrincipalId`/`cmsAdminPassword`/`cmsSecretKey`/`postgresAdminPassword` BCP258, which are intentionally injected at deploy time).
- Deploy to prod is a separate, manual operator step — see follow-up PR for automation. This PR is safe to merge dark; it's a no-op until someone runs the deploy workflow with the new param block in scope.