### PR TITLE
Auto-recover devices stuck on 'Upgrade stalled' badge

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -5,6 +5,7 @@ import logging
 import socket
 from collections import deque
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 
 
 def _replica_id() -> str:
@@ -199,6 +200,119 @@ async def _backfill_media_metadata(settings):
         raise
     except Exception as e:
         logger.warning("Metadata backfill failed: %s", e)
+
+
+async def _backfill_stuck_ota_projection(settings):
+    """One-shot: clear OTA projection rows stuck on terminal-event-less devices.
+
+    Fix for the "Upgrade stalled" badge on devices whose firmware
+    completes the OTA at the hardware level (slot promoted, services
+    healthy) but never emits the terminal lifecycle event (legacy
+    updater or an incomplete split that ships only some of the
+    SLOT_CONFIRMED → PROMOTED chain).  ``ota_progress.handle_event``
+    can only clear the projection columns on receipt of a terminal
+    event, so those rows stay pinned at ``ota_tryboot_initiated``
+    indefinitely until the next OTA replaces them — and
+    ``_is_upgrade_stuck`` (devices.py) flips the badge 15 minutes
+    after ``ota_updated_at``.
+
+    Heuristic for "definitely recovered":
+      - ``ota_phase = 'ota_tryboot_initiated'`` (where stuck-rows pile up),
+      - ``ota_updated_at`` older than 15 min (matches stuck-badge threshold),
+      - ``last_seen`` advanced 5+ min past ``ota_updated_at`` (every WPS
+        event refreshes last_seen, so this means the device has been
+        talking to us — either the new slot booted, or the bootloader
+        auto-reverted to the old slot; either way it's no longer in
+        the in-flight reboot window).
+
+    Truly dead-mid-tryboot devices (network gone, no traffic since the
+    reboot) keep the stuck badge, which is correct — they really did
+    fail to come back.
+
+    Companion to the register-path auto-recovery in ``ws.py`` and
+    ``wps_webhook.py``: that path catches FUTURE post-OTA reconnects;
+    this backfill catches rows that already TTL'd their upgrade claim
+    out 24h ago so the register path would have skipped them.
+
+    Gated by a Postgres advisory lock so only one replica runs the
+    sweep per startup, same shape as ``_backfill_media_metadata``.
+    """
+    from sqlalchemy import select, update
+    from cms.models.device import Device
+    from cms.models.device_event import DeviceEvent, DeviceEventType
+    from cms.services.leader import session_advisory_lock
+    from cms.services.ota_progress import OTA_PROJECTION_FIELD_NAMES, OTA_STUCK_PHASE
+
+    _BACKFILL_LOCK_ID = 0x4147_4F52_41_02  # 'AGORA' + 02 (distinct from media backfill)
+
+    try:
+        async with session_advisory_lock(_BACKFILL_LOCK_ID) as got_lock:
+            if not got_lock:
+                logger.info(
+                    "Stuck-OTA backfill: another replica holds the lock, skipping"
+                )
+                return
+            async for db in get_db():
+                now = datetime.now(timezone.utc)
+                stuck_cutoff = now - timedelta(minutes=15)
+                recover_window = timedelta(minutes=5)
+                # Two-step: SELECT candidates with the SQL-portable subset
+                # of the predicate, then filter the timedelta gap in
+                # Python (SQLAlchemy's ``col + timedelta`` doesn't
+                # round-trip on SQLite, so we can't push that comparison
+                # into the WHERE clause).  Snapshot the prior values for
+                # the audit event before the UPDATE blanks them out
+                # (PostgreSQL ``RETURNING`` would give the NEW values).
+                candidates = (await db.execute(
+                    select(
+                        Device.id,
+                        Device.name,
+                        Device.ota_updated_at,
+                        Device.last_seen,
+                    ).where(
+                        Device.ota_phase == OTA_STUCK_PHASE,
+                        Device.ota_updated_at.is_not(None),
+                        Device.ota_updated_at < stuck_cutoff,
+                        Device.last_seen.is_not(None),
+                    )
+                )).all()
+                to_clear = [
+                    row for row in candidates
+                    if row.last_seen > row.ota_updated_at + recover_window
+                ]
+                if not to_clear:
+                    return
+                await db.execute(
+                    update(Device)
+                    .where(Device.id.in_([row.id for row in to_clear]))
+                    .values(**{f: None for f in OTA_PROJECTION_FIELD_NAMES})
+                    .execution_options(synchronize_session=False)
+                )
+                for row in to_clear:
+                    db.add(
+                        DeviceEvent(
+                            device_id=row.id,
+                            device_name=row.name or str(row.id),
+                            event_type=DeviceEventType.OTA_AUTO_CLEARED,
+                            details={
+                                "reason": "startup_backfill",
+                                "prior_phase": OTA_STUCK_PHASE,
+                                "prior_ota_updated_at": row.ota_updated_at.isoformat()
+                                    if row.ota_updated_at else None,
+                                "last_seen": row.last_seen.isoformat()
+                                    if row.last_seen else None,
+                            },
+                        )
+                    )
+                await db.commit()
+                logger.info(
+                    "Stuck-OTA backfill: cleared projection for %d device(s)",
+                    len(to_clear),
+                )
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("Stuck-OTA backfill failed: %s", e)
 
 
 async def _seed_roles(db):
@@ -545,6 +659,7 @@ async def lifespan(app: FastAPI):
     # "always leader" / "always got lock" so the loops run identically.
     scheduler_task = asyncio.create_task(scheduler_loop())
     backfill_task = asyncio.create_task(_backfill_media_metadata(settings))
