### PR TITLE
Fix #618: surface 'No Targets' on dashboard when schedule's group has no devices

### DIFF
--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -526,8 +526,17 @@ def get_upcoming_schedules(
             # so a single-target schedule ends up here rather than in
             # schedule_wide.)
             sid_str = str(s.id)
-            targets = _targets_by_sched.get(sid_str)
-            if targets:
+            # Empty-group / no-adopted-targets check.  When the caller
+            # supplies ``target_devices_by_schedule`` and this schedule
+            # resolves to zero adopted targets (group has no devices,
+            # only non-adopted devices, or schedule has no group at
+            # all), the schedule cannot start.  Surface explicitly so
+            # the dashboard doesn't sit on "Starting…" forever (#618).
+            if target_devices_by_schedule is not None:
+                targets = _targets_by_sched.get(sid_str, set())
+                if not targets:
+                    results.append(_no_targets_entry(s, local_now))
+                    continue
                 if all((sid_str, did) in _per_device_skipped for did in targets):
                     continue
             # Check if genuinely preempted (higher-priority schedule active on same target)
@@ -710,6 +719,41 @@ def _starting_entry(s: Schedule, local_now: datetime) -> dict:
         "starts_in_seconds": 0,
         "day_label": "today",
         "starting": True,
+    }
+
+
+def _no_targets_entry(s: Schedule, local_now: datetime) -> dict:
+    """Build an entry for a schedule whose group has no adopted devices.
+
+    Same shape as :func:`_starting_entry` so the dashboard can render
+    it in the Coming Up section, but marked ``no_targets=True`` (and
+    ``starting=False``) so the template surfaces a "No Targets" badge
+    instead of the pulsing "Starting…" badge that implies imminent
+    playback.  See #618.
+    """
+    start_dt = datetime.combine(local_now.date(), s.start_time)
+    end_dt = datetime.combine(local_now.date(), s.end_time)
+    if s.end_time <= s.start_time:
+        end_dt += timedelta(days=1)
+    duration_mins = int((end_dt - start_dt).total_seconds() / 60)
+    duration_secs = int((end_dt - start_dt).total_seconds())
+
+    target_name = s.group.name if s.group else None
+
+    return {
+        "schedule_name": s.name,
+        "asset_filename": _asset_display_name(s.asset),
+        "target_name": target_name or "—",
+        "target_type": "group",
+        "start_time": s.start_time.strftime("%I:%M %p").lstrip("0"),
+        "end_time": s.end_time.strftime("%I:%M %p").lstrip("0"),
+        "duration_mins": duration_mins,
+        "duration_secs": duration_secs,
+        "countdown": "no_targets",
+        "starts_in_seconds": 0,
+        "day_label": "today",
+        "starting": False,
+        "no_targets": True,
     }
 
 

--- a/cms/templates/dashboard.html
+++ b/cms/templates/dashboard.html
@@ -247,13 +247,13 @@
         </thead>
         <tbody>
             {% for u in upcoming_today %}
