### PR TITLE
Composed Slide Phase 1A: bundle publish + live preview

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -1,0 +1,322 @@
+"""Composed-slide bundle builder.
+
+Renders a :class:`~cms.composed.schema.Layout` into a single
+self-contained HTML document with all CSS / JS / fonts / images
+inlined as data URIs or embedded ``<style>`` / ``<script>`` blocks.
+
+The resulting bundle has **zero external src= / href= references**
+to non-``data:`` URLs.  This is the file we ship to devices: the
+existing per-asset cache layer downloads it once and replays it
+offline-tolerantly.
+
+Determinism: building the same layout twice yields byte-identical
+output (so :func:`hashlib.sha256` is a stable cache key).  We achieve
+this by iterating widgets in their layout order and de-duplicating
+static assets by content hash *in first-appearance order*.
+
+See ``plan.md`` for the delivery / artifact contract.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import uuid
+from dataclasses import dataclass
+
+from cms.composed.registry import (
+    Widget,
+    WidgetRegistry,
+    WidgetRender,
+    WidgetStaticAsset,
+    get_registry,
+)
+from cms.composed.schema import (
+    CANVAS_HEIGHT,
+    CANVAS_WIDTH,
+    GRID_COLS,
+    GRID_ROWS,
+    Layout,
+    WidgetInstance,
+)
+from cms.composed.validate import ValidationError, validate_layout
+
+
+class BundleValidationError(Exception):
+    """Raised when :func:`build_bundle` is called on an invalid layout.
+
+    Carries the structured validator errors so callers (the publish
+    service, the preview endpoint) can surface them to the user.
+    """
+
+    def __init__(self, errors: list[ValidationError]) -> None:
+        self.errors = errors
+        msgs = "; ".join(f"[{e.code}] {e.message}" for e in errors)
+        super().__init__(f"layout has {len(errors)} validation error(s): {msgs}")
+
+
+@dataclass
+class BuiltBundle:
+    """Result of :func:`build_bundle`."""
+
+    html_bytes: bytes
+    sha256_hex: str
+    source_asset_ids: list[uuid.UUID]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _instance_id_str(inst: WidgetInstance) -> str:
+    # Keep the on-the-wire UUID format the editor sees; widgets scope
+    # CSS classes by this string verbatim.
+    return str(inst.id)
+
+
+def _grid_area_style(inst: WidgetInstance) -> str:
+    cell = inst.cell
+    # CSS grid is 1-indexed; row-end / column-end are exclusive (the
+    # "span N" syntax keeps the intent obvious in the emitted markup).
+    return (
+        f"grid-row: {cell.row} / span {cell.rowspan}; "
+        f"grid-column: {cell.col} / span {cell.colspan};"
+    )
+
+
+def _data_uri(asset: WidgetStaticAsset) -> str:
+    if isinstance(asset.content, bytes):
+        payload = base64.b64encode(asset.content).decode("ascii")
+        return f"data:{asset.mime};base64,{payload}"
+    # Text content — still base64 it so we don't have to URL-escape
+    # arbitrary characters and so binary/text behave the same.
+    payload = base64.b64encode(asset.content.encode("utf-8")).decode("ascii")
+    return f"data:{asset.mime};base64,{payload}"
+
+
+def _hash_text(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def _resolve_widget(reg: WidgetRegistry, inst: WidgetInstance) -> Widget:
+    w = reg.get(inst.type)
+    if w is None:
+        # Defensive — validate_layout should have caught this already.
+        raise BundleValidationError(
+            [
+                ValidationError(
+                    code="unknown_widget_type",
+                    message=f"widget {inst.id}: unknown type {inst.type!r}",
+                    widget_id=str(inst.id),
+                )
+            ]
+        )
+    return w
+
+
+# ── Main entrypoint ──────────────────────────────────────────────────
+
+
+def build_bundle(
+    layout: Layout,
+    registry: WidgetRegistry | None = None,
+) -> BuiltBundle:
+    """Render ``layout`` to a self-contained HTML bundle.
+
+    Raises :class:`BundleValidationError` if the layout fails
+    :func:`~cms.composed.validate.validate_layout`.  The check is
+    redundant with the editor's save-time validation but kept as
+    defense-in-depth so we never embed a bad layout.
+    """
+
+    reg = registry if registry is not None else get_registry()
+
+    # 1. Defensive validation.
+    errors = validate_layout(layout, reg)
+    if errors:
+        raise BundleValidationError(errors)
+
+    # 2. Render each widget, collecting css/js/static assets +
+    #    accumulated referenced asset IDs for staleness tracking.
+    rendered: list[tuple[WidgetInstance, WidgetRender]] = []
+    source_asset_ids: list[uuid.UUID] = []
+    seen_asset_ids: set[uuid.UUID] = set()
+
+    for inst in layout.widgets:
+        widget = _resolve_widget(reg, inst)
+        # The validator already constructed + checked the config; re-do
+        # it here so render_html gets a typed config object rather than
+        # a raw dict.  Cheap (Pydantic is fast for small models).
+        config = widget.ConfigSchema.model_validate(inst.config)
+        render: WidgetRender = widget.render_html(
+            config=config,
+            cell=inst.cell,
+            instance_id=_instance_id_str(inst),
+        )
+        rendered.append((inst, render))
+
+        for aid in render.referenced_asset_ids:
+            if aid not in seen_asset_ids:
+                seen_asset_ids.add(aid)
+                source_asset_ids.append(aid)
+
+    # 3. De-dup CSS / JS / static assets by content hash, preserving
+    #    first-appearance order for deterministic output.
+    css_blocks: dict[str, str] = {}
+    js_blocks: dict[str, str] = {}
+    static_assets: dict[str, WidgetStaticAsset] = {}
+
+    for _inst, render in rendered:
+        if render.css.strip():
+            css_blocks.setdefault(_hash_text(render.css), render.css)
+        if render.js.strip():
+            js_blocks.setdefault(_hash_text(render.js), render.js)
+        for sa in render.static_assets:
+            blob = (
+                sa.content if isinstance(sa.content, bytes) else sa.content.encode("utf-8")
+            )
+            key = hashlib.sha256(blob).hexdigest() + ":" + sa.mime
+            static_assets.setdefault(key, sa)
+
+    # 4. Assemble the document.
+    #    All CSS / JS is inlined.  Static assets are turned into data
+    #    URIs when widgets reference them via their own CSS (e.g.
+    #    @font-face url(...) — Phase 1B); here we keep the structural
+    #    skeleton.  For Phase 1A only text widgets exist, so the
+    #    static_assets dict is empty in practice.
+
+    page_css_parts: list[str] = []
+    page_css_parts.append(_base_css(layout))
+    for _h, css in css_blocks.items():
+        page_css_parts.append(css)
+    # Bundle static assets that arrived as kind="css" inline too —
+    # mirrors the per-widget css channel but allows widgets to ship
+    # bigger / library CSS as a static asset for de-dup.
+    for _k, sa in static_assets.items():
+        if sa.kind == "css":
+            text = sa.content if isinstance(sa.content, str) else sa.content.decode("utf-8")
+            page_css_parts.append(text)
+
+    page_js_parts: list[str] = []
+    for _k, sa in static_assets.items():
+        if sa.kind == "js":
+            text = sa.content if isinstance(sa.content, str) else sa.content.decode("utf-8")
+            page_js_parts.append(text)
+    for _h, js in js_blocks.items():
+        page_js_parts.append(js)
+
+    # Per-instance init_js, wrapped in a function so each instance's
+    # locals don't bleed into the next one.  Each block gets its own
+    # ``instanceId`` parameter for convenience inside widget code.
+    init_blocks: list[str] = []
+    for inst, render in rendered:
+        if render.init_js:
+            wid = _instance_id_str(inst)
+            init_blocks.append(
+                "(function(instanceId){\n"
+                + render.init_js
+                + "\n}).call(null, " + _js_string_literal(wid) + ");"
+            )
+
+    init_script = ""
+    if init_blocks:
+        init_script = (
+            "document.addEventListener('DOMContentLoaded', function(){\n"
+            + "\n".join(init_blocks)
+            + "\n});"
+        )
+
+    widget_html_blocks: list[str] = []
+    for inst, render in rendered:
+        wid = _instance_id_str(inst)
+        widget_html_blocks.append(
+            f'<div class="cw-cell" data-widget-instance="{html.escape(wid)}" '
+            f'style="{_grid_area_style(inst)}">{render.html}</div>'
+        )
+
+    doc = _DOC_TEMPLATE.format(
+        title="Composed Slide",
+        style="\n".join(p for p in page_css_parts if p),
+        body_grid_inner="\n".join(widget_html_blocks),
+        script_body="\n".join(p for p in page_js_parts if p),
+        init_script=init_script,
+    )
+
+    html_bytes = doc.encode("utf-8")
+    sha = hashlib.sha256(html_bytes).hexdigest()
+    return BuiltBundle(
+        html_bytes=html_bytes,
+        sha256_hex=sha,
+        source_asset_ids=source_asset_ids,
+    )
+
+
+# ── Templates / boilerplate ──────────────────────────────────────────
+
+
+def _base_css(layout: Layout) -> str:
+    bg = layout.background.color
+    return (
+        "html,body{margin:0;padding:0;width:100%;height:100%;"
+        "background:#000;overflow:hidden;}\n"
+        ".cw-canvas{position:relative;width:100vw;height:100vh;"
+        f"background:{bg};display:grid;"
+        f"grid-template-columns:repeat({GRID_COLS}, 1fr);"
+        f"grid-template-rows:repeat({GRID_ROWS}, 1fr);}}\n"
+        ".cw-cell{position:relative;overflow:hidden;}"
+    )
+
+
+def _js_string_literal(s: str) -> str:
+    """Serialise a Python string for safe embedding in a JS string.
+
+    Stricter than :func:`json.dumps` for our needs — we want to keep
+    HTML special chars escaped too so a stray ``</script>`` in a
+    widget's instance id (it can't happen for UUIDs, but be defensive)
+    doesn't terminate the script block.
+    """
+
+    out_chars: list[str] = ["'"]
+    for ch in s:
+        if ch == "'":
+            out_chars.append("\\'")
+        elif ch == "\\":
+            out_chars.append("\\\\")
+        elif ch == "<":
+            out_chars.append("\\x3c")
+        elif ch == ">":
+            out_chars.append("\\x3e")
+        elif ch == "\n":
+            out_chars.append("\\n")
+        elif ch == "\r":
+            out_chars.append("\\r")
+        else:
+            out_chars.append(ch)
+    out_chars.append("'")
+    return "".join(out_chars)
+
+
+# The document is small and intentionally readable so a human can
+# open a saved bundle and reason about it without un-minifying.
+_DOC_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width={CW},height={CH}">
+<meta name="generator" content="agora-cms composed-bundle/1">
+<title>{title}</title>
+<style>
+{style}
+</style>
+</head>
+<body>
+<div class="cw-canvas">
+{body_grid_inner}
+</div>
+<script>
+{script_body}
+{init_script}
+</script>
+</body>
+</html>
+""".replace("{CW}", str(CANVAS_WIDTH)).replace("{CH}", str(CANVAS_HEIGHT))

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -1,0 +1,154 @@
+"""Phase 1A: publish a composed slide's layout to the asset cache.
+
+Renders ``ComposedSlide.layout_json`` to a self-contained HTML bundle
+via :func:`cms.composed.bundle.build_bundle`, writes the bytes to the
+shared asset storage path, and updates the bound :class:`Asset` row's
+``filename`` / ``size_bytes`` / ``checksum`` so the existing device
+sync pipeline picks it up automatically.
+
+Phase 1A is explicit-publish only — no auto-rebuild on referenced
+asset changes (that affordance lives in the Phase 2 editor UI).
+Calling :func:`publish_composed_slide` flips ``is_draft`` to ``False``
+and records ``bundle_built_at`` + ``bundle_source_asset_ids`` for the
+stale-bundle detector to use later.
+
+The publish is idempotent on content: if the freshly-built bundle's
+SHA matches the asset's current checksum, we skip the disk write and
+only update ``bundle_built_at`` (so the editor's "last built" UI
+still ticks).  Because the bundle filename is content-addressed
+(``composed-{asset_id}-{sha[:12]}.html``), re-publishing identical
+content also re-points at the same file rather than orphaning a new
+one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.composed.bundle import BundleValidationError, build_bundle
+from cms.composed.registry import get_registry
+from cms.composed.schema import Layout
+from cms.models.composed_slide import ComposedSlide
+from shared.models.asset import Asset, AssetType
+from shared.services.storage import get_storage
+
+
+class PublishError(Exception):
+    """Raised when a composed slide cannot be published.
+
+    Wraps the underlying cause (missing asset row, missing composed
+    slide row, invalid layout JSON, validation failure).  Caller is
+    expected to translate this into an HTTP 4xx / friendly error.
+    """
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Outcome of a publish call, returned for logging / UI."""
+
+    asset_id: uuid.UUID
+    composed_slide_id: uuid.UUID
+    filename: str
+    checksum: str
+    size_bytes: int
+    rebuilt: bool  # False if content matched existing checksum (no-op write)
+    bundle_built_at: datetime
+
+
+def _bundle_filename(asset_id: uuid.UUID, sha256_hex: str) -> str:
+    # Content-addressed but namespaced by asset, so two different
+    # composed slides with byte-identical bundles still land in
+    # different files (avoids any future collision-by-coincidence and
+    # makes "which composed slide owns this file?" trivial to answer
+    # from the filename alone).
+    return f"composed-{asset_id}-{sha256_hex[:12]}.html"
+
+
+async def publish_composed_slide(
+    asset_id: uuid.UUID, db: AsyncSession,
+) -> PublishResult:
+    """Build and publish the bundle for the composed slide bound to ``asset_id``.
+
+    On success:
+      * The asset row's ``filename`` / ``size_bytes`` / ``checksum``
+        point at the freshly-written bundle.
+      * The composed slide row's ``is_draft`` is False,
+        ``bundle_built_at`` is now (UTC), and
+        ``bundle_source_asset_ids`` is the list returned by the bundle
+        builder.
+      * ``db.commit()`` is **not** called — the caller controls the
+        transaction boundary (matches the existing asset-router
+        convention).
+    """
+    asset = await db.get(Asset, asset_id)
+    if asset is None:
+        raise PublishError(f"Asset {asset_id} not found")
+    if asset.asset_type != AssetType.COMPOSED:
+        raise PublishError(
+            f"Asset {asset_id} is {asset.asset_type.value}, not composed",
+        )
+
+    cs_result = await db.execute(
+        select(ComposedSlide).where(ComposedSlide.asset_id == asset_id),
+    )
+    composed = cs_result.scalar_one_or_none()
+    if composed is None:
+        raise PublishError(f"No composed slide row bound to asset {asset_id}")
+
+    # Layout JSON → Pydantic.  This will raise pydantic.ValidationError
+    # on shape problems; the caller can catch it or let it bubble.
+    try:
+        layout = Layout.model_validate(composed.layout_json)
+    except Exception as e:  # noqa: BLE001 — re-wrap for caller clarity
+        raise PublishError(f"Invalid layout JSON: {e}") from e
+
+    # Trigger auto-registration of all built-in widgets.
+    import cms.composed.widgets  # noqa: F401
+
+    registry = get_registry()
+    try:
+        built = build_bundle(layout, registry)
+    except BundleValidationError as e:
+        raise PublishError(
+            "Layout failed validation: "
+            + "; ".join(f"{err.code}: {err.message}" for err in e.errors),
+        ) from e
+
+    filename = _bundle_filename(asset_id, built.sha256_hex)
+    storage = get_storage()
+    from cms.auth import get_settings as _get_settings
+    storage_dir = _get_settings().asset_storage_path
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    dest = storage_dir / filename
+
+    rebuilt = asset.checksum != built.sha256_hex
+    if rebuilt:
+        dest.write_bytes(built.html_bytes)
+        await storage.on_file_stored(filename)
+
+        asset.filename = filename
+        asset.size_bytes = len(built.html_bytes)
+        asset.checksum = built.sha256_hex
+
+    now = datetime.now(timezone.utc)
+    composed.is_draft = False
+    composed.bundle_built_at = now
+    composed.bundle_source_asset_ids = list(built.source_asset_ids)
+
+    await db.flush()
+
+    return PublishResult(
+        asset_id=asset_id,
+        composed_slide_id=composed.id,
+        filename=asset.filename,
+        checksum=asset.checksum,
+        size_bytes=asset.size_bytes,
+        rebuilt=rebuilt,
+        bundle_built_at=now,
+    )

