### PR TITLE
tests: stabilize test_12 logs_roundtrip by installing logs_synth in fixture

### DIFF
--- a/tests/nightly/test_12_logs_roundtrip.py
+++ b/tests/nightly/test_12_logs_roundtrip.py
@@ -5,12 +5,16 @@ multi-replica-safe async outbox introduced in PR #345:
 
 1. Happy-ish path — ``POST /api/logs/requests`` enqueues an outbox row,
    CMS forwards the ``request_logs`` command over WS, and the simulator
-   records it with ``services`` and ``since`` as sent. The simulator
-   container has no ``journalctl`` binary, so the device eventually
-   responds with an error that flips the row to ``failed``; we poll
-   ``GET /api/logs/requests/{id}`` until the row reaches a terminal
-   state (ready or failed). Proof of delivery is the recorded command
-   on the sim, which is independent of the terminal row status.
+   records it with ``services`` and ``since`` as sent. The fixture
+   installs a small ``logs_synth`` profile on the device so the sim's
+   journalctl shim returns synthetic bytes promptly (instead of
+   blocking on a real ``journalctl`` subprocess that hangs without
+   dbus inside the smoke container — see notes on the prior flake of
+   this test). The device replies with ``logs_response`` which flips
+   the row to ``ready``; we poll ``GET /api/logs/requests/{id}`` until
+   the row reaches a terminal state (ready or failed). Proof of
+   delivery is the recorded command on the sim, which is independent
+   of the terminal row status.
 
 2. Unknown device — ``POST /api/logs/requests`` returns 404 from the
    access-check guard that loads the device row.
@@ -37,6 +41,13 @@ LOGS_POLL_TIMEOUT_S = 45.0
 OFFLINE_DURATION_S = 20.0
 OFFLINE_DETECT_TIMEOUT_S = 30.0
 ONLINE_DETECT_TIMEOUT_S = 45.0
+
+# Small per-service synthetic payload installed on the sim so that
+# ``_handle_request_logs`` short-circuits the real journalctl
+# subprocess (which can block ~30s per service in the smoke container
+# where dbus is unavailable). 5 KB × 2 services keeps us comfortably
+# under the WS JSON-path frame ceiling.
+SYNTH_BYTES_PER_SERVICE = 5 * 1024
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -104,7 +115,24 @@ def logs_device(
     dev_id = ids[0]
     _wait_for_online(authenticated_page, dev_id, True, timeout=30.0)
     simulator.reset_recording(dev_id)
-    return dev_id
+    # Install a small synthetic-logs profile so the sim's
+    # ``_handle_request_logs`` skips the real journalctl subprocess
+    # (which can block ~30s per service inside the smoke container).
+    # Without this, the row can stay at ``sent`` past LOGS_POLL_TIMEOUT_S
+    # and the test flakes.
+    simulator.set_logs(
+        dev_id,
+        {svc: SYNTH_BYTES_PER_SERVICE for svc in
+         ("agora-player", "agora-cms-client")},
+    )
+    try:
+        yield dev_id
+    finally:
+        # Always clear so downstream tests see vanilla sim behaviour.
+        try:
+            simulator.clear_logs(dev_id)
+        except Exception:
+            pass
 
 
 # ── tests ────────────────────────────────────────────────────────────────
@@ -154,9 +182,10 @@ def test_request_logs_delivers_request_logs_command_to_device(
     assert payload.get("since") == since
     assert payload.get("request_id") == request_id
 
-    # The row should eventually reach a terminal state. Simulator has no
-    # journalctl, so "failed" is the most likely terminal status; a
-    # sufficiently-rigged sim could return "ready". Either is fine.
+    # The row should eventually reach a terminal state. The fixture
+    # installs a small logs_synth profile so the sim returns synthetic
+    # logs promptly and the row goes "ready"; we still accept "failed"
+    # to keep this test resilient to changes in the sim's error path.
     final = _poll_log_request(page, request_id, timeout=LOGS_POLL_TIMEOUT_S)
     assert final.get("status") in ("ready", "failed"), (
         f"log request {request_id} did not reach terminal status in "


### PR DESCRIPTION
## Root cause

The sim's `_handle_request_logs` runs `subprocess.run(["journalctl", "-u", <service>, ...], timeout=30)` **sequentially per service**. Only `FileNotFoundError` triggers the fast-path early break — when `journalctl` is present but **dbus is not** (the case inside the smoke Docker container), the call instead **blocks up to 30s per service** before `TimeoutExpired` fires.

The test passes 2 services (`agora-player`, `agora-cms-client`), so worst-case sim response time is **~60s** — longer than the test's `LOGS_POLL_TIMEOUT_S = 45s` poll window. When CI runners are loaded enough that journalctl actually takes its full timeout, the outbox row sits at `sent` past the test deadline and the assertion fails.

This matches the observed flake rate: 2 failures in ~30 Smoke Test runs on main, including the PR #684 post-merge run (passed on rerun) and an unrelated 2026-05-30 run on commit `5b71f39e`. Same test, same assertion (line 161).

## Fix

Install a small `logs_synth` profile in the `logs_device` fixture. The sim's startup-installed shim intercepts journalctl subprocess calls when `profile.logs_synth` is set, returning synthetic bytes instead of invoking the real binary — so `_handle_request_logs` returns promptly and the row flips to `ready` well within the 45s window.

The test's terminal assertion already accepted both `ready` and `failed`, so the test contract is unchanged. This mirrors the pattern used by the sibling `test_12b_logs_success_paths.py` fixture.

## Why not just bump the timeout

A timeout bump masks a 60s worst-case sim response time as if it were normal, and doesn't help if dbus availability gets even worse. Eliminating the journalctl subprocess in the test path is the real fix.