-            <tr{% if u.preempted %} class="preempted-row"{% elif u.device_offline %} class="starting-row"{% elif u.starting %} class="starting-row"{% endif %}>
+            <tr{% if u.preempted %} class="preempted-row"{% elif u.no_targets %} class="starting-row"{% elif u.device_offline %} class="starting-row"{% elif u.starting %} class="starting-row"{% endif %}>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.schedule_name }}</span><span class="tooltip">{{ u.schedule_name }}</span></span>{% if u.preempted %} <span class="badge badge-preempted">preempted</span>{% endif %}</td>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.target_name }}</span><span class="tooltip">{{ u.target_name }}</span></span>{% if u.target_type == 'group' %} <span class="badge badge-builtin">group</span>{% endif %}</td>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.asset_filename }}</span><span class="tooltip">{{ u.asset_filename }}</span></span></td>
                 <td>{{ u.start_time }} – {{ u.end_time }}</td>
                 <td>{% if u.duration_secs < 60 %}{{ u.duration_secs }} second{{ 's' if u.duration_secs != 1 else '' }}{% elif u.duration_mins >= 60 %}{{ u.duration_mins // 60 }} hour{{ 's' if u.duration_mins // 60 != 1 else '' }}{% if u.duration_mins % 60 %}, {{ u.duration_mins % 60 }} minute{{ 's' if u.duration_mins % 60 != 1 else '' }}{% endif %}{% else %}{{ u.duration_mins }} minute{{ 's' if u.duration_mins != 1 else '' }}{% endif %}</td>
-                <td class="{% if u.preempted %}text-warning{% elif u.device_offline or u.starting %}{% else %}text-success{% endif %}">{% if u.device_offline %}<span class="badge badge-offline">Device Offline</span>{% elif u.starting %}<span class="badge badge-started pulse-badge">Starting…</span>{% else %}{{ u.countdown }}{% if u.resumes_at %} <small>({{ u.resumes_at }})</small>{% endif %}{% endif %}</td>
+                <td class="{% if u.preempted %}text-warning{% elif u.no_targets or u.device_offline or u.starting %}{% else %}text-success{% endif %}">{% if u.no_targets %}<span class="has-tooltip"><span class="badge badge-offline">No Targets</span><span class="tooltip">This schedule's group has no devices — add a device to the group to start playback</span></span>{% elif u.device_offline %}<span class="badge badge-offline">Device Offline</span>{% elif u.starting %}<span class="badge badge-started pulse-badge">Starting…</span>{% else %}{{ u.countdown }}{% if u.resumes_at %} <small>({{ u.resumes_at }})</small>{% endif %}{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -275,13 +275,13 @@
         </thead>
         <tbody>
             {% for u in upcoming_tomorrow %}
-            <tr{% if u.preempted %} class="preempted-row"{% elif u.device_offline %} class="starting-row"{% elif u.starting %} class="starting-row"{% endif %}>
+            <tr{% if u.preempted %} class="preempted-row"{% elif u.no_targets %} class="starting-row"{% elif u.device_offline %} class="starting-row"{% elif u.starting %} class="starting-row"{% endif %}>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.schedule_name }}</span><span class="tooltip">{{ u.schedule_name }}</span></span>{% if u.preempted %} <span class="badge badge-preempted">preempted</span>{% endif %}</td>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.target_name }}</span><span class="tooltip">{{ u.target_name }}</span></span>{% if u.target_type == 'group' %} <span class="badge badge-builtin">group</span>{% endif %}</td>
                 <td><span class="has-tooltip"><span class="cell-truncate-text">{{ u.asset_filename }}</span><span class="tooltip">{{ u.asset_filename }}</span></span></td>
                 <td>{{ u.start_time }} – {{ u.end_time }}</td>
                 <td>{% if u.duration_secs < 60 %}{{ u.duration_secs }} second{{ 's' if u.duration_secs != 1 else '' }}{% elif u.duration_mins >= 60 %}{{ u.duration_mins // 60 }} hour{{ 's' if u.duration_mins // 60 != 1 else '' }}{% if u.duration_mins % 60 %}, {{ u.duration_mins % 60 }} minute{{ 's' if u.duration_mins % 60 != 1 else '' }}{% endif %}{% else %}{{ u.duration_mins }} minute{{ 's' if u.duration_mins != 1 else '' }}{% endif %}</td>
-                <td class="{% if u.preempted %}text-warning{% elif u.device_offline or u.starting %}{% else %}text-muted{% endif %}">{% if u.device_offline %}<span class="badge badge-offline">Device Offline</span>{% elif u.starting %}<span class="badge badge-started pulse-badge">Starting…</span>{% else %}{{ u.countdown }}{% if u.resumes_at %} <small>({{ u.resumes_at }})</small>{% endif %}{% endif %}</td>
+                <td class="{% if u.preempted %}text-warning{% elif u.no_targets or u.device_offline or u.starting %}{% else %}text-muted{% endif %}">{% if u.no_targets %}<span class="has-tooltip"><span class="badge badge-offline">No Targets</span><span class="tooltip">This schedule's group has no devices — add a device to the group to start playback</span></span>{% elif u.device_offline %}<span class="badge badge-offline">Device Offline</span>{% elif u.starting %}<span class="badge badge-started pulse-badge">Starting…</span>{% else %}{{ u.countdown }}{% if u.resumes_at %} <small>({{ u.resumes_at }})</small>{% endif %}{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -375,7 +375,7 @@ async function endNow(scheduleId, deviceId) {
             pending: (data.pending_ids || []).sort(),
             orphaned: (data.orphaned_ids || []).sort(),
             offline: (data.offline_ids || []).sort(),
-            upcoming: (data.upcoming || []).map(u => u.schedule_name + ':' + u.day_label + (u.device_offline ? ':offline' : u.starting ? ':starting' : u.preempted ? ':preempted' : '')).sort(),
+            upcoming: (data.upcoming || []).map(u => u.schedule_name + ':' + u.day_label + (u.no_targets ? ':notargets' : u.device_offline ? ':offline' : u.starting ? ':starting' : u.preempted ? ':preempted' : '')).sort(),
         });
     }
 

