### PR TITLE
Composed Slide Phase 0: foundation models + registry + validator (no UI)

### DIFF
--- a/alembic/versions/0037_composed_slides.py
+++ b/alembic/versions/0037_composed_slides.py
@@ -1,0 +1,111 @@
+"""Alembic migration 0037 — composed_slides table + AssetType.COMPOSED.
+
+Backs the new Composed Slide asset type.  See
+:mod:`cms.models.composed_slide` and ``plan.md`` for the design.
+
+The AssetType enum is extended with a new value, ``composed``.  On
+Postgres this requires an explicit ``ALTER TYPE``; SQLite stores the
+enum as a plain string so no DDL is needed there.
+
+Revision ID: 0037
+Revises: 0036
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def _json_type(bind):
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.JSONB()
+    return sa.JSON()
+
+
+def _uuid_array_type(bind):
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.ARRAY(
+            sa.dialects.postgresql.UUID(as_uuid=True)
+        )
+    # SQLite has no array; store the list as JSON.
+    return sa.JSON()
+
+
+def _uuid_type(bind):
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.UUID(as_uuid=True)
+    # SQLite: 36-char string holds the UUID hex form.
+    return sa.String(length=36)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ── Extend the AssetType enum (Postgres only) ─────────────────
+    # ALTER TYPE ... ADD VALUE is not transactional in older PG
+    # versions; run it on the connection directly so Alembic doesn't
+    # wrap it in a transaction it can't honour.
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'composed'")
+
+    # ── composed_slides table ────────────────────────────────────
+    op.create_table(
+        "composed_slides",
+        sa.Column("id", _uuid_type(bind), primary_key=True, nullable=False),
+        sa.Column(
+            "asset_id",
+            _uuid_type(bind),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("layout_json", _json_type(bind), nullable=False),
+        sa.Column(
+            "schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+        sa.Column(
+            "is_draft",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("last_ai_prompt", sa.Text(), nullable=True),
+        sa.Column("last_ai_model", sa.Text(), nullable=True),
+        sa.Column("bundle_built_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("bundle_source_asset_ids", _uuid_array_type(bind), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "ix_composed_slides_asset_id",
+        "composed_slides",
+        ["asset_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    # Postgres can't drop a single value from an enum, and we're not
+    # going to ship a downgrade path that orphans composed assets.
+    # Drop the table only; the unused enum value is harmless.
+    raise NotImplementedError("downgrade of 0037 is not supported")

--- a/alembic/versions/0037_composed_slides.py
+++ b/alembic/versions/0037_composed_slides.py
@@ -64,7 +64,6 @@ def upgrade() -> None:
             _uuid_type(bind),
             sa.ForeignKey("assets.id", ondelete="CASCADE"),
             nullable=False,
-            unique=True,
         ),
         sa.Column("layout_json", _json_type(bind), nullable=False),
         sa.Column(

--- a/cms/composed/__init__.py
+++ b/cms/composed/__init__.py
@@ -1,0 +1,16 @@
+"""Composed Slide subsystem.
+
+Modules:
+
+* :mod:`cms.composed.schema` — Pydantic layout / cell / widget-instance
+  schemas. Locked-in v1 constraints: fixed 1920×1080 canvas, fixed
+  12×8 grid.
+* :mod:`cms.composed.registry` — widget plugin contract + global
+  registry. Every widget subclasses :class:`Widget`.
+* :mod:`cms.composed.validate` — semantic layout validator. Runs in
+  addition to Pydantic shape validation on save, on AI output, and
+  defensively at bundle build time.
+
+Phase 1A adds ``cms.composed.bundle`` (the self-contained HTML
+builder).  Phase 1B+ adds widgets under ``cms.composed.widgets.``.
+"""

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -1,0 +1,162 @@
+"""Widget plugin contract + global registry.
+
+Every widget lives in ``cms/composed/widgets/<slug>.py`` and subclasses
+:class:`Widget`.  The registry discovers all widgets at import time
+(Phase 1B wires the auto-import; for Phase 0 only the abstract base
+and an explicit ``register`` API ship).
+
+See ``plan.md`` for the full design.  The non-obvious rules:
+
+* Every widget must scope its DOM IDs and CSS classes to
+  ``instance_id``.  The bundle builder will fail-loud if a widget
+  emits a non-scoped selector for a class it also emits in ``css``.
+* ``WidgetRender.referenced_asset_ids`` enables stale-bundle detection
+  (the builder records the union of these alongside ``bundle_built_at``).
+* ``migrate_config`` defaults to identity.  Bump ``config_version`` on
+  any breaking change to the widget's config shape and provide a
+  migration so older saved layouts continue to load.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel
+
+from cms.composed.schema import Cell
+
+
+@dataclass
+class WidgetStaticAsset:
+    """A binary or text asset the widget needs in the bundle.
+
+    The bundle builder is responsible for inlining these (data URIs
+    for binary content; embedded ``<style>`` / ``<script>`` blocks
+    for text content).  De-duped across instances by content hash.
+    """
+
+    kind: Literal["font", "image", "js", "css"]
+    content: bytes | str
+    mime: str
+
+
+@dataclass
+class WidgetRender:
+    """Result of a widget's ``render_html`` call.
+
+    Returned to the bundle builder, which assembles the final
+    single-file HTML.  Instance-scoping is the widget's responsibility
+    (see module docstring).
+    """
+
+    html: str
+    css: str = ""
+    js: str = ""
+    init_js: str | None = None
+    static_assets: list[WidgetStaticAsset] = field(default_factory=list)
+    referenced_asset_ids: list[uuid.UUID] = field(default_factory=list)
+
+
+class Widget:
+    """Base class every widget plugin extends.
+
+    Subclasses MUST set ``slug``, ``display_name``, ``icon``, and
+    ``ConfigSchema``.  ``config_version`` defaults to 1; bump it on
+    breaking config changes and supply ``migrate_config``.
+
+    All instance methods receive validated config + a stable
+    ``instance_id``.  Widgets must scope DOM/CSS to that ID — see the
+    "Instance scoping rule" in plan.md.
+    """
+
+    # Subclasses override these as plain class attributes.
+    slug: ClassVar[str]
+    display_name: ClassVar[str]
+    icon: ClassVar[str]
+    ConfigSchema: ClassVar[type[BaseModel]]
+    config_version: ClassVar[int] = 1
+
+    # ── Mandatory overrides ──────────────────────────────────────
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+    ) -> WidgetRender:
+        raise NotImplementedError
+
+    def editor_template(self) -> str:
+        """Path (relative to the Jinja loader) to the settings panel."""
+        raise NotImplementedError
+
+    def default_config(self) -> dict:
+        """Config dict for a newly-dropped widget.
+
+        Must validate against ``ConfigSchema``.
+        """
+        raise NotImplementedError
+
+    # ── Optional overrides ───────────────────────────────────────
+    def migrate_config(self, raw: dict, from_version: int) -> dict:
+        """Upgrade an older config dict to ``config_version``.
+
+        Default is identity (safe for additive changes guarded by
+        ``Optional`` fields with sensible defaults).  Override on
+        renames, removals, or required-field additions.
+        """
+        return raw
+
+    def validate_semantic(self, config: BaseModel) -> list[str]:
+        """Cross-field / external checks beyond Pydantic shape.
+
+        Examples: a referenced asset ID exists, a referenced asset is
+        of the expected type, an URL matches the allowlist.  Return a
+        list of human-readable error messages; empty list = ok.
+
+        Default: no extra checks.
+        """
+        return []
+
+
+class WidgetRegistry:
+    """In-process registry of available widget plugins.
+
+    The default :func:`get_registry` returns a process-wide singleton.
+    Tests can construct a fresh registry to isolate plugin sets.
+    """
+
+    def __init__(self) -> None:
+        self._widgets: dict[str, Widget] = {}
+
+    def register(self, widget: Widget) -> None:
+        slug = widget.slug
+        if not slug:
+            raise ValueError("widget.slug is required")
+        if slug in self._widgets:
+            raise ValueError(f"widget slug already registered: {slug!r}")
+        self._widgets[slug] = widget
+
+    def get(self, slug: str) -> Widget | None:
+        return self._widgets.get(slug)
+
+    def has(self, slug: str) -> bool:
+        return slug in self._widgets
+
+    def slugs(self) -> list[str]:
+        return sorted(self._widgets.keys())
+
+    def all(self) -> list[Widget]:
+        return [self._widgets[s] for s in self.slugs()]
+
+
+# Process-wide registry.  Phase 1A will populate it with the trivial
+# text widget; Phase 1B fills it out.  Phase 0 ships empty so that
+# all behaviour (including "unknown widget type" rejection) is
+# testable without committing to any specific widget implementations.
+_REGISTRY = WidgetRegistry()
+
+
+def get_registry() -> WidgetRegistry:
+    return _REGISTRY