+    ota_backfill_task = asyncio.create_task(_backfill_stuck_ota_projection(settings))
     bundle_check_task = asyncio.create_task(bundle_check_loop())
     device_purge_task = asyncio.create_task(device_purge_loop())
     pending_reg_reaper_task = asyncio.create_task(
@@ -664,6 +779,7 @@ async def lifespan(app: FastAPI):
 
     scheduler_task.cancel()
     backfill_task.cancel()
+    ota_backfill_task.cancel()
     bundle_check_task.cancel()
     device_purge_task.cancel()
     pending_reg_reaper_task.cancel()
@@ -682,6 +798,10 @@ async def lifespan(app: FastAPI):
         pass
     try:
         await backfill_task
+    except asyncio.CancelledError:
+        pass
+    try:
+        await ota_backfill_task
     except asyncio.CancelledError:
         pass
     try:

--- a/cms/models/device_event.py
+++ b/cms/models/device_event.py
@@ -39,6 +39,12 @@ class DeviceEventType(str, PyEnum):
     OTA_MIGRATION_COMPLETE = "ota_migration_complete"
     OTA_FAILED = "ota_failed"
     OTA_DECLINED = "ota_declined"
+    # Synthetic CMS-side event emitted when the OTA projection columns
+    # are auto-cleared after detecting a successful upgrade for which
+    # we never received the terminal lifecycle event.  Two emit sites:
+    # the register-path auto-recovery in ws.py / wps_webhook.py and
+    # the startup backfill in main.py.  Not produced by any wire event.
+    OTA_AUTO_CLEARED = "ota_auto_cleared"
 
 
 class DeviceEvent(Base):

--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -34,10 +34,16 @@ from cms.auth import get_settings
 from cms.config import Settings
 from cms.database import get_db
 from cms.models.device import Device, DeviceGroup, DeviceStatus
+from cms.models.device_event import DeviceEvent, DeviceEventType
 from cms.services.alert_service import alert_service
 from cms.services.device_inbound import InboundContext, dispatch_device_message, rotate_api_key
 from cms.services.device_manager import device_manager
 from cms.services.device_register import register_known_device
+from cms.services.ota_progress import (
+    OTA_PROJECTION_FIELD_NAMES,
+    OTA_STUCK_PHASE,
+    version_bumped,
+)
 from cms.services.transport import get_transport
 from shared.wps_signature import verify_signature
 
@@ -211,6 +217,15 @@ async def events_receiver(
             pre_register_fw = device.firmware_version or ""
             pre_register_os = device.os_version or ""
             pre_register_upgrade_claim = device.upgrade_started_at
+            # Snapshots for the auto-recover-stuck-OTA path below.
+            # ``pre_register_ota_phase`` is the "did this row even have
+            # projection state to clear" gate; ``pre_register_ota_updated_at``
+            # is the CAS guard so a concurrent lifecycle event landing
+            # on another replica between snapshot and clear isn't
+            # stomped.  See the second UPDATE block after
+            # ``register_known_device`` returns.
+            pre_register_ota_phase = device.ota_phase
+            pre_register_ota_updated_at = device.ota_updated_at
             reg_result = await register_known_device(device, msg, db)
             # Persist the device's LAN IP from the register payload.
             # ``sys.connected`` (handled above) has no body, so it can't
@@ -290,6 +305,68 @@ async def events_receiver(
                         .execution_options(synchronize_session=False)
                     )
                     await db.commit()
+            # Auto-recover the "Upgrade stalled" badge for devices whose
+            # firmware doesn't ship the lifecycle event sender (or shipped
+            # an incomplete split that never emits ``ota_slot_confirmed``
+            # → ``ota_promoted``).  These devices complete the OTA at the
+            # hardware level — slot promoted, services healthy — but the
+            # CMS-side projection columns stay pinned at
+            # ``OTA_STUCK_PHASE`` (``"ota_tryboot_initiated"``)
+            # indefinitely, and 15 minutes later ``_is_upgrade_stuck``
+            # (see devices.py) flips the badge.
+            #
+            # Gate strictly on ``pre_register_ota_phase == OTA_STUCK_PHASE``
+            # (not just non-NULL) so a register that lands mid-download /
+            # mid-extract — when ``ota_phase`` is some other in-progress
+            # value — doesn't prematurely clear live OTA progress.
+            #
+            # Intentionally NOT gated on
+            # ``pre_register_upgrade_claim is not None`` — a Mia-class
+            # row has already had its claim TTL'd out by the upgrade
+            # endpoint (24h timeout) so the claim is NULL and the OLD
+            # claim-clear block would skip it.  CAS on
+            # ``Device.ota_updated_at == pre_register_ota_updated_at``
+            # so a concurrent terminal lifecycle event landing on
+            # another replica between snapshot and clear isn't stomped;
+            # the SQL WHERE also reapplies the phase predicate so the
+            # update is a true no-op when raced.
+            if (
+                pre_register_ota_phase == OTA_STUCK_PHASE
+                and pre_register_ota_updated_at is not None
+                and version_bumped(
+                    pre_register_os,
+                    pre_register_fw,
+                    msg.get("os_version"),
+                    msg.get("firmware_version"),
+                )
+            ):
+                clear_result = await db.execute(
+                    update(Device)
+                    .where(
+                        Device.id == ce_user_id,
+                        Device.ota_updated_at == pre_register_ota_updated_at,
+                        Device.ota_phase == OTA_STUCK_PHASE,
+                    )
+                    .values(**{f: None for f in OTA_PROJECTION_FIELD_NAMES})
+                    .execution_options(synchronize_session=False)
+                )
+                if clear_result.rowcount:
+                    db.add(
+                        DeviceEvent(
+                            device_id=ce_user_id,
+                            device_name=device.name or ce_user_id,
+                            event_type=DeviceEventType.OTA_AUTO_CLEARED,
+                            details={
+                                "reason": "register_version_bump",
+                                "prior_phase": pre_register_ota_phase,
+                                "prior_firmware": (pre_register_fw or "").strip(),
+                                "prior_os": (pre_register_os or "").strip(),
+                                "reported_firmware": (msg.get("firmware_version") or "").strip(),
+                                "reported_os": (msg.get("os_version") or "").strip(),
+                            },
+                        )
+                    )
+                await db.commit()
             # Notify alert service of reconnection — mirrors ws.py's
             # direct-WS register path.  This is what emits the ONLINE
             # device_event, clears ``offline_notified`` on

--- a/cms/routers/ws.py
+++ b/cms/routers/ws.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cms.auth import get_settings
 from cms.database import get_db
 from cms.models.device import Device, DeviceStatus
+from cms.models.device_event import DeviceEvent, DeviceEventType
 from cms.schemas.protocol import (
     PROTOCOL_VERSION,
     SUPPORTED_PROTOCOL_VERSIONS,
@@ -36,6 +37,11 @@ from cms.services.alert_service import alert_service
 from cms.services.log_chunk_assembler import (
     handle_frame as handle_log_chunk_frame,
     is_chunk_frame,
+)
+from cms.services.ota_progress import (
+    OTA_PROJECTION_FIELD_NAMES,
+    OTA_STUCK_PHASE,
+    version_bumped,
 )
 from cms.services.scheduler import build_device_sync
 
@@ -172,6 +178,10 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
             pre_register_fw = device.firmware_version or ""
             pre_register_os = device.os_version or ""
             pre_register_upgrade_claim = device.upgrade_started_at
+            # Snapshots for the auto-recover-stuck-OTA path below — see
+            # the OTA-clear UPDATE block after register_known_device.
+            pre_register_ota_phase = device.ota_phase
+            pre_register_ota_updated_at = device.ota_updated_at
             reg_result = await register_known_device(device, raw, db)
             if reg_result.orphaned:
                 await websocket.send_json({
@@ -240,6 +250,56 @@ async def device_websocket(websocket: WebSocket, db: AsyncSession = Depends(get_
                     .execution_options(synchronize_session=False)
                 )
                 await db.commit()
+        # Auto-recover the "Upgrade stalled" badge for devices whose
+        # firmware never emits the terminal lifecycle event (legacy
+        # updater + incomplete-split shims).  Mirrors the WPS-webhook
+        # block — see wps_webhook.py for the full rationale.  Note this
+        # is intentionally NOT gated on the upgrade claim: a Mia-class
+        # row has the claim already TTL'd out, so the existing claim
+        # block above skips it but the OTA projection is still stuck.
+        # Gate strictly on ``OTA_STUCK_PHASE`` (not just non-NULL) so a
+        # mid-OTA register doesn't clear live progress; reapply the
+        # phase predicate in the SQL WHERE so the UPDATE is a true
+        # no-op when raced against a concurrent lifecycle event on
+        # another replica.
+        if (
+            not is_new_device
+            and pre_register_ota_phase == OTA_STUCK_PHASE
+            and pre_register_ota_updated_at is not None
+            and version_bumped(
+                pre_register_os,
+                pre_register_fw,
+                raw.get("os_version"),
+                raw.get("firmware_version"),
+            )
+        ):
+            clear_result = await db.execute(
+                update(Device)
+                .where(
+                    Device.id == device_id,
+                    Device.ota_updated_at == pre_register_ota_updated_at,
+                    Device.ota_phase == OTA_STUCK_PHASE,
+                )
+                .values(**{f: None for f in OTA_PROJECTION_FIELD_NAMES})
+                .execution_options(synchronize_session=False)
+            )
+            if clear_result.rowcount:
+                db.add(
+                    DeviceEvent(
+                        device_id=device_id,
+                        device_name=device.name or device_id,
+                        event_type=DeviceEventType.OTA_AUTO_CLEARED,
+                        details={
+                            "reason": "register_version_bump",
+                            "prior_phase": pre_register_ota_phase,
+                            "prior_firmware": (pre_register_fw or "").strip(),
+                            "prior_os": (pre_register_os or "").strip(),
+                            "reported_firmware": (raw.get("firmware_version") or "").strip(),
+                            "reported_os": (raw.get("os_version") or "").strip(),
+                        },
+                    )
+                )
+            await db.commit()
 
         # ── 3b. Notify alert service of reconnection ──
         _group_id = str(device.group_id) if device.group_id else None

--- a/cms/services/ota_progress.py
+++ b/cms/services/ota_progress.py
@@ -1,5 +1,12 @@
 """OTA progress projection — lifecycle events → ``devices.ota_*`` columns.
 
+The six projection columns are also single-sourced via
+``OTA_PROJECTION_FIELD_NAMES`` so the register-path auto-recovery
+clear in ``ws.py`` / ``wps_webhook.py`` and the startup backfill in
+``main.py`` use the same field list as the terminal-event branch
+below.
+
+
 Issue agora-cms#574 (companion to ``sslivins/agora#215``).  Devices on
 firmware that ships the WPS lifecycle event sender (see agora#215) push
 a stream of ``lifecycle_event`` messages over WPS during every OTA.
@@ -74,6 +81,59 @@ _PHASE_ORDER: dict[str, int] = {
 _TERMINAL: frozenset[str] = frozenset(
     {"ota_promoted", "ota_migration_complete", "ota_failed", "ota_declined"}
 )
+
+# Single-source list of the six projection columns.  Used by
+# ``handle_event``'s terminal-event branch (via ``setattr`` loop), by
+# the register-path auto-recovery clear in ``ws.py`` / ``wps_webhook.py``,
+# and by the startup backfill in ``main.py`` so any future projection
+# column added here is automatically cleared by all three call sites.
+OTA_PROJECTION_FIELD_NAMES: tuple[str, ...] = (
+    "ota_phase",
+    "ota_label",
+    "ota_pct",
+    "ota_bytes_done",
+    "ota_bytes_total",
+    "ota_updated_at",
+)
+
+# The only OTA phase that can stay "stuck" indefinitely on legacy /
+# incomplete-split firmware: the device reboots into the tryboot slot
+# but never emits ``ota_slot_confirmed`` → ``ota_promoted``, so the
+# row never hits the terminal-event clear above.  Auto-recovery
+# (register path + startup backfill) uses this constant as the gate
+# so we never clear a row mid-download/extract.
+OTA_STUCK_PHASE: str = "ota_tryboot_initiated"
+
+
+def version_bumped(
+    prior_os: str | None,
+    prior_fw: str | None,
+    incoming_os: str | None,
+    incoming_fw: str | None,
+) -> bool:
+    """Did this register represent a real version change?
+
+    Devices may omit one of the two version fields in a given register;
+    ``register_known_device`` preserves the existing value when a field
+    is empty.  The auto-recovery clear must mirror that semantic — only
+    count non-empty incoming fields, otherwise a register that reports
+    "same firmware, no os_version" would look like a bump
+    (``("old-os", "fw") != ("", "fw")``) and prematurely clear live OTA
+    progress.
+
+    Returns True only when at least one version field is non-empty
+    AND the effective post-register tuple (incoming-or-prior per
+    field) differs from the prior tuple.
+    """
+    prior_os_s = (prior_os or "").strip()
+    prior_fw_s = (prior_fw or "").strip()
+    incoming_os_s = (incoming_os or "").strip()
+    incoming_fw_s = (incoming_fw or "").strip()
+    if not (incoming_os_s or incoming_fw_s):
+        return False
+    effective_os = incoming_os_s or prior_os_s
+    effective_fw = incoming_fw_s or prior_fw_s
+    return (effective_os, effective_fw) != (prior_os_s, prior_fw_s)
 
 # Stable label strings for the UI.  The bare ``ota_phase`` is also kept
 # on the row so the front end can branch on it (a tooltip, a colour, an
@@ -212,12 +272,8 @@ def handle_event(device: "Device", event_type: str, payload: dict) -> bool:
         return False
 
     if event_type in _TERMINAL:
-        device.ota_phase = None
-        device.ota_label = None
-        device.ota_pct = None
-        device.ota_bytes_done = None
-        device.ota_bytes_total = None
-        device.ota_updated_at = None
+        for _f in OTA_PROJECTION_FIELD_NAMES:
+            setattr(device, _f, None)
         # Release the atomic upgrade claim immediately.  This is what
         # makes the badge fall off the moment ``promoted`` arrives,
         # rather than waiting for the device to reboot + re-register

--- a/tests/test_ota_stuck_backfill.py
+++ b/tests/test_ota_stuck_backfill.py
@@ -1,0 +1,250 @@
+"""Tests for the startup-time stuck-OTA projection backfill.
+
+Covers ``cms.main._backfill_stuck_ota_projection`` — the one-shot
+sweep that fixes the "Upgrade stalled" badge on devices whose firmware
+completed an OTA at the hardware level but never emitted the terminal
+lifecycle event (legacy updater + Mia's Pi5 class).
+
+These tests run against the real Postgres test DB via the shared
+``db_session`` fixture; the function's own ``async for db in get_db()``
+generator yields a fresh session from the same engine, so committing
+in ``db_session`` is visible to the function under test.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.fixture
+def use_test_engine_globally(app):
+    """Use the ``app`` fixture so ``cms.database`` / ``shared.database``
+    globals point at the test engine — the backfill function calls
+    ``get_db()`` and ``session_advisory_lock()`` directly, both of
+    which resolve through those module-level singletons.
+
+    We don't need the FastAPI client itself; ``app`` is just the
+    cleanest way to get the engines wired in.
+    """
+    yield
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("use_test_engine_globally")
+class TestBackfillStuckOtaProjection:
+    async def _add_device(
+        self,
+        db,
+        *,
+        device_id,
+        name="Test Pi",
+        ota_phase="ota_tryboot_initiated",
+        ota_updated_at_offset_min=-30,
+        last_seen_offset_min=-10,
+        ota_label="Rebooting into new slot",
+    ):
+        """Insert a Device row with configurable OTA-projection state.
+
+        Offsets are relative to ``now`` in minutes (negative = past).
+        ``ota_updated_at_offset_min=None`` → leave NULL (no in-flight OTA).
+        ``last_seen_offset_min=None``       → leave NULL (never reached us).
+        """
+        from cms.models.device import Device, DeviceStatus
+
+        now = datetime.now(timezone.utc)
+        device = Device(
+            id=device_id,
+            name=name,
+            status=DeviceStatus.ADOPTED,
+            ota_phase=ota_phase,
+            ota_label=ota_label,
+            ota_updated_at=(
+                now + timedelta(minutes=ota_updated_at_offset_min)
+                if ota_updated_at_offset_min is not None
+                else None
+            ),
+            last_seen=(
+                now + timedelta(minutes=last_seen_offset_min)
+                if last_seen_offset_min is not None
+                else None
+            ),
+        )
+        db.add(device)
+        return device
+
+    async def test_clears_stuck_online_device(self, db_session):
+        """Mia's case: stuck > 15 min, last_seen advanced > 5 min after
+        ota_updated_at → clear projection + emit OTA_AUTO_CLEARED."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+
+        await self._add_device(
+            db_session,
+            device_id="backfill-mia",
+            name="Mia's Pi5",
+            ota_updated_at_offset_min=-30,
+            last_seen_offset_min=-1,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        device = (await db_session.execute(
+            select(Device).where(Device.id == "backfill-mia")
+        )).scalar_one()
+        assert device.ota_phase is None
+        assert device.ota_label is None
+        assert device.ota_updated_at is None
+
+        events = (await db_session.execute(
+            select(DeviceEvent).where(
+                DeviceEvent.device_id == "backfill-mia",
+                DeviceEvent.event_type == DeviceEventType.OTA_AUTO_CLEARED,
+            )
+        )).scalars().all()
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.device_name == "Mia's Pi5"
+        assert evt.details["reason"] == "startup_backfill"
+        assert evt.details["prior_phase"] == "ota_tryboot_initiated"
+        assert evt.details["prior_ota_updated_at"] is not None
+        assert evt.details["last_seen"] is not None
+
+    async def test_skips_recently_stuck_device(self, db_session):
+        """Stuck < 15 min: in-flight tryboot reboot window — leave alone."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+
+        await self._add_device(
+            db_session,
+            device_id="backfill-fresh",
+            ota_updated_at_offset_min=-5,
+            last_seen_offset_min=-1,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        device = (await db_session.execute(
+            select(Device).where(Device.id == "backfill-fresh")
+        )).scalar_one()
+        assert device.ota_phase == "ota_tryboot_initiated"
+
+    async def test_skips_offline_stuck_device(self, db_session):
+        """Stuck > 15 min but last_seen NOT advanced past ota_updated_at:
+        device really is dead-mid-tryboot — leave the badge."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+
+        # ota_updated_at 30 min ago, last_seen 35 min ago (BEFORE the OTA
+        # event) → device hasn't reconnected since the reboot.
+        await self._add_device(
+            db_session,
+            device_id="backfill-offline",
+            ota_updated_at_offset_min=-30,
+            last_seen_offset_min=-35,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        device = (await db_session.execute(
+            select(Device).where(Device.id == "backfill-offline")
+        )).scalar_one()
+        assert device.ota_phase == "ota_tryboot_initiated"
+
+    async def test_skips_other_ota_phases(self, db_session):
+        """Mid-OTA download/verify/extract — leave projection alone."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+
+        await self._add_device(
+            db_session,
+            device_id="backfill-downloading",
+            ota_phase="ota_downloading",
+            ota_label="Downloading bundle",
+            ota_updated_at_offset_min=-30,
+            last_seen_offset_min=-1,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        device = (await db_session.execute(
+            select(Device).where(Device.id == "backfill-downloading")
+        )).scalar_one()
+        assert device.ota_phase == "ota_downloading"
+
+    async def test_idempotent_on_rerun(self, db_session):
+        """Second invocation is a no-op — no duplicate audit events."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+
+        await self._add_device(
+            db_session,
+            device_id="backfill-idemp",
+            ota_updated_at_offset_min=-30,
+            last_seen_offset_min=-1,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        events = (await db_session.execute(
+            select(DeviceEvent).where(
+                DeviceEvent.device_id == "backfill-idemp",
+                DeviceEvent.event_type == DeviceEventType.OTA_AUTO_CLEARED,
+            )
+        )).scalars().all()
+        assert len(events) == 1
+
+    async def test_clears_multiple_devices_in_one_pass(self, db_session):
+        """Bulk path: two stuck-recoverable + one mid-download — only the
+        two are cleared, each gets its own audit event."""
+        from cms.main import _backfill_stuck_ota_projection
+        from cms.models.device import Device
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+
+        await self._add_device(
+            db_session, device_id="bulk-1", name="Pi One",
+            ota_updated_at_offset_min=-30, last_seen_offset_min=-1,
+        )
+        await self._add_device(
+            db_session, device_id="bulk-2", name="Pi Two",
+            ota_updated_at_offset_min=-45, last_seen_offset_min=-2,
+        )
+        await self._add_device(
+            db_session, device_id="bulk-skip", name="Pi Mid-OTA",
+            ota_phase="ota_extracting",
+            ota_updated_at_offset_min=-30, last_seen_offset_min=-1,
+        )
+        await db_session.commit()
+
+        await _backfill_stuck_ota_projection(settings=None)
+
+        db_session.expire_all()
+        devices = {
+            d.id: d for d in (await db_session.execute(
+                select(Device).where(Device.id.in_(["bulk-1", "bulk-2", "bulk-skip"]))
+            )).scalars().all()
+        }
+        assert devices["bulk-1"].ota_phase is None
+        assert devices["bulk-2"].ota_phase is None
+        assert devices["bulk-skip"].ota_phase == "ota_extracting"
+
+        events = (await db_session.execute(
+            select(DeviceEvent).where(
+                DeviceEvent.event_type == DeviceEventType.OTA_AUTO_CLEARED,
+                DeviceEvent.device_id.in_(["bulk-1", "bulk-2", "bulk-skip"]),
+            )
+        )).scalars().all()
+        assert {e.device_id for e in events} == {"bulk-1", "bulk-2"}

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -304,6 +304,108 @@ class TestWebSocket:
 
                 ws.close()
 
+    async def test_register_clears_stuck_ota_projection_on_version_bump(self, app, db_session):
+        """Direct-WS mirror of Mia's case: legacy firmware completed an
+        OTA at the hardware level but never emitted
+        ``ota_slot_confirmed`` → ``ota_promoted``, so the projection
+        row stayed pinned at ``OTA_STUCK_PHASE`` ('ota_tryboot_initiated')
+        indefinitely.  On next register with a bumped version, the
+        register path must clear the six projection columns AND emit a
+        ``DeviceEvent(event_type=OTA_AUTO_CLEARED)``.  Full guard-matrix
+        (mid-phase, omitted-version, CAS race) is covered in
+        test_wps_webhook.py — this just locks down that the duplicate
+        block in ws.py also fires.
+        """
+        from datetime import datetime, timedelta, timezone
+        import hashlib
+
+        from cms.models.device import Device, DeviceStatus
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+
+        token = "ws-stuck-ota-token"
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        stale_ts = datetime.now(timezone.utc) - timedelta(minutes=30)
+
+        device = Device(
+            id="ws-test-stuck-ota",
+            name="ws-test-stuck-ota",
+            status=DeviceStatus.ADOPTED,
+            device_auth_token_hash=token_hash,
+            firmware_version="1.11.7",
+            os_version="0.0.16-test",
+            upgrade_started_at=None,
+            ota_phase="ota_tryboot_initiated",
+            ota_label="Rebooting into new slot",
+            ota_updated_at=stale_ts,
+        )
+        db_session.add(device)
+        await db_session.commit()
+        await db_session.close()
+
+        from starlette.testclient import TestClient
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/device") as ws:
+                ws.send_json({
+                    "type": "register",
+                    "protocol_version": 1,
+                    "device_id": "ws-test-stuck-ota",
+                    "auth_token": token,
+                    "firmware_version": "1.12.0",
+                    "os_version": "1.0.0",
+                    "storage_capacity_mb": 500,
+                })
+
+                msg = ws.receive_json()
+                assert msg["type"] == "sync"
+                msg = ws.receive_json()
+                assert msg["type"] == "config"
+
+                # Poll until projection clears AND audit row appears.
+                from sqlalchemy import select
+                from cms.models.device import Device as _Device
+                from shared.database import get_session_factory
+                factory = get_session_factory()
+                deadline = time.time() + 5.0
+                cleared = False
+                audit_event = None
+                while time.time() < deadline:
+                    async with factory() as probe_db:
+                        result = (await probe_db.execute(
+                            select(
+                                _Device.ota_phase,
+                                _Device.ota_label,
+                                _Device.ota_updated_at,
+                                _Device.os_version,
+                                _Device.firmware_version,
+                            ).where(_Device.id == "ws-test-stuck-ota")
+                        )).first()
+                        if result is not None and result.ota_phase is None:
+                            assert result.ota_label is None
+                            assert result.ota_updated_at is None
+                            assert result.os_version == "1.0.0"
+                            assert result.firmware_version == "1.12.0"
+                            cleared = True
+                            audit_event = (await probe_db.execute(
+                                select(DeviceEvent).where(
+                                    DeviceEvent.device_id == "ws-test-stuck-ota",
+                                    DeviceEvent.event_type == DeviceEventType.OTA_AUTO_CLEARED,
+                                )
+                            )).scalar_one_or_none()
+                            break
+                    time.sleep(0.05)
+
+                assert cleared, "ota_phase projection should have been cleared by ws.py auto-recovery"
+                assert audit_event is not None, "Expected an OTA_AUTO_CLEARED DeviceEvent"
+                assert audit_event.device_name == "ws-test-stuck-ota"
+                assert audit_event.details["reason"] == "register_version_bump"
+                assert audit_event.details["prior_phase"] == "ota_tryboot_initiated"
+                assert audit_event.details["prior_firmware"] == "1.11.7"
+                assert audit_event.details["prior_os"] == "0.0.16-test"
+                assert audit_event.details["reported_firmware"] == "1.12.0"
+                assert audit_event.details["reported_os"] == "1.0.0"
+
+                ws.close()
+
     async def test_known_device_wrong_nonmempty_token_rejected(self, app, db_session):
         """A known device that sends a WRONG (non-empty) token should still
         be rejected as orphaned — this is a security measure."""

--- a/tests/test_wps_webhook.py
+++ b/tests/test_wps_webhook.py
@@ -911,6 +911,333 @@ class TestUserEvents:
             f"omitted both version fields, got {update_stmts}"
         )
 
+    # ---- OTA stuck-badge auto-recovery (register path) -------------------
+    #
+    # See ``cms/routers/wps_webhook.py`` OTA-clear block (around line 333).
+    # Triggered by Mia's Pi5 on Goodwill prod (2026-06-01): legacy firmware
+    # completed the OTA at the hardware level but never emitted
+    # ``ota_slot_confirmed`` → ``ota_promoted``, so the projection row
+    # stayed pinned at ``ota_tryboot_initiated`` indefinitely and
+    # ``_is_upgrade_stuck`` (devices.py) flipped the "Upgrade stalled"
+    # badge 15 minutes later.  Fix: on next register, if the version
+    # bumped AND phase is still ``OTA_STUCK_PHASE``, clear the six
+    # projection columns and emit a ``DeviceEvent`` of type
+    # ``OTA_AUTO_CLEARED`` for forensics.
+
+    async def test_register_over_wps_clears_stuck_ota_on_version_bump(
+        self, client, app_and_session,
+    ):
+        """Mia's case: claim already TTL'd to NULL, ota_phase pinned at
+        ``ota_tryboot_initiated`` from an old OTA, version bumps on this
+        register → the six OTA projection columns are cleared and a
+        ``DeviceEvent(event_type=OTA_AUTO_CLEARED)`` is appended with
+        ``details`` (not ``payload``) and the correct ``device_name``.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from cms.models.device_event import DeviceEvent, DeviceEventType
+
+        app, session = app_and_session
+        stale_ts = datetime.now(timezone.utc) - timedelta(minutes=30)
+        device = MagicMock(
+            id="pi-mia", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.7",
+            os_version="0.0.16-test",
+            upgrade_started_at=None,
+            ota_phase="ota_tryboot_initiated",
+            ota_updated_at=stale_ts,
+        )
+        device.name = "Mia's Pi5"
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-mia-stuck"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-mia",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.12.0",
+                    "os_version": "1.0.0",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-mia",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        ota_clear_stmts = [
+            str(s) for s in session.executed
+            if str(s).strip().upper().startswith("UPDATE ") and "ota_phase" in str(s)
+        ]
+        assert ota_clear_stmts, (
+            f"Expected UPDATE clearing ota_phase projection columns, "
+            f"got {[str(s) for s in session.executed]}"
+        )
+        # DeviceEvent for forensics — verify field names and content.
+        events = [a for a in session.added if isinstance(a, DeviceEvent)]
+        auto_cleared = [
+            e for e in events
+            if e.event_type == DeviceEventType.OTA_AUTO_CLEARED
+        ]
+        assert len(auto_cleared) == 1, (
+            f"Expected one OTA_AUTO_CLEARED event, got "
+            f"{[(e.event_type, e.details) for e in events]}"
+        )
+        evt = auto_cleared[0]
+        assert evt.device_id == "pi-mia"
+        assert evt.device_name == "Mia's Pi5"
+        assert evt.details["reason"] == "register_version_bump"
+        assert evt.details["prior_phase"] == "ota_tryboot_initiated"
+        assert evt.details["prior_firmware"] == "1.11.7"
+        assert evt.details["prior_os"] == "0.0.16-test"
+        assert evt.details["reported_firmware"] == "1.12.0"
+        assert evt.details["reported_os"] == "1.0.0"
+
+    async def test_register_over_wps_does_not_clear_ota_mid_download(
+        self, client, app_and_session,
+    ):
+        """Phase gate: a register that lands while ``ota_phase`` is a
+        live in-progress phase (download / extract / stage) must NOT
+        clear live OTA progress, even if the version appears to have
+        bumped.  Only ``OTA_STUCK_PHASE`` ('ota_tryboot_initiated')
+        triggers the auto-recovery clear.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from cms.models.device_event import DeviceEvent
+
+        app, session = app_and_session
+        recent_ts = datetime.now(timezone.utc) - timedelta(seconds=30)
+        device = MagicMock(
+            id="pi-mid", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.7",
+            os_version="0.0.16-test",
+            upgrade_started_at=None,
+            ota_phase="ota_download_progress",
+            ota_updated_at=recent_ts,
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-mid-dl"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-mid",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.12.0",
+                    "os_version": "1.0.0",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-mid",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        ota_clear_stmts = [
+            str(s) for s in session.executed
+            if str(s).strip().upper().startswith("UPDATE ") and "ota_phase" in str(s)
+        ]
+        assert not ota_clear_stmts, (
+            f"Did not expect ota_phase UPDATE for non-stuck phase, "
+            f"got {ota_clear_stmts}"
+        )
+        events = [a for a in session.added if isinstance(a, DeviceEvent)]
+        assert not any(
+            e.event_type == "ota_auto_cleared" for e in events
+        ), f"Did not expect OTA_AUTO_CLEARED event, got {[e.event_type for e in events]}"
+
+    async def test_register_over_wps_omitted_version_field_is_not_a_bump(
+        self, client, app_and_session,
+    ):
+        """``version_bumped()`` mirrors ``register_known_device``: an
+        omitted (empty) incoming field means "preserve prior".  A
+        register that reports the same firmware and omits ``os_version``
+        therefore evaluates to (effective_os, effective_fw) ==
+        (prior_os, prior_fw) → not a bump → no OTA clear.
+
+        Without this guard, ``("0.0.16", "1.11.20") != ("", "1.11.20")``
+        would look like a bump and prematurely clear a row that's
+        actually just sitting in tryboot waiting for the slot-confirm
+        event that's seconds away.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from cms.models.device_event import DeviceEvent
+
+        app, session = app_and_session
+        stale_ts = datetime.now(timezone.utc) - timedelta(minutes=30)
+        device = MagicMock(
+            id="pi-omit", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.20",
+            os_version="0.0.16-test",
+            upgrade_started_at=None,
+            ota_phase="ota_tryboot_initiated",
+            ota_updated_at=stale_ts,
+        )
+        session.device_row = device
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-omit-os"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-omit",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.11.20",
+                    # os_version intentionally omitted
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-omit",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        ota_clear_stmts = [
+            str(s) for s in session.executed
+            if str(s).strip().upper().startswith("UPDATE ") and "ota_phase" in str(s)
+        ]
+        assert not ota_clear_stmts, (
+            f"Did not expect ota_phase UPDATE when omitted field is "
+            f"effectively the same version, got {ota_clear_stmts}"
+        )
+        events = [a for a in session.added if isinstance(a, DeviceEvent)]
+        assert not any(
+            getattr(e, "event_type", None) == "ota_auto_cleared" for e in events
+        )
+
+    async def test_register_over_wps_cas_race_skips_audit_event(
+        self, client, app_and_session,
+    ):
+        """Concurrent replica race: a terminal lifecycle event landed on
+        another replica between snapshot and clear, so the CAS UPDATE's
+        WHERE no longer matches (``ota_updated_at`` moved AND/OR
+        ``ota_phase`` is no longer ``OTA_STUCK_PHASE``).  The UPDATE
+        returns ``rowcount == 0``; the audit ``DeviceEvent`` must NOT
+        be emitted (otherwise we'd log a phantom clear).
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from cms.models.device_event import DeviceEvent
+
+        app, session = app_and_session
+        stale_ts = datetime.now(timezone.utc) - timedelta(minutes=30)
+        device = MagicMock(
+            id="pi-race", name="Kiosk", group_id=None,
+            status=MagicMock(value="adopted"),
+            firmware_version="1.11.7",
+            os_version="0.0.16-test",
+            upgrade_started_at=None,
+            ota_phase="ota_tryboot_initiated",
+            ota_updated_at=stale_ts,
+        )
+        session.device_row = device
+
+        # Force rowcount=0 for any UPDATE that touches ota_phase.
+        original_execute = session.execute
+        async def execute_with_zero_ota_rowcount(stmt, *args, **kwargs):
+            result = await original_execute(stmt, *args, **kwargs)
+            stmt_str = str(stmt)
+            if stmt_str.strip().upper().startswith("UPDATE ") and "ota_phase" in stmt_str:
+                result.rowcount = 0
+            return result
+        session.execute = execute_with_zero_ota_rowcount
+
+        fake_transport = MagicMock()
+        fake_transport.send_to_device = AsyncMock(return_value=True)
+
+        cid = "conn-race"
+        with patch(
+            "cms.routers.wps_webhook.register_known_device",
+            new=AsyncMock(return_value=MagicMock(
+                orphaned=False, auth_assigned=None,
+            )),
+        ), patch(
+            "cms.routers.wps_webhook.get_transport",
+            new=lambda: fake_transport,
+        ):
+            r = await client.post(
+                "/internal/wps/events",
+                content=json.dumps({
+                    "type": "register", "device_id": "pi-race",
+                    "auth_token": "valid-token",
+                    "firmware_version": "1.12.0",
+                    "os_version": "1.0.0",
+                }).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "ce-type": "azure.webpubsub.user.message",
+                    "ce-connectionId": cid,
+                    "ce-userId": "pi-race",
+                    "ce-eventName": "register",
+                    "ce-signature": _sig(cid),
+                },
+            )
+        assert r.status_code == 204
+        # UPDATE was attempted (CAS form) — that's expected and harmless.
+        ota_clear_stmts = [
+            str(s) for s in session.executed
+            if str(s).strip().upper().startswith("UPDATE ") and "ota_phase" in str(s)
+        ]
+        assert ota_clear_stmts, "Expected CAS UPDATE to be attempted"
+        # But NO audit event should be appended since rowcount was 0.
+        events = [a for a in session.added if isinstance(a, DeviceEvent)]
+        assert not any(
+            e.event_type == "ota_auto_cleared" for e in events
+        ), (
+            f"Did not expect OTA_AUTO_CLEARED event when CAS race "
+            f"caused rowcount=0, got {[e.event_type for e in events]}"
+        )
+
     async def test_register_over_wps_orphaned_device(self, client, app_and_session):
         """Orphaned result returns 204 without pushing — direct-WS path
         would close 4004 but over WPS we can't close from here."""


### PR DESCRIPTION
Mia's Pi5 (Goodwill prod) showed the **Upgrade stalled** badge despite being online and on the expected firmware. Root cause: very old pre-1.0.0 updater on the prior image completed the OTA at the hardware level (slot promoted, services healthy) but never emitted the terminal `SLOT_CONFIRMED`/`PROMOTED` lifecycle event. `ota_progress.handle_event` only clears the projection columns on receipt of a terminal event, so `ota_phase` stayed pinned at `ota_tryboot_initiated` and `_is_upgrade_stuck` flipped the badge 15 min later. Only manual `UPDATE devices SET ota_phase=NULL` cleared it.

This was a 1-line fix for 1 device, but would be very painful at 200+ devices. Three CMS-side recovery paths so it self-heals:

### 1. Register-path version-bump detection (`ws.py` + `wps_webhook.py`)
When a device registers reporting a `firmware_version` newer than its prior value, clear the OTA projection columns in the same transaction. Catches future post-OTA reconnects.

### 2. Startup backfill (`cms/main.py::_backfill_stuck_ota_projection`)
Sweep for devices stuck >15 min whose `last_seen` advanced 5+ min past `ota_updated_at` (meaning they survived the reboot and are talking to us — either the new slot booted, or the bootloader auto-reverted). Gated by a Postgres advisory lock (id `0x4147_4F52_41_02`) so only one replica runs per startup, same pattern as `_backfill_media_metadata`. Catches rows that TTL'd their upgrade claim out 24h ago.

Predicate uses SELECT + filter-in-Python rather than `Device.last_seen > Device.ota_updated_at + recover_window` in the WHERE clause, because SQLAlchemy's `column + timedelta` doesn't round-trip on SQLite (and snapshotting via SELECT also avoids the Postgres-`RETURNING`-returns-NEW-values trap for audit details).

### 3. `DeviceEventType.OTA_AUTO_CLEARED` for audit visibility
Captures `prior_phase`, `prior_ota_updated_at`, `last_seen`, and `reason` (`register_version_bump` | `startup_backfill`) on the event details.

## After deploy
- **Dev**: Mia's Pi5 equivalent on dev will self-heal on next CMS restart (Phase 2 backfill).
- **Prod**: Mia's Pi5 will self-heal on the next CMS restart after prod deploy. No manual SQL needed.

## Tests
- 4 WPS-path tests + 1 direct-WS test (register-path)
- 6 backfill tests (predicate edges, idempotency, multi-device)

Local subset green; full suite via CI.