--- a/tests/test_per_device_skip_upcoming.py
+++ b/tests/test_per_device_skip_upcoming.py
@@ -115,12 +115,12 @@ class TestPerDeviceSkipHidesSchedule:
         assert len(result) == 1
         assert result[0]["starting"] is True
 
-    def test_targets_only_pending_devices_does_not_hide(self):
-        """If ADOPTED target set is empty (e.g. all devices pending),
-        ``target_devices_by_schedule`` maps to an empty set — the
-        per-device branch's ``all(...)`` on empty is True, but the
-        helper returns an empty set only when group has no ADOPTED
-        devices.  Guard: we only filter when ``targets`` is truthy."""
+    def test_empty_target_set_emits_no_targets_entry(self):
+        """When a schedule's group has no adopted devices,
+        ``target_devices_by_schedule`` maps to an empty set.  The
+        dashboard should surface this as a "No Targets" badge instead
+        of getting stuck on "Starting…" forever (issue #618).
+        """
         gid = uuid.uuid4()
         s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="empty-targets")
         now = _noon_utc()
@@ -129,6 +129,23 @@ class TestPerDeviceSkipHidesSchedule:
             per_device_skipped=set(),
             target_devices_by_schedule={str(s.id): set()},
         )
-        # Empty targets → per-device branch skipped → legacy "starting"
         assert len(result) == 1
-        assert result[0]["starting"] is True
+        assert result[0]["no_targets"] is True
+        assert result[0]["starting"] is False
+        assert result[0]["countdown"] == "no_targets"
+
+    def test_empty_target_set_no_per_device_arg(self):
+        """No per-device skip arg, just empty targets — still emits
+        no_targets so callers that only pass target_devices_by_schedule
+        (e.g. the dashboard JSON endpoint) get the right entry.
+        """
+        gid = uuid.uuid4()
+        s = _make_schedule(time(8, 0), time(17, 0), group_id=gid, name="empty-targets-2")
+        now = _noon_utc()
+        result = get_upcoming_schedules(
+            [s], now, UTC, now_playing=[],
+            target_devices_by_schedule={str(s.id): set()},
+        )
+        assert len(result) == 1
+        assert result[0]["no_targets"] is True
+


### PR DESCRIPTION
Closes #618

Previously, a schedule whose group had zero devices would sit on the pulsing `Starting…` badge in Coming Up forever — the scheduler had no winner to surface and no signal that the schedule literally could not run.

## Changes

- `cms/services/scheduler.py`: `get_upcoming_schedules` now checks whether `target_devices_by_schedule` resolves to an empty set for a now-active schedule and emits a new `_no_targets_entry` (same shape as `_starting_entry` but with `no_targets=True`, `starting=False`). Guarded on `target_devices_by_schedule is not None` so legacy callers / tests are unaffected.
- `cms/templates/dashboard.html`: both Today and Tomorrow upcoming sections render the new `no_targets` state as a 'No Targets' badge with a tooltip ('This schedule's group has no devices — add a device to the group to start playback'). JS polling fingerprint at line 378 includes `:notargets` so state flips trigger a re-render.
- `tests/test_per_device_skip_upcoming.py`: replaced the test that asserted the old (buggy) 'starting' behavior with two new tests asserting `no_targets=True` is emitted (with and without `per_device_skipped` arg).

## Follow-up (intentionally out of scope)

Bug body suggested a save-time warning on the schedule form when the chosen group has zero devices. Scoped this PR to the dashboard surface only — happy to do the form warning as a follow-up.