--- a/cms/composed/schema.py
+++ b/cms/composed/schema.py
@@ -1,0 +1,189 @@
+"""Pydantic schemas for the Composed Slide layout document.
+
+The layout document is the single source of truth for a composed
+slide's authoring state.  It is stored as-is in
+``composed_slides.layout_json`` and is the input to both the live
+preview endpoint and the offline bundle builder.
+
+v1 constraints (locked in 2026-06-03, see ``plan.md``):
+
+* Canvas is fixed at 1920×1080 (16:9).  Per-device profiles are
+  deferred to a future major schema bump.
+* Grid is fixed at 12 columns × 8 rows.  Snap-to-cell editor.
+* No layering / z-index.  Cells must not overlap; the semantic
+  validator (:mod:`cms.composed.validate`) enforces this.
+
+The actual content of a widget's ``config`` dict is opaque at this
+layer — each widget defines its own ``ConfigSchema``.  The
+validator dispatches per-instance via the registry to validate
+configs in their widget's terms.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+# ── Locked-in v1 constants ────────────────────────────────────────────
+# These are intentionally not configurable in the schema.  Changing
+# them is a breaking change that requires a ``schema_version`` bump
+# and a per-widget migration story.
+
+CANVAS_WIDTH = 1920
+CANVAS_HEIGHT = 1080
+GRID_COLS = 12
+GRID_ROWS = 8
+SCHEMA_VERSION = 1
+
+
+class Cell(BaseModel):
+    """A widget instance's placement on the snap grid.
+
+    Coordinates are 1-indexed and inclusive on both ends (matching CSS
+    grid-row / grid-column semantics).  ``row=1, col=1, rowspan=1,
+    colspan=1`` is the top-left cell occupying exactly one grid cell.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    row: int = Field(..., ge=1, le=GRID_ROWS)
+    col: int = Field(..., ge=1, le=GRID_COLS)
+    rowspan: int = Field(default=1, ge=1, le=GRID_ROWS)
+    colspan: int = Field(default=1, ge=1, le=GRID_COLS)
+
+
+class WidgetInstance(BaseModel):
+    """One placed widget in a composed-slide layout.
+
+    ``id`` is a stable UUID assigned by the editor on widget drop and
+    persisted thereafter.  The bundle builder uses it to scope DOM
+    IDs and CSS classes (see ``plan.md`` — Instance scoping rule).
+
+    ``type`` is the widget slug (e.g. ``"text"``, ``"clock"``); it
+    must match a widget registered in :mod:`cms.composed.registry`.
+    The semantic validator rejects layouts that reference an unknown
+    type.
+
+    ``config`` is the widget-specific config dict, validated by the
+    registered widget's ``ConfigSchema`` and ``validate_semantic``
+    hook in :func:`cms.composed.validate.validate_layout`.
+
+    ``config_version`` is recorded at save time from the widget's
+    current ``config_version``.  On load, mismatched versions are
+    upgraded via the widget's ``migrate_config`` hook and re-persisted.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: uuid.UUID
+    type: str = Field(..., min_length=1, max_length=64)
+    cell: Cell
+    config: dict = Field(default_factory=dict)
+    config_version: int = Field(default=1, ge=1)
+
+    @field_validator("type")
+    @classmethod
+    def _type_slug_shape(cls, v: str) -> str:
+        # Slugs are lower-snake to match the on-disk widget module
+        # filenames (``cms/composed/widgets/<slug>.py``) and to keep
+        # them safe for use in CSS class names / DOM IDs.
+        if not v.replace("_", "").isalnum() or not v.islower():
+            raise ValueError(
+                "widget type slug must be lowercase alphanumeric with optional underscores"
+            )
+        return v
+
+
+class Background(BaseModel):
+    """Slide-wide background settings.
+
+    v1 supports a solid colour only.  Image / gradient backgrounds
+    are deferred.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    color: str = Field(default="#000000", pattern=r"^#[0-9a-fA-F]{6}$")
+
+
+class Grid(BaseModel):
+    """Locked grid dimensions.
+
+    Pinned in the schema so any layout JSON that disagrees is
+    rejected at load time — protects us from old clients writing
+    layouts with a different grid after a schema bump.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rows: int = Field(default=GRID_ROWS)
+    cols: int = Field(default=GRID_COLS)
+
+    @field_validator("rows")
+    @classmethod
+    def _rows_locked(cls, v: int) -> int:
+        if v != GRID_ROWS:
+            raise ValueError(f"grid.rows must be {GRID_ROWS} in schema v{SCHEMA_VERSION}")
+        return v
+
+    @field_validator("cols")
+    @classmethod
+    def _cols_locked(cls, v: int) -> int:
+        if v != GRID_COLS:
+            raise ValueError(f"grid.cols must be {GRID_COLS} in schema v{SCHEMA_VERSION}")
+        return v
+
+
+class Canvas(BaseModel):
+    """Locked canvas pixel dimensions (1920×1080)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    width: int = Field(default=CANVAS_WIDTH)
+    height: int = Field(default=CANVAS_HEIGHT)
+
+    @field_validator("width")
+    @classmethod
+    def _w_locked(cls, v: int) -> int:
+        if v != CANVAS_WIDTH:
+            raise ValueError(f"canvas.width must be {CANVAS_WIDTH} in schema v{SCHEMA_VERSION}")
+        return v
+
+    @field_validator("height")
+    @classmethod
+    def _h_locked(cls, v: int) -> int:
+        if v != CANVAS_HEIGHT:
+            raise ValueError(f"canvas.height must be {CANVAS_HEIGHT} in schema v{SCHEMA_VERSION}")
+        return v
+
+
+class Layout(BaseModel):
+    """Top-level composed-slide layout document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=SCHEMA_VERSION)
+    canvas: Canvas = Field(default_factory=Canvas)
+    grid: Grid = Field(default_factory=Grid)
+    background: Background = Field(default_factory=Background)
+    widgets: list[WidgetInstance] = Field(default_factory=list)
+
+    @field_validator("schema_version")
+    @classmethod
+    def _schema_version_supported(cls, v: int) -> int:
+        # The Pydantic layer only accepts the *current* version.
+        # Migration from older versions is handled in a separate
+        # ``load_and_migrate`` path (not yet wired up — Phase 1B
+        # introduces the first config-version bump worth migrating).
+        if v != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported layout schema_version {v}; current is {SCHEMA_VERSION}"
+            )
+        return v
+
+
+def empty_layout() -> Layout:
+    """Return a fresh empty layout for a brand-new composed slide."""
+    return Layout()

--- a/cms/composed/validate.py
+++ b/cms/composed/validate.py
@@ -1,0 +1,172 @@
+"""Semantic layout validator.
+
+Pydantic only validates the *shape* of a layout document.  This
+module adds the cross-cutting and per-widget checks the editor, the
+AI generate endpoint, and (defensively) the bundle builder all need:
+
+* Cells fit within grid bounds (also enforced by Pydantic for single
+  cells, but rowspan/colspan can still push past the edge).
+* No overlapping cells (v1 has no z-index).
+* Every widget instance's ``type`` is in the registry.
+* Per-widget config validates against ``ConfigSchema`` and the
+  widget's own ``validate_semantic`` hook.
+* Widget instance IDs are unique within the layout.
+
+The validator returns a list of :class:`ValidationError` rather than
+raising, so the editor can surface multiple problems at once.
+Empty list = ok.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import ValidationError as PydanticValidationError
+
+from cms.composed.registry import Widget, WidgetRegistry, get_registry
+from cms.composed.schema import GRID_COLS, GRID_ROWS, Cell, Layout, WidgetInstance
+
+
+@dataclass
+class ValidationError:
+    """One human-readable layout problem.
+
+    ``widget_id`` is set when the problem is scoped to a specific
+    widget instance; ``None`` for layout-wide issues (e.g. overlaps).
+    """
+
+    code: str
+    message: str
+    widget_id: str | None = None
+
+
+def _cell_cells(cell: Cell) -> set[tuple[int, int]]:
+    """Expand a Cell into the set of (row, col) tuples it occupies."""
+    return {
+        (r, c)
+        for r in range(cell.row, cell.row + cell.rowspan)
+        for c in range(cell.col, cell.col + cell.colspan)
+    }
+
+
+def _cell_out_of_bounds(cell: Cell) -> bool:
+    return (
+        cell.row + cell.rowspan - 1 > GRID_ROWS
+        or cell.col + cell.colspan - 1 > GRID_COLS
+    )
+
+
+def _validate_one_widget(
+    instance: WidgetInstance,
+    widget: Widget,
+) -> list[ValidationError]:
+    """Run Pydantic + semantic validation on one widget's config."""
+    errors: list[ValidationError] = []
+
+    try:
+        config_model = widget.ConfigSchema.model_validate(instance.config)
+    except PydanticValidationError as exc:
+        for err in exc.errors():
+            loc = ".".join(str(p) for p in err.get("loc", ()))
+            errors.append(
+                ValidationError(
+                    code="widget_config_shape",
+                    message=f"{loc or 'config'}: {err.get('msg', 'invalid')}",
+                    widget_id=str(instance.id),
+                )
+            )
+        # If shape is wrong, semantic validation will likely also fail
+        # in confusing ways — stop here for this widget.
+        return errors
+
+    for msg in widget.validate_semantic(config_model):
+        errors.append(
+            ValidationError(
+                code="widget_config_semantic",
+                message=msg,
+                widget_id=str(instance.id),
+            )
+        )
+
+    return errors
+
+
+def validate_layout(
+    layout: Layout,
+    registry: WidgetRegistry | None = None,
+) -> list[ValidationError]:
+    """Validate a layout against the registry; return all problems."""
+    reg = registry if registry is not None else get_registry()
+    errors: list[ValidationError] = []
+
+    # ── Widget instance ID uniqueness ───────────────────────────
+    seen_ids: set[str] = set()
+    for inst in layout.widgets:
+        wid = str(inst.id)
+        if wid in seen_ids:
+            errors.append(
+                ValidationError(
+                    code="duplicate_widget_id",
+                    message=f"duplicate widget instance id {wid}",
+                    widget_id=wid,
+                )
+            )
+        seen_ids.add(wid)
+
+    # ── Per-widget bounds + per-cell ownership ──────────────────
+    # Map every occupied (row,col) → widget id so we can report
+    # *which* two widgets collide instead of just "something overlaps".
+    occupied: dict[tuple[int, int], str] = {}
+    for inst in layout.widgets:
+        wid = str(inst.id)
+
+        if _cell_out_of_bounds(inst.cell):
+            errors.append(
+                ValidationError(
+                    code="cell_out_of_bounds",
+                    message=(
+                        f"widget {wid} occupies "
+                        f"({inst.cell.row},{inst.cell.col}) "
+                        f"+{inst.cell.rowspan}x{inst.cell.colspan} "
+                        f"which extends past the {GRID_ROWS}x{GRID_COLS} grid"
+                    ),
+                    widget_id=wid,
+                )
+            )
+            # Don't try to mark cells for an out-of-bounds widget —
+            # we'd just generate noise.  Move on.
+            continue
+
+        for rc in _cell_cells(inst.cell):
+            existing = occupied.get(rc)
+            if existing is not None and existing != wid:
+                errors.append(
+                    ValidationError(
+                        code="cells_overlap",
+                        message=(
+                            f"widgets {existing} and {wid} both occupy "
+                            f"cell ({rc[0]},{rc[1]})"
+                        ),
+                        widget_id=wid,
+                    )
+                )
+            else:
+                occupied[rc] = wid
+
+    # ── Per-widget config validation via registry ───────────────
+    for inst in layout.widgets:
+        wid = str(inst.id)
+        widget = reg.get(inst.type)
+        if widget is None:
+            errors.append(
+                ValidationError(
+                    code="unknown_widget_type",
+                    message=f"widget {wid}: unknown widget type {inst.type!r}",
+                    widget_id=wid,
+                )
+            )
+            continue
+
+        errors.extend(_validate_one_widget(inst, widget))
+
+    return errors

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -25,6 +25,7 @@ from cms.models.asset_view import AssetView  # noqa: F401
 from cms.models.chat_message import ChatMessage  # noqa: F401
 from cms.models.chat_pending_approval import ChatPendingApproval  # noqa: F401
 from cms.models.chat_thread import ChatThread  # noqa: F401
