### PR TITLE
Auto-seed mcp-service-key on startup; simplify prod-rollout runbook

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -269,13 +269,30 @@ async def service_key_rotation_loop() -> None:
                         has_key = await get_setting(
                             db, SETTING_MCP_SERVICE_KEY_HASH
                         )
-                        if enabled == "true" and has_key:
+                        if enabled == "true":
+                            # Two cases share one code path:
+                            # * bootstrap (has_key is empty) — newly
+                            #   deployed env where MCP was opted in via
+                            #   bicepparam but no operator has clicked
+                            #   the MCP toggle yet. Without this branch
+                            #   the assistant + every API key would
+                            #   fail until someone hits the UI.
+                            # * rotate (has_key set) — periodic cycle.
+                            # provision_service_key handles both: it
+                            # always generates a fresh key, overwrites
+                            # the DB hash, and pushes the raw key to
+                            # the configured KV.
                             await provision_service_key(
                                 db, settings.service_key_path,
                                 keyvault_uri=settings.azure_keyvault_uri,
                             )
                             await notify_mcp_reload(settings)
-                            logger.info("MCP service key rotated")
+                            if has_key:
+                                logger.info("MCP service key rotated")
+                            else:
+                                logger.info(
+                                    "MCP service key bootstrapped on startup"
+                                )
             except asyncio.CancelledError:
                 return
             except Exception:

--- a/docs/security/assistant-prod-rollout.md
+++ b/docs/security/assistant-prod-rollout.md
@@ -26,6 +26,12 @@ steps below cannot be run from CI until that gap is closed — see
 
 ## Procedure
 
+After all the automation that landed in 2026-05-31's prod-readiness
+work, the operator-driven path on a fresh env collapses to: **deploy →
+grant 3 roles → burn in AOAI RBAC → use the feature**. Steps 3, 5,
+and 6 below are kept for reference but are now no-ops or one-line
+overrides.
+
 ### 1. Provision AOAI
 
 Run the bicep deploy with `deployAzureOpenAI=true` against the prod
@@ -79,21 +85,25 @@ az containerapp show -g <prod-rg> -n agoracms-cms      --query identity.principa
 az containerapp show -g <prod-rg> -n agora-cms-mcp     --query identity.principalId -o tsv
 ```
 
-### 3. Seed `mcp-service-key`
+### 3. Seed `mcp-service-key` *(automated as of 2026-05-31)*
 
-The MCP container creates this KV secret on its first startup IF its
-MI can write to KV. To trigger:
+`service_key_rotation_loop` in `cms/main.py` now self-heals this on
+every CMS startup: if MCP is enabled but no key hash exists in
+`cms_settings`, it generates one, writes the hash to the DB and the
+raw key to the configured KV, then notifies MCP to reload. **No
+operator action required** — the seed lands within ~60 s of the CMS
+container becoming ready.
 
-1. Open the CMS Settings page → MCP tab.
-2. Toggle MCP **off**, save.
-3. Toggle MCP **on** again, save.
-
-This restarts the MCP container, which re-reads its config, sees the
-key is missing, and creates it. Confirm with:
+If you want to verify:
 
 ```sh
 az keyvault secret show --vault-name <prod-kv> --name mcp-service-key --query attributes.created -o tsv
 ```
+
+Look for a log line `MCP service key bootstrapped on startup` on the
+first CMS revision after the deploy. Subsequent revisions will log
+`MCP service key rotated` instead (same code path, different log
+because the hash already existed).
 
 ### 4. Burn the AOAI RBAC propagation window
 
@@ -109,11 +119,15 @@ not yet ready — wait a minute, retry) or succeeds. Once you get two
 consecutive successes, the cascade is burned in and real users won't
 see it.
 
-### 5. Flip the allowlist
+### 5. Flip the allowlist *(skip for the canary operator)*
 
-Settings → Assistant card → paste the UUIDs of the users you want to
-enable. Start with one ("stesli@" or the Goodwill prod equivalent),
-verify end-to-end, then expand.
+Anyone with `settings:write` permission (the admin escape hatch in
+`assistant_enabled_for`) is **always** enabled regardless of the
+allowlist contents. The first operator running this runbook in prod
+is by definition an admin and does not need to add themselves.
+
+When you're ready to expand beyond admins: Settings → Assistant card
+→ paste the UUIDs of the users you want to enable.
 
 ```sql
 -- Look up a user UUID:
@@ -121,18 +135,13 @@ SELECT id, username, email FROM users WHERE email = 'stesli@example.com';
 ```
 
 The allowlist is a JSON array stored in `cms_settings` under key
-`assistant_enabled_user_ids`. The admin user (anyone with
-`settings:write`) is always enabled as a permanent escape hatch — you
-do not need to add yourself.
+`assistant_enabled_user_ids`.
 
-### 6. Set the monthly budget cap
+### 6. Set the monthly budget cap *(default is $5; skip unless changing)*
 
-Settings → Assistant card → **Monthly budget (USD)**. Defaults to $5
-per user per month if unset.
-
-* `cap > 0` — normal enforcement; HTTP 429 once exceeded
-* `cap = 0` — feature paused (sends respond with budget-exceeded error)
-* `cap < 0` — unlimited (for emergency / debug; record why in audit log)
+`budget.py` defaults to **$5 / user / month** when the setting is
+unset — matches the dev env. Override via Settings → Assistant card →
+**Monthly budget (USD)** only if you want a different cap.
 
 ### 7. Verify
 

--- a/tests/test_mcp_auto_rotate.py
+++ b/tests/test_mcp_auto_rotate.py
@@ -107,16 +107,25 @@ class TestServiceKeyRotationLoop:
         mock_deps["notify"].assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_rotation_skips_when_no_key_hash(self, mock_deps):
-        """When no key hash exists (MCP never enabled), rotation skips."""
+    async def test_rotation_bootstraps_when_no_key_hash(self, mock_deps):
+        """When MCP is enabled but no key hash exists, the loop seeds one.
+
+        This is the bootstrap path: the operator opted MCP in via
+        bicepparam but never clicked the Settings → MCP toggle. Without
+        this branch, prod stays stuck — the assistant + every MCP API
+        key would 401 indefinitely. Pre-2026-05-31 the loop required
+        ``has_key`` truthy and would skip; the fix in
+        ``service_key_rotation_loop`` collapsed bootstrap and rotation
+        into one ``provision_service_key`` call.
+        """
         call_count = 0
 
         async def sleep_side_effect(seconds):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return
-            raise asyncio.CancelledError()
+                return  # initial 60s startup delay
+            raise asyncio.CancelledError()  # stop after first tick
 
         mock_deps["sleep"].side_effect = sleep_side_effect
         mock_deps["get_setting"].side_effect = lambda db, key: {
@@ -133,8 +142,8 @@ class TestServiceKeyRotationLoop:
             from cms.main import service_key_rotation_loop
             await service_key_rotation_loop()
 
-        mock_deps["provision"].assert_not_awaited()
-        mock_deps["notify"].assert_not_awaited()
+        mock_deps["provision"].assert_awaited_once()
+        mock_deps["notify"].assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_rotation_cancels_cleanly_during_startup(self, mock_deps):


### PR DESCRIPTION
## What

Drops one operator step from the Assistant prod-rollout runbook by making service_key_rotation_loop self-heal the bootstrap case.

### Before
On a freshly-deployed env (MCP opted in via bicepparam, but no operator has clicked the MCP toggle in Settings), the periodic rotation loop in cms/main.py:272 checked if enabled == "true" and has_key and bailed — leaving mcp-service-key permanently missing from KV. The runbook step 3 told operators to open Settings → MCP → toggle off → toggle on to force a write.

### After
Drop the nd has_key clause. provision_service_key is the same regardless of whether a key already exists (generate fresh → overwrite DB hash → push raw to KV → ping MCP reload). The log message branches so bootstrap and rotation remain distinguishable in App Insights.

## Why now

This is the second of two PRs prepping Goodwill prod for the Assistant feature:
- #680 — opts prod into AOAI via bicepparam (in flight)
- this PR — eliminates the manual MCP toggle on first deploy

## Runbook impact

Step 3 is now automated; the canary operator (anyone with `settings:write`) is auto-allowlisted via the admin escape hatch in `assistant_enabled_for`, so step 5 is a no-op for them too; default budget is already \ so step 6 is a no-op unless overriding. Net operator-driven path on a fresh env: deploy → grant 3 RBAC roles → burn in AOAI → use.

## Tests

- 	est_rotation_bootstraps_when_no_key_hash — was _skips_; inverted to pin the new behavior. Asserts `provision_service_key` AND `notify_mcp_reload` are both awaited when `mcp_enabled='true'` and the hash is unset.
- Existing rotate / disabled / cancel tests unchanged.

## Risk

- **Idempotency:** `provision_service_key` is destructive (always generates fresh). On a healthy env it already runs every hour for rotation; this change adds one extra invocation at first startup. Same blast radius.
- **Leader lease:** the loop already runs under `LeaderLease` so multi-replica races are handled.
- **Backwards compat:** any env that was working before still has the hash set; the new code path is functionally identical for those.