### PR TITLE
Fix empty Group column in event log + wrap long Event badges

### DIFF
--- a/cms/routers/wps_webhook.py
+++ b/cms/routers/wps_webhook.py
@@ -443,6 +443,22 @@ async def events_receiver(
                 ce_user_id, ce_connection_id,
             )
 
+        # Snapshot the device's group name so DeviceEvent rows persist a
+        # human-readable Group column (the event_log template renders
+        # ``event.group_name or '—'``).  Mirrors the lookup the
+        # ``device_reconnected`` register branch above does — without
+        # this, every WPS-delivered event (i.e. the entire Pi fleet)
+        # lands with ``group_name=''`` even when ``group_id`` is set,
+        # leaving the Group column permanently blank.
+        _ctx_group_name = ""
+        if device.group_id:
+            _grp_q = await db.execute(
+                select(DeviceGroup.name).where(
+                    DeviceGroup.id == device.group_id,
+                )
+            )
+            _ctx_group_name = _grp_q.scalar_one_or_none() or ""
+
         ctx = InboundContext(
             device_id=ce_user_id,
             device=device,
@@ -451,7 +467,7 @@ async def events_receiver(
             group_id=str(device.group_id) if device.group_id else None,
             device_name=device.name or ce_user_id,
             device_status=device.status.value if device.status else "pending",
-            group_name="",
+            group_name=_ctx_group_name,
             received_at=received_at,
         )
 

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -407,6 +407,17 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .badge-muted { background: #555; color: #ccc; }
 .badge-offline { background: var(--warning); color: #000; }
 .badge-usage { background: var(--primary); color: #fff; }
+
+/* Event log table: badges can otherwise overflow the fixed-width Event
+ * column and run into the Device column.  Allow wrap inside the badge
+ * pill so the column width is respected on narrow viewports. */
+.event-log-table .badge {
+    white-space: normal;
+    max-width: 100%;
+    line-height: 1.2;
+    text-align: center;
+    overflow-wrap: anywhere;
+}
 .text-success { color: var(--success); }
 .text-muted { color: var(--text-muted); }
 

--- a/cms/templates/event_log.html
+++ b/cms/templates/event_log.html
@@ -62,7 +62,7 @@
 {%- endmacro %}
 
 <div class="card">
-    <table style="table-layout: fixed; width: 100%;">
+    <table class="event-log-table" style="table-layout: fixed; width: 100%;">
         <thead>
             <tr>
                 <th style="width:2rem;"></th>


### PR DESCRIPTION
Two small event-log polish fixes.

### 1. Group column always showed dash
`cms/routers/wps_webhook.py` was building `InboundContext` with `group_name=''` hardcoded. Since the entire Pi fleet runs over WPS in prod, every lifecycle `DeviceEvent` row (online/offline, upgrade started/complete/failed, etc.) persisted an empty `group_name` and the event log Group column rendered an em-dash regardless of whether the device was in a group.

Fix mirrors the lookup the `device_reconnected` register branch already does ~70 lines earlier: `SELECT name FROM device_groups WHERE id = device.group_id` when `group_id` is set, then pass the result into `InboundContext` instead of the empty string.

Old rows will continue to render an em-dash - only new events written after this deploys will populate the column. Not worth a backfill migration for cosmetic-only history.

### 2. Long Event badges overflowed into Device column
Some of the new `Upgrade ...` badges are wide enough that on a narrow viewport they pushed past the 12% fixed-width Event column and ran into the Device column.

Added a scoped CSS rule (`.event-log-table .badge`) that allows wrapping inside the badge pill, plus `class=event-log-table` on the table element so the rule only affects the event log (Status badges elsewhere are unchanged).

### Tests
36 tests in `test_wps_webhook.py` pass.