+from cms.models.composed_slide import ComposedSlide  # noqa: F401
 from cms.models.user import Role, User, UserGroup  # noqa: F401
 
 # ── CMS-only relationships ──

--- a/cms/models/composed_slide.py
+++ b/cms/models/composed_slide.py
@@ -1,0 +1,105 @@
+"""ComposedSlide model — backing data for a Composed Slide asset.
+
+A *composed slide* is a CMS-authored multi-widget canvas (text, image,
+clock, ticker, video, ...) that is rendered to a single self-contained
+HTML bundle and shipped to devices like any other cacheable asset.
+
+One row in this table is bound 1:1 to an :class:`Asset` row of
+:attr:`AssetType.COMPOSED`.  The asset row carries the cache metadata
+(``url``, ``size_bytes``, ``checksum``); this row carries the
+authoring state: the layout JSON, draft flag, AI prompt history, and
+bundle build metadata used to detect when the bundle is stale w.r.t.
+its source assets.
+
+See :mod:`cms.composed` for the schema, registry, validator, and
+(later) bundle builder.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Boolean, Text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+from shared.database import Base
+
+
+# Use JSONB on Postgres, JSON on SQLite (used in unit tests).  The
+# SQLAlchemy type-decorator pattern is `JSONB().with_variant(JSON(),
+# "sqlite")`, which gives us JSONB perf in prod and a working column
+# in the test matrix.
+_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+# bundle_source_asset_ids is a Postgres ARRAY(UUID) so we can do
+# set-membership queries like "all composed slides that reference
+# asset X" cheaply.  On SQLite we fall back to JSON storage of the
+# same list; the application code reads it as a Python list either
+# way.
+_UUID_ARRAY = ARRAY(PG_UUID(as_uuid=True)).with_variant(JSON(), "sqlite")
+
+
+class ComposedSlide(Base):
+    """Authoring + bundle-metadata row for a Composed Slide asset."""
+
+    __tablename__ = "composed_slides"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # One composed_slide per asset, cascade-deleted with the asset.
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("assets.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    # The full layout document.  Shape is validated by
+    # :class:`cms.composed.schema.Layout` (Pydantic) on every write;
+    # ``schema_version`` mirrors ``Layout.schema_version`` and is
+    # denormalized here so we can filter / migrate rows without
+    # parsing every JSON blob.
+    layout_json: Mapped[dict] = mapped_column(_JSON, nullable=False)
+    schema_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+
+    # Draft state — True until the user explicitly publishes.  The
+    # bundle builder refuses to publish a draft layout to the asset
+    # cache; it can still be live-previewed.
+    is_draft: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+
+    # Last AI prompt used to (re)generate this layout, kept for
+    # debugging / future "rerun with tweak" UX.  NULL for hand-built
+    # layouts.  ``last_ai_model`` stores deployment + model + date so
+    # we can correlate output quality with a specific AOAI revision.
+    last_ai_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_ai_model: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Bundle build metadata.  ``bundle_built_at`` is set whenever the
+    # builder writes a fresh HTML bundle to the asset cache;
+    # ``bundle_source_asset_ids`` records every referenced asset at
+    # build time so the editor can detect "source X changed since the
+    # bundle was last built" and prompt for a rebuild.
+    bundle_built_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    bundle_source_asset_ids: Mapped[list[uuid.UUID] | None] = mapped_column(
+        _UUID_ARRAY, nullable=True
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    asset = relationship("Asset", foreign_keys=[asset_id])

--- a/cms/models/composed_slide.py
+++ b/cms/models/composed_slide.py
@@ -18,7 +18,7 @@ See :mod:`cms.composed` for the schema, registry, validator, and
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Boolean, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, Boolean, Text, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
@@ -94,12 +94,17 @@ class ComposedSlide(Base):
     )
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("CURRENT_TIMESTAMP"),
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
+        server_default=text("CURRENT_TIMESTAMP"),
     )
 
     asset = relationship("Asset", foreign_keys=[asset_id])

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -190,7 +190,7 @@
 <input type="hidden" id="_tz" value="{{ current_timezone }}">
 <input type="hidden" id="_tzOptions" value='{{ tz_options | tojson }}'>
 <script>
-const ASSET_ICONS = {"video": "🎬", "image": "📷", "webpage": "🌐", "stream": "📡", "saved_stream": "📼", "slideshow": "🎞️"};
+const ASSET_ICONS = {"video": "🎬", "image": "📷", "webpage": "🌐", "stream": "📡", "saved_stream": "📼", "slideshow": "🎞️", "composed": "🧩"};
 const _scheduleData = {
     assets: [{% for a in assets %}{"id":"{{ a.id }}","name":"{{ a.display_name or a.original_filename or a.filename }}","type":"{{ a.asset_type.value }}","duration":{{ a.duration_seconds|default('null', true) if a.duration_seconds else 'null' }},"global":{{ 'true' if a.is_global else 'false' }},"groups":{{ a._group_ids_json | tojson }},"ready":{{ 'true' if a.ready_for_selection else 'false' }},"notReadyReason":{{ (a.not_ready_reason or '') | tojson }}}{% if not loop.last %},{% endif %}{% endfor %}],
     groups: [{% for g in groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}],

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -91,6 +91,7 @@ _ASSET_ICONS = {
     "stream": "📡",
     "saved_stream": "📼",
     "slideshow": "🎞️",
+    "composed": "🧩",
 }
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4364,6 +4364,7 @@ components:
       - stream
       - saved_stream
       - slideshow
+      - composed
       title: AssetType
     AssetUsage:
       properties:

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -18,6 +18,7 @@ class AssetType(str, PyEnum):
     STREAM = "stream"          # live stream — played directly via URL
     SAVED_STREAM = "saved_stream"  # captured stream — downloaded & transcoded for offline playback
     SLIDESHOW = "slideshow"    # synthetic asset — ordered list of image/video sources resolved on the device
+    COMPOSED = "composed"      # CMS-authored multi-widget slide; rendered to a self-contained HTML bundle
 
 
 class VariantStatus(str, PyEnum):

--- a/tests/test_asset_icons.py
+++ b/tests/test_asset_icons.py
@@ -33,6 +33,7 @@ EXPECTED_ICONS = {
     "stream": "📡",
     "saved_stream": "📼",
     "slideshow": "🎞️",
+    "composed": "🧩",
 }
 
 

--- a/tests/test_composed_model.py
+++ b/tests/test_composed_model.py
@@ -1,0 +1,106 @@
+"""Phase 0 tests for the ComposedSlide ORM model."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from cms.composed.schema import empty_layout
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+
+@pytest.mark.asyncio
+async def test_composed_slide_can_be_persisted_and_queried(db_session):
+    asset = Asset(
+        filename="composed-1",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.commit()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=empty_layout().model_dump(mode="json"),
+    )
+    db_session.add(cs)
+    await db_session.commit()
+
+    res = await db_session.execute(
+        select(ComposedSlide).where(ComposedSlide.asset_id == asset.id)
+    )
+    fetched = res.scalar_one()
+    assert fetched.asset_id == asset.id
+    assert fetched.is_draft is True
+    assert fetched.schema_version == 1
+    assert fetched.bundle_built_at is None
+    assert fetched.last_ai_prompt is None
+    assert fetched.layout_json["schema_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_composed_slide_cascade_deletes_with_asset(db_session):
+    asset = Asset(
+        filename="composed-2",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.commit()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=empty_layout().model_dump(mode="json"),
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    cs_id = cs.id
+
+    await db_session.delete(asset)
+    await db_session.commit()
+
+    res = await db_session.execute(
+        select(ComposedSlide).where(ComposedSlide.id == cs_id)
+    )
+    assert res.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_composed_slide_asset_id_is_unique(db_session):
+    from sqlalchemy.exc import IntegrityError
+
+    asset = Asset(
+        filename="composed-3",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.commit()
+
+    db_session.add(
+        ComposedSlide(
+            asset_id=asset.id,
+            layout_json=empty_layout().model_dump(mode="json"),
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        ComposedSlide(
+            asset_id=asset.id,
+            layout_json=empty_layout().model_dump(mode="json"),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+def test_asset_type_includes_composed():
+    assert AssetType.COMPOSED.value == "composed"

--- a/tests/test_composed_schema.py
+++ b/tests/test_composed_schema.py
@@ -1,0 +1,150 @@
+"""Phase 0 tests for composed-slide Pydantic schemas."""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from cms.composed.schema import (
+    CANVAS_HEIGHT,
+    CANVAS_WIDTH,
+    GRID_COLS,
+    GRID_ROWS,
+    SCHEMA_VERSION,
+    Background,
+    Canvas,
+    Cell,
+    Grid,
+    Layout,
+    WidgetInstance,
+    empty_layout,
+)
+
+
+# ── Layout JSON round-trip ────────────────────────────────────────────
+
+
+def test_empty_layout_has_locked_defaults():
+    layout = empty_layout()
+    assert layout.schema_version == SCHEMA_VERSION
+    assert layout.canvas.width == CANVAS_WIDTH
+    assert layout.canvas.height == CANVAS_HEIGHT
+    assert layout.grid.rows == GRID_ROWS
+    assert layout.grid.cols == GRID_COLS
+    assert layout.widgets == []
+    assert layout.background.color == "#000000"
+
+
+def test_layout_round_trips_through_json():
+    original = Layout(
+        widgets=[
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="text",
+                cell=Cell(row=1, col=1, rowspan=2, colspan=3),
+                config={"text": "hello"},
+                config_version=1,
+            )
+        ],
+        background=Background(color="#ff00ff"),
+    )
+    payload = original.model_dump_json()
+    parsed = Layout.model_validate_json(payload)
+    assert parsed == original
+
+    # also via model_dump → dict → model_validate
+    as_dict = json.loads(payload)
+    parsed2 = Layout.model_validate(as_dict)
+    assert parsed2 == original
+
+
+# ── Locked dimensions rejected ────────────────────────────────────────
+
+
+def test_canvas_rejects_non_locked_dimensions():
+    with pytest.raises(PydanticValidationError):
+        Canvas(width=1280, height=720)
+
+
+def test_grid_rejects_non_locked_dimensions():
+    with pytest.raises(PydanticValidationError):
+        Grid(rows=4, cols=6)
+
+
+def test_layout_rejects_unsupported_schema_version():
+    with pytest.raises(PydanticValidationError):
+        Layout(schema_version=999)
+
+
+# ── Cell bounds (Pydantic-level) ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(row=0, col=1),                # row < 1
+        dict(row=1, col=0),                # col < 1
+        dict(row=GRID_ROWS + 1, col=1),    # row > grid
+        dict(row=1, col=GRID_COLS + 1),    # col > grid
+        dict(row=1, col=1, rowspan=0),     # rowspan < 1
+        dict(row=1, col=1, colspan=0),     # colspan < 1
+    ],
+)
+def test_cell_rejects_bad_basic_values(kwargs):
+    with pytest.raises(PydanticValidationError):
+        Cell(**kwargs)
+
+
+def test_cell_accepts_legitimate_values():
+    Cell(row=1, col=1, rowspan=GRID_ROWS, colspan=GRID_COLS)
+
+
+# ── Widget slug shape ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("slug", ["text", "scrolling_ticker", "clock24", "a1b2"])
+def test_widget_type_accepts_valid_slugs(slug):
+    WidgetInstance(
+        id=uuid.uuid4(),
+        type=slug,
+        cell=Cell(row=1, col=1),
+    )
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["Text", "TEXT", "scrolling-ticker", "scrolling ticker", "ticker!", "", "with.dot"],
+)
+def test_widget_type_rejects_invalid_slugs(slug):
+    with pytest.raises(PydanticValidationError):
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type=slug,
+            cell=Cell(row=1, col=1),
+        )
+
+
+# ── extra="forbid" applies to all schemas ────────────────────────────
+
+
+def test_layout_extra_field_rejected():
+    with pytest.raises(PydanticValidationError):
+        Layout.model_validate({"schema_version": SCHEMA_VERSION, "rogue": 1})
+
+
+def test_cell_extra_field_rejected():
+    with pytest.raises(PydanticValidationError):
+        Cell.model_validate({"row": 1, "col": 1, "rogue": 2})
+
+
+# ── Background colour shape ──────────────────────────────────────────
+
+
+def test_background_rejects_non_hex_colour():
+    with pytest.raises(PydanticValidationError):
+        Background(color="red")
+    with pytest.raises(PydanticValidationError):
+        Background(color="#abc")  # 3-digit hex not supported in v1

--- a/tests/test_composed_validate.py
+++ b/tests/test_composed_validate.py
@@ -1,0 +1,269 @@
+"""Phase 0 tests for composed-slide semantic validator."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cms.composed.registry import (
+    Widget,
+    WidgetRegistry,
+    WidgetRender,
+)
+from cms.composed.schema import (
+    GRID_COLS,
+    GRID_ROWS,
+    Cell,
+    Layout,
+    WidgetInstance,
+)
+from cms.composed.validate import validate_layout
+
+
+# ── Stub widget for tests ────────────────────────────────────────────
+
+
+class _StubConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    text: str = Field(..., min_length=1)
+
+
+class _SemanticConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    asset_id: uuid.UUID
+
+
+class _StubWidget(Widget):
+    slug = "stub"
+    display_name = "Stub"
+    icon = "stub-icon"
+    ConfigSchema = _StubConfig
+
+    def render_html(self, config, cell, instance_id):
+        return WidgetRender(html=f"<div>{config.text}</div>")
+
+    def editor_template(self):
+        return "stub.html"
+
+    def default_config(self):
+        return {"text": "hi"}
+
+
+class _SemanticWidget(Widget):
+    """Widget whose semantic hook rejects a known sentinel asset."""
+
+    slug = "semantic"
+    display_name = "Semantic"
+    icon = "semantic-icon"
+    ConfigSchema = _SemanticConfig
+
+    BAD = uuid.UUID("00000000-0000-0000-0000-deadbeefdead")
+
+    def render_html(self, config, cell, instance_id):
+        return WidgetRender(html="<div>semantic</div>")
+
+    def editor_template(self):
+        return "semantic.html"
+
+    def default_config(self):
+        return {"asset_id": str(uuid.uuid4())}
+
+    def validate_semantic(self, config):
+        if config.asset_id == self.BAD:
+            return ["asset not found"]
+        return []
+
+
+def _registry() -> WidgetRegistry:
+    reg = WidgetRegistry()
+    reg.register(_StubWidget())
+    reg.register(_SemanticWidget())
+    return reg
+
+
+def _wi(*, type="stub", cell=None, config=None, wid=None) -> WidgetInstance:
+    return WidgetInstance(
+        id=wid or uuid.uuid4(),
+        type=type,
+        cell=cell or Cell(row=1, col=1),
+        config=config if config is not None else {"text": "hi"},
+    )
+
+
+# ── Valid layouts ────────────────────────────────────────────────────
+
+
+def test_valid_layout_returns_no_errors():
+    layout = Layout(
+        widgets=[
+            _wi(cell=Cell(row=1, col=1, colspan=4)),
+            _wi(cell=Cell(row=1, col=5, colspan=8)),
+            _wi(cell=Cell(row=2, col=1, rowspan=GRID_ROWS - 1, colspan=GRID_COLS)),
+        ]
+    )
+    assert validate_layout(layout, _registry()) == []
+
+
+def test_empty_layout_is_valid():
+    assert validate_layout(Layout(), _registry()) == []
+
+
+# ── Cell bounds (rowspan/colspan beyond grid) ────────────────────────
+
+
+def test_rowspan_extending_past_grid_is_rejected():
+    layout = Layout(
+        widgets=[
+            _wi(cell=Cell(row=GRID_ROWS, col=1, rowspan=2)),
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    codes = [e.code for e in errors]
+    assert "cell_out_of_bounds" in codes
+
+
+def test_colspan_extending_past_grid_is_rejected():
+    layout = Layout(
+        widgets=[
+            _wi(cell=Cell(row=1, col=GRID_COLS, colspan=2)),
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "cell_out_of_bounds" for e in errors)
+
+
+# ── Overlap detection ────────────────────────────────────────────────
+
+
+def test_overlap_reports_both_widget_ids():
+    a = uuid.uuid4()
+    b = uuid.uuid4()
+    layout = Layout(
+        widgets=[
+            _wi(wid=a, cell=Cell(row=1, col=1, rowspan=2, colspan=2)),
+            _wi(wid=b, cell=Cell(row=2, col=2, rowspan=2, colspan=2)),
+        ]
+    )
+    errors = [e for e in validate_layout(layout, _registry()) if e.code == "cells_overlap"]
+    assert errors, "expected cells_overlap"
+    msg = errors[0].message
+    assert str(a) in msg
+    assert str(b) in msg
+
+
+def test_adjacent_widgets_do_not_overlap():
+    layout = Layout(
+        widgets=[
+            _wi(cell=Cell(row=1, col=1, colspan=6)),
+            _wi(cell=Cell(row=1, col=7, colspan=6)),
+        ]
+    )
+    assert validate_layout(layout, _registry()) == []
+
+
+# ── Duplicate IDs ────────────────────────────────────────────────────
+
+
+def test_duplicate_widget_ids_are_rejected():
+    shared = uuid.uuid4()
+    layout = Layout(
+        widgets=[
+            _wi(wid=shared, cell=Cell(row=1, col=1)),
+            _wi(wid=shared, cell=Cell(row=1, col=2)),
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "duplicate_widget_id" for e in errors)
+
+
+# ── Unknown widget type ──────────────────────────────────────────────
+
+
+def test_unknown_widget_type_is_rejected():
+    layout = Layout(
+        widgets=[
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="not_a_real_widget",
+                cell=Cell(row=1, col=1),
+                config={},
+            )
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "unknown_widget_type" for e in errors)
+
+
+# ── Per-widget config validation ─────────────────────────────────────
+
+
+def test_widget_config_shape_violation_reported():
+    layout = Layout(
+        widgets=[
+            _wi(config={"text": ""}),  # min_length=1 fails
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "widget_config_shape" for e in errors)
+
+
+def test_widget_config_unknown_field_reported():
+    layout = Layout(
+        widgets=[
+            _wi(config={"text": "ok", "rogue": True}),  # extra=forbid
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "widget_config_shape" for e in errors)
+
+
+def test_widget_semantic_failure_reported():
+    layout = Layout(
+        widgets=[
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="semantic",
+                cell=Cell(row=1, col=1),
+                config={"asset_id": str(_SemanticWidget.BAD)},
+            )
+        ]
+    )
+    errors = validate_layout(layout, _registry())
+    assert any(e.code == "widget_config_semantic" for e in errors)
+
+
+def test_widget_semantic_passes_for_good_asset():
+    layout = Layout(
+        widgets=[
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="semantic",
+                cell=Cell(row=1, col=1),
+                config={"asset_id": str(uuid.uuid4())},
+            )
+        ]
+    )
+    assert validate_layout(layout, _registry()) == []
+
+
+# ── Registry behaviour ───────────────────────────────────────────────
+
+
+def test_registry_rejects_duplicate_slug():
+    reg = WidgetRegistry()
+    reg.register(_StubWidget())
+    import pytest as _pt
+
+    with _pt.raises(ValueError):
+        reg.register(_StubWidget())
+
+
+def test_registry_lookup_helpers():
+    reg = _registry()
+    assert reg.has("stub")
+    assert not reg.has("nope")
+    assert reg.get("stub") is not None
+    assert reg.get("nope") is None
+    assert "stub" in reg.slugs()
+    assert "semantic" in reg.slugs()


### PR DESCRIPTION
## Phase 0 of the Composed Slide feature

Backend-only foundation. Backend can now store a composed slide and
round-trip a layout JSON, but the asset type is not yet wired into
any UI, scheduler, or device delivery path — that comes in Phases
1A through 4 (see `session-state/.../plan.md` for the full
seven-phase roadmap).

## What's in this PR

- `AssetType.COMPOSED = 'composed'` enum value
- `cms/models/composed_slide.py` ORM model (JSONB layout, draft
  flag, AI prompt history, bundle metadata, cascade FK to assets)
- `alembic/versions/0037_composed_slides.py` migration —
  extends the `assettype` Postgres enum with
  `ALTER TYPE ... ADD VALUE IF NOT EXISTS` and creates the
  `composed_slides` table
- `cms/composed/` subsystem:
  - `schema.py` — Pydantic `Layout` / `Canvas` / `Grid` /
    `Cell` / `Background` / `WidgetInstance` with the v1
    locked constants (1920×1080, 12×8 grid, `schema_version=1`)
    enforced via `field_validator`
  - `registry.py` — `Widget` base, `WidgetRender`,
    `WidgetStaticAsset`, `WidgetRegistry`, process-wide
    `get_registry()` singleton. Ships empty in Phase 0; concrete
    widgets land in 1A/1B/1C
  - `validate.py` — `validate_layout()` returns a structured
    `list[ValidationError]` with codes `duplicate_widget_id`,
    `cell_out_of_bounds`, `cells_overlap`,
    `unknown_widget_type`, `widget_config_shape`,
    `widget_config_semantic`
- 44 unit tests across three files (round-trip, locked dimensions,
  slug shape rules, `extra=forbid`, overlap detection w/ both
  widget IDs, semantic validation, cascade delete, asset_id
  uniqueness, `AssetType.COMPOSED` presence)

## What's intentionally not in this PR

- No bundle builder (Phase 1A)
- No concrete widgets (Phase 1A ships `text`; 1B adds `image` /
  `clock` / `ticker`; 1C adds `video`)
- No scheduler / device-delivery integration (Phase 1A)
- No editor UI — the existing `Composed Slide` tile in
  `assets_new.html` stays disabled (Phase 2)
- No AI generation endpoint (Phase 3)

## Test results

All 44 new tests pass locally on SQLite (CI will run them on
Postgres):

`44 passed in 3.06s`

Migration file parses cleanly (`revision: 0037`,
`down_revision: 0036`).