### PR TITLE
fix(auth): resolve MCP service-key requests to real on-behalf-of user

### DIFF
--- a/cms/auth.py
+++ b/cms/auth.py
@@ -91,15 +91,19 @@ async def _resolve_user_from_api_key(
     from datetime import datetime, timezone
     key_row.last_used_at = datetime.now(timezone.utc)
     await db.commit()
-    # Legacy keys without a user_id: fall back to admin user
+    # Legacy keys without a user_id: fall back to *any* active admin.
+    # Use ``.first()`` not ``scalar_one_or_none()`` — multi-admin envs
+    # are normal in prod and the latter raises ``MultipleResultsFound``.
     if key_row.user is None:
         admin = await db.execute(
             select(User)
             .options(selectinload(User.role))
             .join(User.role)
             .where(Role.name == "Admin", User.is_active.is_(True))
+            .order_by(User.id)
+            .limit(1)
         )
-        admin_user = admin.scalar_one_or_none()
+        admin_user = admin.scalars().first()
         if admin_user is None:
             return None
         return admin_user, key_row
@@ -164,9 +168,11 @@ async def get_current_user(
     """Return the authenticated User or raise 401.
 
     Checks API key header first, then session cookie.
-    Service keys (agora_svc_) get special handling — they authenticate as
-    an admin user with the real user recorded via X-On-Behalf-Of header.
-    MCP-type keys are blocked from REST API (MCP server uses the service key).
+    Service keys (``agora_svc_``) get special handling: when
+    ``X-On-Behalf-Of`` carries a user UUID the request runs under that
+    user's real permissions; otherwise it falls back to an arbitrary
+    active Admin (legacy direct-service-key callers).  MCP-type keys
+    are blocked from REST API (MCP server uses the service key).
     """
     # API key auth
     api_key = request.headers.get("X-API-Key")
@@ -178,15 +184,48 @@ async def get_current_user(
                 on_behalf_of = request.headers.get("X-On-Behalf-Of", "MCP Service")
                 request.state.auth_method = "mcp_service"
                 request.state.on_behalf_of = on_behalf_of
-                # Return admin user for permission checks
+
+                # Preferred path: ``X-On-Behalf-Of`` carries the real
+                # caller's UUID, so resolve to that user and run the
+                # request under their real permissions (not a synthetic
+                # Admin).  This matches the ``/api/mcp/auth`` contract
+                # documented in ``cms/routers/mcp.py``.
+                try:
+                    user_id = uuid.UUID(on_behalf_of)
+                except (ValueError, TypeError):
+                    user_id = None
+                if user_id is not None:
+                    result = await db.execute(
+                        select(User)
+                        .options(selectinload(User.role),
+                                 selectinload(User.groups).selectinload(UserGroup.group))
+                        .where(User.id == user_id, User.is_active.is_(True))
+                    )
+                    obo_user = result.scalar_one_or_none()
+                    if obo_user is not None:
+                        return obo_user
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="On-behalf-of user not found or inactive",
+                    )
+
+                # Legacy fallback for direct service-key callers that
+                # don't send a UUID (e.g. older MCP builds that send a
+                # display name, or ad-hoc tooling).  Return an arbitrary
+                # active Admin so permission checks succeed.  Multiple
+                # admins are valid (and normal in prod), so explicitly
+                # ``.first()`` rather than ``.scalar_one_or_none()`` —
+                # the latter raises ``MultipleResultsFound``.
                 admin = await db.execute(
                     select(User)
                     .options(selectinload(User.role),
                              selectinload(User.groups).selectinload(UserGroup.group))
                     .join(User.role)
                     .where(Role.name == "Admin", User.is_active.is_(True))
+                    .order_by(User.id)
+                    .limit(1)
                 )
-                admin_user = admin.scalar_one_or_none()
+                admin_user = admin.scalars().first()
                 if admin_user is None:
                     raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                                         detail="No admin user available for service key")

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -43,6 +43,7 @@ mcp = FastMCP(
 _ctx_api_key: contextvars.ContextVar[str] = contextvars.ContextVar("api_key")
 _ctx_permissions: contextvars.ContextVar[list[str]] = contextvars.ContextVar("permissions", default=[])
 _ctx_user_name: contextvars.ContextVar[str] = contextvars.ContextVar("user_name", default="unknown")
+_ctx_on_behalf_of: contextvars.ContextVar[str] = contextvars.ContextVar("on_behalf_of", default="")
 
 # Tool → required permission mapping
 TOOL_PERMISSIONS: dict[str, str | None] = {
@@ -104,10 +105,14 @@ TOOL_PERMISSIONS: dict[str, str | None] = {
 
 def _get_client() -> CMSClient:
     """Return a CMSClient using the service key and current user's identity."""
+    # Prefer the on-behalf-of UUID so CMS can run the request under the
+    # real caller's permissions; fall back to the display name for
+    # personal-MCP-key auth (where no UUID is returned).
+    obo = _ctx_on_behalf_of.get() or _ctx_user_name.get()
     return CMSClient(
         base_url=CMS_BASE_URL,
         api_key=_service_key,
-        on_behalf_of=_ctx_user_name.get(),
+        on_behalf_of=obo,
     )
 
 
@@ -1377,6 +1382,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         _ctx_api_key.set(raw_key)
         _ctx_permissions.set(auth_data.get("permissions", []))
         _ctx_user_name.set(auth_data.get("user", "unknown"))
+        _ctx_on_behalf_of.set(auth_data.get("on_behalf_of", ""))
 
         logger.info(
             "Authenticated MCP user: %s (role: %s, %d permissions, auth=%s)",

--- a/tests/test_auth_service_key_multi_admin.py
+++ b/tests/test_auth_service_key_multi_admin.py
@@ -1,0 +1,116 @@
+"""Tests for the MCP service-key path in ``cms.auth.get_current_user``.
+
+This is the CMS-side auth that fires when MCP calls back into CMS REST
+endpoints via ``cms_client.py`` (X-API-Key: agora_svc_..., X-On-Behalf-Of: <uuid>).
+
+Two regressions are pinned here:
+
+* Multi-admin envs (≥2 active Admins) MUST NOT raise
+  ``MultipleResultsFound`` — historically the legacy fallback used
+  ``scalar_one_or_none`` which crashed the moment a second admin
+  existed.  Goodwill prod hit this on every MCP→CMS call.
+* A valid ``X-On-Behalf-Of`` UUID MUST resolve to that real user
+  (with their real permissions) — not to "some admin".  This is what
+  lets per-user RBAC actually work through the Assistant.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from cms.auth import (
+    SERVICE_KEY_PREFIX,
+    SETTING_MCP_ENABLED,
+    SETTING_MCP_SERVICE_KEY_HASH,
+    _hash_api_key,
+    hash_password,
+    set_setting,
+)
+from cms.models.user import Role, User
+
+
+async def _seed_service_key(db_session) -> str:
+    raw = SERVICE_KEY_PREFIX + "test_service_key_value_for_get_current_user"
+    await set_setting(db_session, SETTING_MCP_ENABLED, "true")
+    await set_setting(db_session, SETTING_MCP_SERVICE_KEY_HASH, _hash_api_key(raw))
+    await db_session.commit()
+    return raw
+
+
+async def _create_user(db_session, *, username: str, role_name: str) -> User:
+    role = (await db_session.execute(
+        select(Role).where(Role.name == role_name)
+    )).scalar_one()
+    user = User(
+        username=username,
+        email=f"{username}@test.com",
+        display_name=username.title(),
+        password_hash=hash_password("x"),
+        role_id=role.id,
+        is_active=True,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+class TestServiceKeyMultiAdmin:
+    """Regression: multi-admin envs broke MCP→CMS with MultipleResultsFound."""
+
+    async def test_service_key_without_obo_does_not_crash_on_multi_admin(
+        self, client, db_session
+    ):
+        """Two active Admins + no UUID header → falls back to *some* admin."""
+        await _create_user(db_session, username="admin2", role_name="Admin")
+        service_key = await _seed_service_key(db_session)
+
+        resp = await client.get(
+            "/api/devices",
+            headers={
+                "X-API-Key": service_key,
+                "X-On-Behalf-Of": "MCP Service",  # not a UUID → legacy path
+            },
+        )
+        # Anything that ISN'T 500 means we didn't blow up resolving the
+        # admin user.  /api/devices may legitimately 200 (empty list) or
+        # require an extra setup step depending on conftest; the bug
+        # was a hard 500 on every request, so just assert non-500.
+        assert resp.status_code != 500, resp.text
+
+    async def test_service_key_with_obo_uuid_uses_real_user(
+        self, client, db_session
+    ):
+        """Valid UUID header → request runs as that user, not 'some admin'."""
+        operator = await _create_user(
+            db_session, username="op-real-user", role_name="Operator"
+        )
+        service_key = await _seed_service_key(db_session)
+
+        resp = await client.get(
+            "/api/devices",
+            headers={
+                "X-API-Key": service_key,
+                "X-On-Behalf-Of": str(operator.id),
+            },
+        )
+        # Operator has devices:read → should succeed (not 403).
+        assert resp.status_code != 500, resp.text
+        assert resp.status_code != 403, resp.text
+
+    async def test_service_key_with_unknown_uuid_is_rejected(
+        self, client, db_session
+    ):
+        """Valid-shape but unknown UUID → 403 (must NOT silently fall back)."""
+        import uuid as _uuid
+
+        service_key = await _seed_service_key(db_session)
+        resp = await client.get(
+            "/api/devices",
+            headers={
+                "X-API-Key": service_key,
+                "X-On-Behalf-Of": str(_uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 403, resp.text


### PR DESCRIPTION
## Why

stesli@ hit a hard 500 on every Assistant MCP tool call against Goodwill prod (e.g. `list_assets`). App Insights showed `sqlalchemy.exc.MultipleResultsFound` at `cms/auth.py` in the service-key branch — the path used `.scalar_one_or_none()` on a 'pick any Admin' lookup that returns 1 row in dev but multiple rows in prod.

The deeper bug behind that crash: even when not crashing, the service-key path returned an arbitrary Admin, so **every MCP tool call ran with stealth-Admin permissions regardless of who actually invoked it**. A non-admin Assistant user would see (and could mutate) resources outside their group.

## What this PR does

1. **CMS** (`cms/auth.py`): service-key path now parses `X-On-Behalf-Of` as a UUID and loads that user — request runs under their real role/groups/permissions. Legacy direct-service-key callers (non-UUID header) still fall back to 'any active admin', but via `.scalars().first()` so multi-admin envs don't crash. Fixed the same multi-admin pattern on the legacy-key-no-user fallback (~line 102) while in the area.

2. **MCP** (`mcp/server.py`): new `_ctx_on_behalf_of` contextvar populated from `auth_data['on_behalf_of']` (the UUID already shipped in `/api/mcp/auth`'s response). `_get_client()` now sends UUID-first, falling back to the display name for the personal-MCP-key path (which has no UUID).

3. **Tests** (`tests/test_auth_service_key_multi_admin.py`): 3 regression tests — multi-admin no-crash, UUID-resolves-to-real-user, unknown-UUID-403.

## Risk

Backward-compatible for direct service-key callers (any non-UUID header → 'some admin', same effective behavior as before sans crash). The behavior change only kicks in when MCP forwards a UUID, which it now does. Burn-in plan: re-test `list_assets` in prod UI; confirm a non-admin user only sees their group's resources.

## Cross-service deploy

CMS + MCP ship together in the same bicep workflow, so no version-skew window.