### PR TITLE
fix: download-logs 403 — stop comparing CMS UUID vs Pi CPU serial in upload guard

### DIFF
--- a/cms/routers/log_requests.py
+++ b/cms/routers/log_requests.py
@@ -327,8 +327,11 @@ async def download_log_request(
 #
 # Kept on its own APIRouter so the user-auth ``require_auth`` dep on the
 # one above doesn't also apply here.  Device auth is the X-Device-API-Key
-# header (same header as the asset-download path) + a path-match check
-# so a device can't upload on another device's behalf.
+# header (same header as the asset-download path); ownership is enforced
+# by checking the authenticated device against the outbox row's owner,
+# not against the path's ``device_id`` (which is a Pi-supplied identifier
+# — historically the Pi's CPU serial — that does not necessarily equal
+# the CMS-canonical ``Device.id`` for UUID-adopted devices).
 
 device_upload_router = APIRouter(prefix="/api/devices")
 
@@ -363,19 +366,18 @@ async def upload_log_bundle(
 ):
     """Accept a Pi-originated tar.gz log bundle for ``request_id``.
 
-    The authenticated device must match the path ``device_id`` so a
+    The path ``device_id`` is informational only — historically the Pi
+    sends its CPU serial here, which does **not** equal the CMS-canonical
+    ``Device.id`` for UUID-adopted devices.  Ownership is enforced by
+    comparing the authenticated ``device.id`` to ``row.device_id`` so a
     compromised Pi can't poison another device's row.
     """
-    if device.id != device_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Authenticated device does not match path device_id",
-        )
+    del device_id  # unused — see docstring
 
     row = await log_outbox.get(db, request_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Log request not found")
-    if row.device_id != device_id:
+    if row.device_id != device.id:
         raise HTTPException(
             status_code=404,
             detail="Log request not found for this device",
@@ -393,7 +395,7 @@ async def upload_log_bundle(
         # don't overwrite an in-flight bundle.
         raise HTTPException(status_code=409, detail=f"Unexpected status {row.status}")
 
-    blob_path = f"{device_id}/{request_id}.tar.gz"
+    blob_path = f"{device.id}/{request_id}.tar.gz"
 
     # Stream → blob with the bounded body iterator.  HTTPException from
     # the limiter bubbles up as a 413 before any partial blob is left

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2478,7 +2478,10 @@ paths:
       description: |-
         Accept a Pi-originated tar.gz log bundle for ``request_id``.
 
-        The authenticated device must match the path ``device_id`` so a
+        The path ``device_id`` is informational only — historically the Pi
+        sends its CPU serial here, which does **not** equal the CMS-canonical
+        ``Device.id`` for UUID-adopted devices.  Ownership is enforced by
+        comparing the authenticated ``device.id`` to ``row.device_id`` so a
         compromised Pi can't poison another device's row.
       operationId: upload_log_bundle_api_devices__device_id__logs__request_id__upload_post
       parameters:

--- a/tests/nightly/test_12_logs_roundtrip.py
+++ b/tests/nightly/test_12_logs_roundtrip.py
@@ -5,12 +5,16 @@ multi-replica-safe async outbox introduced in PR #345:
 
 1. Happy-ish path — ``POST /api/logs/requests`` enqueues an outbox row,
    CMS forwards the ``request_logs`` command over WS, and the simulator
-   records it with ``services`` and ``since`` as sent. The simulator
-   container has no ``journalctl`` binary, so the device eventually
-   responds with an error that flips the row to ``failed``; we poll
-   ``GET /api/logs/requests/{id}`` until the row reaches a terminal
-   state (ready or failed). Proof of delivery is the recorded command
-   on the sim, which is independent of the terminal row status.
+   records it with ``services`` and ``since`` as sent. The fixture
+   installs a small ``logs_synth`` profile on the device so the sim's
+   journalctl shim returns synthetic bytes promptly (instead of
+   blocking on a real ``journalctl`` subprocess that hangs without
+   dbus inside the smoke container — see notes on the prior flake of
+   this test). The device replies with ``logs_response`` which flips
+   the row to ``ready``; we poll ``GET /api/logs/requests/{id}`` until
+   the row reaches a terminal state (ready or failed). Proof of
+   delivery is the recorded command on the sim, which is independent
+   of the terminal row status.
 
 2. Unknown device — ``POST /api/logs/requests`` returns 404 from the
    access-check guard that loads the device row.
@@ -37,6 +41,13 @@ LOGS_POLL_TIMEOUT_S = 45.0
 OFFLINE_DURATION_S = 20.0
 OFFLINE_DETECT_TIMEOUT_S = 30.0
 ONLINE_DETECT_TIMEOUT_S = 45.0
+
+# Small per-service synthetic payload installed on the sim so that
+# ``_handle_request_logs`` short-circuits the real journalctl
+# subprocess (which can block ~30s per service in the smoke container
+# where dbus is unavailable). 5 KB × 2 services keeps us comfortably
+# under the WS JSON-path frame ceiling.
+SYNTH_BYTES_PER_SERVICE = 5 * 1024
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -104,7 +115,24 @@ def logs_device(
     dev_id = ids[0]
     _wait_for_online(authenticated_page, dev_id, True, timeout=30.0)
     simulator.reset_recording(dev_id)
-    return dev_id
+    # Install a small synthetic-logs profile so the sim's
+    # ``_handle_request_logs`` skips the real journalctl subprocess
+    # (which can block ~30s per service inside the smoke container).
+    # Without this, the row can stay at ``sent`` past LOGS_POLL_TIMEOUT_S
+    # and the test flakes.
+    simulator.set_logs(
+        dev_id,
+        {svc: SYNTH_BYTES_PER_SERVICE for svc in
+         ("agora-player", "agora-cms-client")},
+    )
+    try:
+        yield dev_id
+    finally:
+        # Always clear so downstream tests see vanilla sim behaviour.
+        try:
+            simulator.clear_logs(dev_id)
+        except Exception:
+            pass
 
 
 # ── tests ────────────────────────────────────────────────────────────────
@@ -154,9 +182,10 @@ def test_request_logs_delivers_request_logs_command_to_device(
     assert payload.get("since") == since
     assert payload.get("request_id") == request_id
 
-    # The row should eventually reach a terminal state. Simulator has no
-    # journalctl, so "failed" is the most likely terminal status; a
-    # sufficiently-rigged sim could return "ready". Either is fine.
+    # The row should eventually reach a terminal state. The fixture
+    # installs a small logs_synth profile so the sim returns synthetic
+    # logs promptly and the row goes "ready"; we still accept "failed"
+    # to keep this test resilient to changes in the sim's error path.
     final = _poll_log_request(page, request_id, timeout=LOGS_POLL_TIMEOUT_S)
     assert final.get("status") in ("ready", "failed"), (
         f"log request {request_id} did not reach terminal status in "

--- a/tests/test_log_requests_api.py
+++ b/tests/test_log_requests_api.py
@@ -494,11 +494,14 @@ class TestUploadLogBundle:
         assert resp.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_wrong_device_key_is_403(
+    async def test_wrong_device_key_is_404(
         self, app, unauthed_client, seeded,
     ):
         # Create another device with its own key and try to upload
-        # against DEVICE_ID using that other key.
+        # against DEVICE_ID's row using that other key.  The anti-
+        # poison check is "row.device_id != device.id" (we no longer
+        # trust the path device_id), so this surfaces as a 404 "not
+        # found for this device" rather than a 403 path-mismatch.
         other_key = "key-other-dev"
         factory = get_session_factory()
         async with factory() as db:
@@ -517,4 +520,66 @@ class TestUploadLogBundle:
             content=b"x",
             headers={"X-Device-API-Key": other_key},
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_path_device_id_may_differ_from_canonical_id(
+        self, app, unauthed_client, seeded,
+    ):
+        """Regression for the download-logs 403 bug.
+
+        UUID-adopted devices send their CPU serial in the URL but the
+        CMS-canonical ``Device.id`` is a server-generated UUID.  The
+        endpoint must accept the upload as long as the authenticated
+        device owns the outbox row — the path ``device_id`` is
+        informational only.  Blob is stored under the canonical id so
+        the prefix is stable regardless of what the Pi puts in the URL.
+        """
+        from cms.services.log_blob import (
+            LocalLogBlobBackend, init_log_storage, set_log_backend,
+        )
+        from cms.auth import get_settings
+
+        settings = app.dependency_overrides[get_settings]()
+        set_log_backend(LocalLogBlobBackend(base_path=settings.asset_storage_path))
+        await init_log_storage(settings)
+
+        # ``DEVICE_ID`` is the canonical row id (think: CMS-generated
+        # UUID).  ``pi_serial_path`` is what the Pi would put in the
+        # URL (its CPU serial) — deliberately not equal to DEVICE_ID.
+        pi_serial_path = "00000000abcd1234"
+        assert pi_serial_path != DEVICE_ID
+
+        factory = get_session_factory()
+        async with factory() as db:
+            row = await log_outbox.create(db, device_id=DEVICE_ID)
+            await db.commit()
+            rid = row.id
+
+        payload = b"divergent-id-upload"
+        resp = await unauthed_client.post(
+            f"/api/devices/{pi_serial_path}/logs/{rid}/upload",
+            content=payload,
+            headers={"X-Device-API-Key": DEVICE_API_KEY},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "ready"
+
+        # Blob is stored under the canonical id (DEVICE_ID), NOT the
+        # serial path the Pi posted to.
+        canonical_blob = (
+            Path(settings.asset_storage_path)
+            / "device-logs" / DEVICE_ID / f"{rid}.tar.gz"
+        )
+        serial_blob = (
+            Path(settings.asset_storage_path)
+            / "device-logs" / pi_serial_path / f"{rid}.tar.gz"
+        )
+        assert canonical_blob.is_file()
+        assert not serial_blob.exists()
+        assert canonical_blob.read_bytes() == payload
+
+        async with factory() as db:
+            row = await log_outbox.get(db, rid)
+            assert row.status == STATUS_READY
+            assert row.blob_path == f"{DEVICE_ID}/{rid}.tar.gz"


### PR DESCRIPTION
# fix: download-logs 403 — stop comparing CMS UUID vs Pi CPU serial in upload guard

## Bug

Settings → Download Logs against any modern (UUID-adopted) device fails with:

```
HTTP 403: {"detail":"Authenticated device does not match path device_id"}
```

Reported by user against Mia's Pi5 (`52096b2e-…`). Affects every UUID-adopted device — the endpoint has likely never worked end-to-end for the modern adopt flow.

## Root cause

Two systems disagree on what "device id" means:

- **Pi-side** (`agora/cms_client/service.py:122-128`): `self.device_id = _get_device_id() = shared.identity.get_device_serial()` — the raw Raspberry Pi CPU serial. Pi builds the URL as `POST /api/devices/{serial}/logs/{rid}/upload`.
- **CMS-side** (`cms/schemas/bootstrap.py:84`): the Pi-supplied serial is treated as **advisory only** during adopt; the CMS generates a UUID for `Device.id`. There is no separate `serial` field on the Device row.

The upload endpoint guard `if device.id != device_id: 403` compares the authenticated `Device.id` (UUID) against the path arg (serial) → always fails for UUID-adopted devices.

A second comparison three lines down — `if row.device_id != device_id` — has the same shape (would fire as 404 if the first guard passed, because `row.device_id` is also the canonical UUID).

## Fix

Server-side only. Pi-side stays exactly as-is (no protocol change, no fleet rollout required):

1. **Drop the path-vs-auth check.** The authenticated device identity (from `X-Device-API-Key`) is what we actually trust; the path arg is a Pi-supplied identifier we cannot reconcile with the canonical id for UUID-adopted devices.
2. **Move the anti-poison check to `row.device_id != device.id`.** Cross-device attack ("Pi A uploads to Pi B's row") is still rejected — just as 404 instead of 403, with the comparison anchored on authenticated identity rather than a URL string.
3. **Anchor `blob_path` on `device.id`** so blobs are stored under the canonical id regardless of what the Pi puts in the URL.

The path `device_id` parameter is kept in the route signature (URL shape unchanged, backward compatible with every deployed Pi) but is now informational. Updated the docstring + module comment to reflect this.

## Why tests didn't catch it

Both sides used **self-consistent fixtures**:

- Pi-side test (`agora/tests/test_request_logs_http_upload.py`) mocks aiohttp and asserts URL shape against itself.
- CMS-side test (`tests/test_log_requests_api.py`) seeded `DEVICE_ID = "dev-logreq-1"` and used the same string for both the row id AND the URL path → the guard tautologically passes.

Neither side exercised the cross-system contract where the two ids differ by design.

## Regression test

New `test_path_device_id_may_differ_from_canonical_id` seeds a Device row with `id = DEVICE_ID` and posts to `/api/devices/<different-pi-serial>/logs/{rid}/upload` with the device's API key. Asserts:

- Endpoint returns 200 `{"status":"ready"}`.
- Blob is written under the canonical id prefix (`DEVICE_ID/<rid>.tar.gz`), NOT the path's serial prefix.
- `row.blob_path` is anchored on the canonical id.

Renamed `test_wrong_device_key_is_403` → `test_wrong_device_key_is_404` to reflect that the cross-device attack now surfaces as a row-not-found 404 (the anti-poison invariant is still enforced; just via auth-anchored ownership instead of path-string comparison).

## Blob path migration

The blob-path prefix changes from path `device_id` (serial) to authenticated `device.id` (UUID) for new uploads. `row.blob_path` is stored verbatim and used verbatim by `download_log_request` and the reaper, so existing blobs (if any) remain reachable. Other code paths that compute `f"{device_id}/{rid}.tar.gz"` (`cms/services/device_inbound.py`, `cms/services/log_chunk_assembler.py`) already use authentication-derived `device_id`, so they aren't affected by this change.

## Files

- `cms/routers/log_requests.py` — drop line-369 guard, anchor row-ownership check + blob_path on `device.id`, update docstring/comment.
- `tests/test_log_requests_api.py` — new regression test for divergent path/canonical ids; rename + update wrong-key test expectations.

## Out of scope

- The Pi-side could also send the canonical UUID in the URL, but that would require the CMS to push the canonical id back to the Pi on adopt and then a fleet-wide updater rollout. Server-side-only fix restores correctness without any client coordination.

Closes the download-logs 403 issue from the Mia Pi5 thread.