--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -1,0 +1,32 @@
+"""Built-in widget plugins for the Composed Slide subsystem.
+
+Importing this package registers every shipped widget into the
+global :class:`cms.composed.registry.WidgetRegistry`.  Add a new
+widget by creating ``cms/composed/widgets/<slug>.py`` exporting a
+``Widget`` subclass, then importing + registering it below.
+
+Phase 1A ships only the trivial text widget; future phases add
+image, clock, ticker, and the minimal video widget.
+
+Auto-registration on import means any code that does
+``import cms.composed.widgets`` (or transitively touches the
+bundle builder, which imports this package) gets a populated
+registry.  Validator unit tests that need an isolated registry
+construct a fresh :class:`WidgetRegistry` instead of using the
+global one.
+"""
+
+from __future__ import annotations
+
+from cms.composed.registry import get_registry
+from cms.composed.widgets.text import TextWidget
+
+_reg = get_registry()
+
+# Idempotent — guards against re-import edge cases (importlib.reload,
+# test session re-import) double-registering and tripping the
+# registry's "already registered" guard.
+if not _reg.has(TextWidget.slug):
+    _reg.register(TextWidget())
+
+__all__ = ["TextWidget"]

--- a/cms/composed/widgets/text.py
+++ b/cms/composed/widgets/text.py
@@ -1,0 +1,120 @@
+"""Trivial text widget — Phase 1A proof-of-concept.
+
+Renders a single piece of HTML-escaped text in a chosen color,
+size, and font family.  Intentionally minimal: enough to prove the
+end-to-end bundle build + publish + device delivery pipeline
+without dragging in font files, image refs, or external resources.
+
+Fonts are restricted to a small system-stack allowlist (``sans``,
+``serif``, ``mono``) so Phase 1A bundles stay self-contained — no
+.woff payloads to embed yet.  Phase 1B adds a richer font story
+(image widget + uploadable font assets).
+
+Instance scoping rule: every CSS class this widget emits includes
+``instance_id`` so two text widgets in the same bundle can have
+different styling without colliding.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import Widget, WidgetRender
+from cms.composed.schema import Cell
+
+
+# Allowlist of font-family slugs → emitted CSS font stack.  Keeping
+# this server-side means malicious config never reaches the bundle
+# as a raw font-family string.
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+
+class TextWidgetConfig(BaseModel):
+    """User-editable config for :class:`TextWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(..., min_length=1, max_length=4096)
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_size_px: int = Field(default=48, ge=8, le=512)
+    font_family: str = Field(default="sans")
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(
+                f"font_family must be one of: {allowed}"
+            )
+        return v
+
+
+class TextWidget(Widget):
+    """Static text — the Phase 1A proof widget."""
+
+    slug: ClassVar[str] = "text"
+    display_name: ClassVar[str] = "Text"
+    icon: ClassVar[str] = "🅰"
+    ConfigSchema: ClassVar[type[BaseModel]] = TextWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "text": "Text",
+            "color": "#ffffff",
+            "font_size_px": 48,
+            "font_family": "sans",
+        }
+
+    def editor_template(self) -> str:
+        # Editor UI ships in Phase 2; the path is reserved here so
+        # the abstract-base contract is satisfied for Phase 1A.
+        return "composed/widgets/text.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+    ) -> WidgetRender:
+        # The base class typing uses BaseModel; narrow for attr access.
+        # validate_layout always calls ConfigSchema.model_validate before
+        # forwarding, so this assertion guards against direct misuse.
+        assert isinstance(config, TextWidgetConfig), (
+            "TextWidget.render_html expects a TextWidgetConfig instance"
+        )
+
+        escaped_text = html.escape(config.text)
+        css_class = f"cw-text-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        html_out = f'<div class="{css_class}">{escaped_text}</div>'
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  text-align: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  font-family: {font_stack};\n"
+            f"  overflow: hidden;\n"
+            f"  word-wrap: break-word;\n"
+            f"}}"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+        )

--- a/cms/main.py
+++ b/cms/main.py
@@ -981,11 +981,13 @@ from cms.routers.roles import router as roles_router  # noqa: E402
 from cms.routers.stream_probe import router as stream_probe_router  # noqa: E402
 from cms.routers.users import router as users_router  # noqa: E402
 from cms.routers.bootstrap import router as bootstrap_router  # noqa: E402
+from cms.routers.composed import router as composed_router  # noqa: E402
 from cms.routers.issue_report import router as issue_report_router  # noqa: E402
 from cms.routers.imager import router as imager_router  # noqa: E402
 from cms.ui import router as ui_router  # noqa: E402
 
 app.include_router(bootstrap_router)
+app.include_router(composed_router)
 app.include_router(devices_router)
 app.include_router(devices_device_router)
 app.include_router(assets_router)

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -1,0 +1,105 @@
+"""Phase 1A: live preview endpoint for composed slides.
+
+Renders the composed slide's current ``layout_json`` to a
+self-contained HTML document via the same bundle builder used at
+publish time, and serves it inline. No bundle is written to disk;
+this is the editor's "live preview" path.
+
+CSP is locked down: only the inline content the bundle builder
+generates is allowed; no external scripts, styles, fonts, or
+images. Frame ancestors are restricted to the CMS origin so the
+preview can render inside an editor ``<iframe>`` but cannot be
+embedded elsewhere.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import require_auth
+from cms.composed.bundle import BundleValidationError, build_bundle
+from cms.composed.registry import get_registry
+from cms.composed.schema import Layout
+from cms.database import get_db
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/composed",
+    dependencies=[Depends(require_auth)],
+    tags=["composed"],
+)
+
+
+_PREVIEW_CSP = (
+    "default-src 'none'; "
+    "script-src 'unsafe-inline'; "
+    "style-src 'unsafe-inline'; "
+    "img-src data:; "
+    "font-src data:; "
+    "media-src data:; "
+    "frame-ancestors 'self'; "
+    "base-uri 'none'; "
+    "form-action 'none'"
+)
+
+
+@router.get("/{asset_id}/preview", response_class=HTMLResponse)
+async def preview_composed_slide(
+    asset_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Live-render the composed slide bound to ``asset_id`` as HTML.
+
+    Returns 404 if the asset doesn't exist or isn't a composed slide.
+    Returns 422 if the saved layout fails Pydantic shape validation
+    or the bundle builder's semantic validation. No disk writes;
+    no asset row mutations.
+    """
+    asset = await db.get(Asset, asset_id)
+    if asset is None or asset.asset_type != AssetType.COMPOSED:
+        raise HTTPException(status_code=404, detail="Composed slide not found")
+
+    cs_result = await db.execute(
+        select(ComposedSlide).where(ComposedSlide.asset_id == asset_id),
+    )
+    composed = cs_result.scalar_one_or_none()
+    if composed is None:
+        raise HTTPException(status_code=404, detail="Composed slide not found")
+
+    try:
+        layout = Layout.model_validate(composed.layout_json)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(
+            status_code=422, detail=f"Invalid layout JSON: {e}",
+        ) from e
+
+    # Trigger auto-registration of all built-in widgets, then build.
+    import cms.composed.widgets  # noqa: F401
+
+    registry = get_registry()
+    try:
+        built = build_bundle(layout, registry)
+    except BundleValidationError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Layout failed validation: "
+                + "; ".join(f"{err.code}: {err.message}" for err in e.errors)
+            ),
+        ) from e
+
+    headers = {
+        "Content-Security-Policy": _PREVIEW_CSP,
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "no-store",
+    }
+    return HTMLResponse(content=built.html_bytes, headers=headers)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -198,6 +198,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /composed/{asset_id}/preview:
+    get:
+      tags:
+      - composed
+      summary: Preview Composed Slide
+      description: |-
+        Live-render the composed slide bound to ``asset_id`` as HTML.
+
+        Returns 404 if the asset doesn't exist or isn't a composed slide.
+        Returns 422 if the saved layout fails Pydantic shape validation
+        or the bundle builder's semantic validation. No disk writes;
+        no asset row mutations.
+      operationId: preview_composed_slide_composed__asset_id__preview_get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/check-updates:
     post:
       summary: Check For Updates
@@ -6925,6 +6959,7 @@ tags:
 - name: assistant-settings
 - name: bootstrap
   description: First-contact registration / adoption endpoints used during device onboarding.
+- name: composed
 - name: devices (device-originated)
   description: Endpoints called by the device firmware itself.
 - name: system

--- a/tests/test_composed_bundle.py
+++ b/tests/test_composed_bundle.py
@@ -1,0 +1,276 @@
+"""Tests for ``cms.composed.bundle.build_bundle``.
+
+Phase 1A scope:
+- Trivial empty layout → valid minimal HTML
+- Single text widget layout → bundle contains the rendered HTML/CSS
+- Bundle has zero external src=/href= refs (anchored on http/https
+  schemes — data: URIs are allowed)
+- Deterministic: same layout → same SHA on rebuild
+- Validation errors raise BundleValidationError
+- Source asset IDs flow through to the BuiltBundle result
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from pydantic import BaseModel, Field
+
+# Import to trigger TextWidget auto-registration into the global
+# registry; the bundle builder uses get_registry() by default.
+import cms.composed.widgets  # noqa: F401
+from cms.composed.bundle import (
+    BuiltBundle,
+    BundleValidationError,
+    build_bundle,
+)
+from cms.composed.registry import (
+    Widget,
+    WidgetRegistry,
+    WidgetRender,
+    get_registry,
+)
+from cms.composed.schema import (
+    Background,
+    Cell,
+    Layout,
+    WidgetInstance,
+    empty_layout,
+)
+
+
+# ── Test helpers ─────────────────────────────────────────────────────
+
+
+def _text_layout(text: str = "Hello", color: str = "#ff0000") -> Layout:
+    return Layout(
+        widgets=[
+            WidgetInstance(
+                id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+                type="text",
+                cell=Cell(row=1, col=1, rowspan=2, colspan=3),
+                config={"text": text, "color": color},
+            ),
+        ],
+    )
+
+
+# ── Tests: structure / minimal cases ─────────────────────────────────
+
+
+class TestEmptyLayout:
+    def test_empty_layout_produces_valid_doc(self):
+        result = build_bundle(empty_layout())
+
+        assert isinstance(result, BuiltBundle)
+        html = result.html_bytes.decode("utf-8")
+        assert html.startswith("<!doctype html>")
+        assert "<html" in html and "</html>" in html
+        assert "cw-canvas" in html
+        # No widget cells.
+        assert "data-widget-instance" not in html
+
+    def test_empty_layout_no_referenced_asset_ids(self):
+        result = build_bundle(empty_layout())
+        assert result.source_asset_ids == []
+
+
+class TestTextWidgetBundle:
+    def test_renders_widget_content_in_doc(self):
+        layout = _text_layout(text="Hello, world", color="#abcdef")
+        result = build_bundle(layout)
+        html = result.html_bytes.decode("utf-8")
+
+        assert "Hello, world" in html
+        # CSS color is propagated.
+        assert "#abcdef" in html
+        # Instance-scoped class survives into the document.
+        assert "cw-text-11111111-1111-1111-1111-111111111111" in html
+        # Cell wrapper sets grid-area placement (row=1 colspan=3).
+        assert "grid-row: 1 / span 2" in html
+        assert "grid-column: 1 / span 3" in html
+
+    def test_html_escapes_user_text(self):
+        layout = _text_layout(text="<script>alert(1)</script>")
+        result = build_bundle(layout)
+        html = result.html_bytes.decode("utf-8")
+
+        # Raw script tag from user input must never appear.
+        assert "<script>alert(1)</script>" not in html
+        # Escaped form should be present in the body.
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+    def test_background_color_threaded_through(self):
+        layout = Layout(
+            background=Background(color="#102030"),
+            widgets=[],
+        )
+        result = build_bundle(layout)
+        assert b"#102030" in result.html_bytes
+
+
+class TestNoExternalReferences:
+    """Bundles ship to devices and must be fully offline-tolerant."""
+
+    EXTERNAL_RE = re.compile(
+        # Match any src= or href= whose value starts with http(s)/// (raw
+        # protocol-relative URLs).  data: URIs are explicitly allowed.
+        r'''(?:src|href)\s*=\s*["'](?:https?:|//)''',
+        re.IGNORECASE,
+    )
+
+    def test_text_widget_bundle_has_no_external_refs(self):
+        layout = _text_layout()
+        html = build_bundle(layout).html_bytes.decode("utf-8")
+
+        match = self.EXTERNAL_RE.search(html)
+        assert match is None, f"unexpected external reference: {match!r}"
+
+    def test_empty_bundle_has_no_external_refs(self):
+        html = build_bundle(empty_layout()).html_bytes.decode("utf-8")
+        assert self.EXTERNAL_RE.search(html) is None
+
+
+class TestDeterminism:
+    def test_same_layout_produces_same_sha_and_bytes(self):
+        layout1 = _text_layout(text="hello", color="#ffffff")
+        layout2 = _text_layout(text="hello", color="#ffffff")
+
+        a = build_bundle(layout1)
+        b = build_bundle(layout2)
+
+        assert a.html_bytes == b.html_bytes
+        assert a.sha256_hex == b.sha256_hex
+
+    def test_different_text_changes_sha(self):
+        a = build_bundle(_text_layout(text="hello"))
+        b = build_bundle(_text_layout(text="world"))
+        assert a.sha256_hex != b.sha256_hex
+
+
+# ── Tests: validation handoff ───────────────────────────────────────
+
+
+class TestValidationHandoff:
+    def test_out_of_bounds_layout_raises(self):
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+                    type="text",
+                    # rowspan=8 starting at row=2 pushes past 8-row grid.
+                    cell=Cell(row=2, col=1, rowspan=8, colspan=1),
+                    config={"text": "x"},
+                ),
+            ],
+        )
+        with pytest.raises(BundleValidationError) as ei:
+            build_bundle(layout)
+        assert any(e.code == "cell_out_of_bounds" for e in ei.value.errors)
+
+    def test_unknown_widget_type_raises(self):
+        # Use an isolated registry with no widgets registered.
+        empty_reg = WidgetRegistry()
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+                    type="text",  # registered globally but NOT in our isolated reg
+                    cell=Cell(row=1, col=1),
+                    config={"text": "x"},
+                ),
+            ],
+        )
+        with pytest.raises(BundleValidationError) as ei:
+            build_bundle(layout, registry=empty_reg)
+        assert any(e.code == "unknown_widget_type" for e in ei.value.errors)
+
+
+# ── Tests: static-asset & init_js plumbing (synthetic widget) ───────
+
+
+class _StaticAssetConfig(BaseModel):
+    msg: str = Field(default="x")
+
+
+class _StaticAssetWidget(Widget):
+    slug = "static_asset_test"
+    display_name = "Static Asset Test"
+    icon = "x"
+    ConfigSchema = _StaticAssetConfig
+    config_version = 1
+
+    def default_config(self):
+        return {"msg": "x"}
+
+    def editor_template(self):
+        return "n/a"
+
+    def render_html(self, config, cell, instance_id):
+        return WidgetRender(
+            html=f'<span id="x-{instance_id}">x</span>',
+            css=f"#x-{instance_id} {{color:red;}}",
+            js="window.__sharedHelper = function(){return 1;};",
+            init_js=f"document.getElementById('x-' + instanceId).dataset.ok='1';",
+        )
+
+
+class TestStaticAssetsAndInitJs:
+    def test_init_js_is_wrapped_in_domcontentloaded_with_instance_id(self):
+        reg = WidgetRegistry()
+        reg.register(_StaticAssetWidget())
+
+        inst_id = uuid.UUID("44444444-4444-4444-4444-444444444444")
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=inst_id,
+                    type="static_asset_test",
+                    cell=Cell(row=1, col=1),
+                    config={"msg": "x"},
+                ),
+            ],
+        )
+        html = build_bundle(layout, registry=reg).html_bytes.decode("utf-8")
+
+        assert "DOMContentLoaded" in html
+        # init_js wrapped in a function and called with the instance id literal.
+        assert str(inst_id) in html
+
+    def test_shared_js_is_deduplicated(self):
+        reg = WidgetRegistry()
+        reg.register(_StaticAssetWidget())
+
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("55555555-5555-5555-5555-555555555555"),
+                    type="static_asset_test",
+                    cell=Cell(row=1, col=1),
+                    config={"msg": "a"},
+                ),
+                WidgetInstance(
+                    id=uuid.UUID("66666666-6666-6666-6666-666666666666"),
+                    type="static_asset_test",
+                    cell=Cell(row=2, col=1),
+                    config={"msg": "b"},
+                ),
+            ],
+        )
+        html = build_bundle(layout, registry=reg).html_bytes.decode("utf-8")
+
+        # The shared helper string should appear exactly once.
+        assert html.count("window.__sharedHelper") == 1
+
+
+class TestRegistryWiring:
+    def test_default_registry_is_global(self):
+        # Sanity check: when no registry is passed, the builder uses
+        # get_registry(), and the text widget is registered there via
+        # the import at the top of this module.
+        assert get_registry().has("text")
+        # And it actually works end-to-end (regression).
+        result = build_bundle(_text_layout())
+        assert b"cw-text-" in result.html_bytes

--- a/tests/test_composed_device_sync.py
+++ b/tests/test_composed_device_sync.py
@@ -1,0 +1,57 @@
+"""Phase 1A: confirm a published COMPOSED asset flows through
+``_resolve_asset_for_device`` like any other single-file asset.
+
+This is a no-edits-expected scheduler/device-sync verification — the
+default branch in ``cms/services/device_inbound.py`` should handle
+COMPOSED transparently because COMPOSED is not in the (VIDEO/IMAGE/
+SAVED_STREAM) transcode set and is not SLIDESHOW.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cms.models.asset import Asset, AssetType
+from cms.services.device_inbound import _resolve_asset_for_device
+
+
+@pytest.mark.asyncio
+async def test_composed_asset_resolves_via_default_file_path(db_session):
+    """A COMPOSED asset must round-trip filename/checksum/size_bytes
+    into a FetchAssetMessage identical to a regular file asset."""
+    asset = Asset(
+        filename="composed-deadbeef.html",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=12345,
+        checksum="abc123def456",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    device = MagicMock()
+    device.profile_id = None
+
+    fake_storage = AsyncMock()
+    fake_storage.get_device_download_url = AsyncMock(
+        return_value="https://cdn/composed-deadbeef.html"
+    )
+
+    with patch("cms.services.device_inbound.get_storage", return_value=fake_storage):
+        fetch = await _resolve_asset_for_device(
+            asset, device, "https://cms.example", db_session,
+        )
+
+    assert fetch is not None
+    assert fetch.asset_name == "composed-deadbeef.html"
+    assert fetch.checksum == "abc123def456"
+    assert fetch.size_bytes == 12345
+    assert fetch.asset_type == "composed"
+    assert fetch.download_url == "https://cdn/composed-deadbeef.html"
+
+    # Confirm storage was called with the asset.filename — NOT a
+    # variant path. That's the contract for non-transcoded assets.
+    fake_storage.get_device_download_url.assert_awaited_once()
+    call_args = fake_storage.get_device_download_url.call_args
+    assert call_args.args[0] == "composed-deadbeef.html"

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -1,0 +1,131 @@
+"""Phase 1A tests for the composed slide live preview endpoint."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+
+def _text_layout(text: str = "hello preview") -> Layout:
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="text",
+            cell=Cell(row=1, col=1, rowspan=1, colspan=4),
+            config={"text": text, "font_size_px": 64},
+            config_version=1,
+        )
+    )
+    return layout
+
+
+async def _make_composed(
+    db_session, *, layout: Layout | None = None
+) -> tuple[Asset, ComposedSlide]:
+    asset = Asset(
+        filename=f"composed-placeholder-{uuid.uuid4()}",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=(layout or _text_layout()).model_dump(mode="json"),
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    return asset, cs
+
+
+@pytest.mark.asyncio
+class TestComposedPreview:
+    async def test_404_when_asset_missing(self, client):
+        resp = await client.get(f"/composed/{uuid.uuid4()}/preview")
+        assert resp.status_code == 404
+
+    async def test_404_when_wrong_asset_type(self, client, db_session):
+        asset = Asset(
+            filename="not_composed.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=100,
+            checksum="abc",
+        )
+        db_session.add(asset)
+        await db_session.commit()
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 404
+
+    async def test_404_when_composed_row_missing(self, client, db_session):
+        # COMPOSED asset row exists but no ComposedSlide attached.
+        asset = Asset(
+            filename="orphan-composed",
+            asset_type=AssetType.COMPOSED,
+            size_bytes=0,
+            checksum="",
+        )
+        db_session.add(asset)
+        await db_session.commit()
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 404
+
+    async def test_happy_path_returns_html_with_widget_content(
+        self, client, db_session
+    ):
+        asset, _cs = await _make_composed(
+            db_session, layout=_text_layout("preview content xyz")
+        )
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/html")
+        body = resp.text
+        assert "preview content xyz" in body
+        # Bundle is a complete HTML document.
+        assert "<html" in body.lower()
+
+    async def test_csp_header_is_locked_down(self, client, db_session):
+        asset, _cs = await _make_composed(db_session)
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200
+        csp = resp.headers.get("content-security-policy", "")
+        assert "default-src 'none'" in csp
+        assert "frame-ancestors 'self'" in csp
+        # No external script/style/img origins allowed.
+        assert "http:" not in csp
+        assert "https:" not in csp
+
+    async def test_no_cache_header_set(self, client, db_session):
+        asset, _cs = await _make_composed(db_session)
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-store"
+
+    async def test_invalid_layout_json_returns_422(self, client, db_session):
+        asset = Asset(
+            filename="bad-layout",
+            asset_type=AssetType.COMPOSED,
+            size_bytes=0,
+            checksum="",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+        # layout_json is not a valid Layout shape.
+        cs = ComposedSlide(asset_id=asset.id, layout_json={"not": "a layout"})
+        db_session.add(cs)
+        await db_session.commit()
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -1,0 +1,248 @@
+"""Phase 1A tests for the composed slide publish service."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from cms.composed.publish import (
+    PublishError,
+    publish_composed_slide,
+)
+from cms.composed.schema import (
+    Cell,
+    Layout,
+    WidgetInstance,
+    empty_layout,
+)
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+
+def _text_layout(text: str = "hello world") -> Layout:
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="text",
+            cell=Cell(row=1, col=1, rowspan=1, colspan=4),
+            config={"text": text, "font_size_px": 64},
+            config_version=1,
+        )
+    )
+    return layout
+
+
+async def _make_composed(db_session, *, layout: Layout | None = None) -> tuple[Asset, ComposedSlide]:
+    asset = Asset(
+        filename=f"composed-placeholder-{uuid.uuid4()}",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=(layout or _text_layout()).model_dump(mode="json"),
+    )
+    db_session.add(cs)
+    await db_session.flush()
+    return asset, cs
+
+
+@pytest.fixture
+def mock_storage_and_dir(tmp_path):
+    """Patch get_storage + asset_storage_path to tmp_path."""
+    mock_storage = MagicMock()
+    mock_storage.on_file_stored = AsyncMock()
+
+    mock_settings = MagicMock()
+    mock_settings.asset_storage_path = tmp_path
+
+    with patch("cms.composed.publish.get_storage", return_value=mock_storage), \
+         patch("cms.auth.get_settings", return_value=mock_settings):
+        yield mock_storage, tmp_path
+
+
+@pytest.mark.asyncio
+async def test_publish_writes_bundle_and_updates_asset(db_session, mock_storage_and_dir):
+    mock_storage, tmp_path = mock_storage_and_dir
+    asset, _ = await _make_composed(db_session)
+    asset_id = asset.id
+
+    result = await publish_composed_slide(asset_id, db_session)
+
+    assert result.rebuilt is True
+    assert result.size_bytes > 0
+    assert len(result.checksum) == 64  # SHA-256 hex
+
+    # Asset row was updated in-place
+    await db_session.refresh(asset)
+    assert asset.filename == result.filename
+    assert asset.checksum == result.checksum
+    assert asset.size_bytes == result.size_bytes
+    assert asset.asset_type == AssetType.COMPOSED
+
+    # Bundle landed on disk
+    bundle_path = tmp_path / asset.filename
+    assert bundle_path.is_file()
+    assert bundle_path.read_bytes() == bundle_path.read_bytes()  # tautology — exists
+
+    # Cloud sync hook fired
+    mock_storage.on_file_stored.assert_awaited_once_with(asset.filename)
+
+
+@pytest.mark.asyncio
+async def test_publish_flips_draft_and_records_metadata(db_session, mock_storage_and_dir):
+    asset, cs = await _make_composed(db_session)
+    assert cs.is_draft is True
+
+    await publish_composed_slide(asset.id, db_session)
+
+    await db_session.refresh(cs)
+    assert cs.is_draft is False
+    assert cs.bundle_built_at is not None
+    # Empty source_asset_ids on a text-only layout is fine (no refs)
+    assert cs.bundle_source_asset_ids == []
+
+
+@pytest.mark.asyncio
+async def test_publish_filename_is_content_addressed(db_session, mock_storage_and_dir):
+    asset, _ = await _make_composed(db_session)
+    asset_id = asset.id
+    result = await publish_composed_slide(asset_id, db_session)
+    # composed-{uuid}-{12 hex chars}.html
+    assert result.filename.startswith(f"composed-{asset_id}-")
+    assert result.filename.endswith(".html")
+    sha_chunk = result.filename[len(f"composed-{asset_id}-"):-len(".html")]
+    assert len(sha_chunk) == 12
+    assert all(c in "0123456789abcdef" for c in sha_chunk)
+
+
+@pytest.mark.asyncio
+async def test_publish_idempotent_when_content_unchanged(db_session, mock_storage_and_dir):
+    mock_storage, _ = mock_storage_and_dir
+    asset, cs = await _make_composed(db_session)
+    asset_id = asset.id
+
+    first = await publish_composed_slide(asset_id, db_session)
+    assert first.rebuilt is True
+    assert mock_storage.on_file_stored.await_count == 1
+
+    second = await publish_composed_slide(asset_id, db_session)
+    assert second.rebuilt is False
+    assert second.checksum == first.checksum
+    assert second.filename == first.filename
+    # Second call did NOT re-upload — still only one storage hook call
+    assert mock_storage.on_file_stored.await_count == 1
+    # bundle_built_at still bumped on no-op publish
+    assert second.bundle_built_at >= first.bundle_built_at
+
+
+@pytest.mark.asyncio
+async def test_publish_rebuilds_when_layout_changes(db_session, mock_storage_and_dir):
+    mock_storage, _ = mock_storage_and_dir
+    asset, cs = await _make_composed(db_session, layout=_text_layout("first"))
+    asset_id = asset.id
+
+    first = await publish_composed_slide(asset_id, db_session)
+
+    cs.layout_json = _text_layout("second").model_dump(mode="json")
+    await db_session.flush()
+
+    second = await publish_composed_slide(asset_id, db_session)
+
+    assert second.rebuilt is True
+    assert second.checksum != first.checksum
+    assert second.filename != first.filename
+    assert mock_storage.on_file_stored.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_for_missing_asset(db_session, mock_storage_and_dir):
+    with pytest.raises(PublishError, match="not found"):
+        await publish_composed_slide(uuid.uuid4(), db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_for_non_composed_asset(db_session, mock_storage_and_dir):
+    asset = Asset(
+        filename="some-image.jpg",
+        asset_type=AssetType.IMAGE,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    with pytest.raises(PublishError, match="not composed"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_when_no_composed_row(db_session, mock_storage_and_dir):
+    asset = Asset(
+        filename="orphan",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    with pytest.raises(PublishError, match="No composed slide row"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_on_invalid_layout(db_session, mock_storage_and_dir):
+    asset = Asset(
+        filename="bad",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json={"schema_version": "not-an-int", "widgets": "not-a-list"},
+    )
+    db_session.add(cs)
+    await db_session.flush()
+
+    with pytest.raises(PublishError, match="Invalid layout JSON"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_on_validation_failure(db_session, mock_storage_and_dir):
+    # Two overlapping widgets — passes Pydantic shape, fails validate_layout.
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="text",
+            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={"text": "a"},
+            config_version=1,
+        )
+    )
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="text",
+            cell=Cell(row=2, col=2, rowspan=2, colspan=2),
+            config={"text": "b"},
+            config_version=1,
+        )
+    )
+    asset, _ = await _make_composed(db_session, layout=layout)
+
+    with pytest.raises(PublishError, match="failed validation"):
+        await publish_composed_slide(asset.id, db_session)

--- a/tests/test_composed_text_widget.py
+++ b/tests/test_composed_text_widget.py
@@ -1,0 +1,185 @@
+"""Tests for cms.composed.widgets.text.TextWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# Side-effect import: triggers global registry population
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import WidgetRender, get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.text import TextWidget, TextWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=1, colspan=1)
+
+
+class TestTextWidgetConfig:
+    def test_minimum_valid_config(self):
+        c = TextWidgetConfig(text="hi")
+        assert c.text == "hi"
+        assert c.color == "#ffffff"
+        assert c.font_size_px == 48
+        assert c.font_family == "sans"
+
+    def test_text_required(self):
+        with pytest.raises(ValidationError):
+            TextWidgetConfig()
+
+    def test_text_min_length(self):
+        with pytest.raises(ValidationError):
+            TextWidgetConfig(text="")
+
+    def test_text_max_length(self):
+        with pytest.raises(ValidationError):
+            TextWidgetConfig(text="x" * 4097)
+
+    def test_text_max_length_boundary_ok(self):
+        TextWidgetConfig(text="x" * 4096)
+
+    def test_color_must_be_hex_6(self):
+        for bad in ("red", "#fff", "#gggggg", "#FFFFFFF", "rgb(0,0,0)", ""):
+            with pytest.raises(ValidationError):
+                TextWidgetConfig(text="hi", color=bad)
+
+    def test_color_uppercase_hex_accepted(self):
+        c = TextWidgetConfig(text="hi", color="#ABCDEF")
+        assert c.color == "#ABCDEF"
+
+    def test_font_size_range_rejects_oob(self):
+        for bad in (0, 7, 513, 1000):
+            with pytest.raises(ValidationError):
+                TextWidgetConfig(text="hi", font_size_px=bad)
+
+    def test_font_size_range_accepts_boundary(self):
+        TextWidgetConfig(text="hi", font_size_px=8)
+        TextWidgetConfig(text="hi", font_size_px=512)
+
+    def test_font_family_allowlist_accepts_known(self):
+        for fam in ("sans", "serif", "mono"):
+            assert (
+                TextWidgetConfig(text="hi", font_family=fam).font_family == fam
+            )
+
+    def test_font_family_rejects_unknown(self):
+        for bad in ("wingdings", "Arial", "", "Sans", "SANS"):
+            with pytest.raises(ValidationError):
+                TextWidgetConfig(text="hi", font_family=bad)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TextWidgetConfig(text="hi", unknown_field="x")
+
+
+class TestTextWidget:
+    def test_default_config_validates(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig.model_validate(w.default_config())
+        assert cfg.text  # non-empty
+        assert cfg.font_family in {"sans", "serif", "mono"}
+
+    def test_editor_template_path_returned(self):
+        # Contract: must return a non-empty path the Jinja loader
+        # could (eventually) resolve.
+        path = TextWidget().editor_template()
+        assert path
+        assert path.endswith(".html")
+
+    def test_render_produces_instance_scoped_class(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(text="hi")
+        instance_id = "11111111-1111-1111-1111-111111111111"
+        out = w.render_html(cfg, _cell(), instance_id)
+        assert isinstance(out, WidgetRender)
+        scoped_class = f"cw-text-{instance_id}"
+        assert scoped_class in out.html, (
+            f"expected {scoped_class!r} in html: {out.html!r}"
+        )
+        assert f".{scoped_class} {{" in out.css, (
+            f"expected scoped css rule for {scoped_class!r} in {out.css!r}"
+        )
+
+    def test_render_escapes_script_tag(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(text='<script>alert("xss")</script>')
+        out = w.render_html(cfg, _cell(), "abc")
+        # No raw <script> may survive into the body
+        assert "<script>" not in out.html
+        assert "</script>" not in out.html
+        # Must appear escaped
+        assert "&lt;script&gt;" in out.html
+        assert "&lt;/script&gt;" in out.html
+
+    def test_render_escapes_ampersand_and_quotes(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(text='A & B "C" \'D\'')
+        out = w.render_html(cfg, _cell(), "abc")
+        assert "&amp;" in out.html
+        # html.escape() with default quote=True encodes " and '
+        assert "&quot;" in out.html
+        assert "&#x27;" in out.html
+
+    def test_render_emits_color_size_and_font(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(
+            text="hi",
+            color="#abcdef",
+            font_size_px=96,
+            font_family="serif",
+        )
+        out = w.render_html(cfg, _cell(), "x")
+        assert "color: #abcdef" in out.css
+        assert "font-size: 96px" in out.css
+        assert "Georgia" in out.css  # serif stack contains Georgia
+
+    def test_render_two_instances_isolated(self):
+        # Two instances with different IDs must produce non-colliding
+        # CSS — proves the instance-scoping rule holds.
+        w = TextWidget()
+        cfg = TextWidgetConfig(text="hi")
+        a = w.render_html(cfg, _cell(), "aaaa")
+        b = w.render_html(cfg, _cell(), "bbbb")
+        assert "cw-text-aaaa" in a.css
+        assert "cw-text-bbbb" in b.css
+        assert "cw-text-aaaa" not in b.css
+        assert "cw-text-bbbb" not in a.css
+
+    def test_render_no_referenced_assets_or_static_assets(self):
+        # Text widget has no asset dependencies in 1A.
+        w = TextWidget()
+        cfg = TextWidgetConfig(text="hi")
+        out = w.render_html(cfg, _cell(), "x")
+        assert out.referenced_asset_ids == []
+        assert out.static_assets == []
+        assert out.js == ""
+        assert out.init_js is None
+
+
+class TestRegistration:
+    def test_text_widget_registered_on_package_import(self):
+        # The top-of-file `import cms.composed.widgets` must have
+        # populated the global registry.
+        reg = get_registry()
+        assert reg.has("text"), (
+            f"text widget missing from global registry; "
+            f"registered slugs: {reg.slugs()}"
+        )
+
+    def test_registered_widget_is_a_text_widget(self):
+        reg = get_registry()
+        w = reg.get("text")
+        assert isinstance(w, TextWidget)
+
+    def test_re_import_does_not_double_register(self):
+        # Re-running the registration block must be a no-op.  This
+        # protects future cms.composed.__init__ changes that might
+        # auto-import widgets from blowing up at startup.
+        import importlib
+
+        import cms.composed.widgets as widgets_pkg
+
+        importlib.reload(widgets_pkg)
+        reg = get_registry()
+        assert reg.has("text")


### PR DESCRIPTION
Phase 1A of the Composed Slide feature: proves the bundle delivery model end-to-end before tackling the real widget set in 1B.

## What's in this PR

- **`cms/composed/publish.py`** - idempotent publish service. Builds a bundle from a composed slide's saved layout, writes it under `asset_storage_path` with a content-addressed filename (`composed-{asset_id}-{sha[:12]}.html`), and updates the Asset row (filename/checksum/size_bytes/is_draft=False) and ComposedSlide bundle metadata (`bundle_built_at`, `bundle_source_asset_ids`). Caller owns the transaction.
- **`cms/routers/composed.py`** - `GET /composed/{id}/preview` live-renders the saved layout via the same `build_bundle` used at publish and returns it inline. CSP locked down to `default-src 'none'` + `frame-ancestors 'self'` (no external origins of any kind), plus `X-Content-Type-Options: nosniff` and `Cache-Control: no-store`. Auth-gated via `require_auth` - editor only, not device path.
- **`cms/main.py`** - wires the new router.

## Scheduler / device path - no edits needed

`cms/services/device_inbound.py::_resolve_asset_for_device` already handles `AssetType.COMPOSED` correctly: it bypasses the SLIDESHOW lazy-import branch, `is_file_asset` is False (COMPOSED isn't in {VIDEO, IMAGE, SAVED_STREAM}), and it falls through to the default block that builds a `FetchAssetMessage` from `asset.filename` / `download_url` / `checksum` / `size_bytes` / `asset_type`. `tests/test_composed_device_sync.py` locks that in.

## Tests

105 composed tests pass. New in this PR:
- `test_composed_publish.py` - 10 tests covering idempotency on content-SHA, filename pattern, validation propagation, bundle metadata round-trip, etc.
- `test_composed_preview.py` - 7 tests covering 404 (missing/wrong-type/orphan), happy-path HTML, CSP lockdown, no-store cache header, 422 on invalid layout JSON.
- `test_composed_device_sync.py` - 1 test pinning the COMPOSED-default-branch scheduler behavior.

## Pi validation gate (after merge / dev deploy)

Hand-build a composed slide row on goodwill-dev, schedule it, confirm Pi100/Pi53 caches the bundle and plays it offline. That's the prerequisite for starting Phase 1B (real widget set).