### PR TITLE
Clean up event log: friendly descriptions + suppress OTA progress spam

### DIFF
--- a/cms/routers/device_events.py
+++ b/cms/routers/device_events.py
@@ -68,7 +68,7 @@ async def list_device_events(
 
     q = q.order_by(DeviceEvent.created_at.desc()).limit(limit)
     result = await db.execute(q)
-    return result.scalars().all()
+    return [DeviceEventOut.from_orm_event(ev) for ev in result.scalars().all()]
 
 
 @router.get("/count")

--- a/cms/schemas/device_event.py
+++ b/cms/schemas/device_event.py
@@ -16,6 +16,30 @@ class DeviceEventOut(BaseModel):
     group_name: str = ""
     event_type: str
     details: dict | None = None
+    description: str = ""
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_orm_event(cls, event) -> "DeviceEventOut":
+        """Build from an ORM ``DeviceEvent`` with ``description`` computed.
+
+        ``DeviceEvent`` doesn't carry a ``description`` column, so
+        ``model_validate`` with ``from_attributes=True`` would set it
+        to the default empty string.  Use this helper from API routes
+        so the polled-JSON path stays in sync with the server-rendered
+        event_log.html.
+        """
+        from cms.services.device_event_descriptions import build_event_description
+        return cls(
+            id=event.id,
+            device_id=event.device_id,
+            device_name=event.device_name,
+            group_id=event.group_id,
+            group_name=event.group_name,
+            event_type=event.event_type,
+            details=event.details,
+            description=build_event_description(event.event_type, event.details),
+            created_at=event.created_at,
+        )

--- a/cms/services/device_event_descriptions.py
+++ b/cms/services/device_event_descriptions.py
@@ -1,0 +1,249 @@
+"""Human-readable descriptions for device events.
+
+Single source of truth used by both:
+
+* ``cms/templates/event_log.html`` (via :func:`build_event_description`
+  populated onto each ORM event in ``cms/ui.py::event_log_page``)
+* ``/api/device-events`` (via :class:`cms.schemas.device_event.DeviceEventOut`
+  populated in ``cms/routers/device_events.py``)
+
+The auto-refresh polling JS on the event log page also uses the
+description from the API response so server-rendered rows and
+freshly-polled rows look identical.
+
+Mirrors the pattern of ``cms/services/audit_service.py::build_description``.
+"""
+
+from __future__ import annotations
+
+from cms.models.device_event import DeviceEventType
+
+
+# Friendly UI label for each event type — used both for the badge text
+# on the event-log page and for the filter dropdown options. New enum
+# values that aren't in this map fall back to a titlecased version of
+# the raw enum value (e.g. ``ota_download_progress`` → ``Ota Download
+# Progress``); add an entry below to override.
+EVENT_TYPE_LABELS: dict[str, str] = {
+    DeviceEventType.ONLINE.value:                  "Online",
+    DeviceEventType.OFFLINE.value:                 "Offline",
+    DeviceEventType.TEMP_HIGH.value:               "Temp High",
+    DeviceEventType.TEMP_CLEARED.value:            "Temp Cleared",
+    DeviceEventType.DISPLAY_CONNECTED.value:       "Display Connected",
+    DeviceEventType.DISPLAY_DISCONNECTED.value:    "Display Disconnected",
+    DeviceEventType.ERROR.value:                   "Error",
+    DeviceEventType.ERROR_CLEARED.value:           "Error Cleared",
+    DeviceEventType.CMS_STARTED.value:             "CMS Started",
+    DeviceEventType.CMS_STOPPED.value:             "CMS Stopped",
+    DeviceEventType.OTA_DOWNLOAD_STARTED.value:    "OTA Download Started",
+    DeviceEventType.OTA_DOWNLOAD_PROGRESS.value:   "OTA Downloading",
+    DeviceEventType.OTA_SIGNATURE_VERIFIED.value:  "OTA Signature Verified",
+    DeviceEventType.OTA_STAGED.value:              "OTA Staged",
+    DeviceEventType.OTA_STAGE_PROGRESS.value:      "OTA Staging",
+    DeviceEventType.OTA_EXTRACT_PROGRESS.value:    "OTA Extracting",
+    DeviceEventType.OTA_TRYBOOT_INITIATED.value:   "OTA Tryboot",
+    DeviceEventType.OTA_SLOT_CONFIRMED.value:      "OTA Slot Confirmed",
+    DeviceEventType.OTA_PROMOTED.value:            "OTA Promoted",
+    DeviceEventType.OTA_MIGRATION_COMPLETE.value:  "OTA Migration Complete",
+    DeviceEventType.OTA_FAILED.value:              "OTA Failed",
+    DeviceEventType.OTA_DECLINED.value:            "OTA Declined",
+    DeviceEventType.OTA_AUTO_CLEARED.value:        "OTA Auto-Cleared",
+}
+
+
+# Badge CSS class per event type.  Keep in sync with the badge palette
+# in ``cms/static/css/`` — anything not listed falls back to
+# ``badge-muted`` (grey).
+EVENT_TYPE_BADGE: dict[str, str] = {
+    DeviceEventType.ONLINE.value:                  "badge-online",
+    DeviceEventType.OFFLINE.value:                 "badge-offline",
+    DeviceEventType.TEMP_HIGH.value:               "badge-warning",
+    DeviceEventType.TEMP_CLEARED.value:            "badge-success",
+    DeviceEventType.DISPLAY_CONNECTED.value:       "badge-online",
+    DeviceEventType.DISPLAY_DISCONNECTED.value:    "badge-offline",
+    DeviceEventType.ERROR.value:                   "badge-danger",
+    DeviceEventType.ERROR_CLEARED.value:           "badge-success",
+    DeviceEventType.CMS_STARTED.value:             "badge-online",
+    DeviceEventType.CMS_STOPPED.value:             "badge-offline",
+    DeviceEventType.OTA_DOWNLOAD_STARTED.value:    "badge-info",
+    DeviceEventType.OTA_DOWNLOAD_PROGRESS.value:   "badge-info",
+    DeviceEventType.OTA_SIGNATURE_VERIFIED.value:  "badge-info",
+    DeviceEventType.OTA_STAGED.value:              "badge-info",
+    DeviceEventType.OTA_STAGE_PROGRESS.value:      "badge-info",
+    DeviceEventType.OTA_EXTRACT_PROGRESS.value:    "badge-info",
+    DeviceEventType.OTA_TRYBOOT_INITIATED.value:   "badge-info",
+    DeviceEventType.OTA_SLOT_CONFIRMED.value:      "badge-info",
+    DeviceEventType.OTA_PROMOTED.value:            "badge-success",
+    DeviceEventType.OTA_MIGRATION_COMPLETE.value:  "badge-success",
+    DeviceEventType.OTA_FAILED.value:              "badge-danger",
+    DeviceEventType.OTA_DECLINED.value:            "badge-warning",
+    DeviceEventType.OTA_AUTO_CLEARED.value:        "badge-muted",
+}
+
+
+def event_type_label(event_type: str) -> str:
+    """Return the friendly badge/dropdown label for an event type.
+
+    Falls back to a titlecased version of the raw enum value for any
+    unmapped event type — guarantees the UI never shows raw
+    ``snake_case`` even when a new enum value ships before this map is
+    updated.
+    """
+    if event_type in EVENT_TYPE_LABELS:
+        return EVENT_TYPE_LABELS[event_type]
+    return event_type.replace("_", " ").title()
+
+
+def event_type_badge_class(event_type: str) -> str:
+    """Return the CSS badge class for an event type."""
+    return EVENT_TYPE_BADGE.get(event_type, "badge-muted")
+
+
+def _ota_version(d: dict) -> str:
+    """Best-effort version label for an OTA event payload.
+
+    ``target_version`` is the canonical field written by
+    ``cms/services/device_inbound.py``.  Falls back to ``release_id``
+    when the device omitted the version (older agora firmware).
+    """
+    return d.get("target_version") or d.get("release_id") or ""
+
+
+def _ota_pct(payload: dict) -> str:
+    """Render ``payload.bytes_done`` / ``bytes_total`` as a percentage."""
+    done = payload.get("bytes_done")
+    total = payload.get("bytes_total")
+    try:
+        if total and isinstance(done, (int, float)) and isinstance(total, (int, float)) and total > 0:
+            return f"{(float(done) / float(total)) * 100:.0f}%"
+    except (TypeError, ValueError):
+        pass
+    return ""
+
+
+def build_event_description(event_type: str, details: dict | None = None) -> str:
+    """Build a human-readable summary for one device event.
+
+    Never returns raw JSON: an unmapped ``event_type`` falls back to
+    its titlecased label so the Details column always shows clean
+    text.  Power users can click the row to expand the raw JSON
+    drawer for forensic detail.
+    """
+    d = details or {}
+
+    if event_type == DeviceEventType.ONLINE.value:
+        return "Back online"
+
+    if event_type == DeviceEventType.OFFLINE.value:
+        kind = d.get("kind")
+        if kind == "stale_heartbeat":
+            return "No heartbeat received within timeout"
+        if kind == "grace_expired":
+            return "Grace period exceeded — device declared offline"
+        if d.get("grace_period") is not None:
+            return f"Grace period: {d['grace_period']}s"
+        return "Device went offline"
+
+    if event_type in (DeviceEventType.TEMP_HIGH.value, DeviceEventType.TEMP_CLEARED.value):
+        temp = d.get("temperature", "?")
+        threshold = d.get("threshold", "?")
+        return f"{temp}°C (threshold: {threshold}°C)"
+
+    if event_type == DeviceEventType.DISPLAY_CONNECTED.value:
+        name = d.get("display_name") or d.get("name")
+        return f"Display connected: {name}" if name else "Display connected"
+
+    if event_type == DeviceEventType.DISPLAY_DISCONNECTED.value:
+        name = d.get("display_name") or d.get("name")
+        return f"Display disconnected: {name}" if name else "Display disconnected"
+
+    if event_type == DeviceEventType.ERROR.value:
+        msg = d.get("message") or d.get("error") or d.get("reason")
+        return f"Error: {msg}" if msg else "Error reported"
+
+    if event_type == DeviceEventType.ERROR_CLEARED.value:
+        msg = d.get("message") or d.get("error") or d.get("reason")
+        return f"Error cleared: {msg}" if msg else "Error cleared"
+
+    if event_type in (DeviceEventType.CMS_STARTED.value, DeviceEventType.CMS_STOPPED.value):
+        version = d.get("version")
+        replica = d.get("replica_id")
+        verb = "started" if event_type == DeviceEventType.CMS_STARTED.value else "stopped"
+        if version and replica:
+            return f"CMS {verb} — version {version} (replica {replica})"
+        if version:
+            return f"CMS {verb} — version {version}"
+        return f"CMS {verb}"
+
+    # ── OTA events ────────────────────────────────────────────────
+    # Payload structure (from cms/services/device_inbound.py:601):
+    #   details = {
+    #     event_id, payload (dict, opaque), release_id,
+    #     target_version, occurred_at, reason, projection_applied,
+    #   }
+    # The nested ``payload`` is the wire-format dict from the device
+    # and is exactly what previously exploded the column width.
+    payload = d.get("payload") or {}
+    version = _ota_version(d)
+    suffix = f" — {version}" if version else ""
+
+    if event_type == DeviceEventType.OTA_DOWNLOAD_STARTED.value:
+        return f"Started downloading update{suffix}"
+
+    if event_type == DeviceEventType.OTA_DOWNLOAD_PROGRESS.value:
+        pct = _ota_pct(payload)
+        if pct:
+            return f"Downloading update{suffix}: {pct}"
+        return f"Downloading update{suffix}"
+
+    if event_type == DeviceEventType.OTA_SIGNATURE_VERIFIED.value:
+        return f"Signature verified{suffix}"
+
+    if event_type == DeviceEventType.OTA_STAGED.value:
+        return f"Update staged{suffix}"
+
+    if event_type == DeviceEventType.OTA_STAGE_PROGRESS.value:
+        phase = payload.get("phase")
+        if phase:
+            return f"Staging update{suffix} ({phase.replace('_', ' ')})"
+        return f"Staging update{suffix}"
+
+    if event_type == DeviceEventType.OTA_EXTRACT_PROGRESS.value:
+        pct = _ota_pct(payload)
+        if pct:
+            return f"Extracting update{suffix}: {pct}"
+        return f"Extracting update{suffix}"
+
+    if event_type == DeviceEventType.OTA_TRYBOOT_INITIATED.value:
+        return f"Rebooting into new slot{suffix}"
+
+    if event_type == DeviceEventType.OTA_SLOT_CONFIRMED.value:
+        return f"New slot confirmed{suffix}"
+
+    if event_type == DeviceEventType.OTA_PROMOTED.value:
+        return f"Update promoted{suffix}"
+
+    if event_type == DeviceEventType.OTA_MIGRATION_COMPLETE.value:
+        return f"Migration complete{suffix}"
+
+    if event_type == DeviceEventType.OTA_FAILED.value:
+        reason = d.get("reason") or payload.get("reason") or payload.get("error")
+        if reason and version:
+            return f"OTA failed{suffix} — {reason}"
+        if reason:
+            return f"OTA failed — {reason}"
+        return f"OTA failed{suffix}" if version else "OTA failed"
+
+    if event_type == DeviceEventType.OTA_DECLINED.value:
+        reason = d.get("reason") or payload.get("reason")
+        if reason:
+            return f"OTA declined{suffix} — {reason}"
+        return f"OTA declined{suffix}" if version else "OTA declined"
+
+    if event_type == DeviceEventType.OTA_AUTO_CLEARED.value:
+        return f"OTA state auto-cleared{suffix}"
+
+    # Unknown event type — never dump raw JSON.  The titlecased label
+    # is always at least readable; ops can click the row to see the
+    # raw payload if they need details.
+    return event_type_label(event_type)

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -581,6 +581,21 @@ async def dispatch_device_message(
 
         mutated = ota_progress.handle_event(device, cms_type.value, payload)
 
+        # Drop noisy progress events from the persisted event log — they
+        # arrive every few seconds during an OTA (download/stage/extract
+        # bytes_done ticks) and add zero audit value over the
+        # surrounding ``*_STARTED`` / ``STAGED`` / ``SLOT_CONFIRMED``
+        # rows.  Live progress badges still update via the projection
+        # call above; we just skip the DeviceEvent insert.
+        PROGRESS_EVENT_TYPES = {
+            DeviceEventType.OTA_DOWNLOAD_PROGRESS.value,
+            DeviceEventType.OTA_STAGE_PROGRESS.value,
+            DeviceEventType.OTA_EXTRACT_PROGRESS.value,
+        }
+        if cms_type.value in PROGRESS_EVENT_TYPES:
+            await db.commit()
+            return
+
         # Audit row.  We write this even when ``mutated`` is False
         # (regression-dropped or unknown sub-payload) so the event log
         # still shows that the device's monotonic event_id was

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -322,6 +322,20 @@ function toggleAuditRow(row) {
     }
 }
 
+function toggleEventRow(row) {
+    const eventId = row.dataset.eventId;
+    const detail = row.nextElementSibling;
+    if (!detail || detail.dataset.detailFor !== eventId) return;
+    const isOpen = row.classList.contains("expanded");
+    if (isOpen) {
+        row.classList.remove("expanded");
+        detail.style.display = "none";
+    } else {
+        row.classList.add("expanded");
+        detail.style.display = "";
+    }
+}
+
 // ── API helpers ──
 async function apiCall(method, url, body = null) {
     const opts = { method, headers: {} };

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -928,6 +928,18 @@ tr.highlight-new td {
 }
 .audit-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
 .audit-detail td:first-child { padding: 0; }
+/* Event log table — same expand/detail pattern as audit log. */
+.event-row { cursor: pointer; }
+.event-row:hover td { background: rgba(255,255,255,0.04); }
+.event-row.expanded .expand-toggle { transform: rotate(90deg); display: inline-block; }
+.event-description { overflow: hidden; }
+.event-description > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.event-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
+.event-detail td:first-child { padding: 0; }
 /* Diff table inside the expand panel — field | from → to */
 .audit-changes {
     width: 100%;

--- a/cms/templates/event_log.html
+++ b/cms/templates/event_log.html
@@ -16,12 +16,9 @@
                 <label style="font-size:0.75rem;">Event Type</label>
                 <select name="event_type" onchange="this.form.submit()" style="padding:0.4rem 0.6rem; font-size:0.85rem;">
                     <option value="">All Events</option>
-                    <option value="online" {% if filter_event_type == 'online' %}selected{% endif %}>Online</option>
-                    <option value="offline" {% if filter_event_type == 'offline' %}selected{% endif %}>Offline</option>
-                    <option value="temp_high" {% if filter_event_type == 'temp_high' %}selected{% endif %}>Temperature High</option>
-                    <option value="temp_cleared" {% if filter_event_type == 'temp_cleared' %}selected{% endif %}>Temperature Cleared</option>
-                    <option value="cms_started" {% if filter_event_type == 'cms_started' %}selected{% endif %}>CMS Started</option>
-                    <option value="cms_stopped" {% if filter_event_type == 'cms_stopped' %}selected{% endif %}>CMS Stopped</option>
+                    {% for ev_value, ev_label in all_event_types %}
+                    <option value="{{ ev_value }}" {% if filter_event_type == ev_value %}selected{% endif %}>{{ ev_label }}</option>
+                    {% endfor %}
                 </select>
             </div>
             <div class="form-group" style="flex:1; min-width:140px; margin-bottom:0;">
@@ -65,61 +62,115 @@
 {%- endmacro %}
 
 <div class="card">
-    <table>
+    <table style="table-layout: fixed; width: 100%;">
         <thead>
             <tr>
-                <th>Time</th>
-                <th>Event</th>
-                <th>Device</th>
-                <th>Group</th>
-                <th>Details</th>
+                <th style="width:2rem;"></th>
+                <th style="width:14%;">Time</th>
+                <th style="width:12%;">Event</th>
+                <th style="width:14%;">Device</th>
+                <th style="width:12%;">Group</th>
+                <th style="width:46%;">Details</th>
             </tr>
         </thead>
         <tbody id="event-log-tbody">
             {% for event in events %}
-            <tr data-event-id="{{ event.id }}">
+            <tr class="event-row" onclick="toggleEventRow(this)" data-event-id="{{ event.id }}">
+                <td class="expand-toggle">▶</td>
                 <td style="white-space:nowrap;" data-utc="{{ event.created_at.isoformat() }}">{{ event.created_at.astimezone(tz).strftime('%b %d, %Y %I:%M:%S %p') }}</td>
-                <td>
-                    {% if event.event_type == 'online' %}
-                    <span class="badge badge-online">Online</span>
-                    {% elif event.event_type == 'offline' %}
-                    <span class="badge badge-offline">Offline</span>
-                    {% elif event.event_type == 'temp_high' %}
-                    <span class="badge badge-warning">Temp High</span>
-                    {% elif event.event_type == 'temp_cleared' %}
-                    <span class="badge badge-success">Temp Cleared</span>
-                    {% elif event.event_type == 'cms_started' %}
-                    <span class="badge badge-online">CMS Started</span>
-                    {% elif event.event_type == 'cms_stopped' %}
-                    <span class="badge badge-offline">CMS Stopped</span>
-                    {% else %}
-                    <span class="badge badge-muted">{{ event.event_type }}</span>
-                    {% endif %}
-                </td>
+                <td><span class="badge {{ event.badge_class }}">{{ event.label }}</span></td>
                 <td>{% if event.device_id %}{{ event.device_name }}{% else %}<span class="text-muted">— System —</span>{% endif %}</td>
                 <td>{{ event.group_name or '—' }}</td>
-                <td>
-                    {% if event.event_type == 'temp_high' and event.details %}
-                    {{ event.details.temperature | default('?') }}°C (threshold: {{ event.details.threshold | default('?') }}°C)
-                    {% elif event.event_type == 'temp_cleared' and event.details %}
-                    {{ event.details.temperature | default('?') }}°C (threshold: {{ event.details.threshold | default('?') }}°C)
-                    {% elif event.event_type == 'offline' and event.details and event.details.kind == 'stale_heartbeat' %}
-                    No heartbeat received within timeout
-                    {% elif event.event_type == 'offline' and event.details and event.details.kind == 'grace_expired' %}
-                    Grace period exceeded — device declared offline
-                    {% elif event.event_type == 'offline' and event.details and event.details.grace_period is defined %}
-                    Grace period: {{ event.details.grace_period }}s
-                    {% elif event.event_type == 'online' %}
-                    Back online
-                    {% elif event.event_type in ['cms_started', 'cms_stopped'] and event.details and event.details.version %}
-                    Version {{ event.details.version }}{% if event.details.replica_id %} (replica {{ event.details.replica_id }}){% endif %}
-                    {% else %}
-                    {{ event.details | tojson if event.details else '—' }}
+                <td class="event-description"><div title="{{ event.description }}">{{ event.description or '—' }}</div></td>
+            </tr>
+            <tr class="event-detail" data-detail-for="{{ event.id }}" style="display: none;">
+                <td></td>
+                <td colspan="5">
+                    <div class="detail-grid">
+                        <div class="detail-item">
+                            <span class="detail-label">Description</span>
+                            <span class="detail-value" style="white-space:normal; word-break:break-word;">{{ event.description or '—' }}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Event</span>
+                            <span class="detail-value"><span class="badge {{ event.badge_class }}">{{ event.label }}</span></span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Device</span>
+                            <span class="detail-value">{% if event.device_id %}{{ event.device_name }}{% else %}— System —{% endif %}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Device ID</span>
+                            <span class="detail-value monospace">{{ event.device_id or '—' }}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Group</span>
+                            <span class="detail-value">{{ event.group_name or '—' }}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Timestamp</span>
+                            <span class="detail-value">{{ event.created_at.astimezone(tz).strftime('%Y-%m-%d %H:%M:%S %Z') }}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Event ID</span>
+                            <span class="detail-value monospace" style="font-size:0.75rem;">{{ event.id }}</span>
+                        </div>
+                    </div>
+                    {% if event.details %}
+                    {# ── Friendly key-value details ── #}
+                    {% set label_map = {
+                        'event_id': 'Wire Event ID',
+                        'target_version': 'Target Version',
+                        'release_id': 'Release ID',
+                        'occurred_at': 'Occurred At',
+                        'reason': 'Reason',
+                        'projection_applied': 'Projection Applied',
+                        'kind': 'Kind',
+                        'grace_period': 'Grace Period (s)',
+                        'temperature': 'Temperature',
+                        'threshold': 'Threshold',
+                        'version': 'Version',
+                        'replica_id': 'Replica ID',
+                        'display_name': 'Display Name',
+                        'name': 'Name',
+                        'message': 'Message',
+                        'error': 'Error',
+                    } %}
+                    {% set detail_items = [] %}
+                    {% for key, val in event.details.items() %}
+                        {% if val is not none and val != '' %}
+                            {% if val is iterable and val is not string and val is not mapping %}
+                                {% set _ = detail_items.append((label_map.get(key, key | replace('_', ' ') | title), val | join(', '))) %}
+                            {% elif val is mapping %}
+                                {# Nested dict (e.g. OTA ``payload``) — skip in the friendly grid; raw JSON below covers it. #}
+                            {% else %}
+                                {% set _ = detail_items.append((label_map.get(key, key | replace('_', ' ') | title), val)) %}
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if detail_items %}
+                    <div style="margin-top:0.75rem;">
+                        <span class="detail-label" style="display:block; margin-bottom:0.25rem;">Details</span>
+                        <div class="detail-grid">
+                            {% for label, value in detail_items %}
+                            <div class="detail-item">
+                                <span class="detail-label">{{ label }}</span>
+                                <span class="detail-value">{{ value }}</span>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endif %}
+                    {# ── Raw JSON toggle ── #}
+                    <div style="margin-top:0.5rem;">
+                        <a href="javascript:void(0)" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'; this.textContent = this.nextElementSibling.style.display === 'none' ? 'Show raw JSON' : 'Hide raw JSON';" class="text-muted" style="font-size:0.75rem; text-decoration:underline;">Show raw JSON</a>
+                        <pre class="audit-json" style="display:none; margin-top:0.25rem;">{{ event.details | tojson(indent=2) }}</pre>
+                    </div>
                     {% endif %}
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="5" class="text-muted" style="text-align:center; padding:2rem;">{% if has_filters %}No events match the current filters.{% else %}No device events yet. Events will appear here as devices connect, disconnect, or report temperature issues.{% endif %}</td></tr>
+            <tr><td colspan="6" class="text-muted" style="text-align:center; padding:2rem;">{% if has_filters %}No events match the current filters.{% else %}No device events yet. Events will appear here as devices connect, disconnect, or report temperature issues.{% endif %}</td></tr>
             {% endfor %}
         </tbody>
     </table>
@@ -181,9 +232,16 @@
     const PER_PAGE = {{ per_page }};
     const POLL_INTERVAL_MS = 15000;
 
+    // event_type -> [badge_class, friendly_label], generated server-side
+    // so adding a DeviceEventType value Just Works without touching JS.
+    const EVENT_TYPE_META = {
+        {% for ev_value, ev_label in all_event_types -%}
+        {{ ev_value | tojson }}: [{{ event_type_badge.get(ev_value, 'badge-muted') | tojson }}, {{ ev_label | tojson }}],
+        {% endfor %}
+    };
+
     const EMPTY_ROW_SELECTOR = "tr td[colspan]";
 
-    // Format ISO timestamp to local tz — matches the global [data-utc] formatter in app.js
     function formatTime(iso) {
         try {
             const d = new Date(iso);
@@ -195,63 +253,137 @@
         }
     }
 
-    function badge(eventType) {
-        const map = {
-            online: ["badge-online", "Online"],
-            offline: ["badge-offline", "Offline"],
-            temp_high: ["badge-warning", "Temp High"],
-            temp_cleared: ["badge-success", "Temp Cleared"],
-            cms_started: ["badge-online", "CMS Started"],
-            cms_stopped: ["badge-offline", "CMS Stopped"],
-        };
-        const [cls, label] = map[eventType] || ["badge-muted", eventType];
-        return `<span class="badge ${cls}">${label}</span>`;
-    }
-
-    function renderDetails(ev) {
-        const d = ev.details || {};
-        if (ev.event_type === "temp_high" || ev.event_type === "temp_cleared") {
-            return `${d.temperature ?? "?"}°C (threshold: ${d.threshold ?? "?"}°C)`;
-        }
-        if (ev.event_type === "offline" && d.kind === "stale_heartbeat") {
-            return "No heartbeat received within timeout";
-        }
-        if (ev.event_type === "offline" && d.kind === "grace_expired") {
-            return "Grace period exceeded — device declared offline";
-        }
-        if (ev.event_type === "offline" && d.grace_period !== undefined) {
-            return `Grace period: ${d.grace_period}s`;
-        }
-        if (ev.event_type === "online") return "Back online";
-        if ((ev.event_type === "cms_started" || ev.event_type === "cms_stopped") && d.version) {
-            return d.replica_id
-                ? `Version ${d.version} (replica ${d.replica_id})`
-                : `Version ${d.version}`;
-        }
-        return ev.details ? JSON.stringify(ev.details) : "—";
-    }
-
     function escapeHtml(s) {
         return String(s ?? "").replace(/[&<>"']/g, c => (
             {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]
         ));
     }
 
-    function rowHtml(ev) {
-        const deviceCell = ev.device_id
+    function badge(eventType) {
+        const meta = EVENT_TYPE_META[eventType] || ["badge-muted", eventType];
+        return `<span class="badge ${meta[0]}">${escapeHtml(meta[1])}</span>`;
+    }
+
+    function labelFor(eventType) {
+        const meta = EVENT_TYPE_META[eventType] || ["badge-muted", eventType];
+        return meta[1];
+    }
+
+    function deviceCell(ev) {
+        return ev.device_id
             ? escapeHtml(ev.device_name)
             : '<span class="text-muted">— System —</span>';
+    }
+
+    // Build the friendly key/value list from ev.details, skipping nested
+    // dicts/empty values to match the server-side render.
+    function detailItemsHtml(details) {
+        if (!details) return "";
+        const labelMap = {
+            event_id: "Wire Event ID",
+            target_version: "Target Version",
+            release_id: "Release ID",
+            occurred_at: "Occurred At",
+            reason: "Reason",
+            projection_applied: "Projection Applied",
+            kind: "Kind",
+            grace_period: "Grace Period (s)",
+            temperature: "Temperature",
+            threshold: "Threshold",
+            version: "Version",
+            replica_id: "Replica ID",
+            display_name: "Display Name",
+            name: "Name",
+            message: "Message",
+            error: "Error",
+        };
+        const titlecase = k => k.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+        const items = [];
+        for (const [k, v] of Object.entries(details)) {
+            if (v === null || v === undefined || v === "") continue;
+            if (Array.isArray(v)) {
+                items.push([labelMap[k] || titlecase(k), v.join(", ")]);
+            } else if (typeof v === "object") {
+                continue; // skip nested dicts; raw JSON below covers them
+            } else {
+                items.push([labelMap[k] || titlecase(k), v]);
+            }
+        }
+        if (items.length === 0) return "";
         return `
-            <td style="white-space:nowrap;" data-utc="${escapeHtml(ev.created_at)}">${formatTime(ev.created_at)}</td>
-            <td>${badge(ev.event_type)}</td>
-            <td>${deviceCell}</td>
-            <td>${escapeHtml(ev.group_name) || "—"}</td>
-            <td>${escapeHtml(renderDetails(ev))}</td>
+            <div style="margin-top:0.75rem;">
+                <span class="detail-label" style="display:block; margin-bottom:0.25rem;">Details</span>
+                <div class="detail-grid">
+                    ${items.map(([l, v]) => `
+                        <div class="detail-item">
+                            <span class="detail-label">${escapeHtml(l)}</span>
+                            <span class="detail-value">${escapeHtml(v)}</span>
+                        </div>
+                    `).join("")}
+                </div>
+            </div>
+        `;
+    }
+
+    function rowsHtml(ev) {
+        const desc = ev.description || "—";
+        const ts = formatTime(ev.created_at);
+        const detailsBlock = ev.details ? `
+            ${detailItemsHtml(ev.details)}
+            <div style="margin-top:0.5rem;">
+                <a href="javascript:void(0)" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'; this.textContent = this.nextElementSibling.style.display === 'none' ? 'Show raw JSON' : 'Hide raw JSON';" class="text-muted" style="font-size:0.75rem; text-decoration:underline;">Show raw JSON</a>
+                <pre class="audit-json" style="display:none; margin-top:0.25rem;">${escapeHtml(JSON.stringify(ev.details, null, 2))}</pre>
+            </div>
+        ` : "";
+        return `
+            <tr class="event-row" onclick="toggleEventRow(this)" data-event-id="${escapeHtml(ev.id)}">
+                <td class="expand-toggle">▶</td>
+                <td style="white-space:nowrap;" data-utc="${escapeHtml(ev.created_at)}">${ts}</td>
+                <td>${badge(ev.event_type)}</td>
+                <td>${deviceCell(ev)}</td>
+                <td>${escapeHtml(ev.group_name) || "—"}</td>
+                <td class="event-description"><div title="${escapeHtml(desc)}">${escapeHtml(desc)}</div></td>
+            </tr>
+            <tr class="event-detail" data-detail-for="${escapeHtml(ev.id)}" style="display:none;">
+                <td></td>
+                <td colspan="5">
+                    <div class="detail-grid">
+                        <div class="detail-item">
+                            <span class="detail-label">Description</span>
+                            <span class="detail-value" style="white-space:normal; word-break:break-word;">${escapeHtml(desc)}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Event</span>
+                            <span class="detail-value">${badge(ev.event_type)}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Device</span>
+                            <span class="detail-value">${ev.device_id ? escapeHtml(ev.device_name) : "— System —"}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Device ID</span>
+                            <span class="detail-value monospace">${escapeHtml(ev.device_id) || "—"}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Group</span>
+                            <span class="detail-value">${escapeHtml(ev.group_name) || "—"}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Timestamp</span>
+                            <span class="detail-value">${ts}</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">Event ID</span>
+                            <span class="detail-value monospace" style="font-size:0.75rem;">${escapeHtml(ev.id)}</span>
+                        </div>
+                    </div>
+                    ${detailsBlock}
+                </td>
+            </tr>
         `;
     }
 
     async function poll() {
-        // Skip polling when tab is hidden to avoid wasted traffic
         if (document.hidden) return;
 
         const params = new URLSearchParams();
@@ -265,35 +397,36 @@
             if (!resp.ok) return;
             const events = await resp.json();
 
-            // Collect existing IDs to detect new ones
             const existingIds = new Set(
-                Array.from(tbody.querySelectorAll("tr[data-event-id]"))
+                Array.from(tbody.querySelectorAll("tr.event-row[data-event-id]"))
                     .map(tr => tr.dataset.eventId)
             );
 
-            // API returns newest first — iterate in reverse so oldest new event
-            // is inserted first and newest ends up at the very top
             const newEvents = events.filter(e => !existingIds.has(e.id));
             if (newEvents.length === 0) return;
 
-            // Remove the empty-state row if present
             const emptyRow = tbody.querySelector(EMPTY_ROW_SELECTOR);
             if (emptyRow) emptyRow.parentElement.remove();
 
+            // API returns newest first; iterate in reverse so newest ends up on top.
             for (let i = newEvents.length - 1; i >= 0; i--) {
-                const ev = newEvents[i];
-                const tr = document.createElement("tr");
-                tr.dataset.eventId = ev.id;
-                tr.innerHTML = rowHtml(ev);
-                tr.style.background = "rgba(46, 204, 113, 0.08)"; // subtle highlight
-                tbody.insertBefore(tr, tbody.firstChild);
-                // Fade the highlight out after a moment
-                setTimeout(() => { tr.style.transition = "background 2s"; tr.style.background = ""; }, 50);
+                const wrapper = document.createElement("tbody");
+                wrapper.innerHTML = rowsHtml(newEvents[i]).trim();
+                const newRow = wrapper.querySelector("tr.event-row");
+                const newDetail = wrapper.querySelector("tr.event-detail");
+                newRow.style.background = "rgba(46, 204, 113, 0.08)";
+                tbody.insertBefore(newDetail, tbody.firstChild);
+                tbody.insertBefore(newRow, tbody.firstChild);
+                setTimeout(() => { newRow.style.transition = "background 2s"; newRow.style.background = ""; }, 50);
             }
 
-            // Trim to PER_PAGE rows (don't let the page grow unbounded)
-            const rows = tbody.querySelectorAll("tr[data-event-id]");
-            for (let i = PER_PAGE; i < rows.length; i++) rows[i].remove();
+            // Trim row pairs to PER_PAGE total events to keep the page bounded.
+            const rows = tbody.querySelectorAll("tr.event-row[data-event-id]");
+            for (let i = PER_PAGE; i < rows.length; i++) {
+                const next = rows[i].nextElementSibling;
+                rows[i].remove();
+                if (next && next.classList.contains("event-detail")) next.remove();
+            }
         } catch {
             // Silent — don't spam toasts on transient network errors
         }

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -2536,6 +2536,29 @@ async def event_log_page(
     result = await db.execute(query)
     events = result.scalars().all()
 
+    # Attach a precomputed, human-readable ``description`` to each
+    # event so the template (and the auto-refresh polling JS, via the
+    # /api/device-events DTO) never has to dump raw JSON into the
+    # Details column.
+    from cms.services.device_event_descriptions import (
+        EVENT_TYPE_BADGE,
+        build_event_description,
+        event_type_label,
+    )
+    from cms.models.device_event import DeviceEventType
+    for ev in events:
+        ev.description = build_event_description(ev.event_type, ev.details)
+        ev.badge_class = EVENT_TYPE_BADGE.get(ev.event_type, "badge-muted")
+        ev.label = event_type_label(ev.event_type)
+
+    # All known event types for the filter dropdown — generated from
+    # the enum so adding a new ``DeviceEventType`` value automatically
+    # picks up filter support without a separate template edit.
+    all_event_types = [
+        (et.value, event_type_label(et.value))
+        for et in DeviceEventType
+    ]
+
     # Distinct devices for filter dropdown (RBAC-filtered, excludes system events)
     dev_q = (
         select(DeviceEvent.device_id, DeviceEvent.device_name)
@@ -2573,6 +2596,8 @@ async def event_log_page(
         "filter_until": until.strip(),
         "available_devices": available_devices,
         "available_groups": available_groups,
+        "all_event_types": all_event_types,
+        "event_type_badge": EVENT_TYPE_BADGE,
     })
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5281,6 +5281,10 @@ components:
             type: object
           - type: 'null'
           title: Details
+        description:
+          type: string
+          title: Description
+          default: ''
         created_at:
           type: string
           format: date-time

--- a/tests/test_event_log_page.py
+++ b/tests/test_event_log_page.py
@@ -184,9 +184,31 @@ async def test_offline_event_kinds_render_humanized(app, client):
     assert "No heartbeat received within timeout" in text
     assert "Grace period exceeded" in text
     assert "Grace period: 120s" in text  # legacy rendering preserved
-    # Raw JSON of the new ``kind`` payloads must NOT bleed through.
-    assert '"kind": "stale_heartbeat"' not in text
-    assert '"kind": "grace_expired"' not in text
+    # Raw JSON of the ``kind`` payloads now lives inside the hidden
+    # raw-JSON drawer in the expandable detail row — that's expected
+    # and intentional, not a regression. The visible Details column
+    # only ever shows the friendly description above.
+    # (Sanity: each humanized string appears above the corresponding
+    # raw payload, which is what the user actually sees.)
+
+
+@pytest.mark.asyncio
+async def test_all_event_types_have_friendly_description():
+    """Every DeviceEventType value must produce a non-empty, non-JSON description.
+
+    Guards against shipping a new enum value without a matching helper
+    branch — without this test, an unknown event type would silently
+    fall back to dumping raw JSON in the Details column (the exact bug
+    this whole feature was meant to fix).
+    """
+    from cms.models.device_event import DeviceEventType
+    from cms.services.device_event_descriptions import build_event_description
+
+    for et in DeviceEventType:
+        desc = build_event_description(et.value, {})
+        assert desc, f"empty description for {et.value}"
+        assert not desc.startswith("{"), f"raw JSON returned for {et.value}: {desc!r}"
+        assert not desc.startswith("["), f"raw JSON returned for {et.value}: {desc!r}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle_events.py
+++ b/tests/test_lifecycle_events.py
@@ -87,9 +87,16 @@ async def _read_events(_device, event_type=None):
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_download_progress_updates_device_and_writes_audit(
+async def test_lifecycle_download_progress_updates_device_but_skips_audit_row(
     app, _device,
 ):
+    """Progress events project to the device but DO NOT persist a DeviceEvent.
+
+    Progress messages arrive every few seconds during an OTA and add
+    no audit value over the surrounding ``*_STARTED`` / ``STAGED`` /
+    ``SLOT_CONFIRMED`` rows — they would just spam the event log.
+    The live progress badge still updates via the projection.
+    """
     msg = {
         "type": MessageType.LIFECYCLE_EVENT.value,
         "event_id": 42,
@@ -110,15 +117,10 @@ async def test_lifecycle_download_progress_updates_device_and_writes_audit(
     # The atomic upgrade claim is NOT cleared (still in flight).
     assert dev.upgrade_started_at is not None
 
+    # No audit row for progress events — explicitly suppressed.
     events = await _read_events(_device,
                                 DeviceEventType.OTA_DOWNLOAD_PROGRESS.value)
-    assert len(events) == 1
-    detail = events[0].details
-    assert detail["event_id"] == 42
-    assert detail["payload"]["bytes_done"] == 250
-    assert detail["release_id"] == "rel-v0.0.30-test"
-    assert detail["target_version"] == "0.0.30-test"
-    assert detail["projection_applied"] is True
+    assert events == []
 
 
 @pytest.mark.asyncio
@@ -188,7 +190,14 @@ async def test_lifecycle_terminal_event_clears_upgrade_claim(app, _device):
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_regression_dropped_event_still_audits(app, _device):
+async def test_lifecycle_regression_dropped_event_audit_policy(app, _device):
+    """Non-progress regression events still write an audit row.
+
+    A regression-dropped transition event still persists with
+    ``projection_applied=False`` so the audit trail is complete.
+    Progress events are suppressed regardless — see
+    ``test_lifecycle_download_progress_updates_device_but_skips_audit_row``.
+    """
     # First event lands.
     forward = {
         "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 10,
@@ -199,28 +208,37 @@ async def test_lifecycle_regression_dropped_event_still_audits(app, _device):
     dev_after_forward = await _read_device(_device)
     assert dev_after_forward.ota_phase == DeviceEventType.OTA_SLOT_CONFIRMED.value
 
-    # A regression event arrives (download_progress, ordinal much
-    # lower than slot_confirmed).  Projection refuses the regression
-    # but we MUST still write an audit row so the device's monotonic
-    # event_id is accounted for in the event log.
+    # A regression non-progress event arrives (staged, ordinal lower
+    # than slot_confirmed).  Projection refuses the regression but we
+    # still write an audit row so the device's monotonic event_id is
+    # accounted for in the event log.
     regression = {
         "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 11,
-        "event_type": "download_progress",
-        "payload": {"bytes_done": 50, "bytes_total": 1000},
+        "event_type": "staged",
+        "payload": {},
     }
     await _dispatch(_device, regression, app)
 
     dev_after = await _read_device(_device)
     # Device state unchanged — slot_confirmed still wins.
     assert dev_after.ota_phase == DeviceEventType.OTA_SLOT_CONFIRMED.value
-    assert dev_after.ota_bytes_done is None  # never set by slot_confirmed
 
-    # But the audit row landed with projection_applied=False so the
-    # event-log surface can still display the dropped event for
-    # debugging.
     regr_events = await _read_events(
-        _device, DeviceEventType.OTA_DOWNLOAD_PROGRESS.value,
+        _device, DeviceEventType.OTA_STAGED.value,
     )
     assert len(regr_events) == 1
     assert regr_events[0].details["event_id"] == 11
     assert regr_events[0].details["projection_applied"] is False
+
+    # And a regression progress event is suppressed — no audit row.
+    progress_regression = {
+        "type": MessageType.LIFECYCLE_EVENT.value, "event_id": 12,
+        "event_type": "download_progress",
+        "payload": {"bytes_done": 50, "bytes_total": 1000},
+    }
+    await _dispatch(_device, progress_regression, app)
+
+    prog_events = await _read_events(
+        _device, DeviceEventType.OTA_DOWNLOAD_PROGRESS.value,
+    )
+    assert prog_events == []


### PR DESCRIPTION
The event log Details column was dumping raw JSON, blowing past column width — same problem we fixed in the audit log. Mirror that pattern.

**Friendly descriptions + expandable details**
- New `cms/services/device_event_descriptions.py` renders a one-line human description per event from the payload (covers all 23 `DeviceEventType` values), plus labels and badge classes.
- `DeviceEventOut` schema gains `description`; `device_events` router uses `from_orm_event` so the JS poller gets the same pre-rendered text as the server-rendered rows.
- `event_log.html` rewritten with paired event-row / event-detail rows — click to expand a drawer with the raw JSON payload. Live-refreshed rows behave identically to server-rendered ones.

**Suppress OTA progress event spam**
- `download_progress` / `stage_progress` / `extract_progress` events arrive every few seconds during an OTA and add zero audit value over the surrounding `*_STARTED` / `STAGED` / `SLOT_CONFIRMED` transitions — they were just spamming the log.
- Drop them at the inbound handler (`device_inbound.py`) BEFORE the `DeviceEvent` insert but AFTER the projection call. Live progress badges still update; only the audit INSERT is skipped.

Tests updated: `test_lifecycle_download_progress_updates_device_but_skips_audit_row` inverts the audit assertion, `test_lifecycle_regression_dropped_event_audit_policy` switches the regression case to a non-progress event (`staged`) and adds explicit coverage that regression-dropped progress events are also suppressed.