### PR TITLE
Push immediate sync on device group_id change

### DIFF
--- a/cms/routers/devices.py
+++ b/cms/routers/devices.py
@@ -484,8 +484,19 @@ async def update_device(
     await db.commit()
     await db.refresh(device, ["group", "default_asset"])
 
+    # If group_id changed, push a full sync immediately.  The new group
+    # may carry schedules that newly target this device (or no longer
+    # do), and the inherited group-default asset may change.  Without
+    # this push the device would wait up to ~15s for the next scheduler
+    # tick to pick up the change.  A full sync covers both schedules and
+    # the effective default in one message, so it subsumes the
+    # default_asset_id / timezone branches below when group_id is also
+    # in this PATCH.
+    if "group_id" in updates:
+        await push_sync_to_device(device_id, db)
+
     # If default_asset_id was changed, resolve effective default and push
-    if "default_asset_id" in updates:
+    elif "default_asset_id" in updates:
         from cms.routers.ws import get_asset_base_url
         base_url = get_asset_base_url(request)
         # Resolve: device default → group default → none (splash)

--- a/tests/test_device_actions.py
+++ b/tests/test_device_actions.py
@@ -193,3 +193,110 @@ class TestSplashFix:
                 mock_sync.assert_called()
         finally:
             device_manager.disconnect("splash-002")
+
+
+@pytest.mark.asyncio
+class TestGroupChangePushSync:
+    """Changing a device's group_id should trigger an immediate full sync
+    so the device picks up the new group's schedules and inherited default
+    asset without waiting ~15s for the next scheduler tick."""
+
+    async def test_setting_group_id_pushes_sync(self, client, db_session):
+        from cms.models.device import Device, DeviceGroup
+
+        group = DeviceGroup(id=uuid.uuid4(), name="Lobby")
+        db_session.add(group)
+        device = Device(id="grp-001", name="Test", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
+            resp = await client.patch(
+                "/api/devices/grp-001",
+                json={"group_id": str(group.id)},
+            )
+            assert resp.status_code == 200
+            mock_sync.assert_called_once()
+            assert mock_sync.call_args[0][0] == "grp-001"
+
+    async def test_clearing_group_id_pushes_sync(self, client, db_session):
+        from cms.models.device import Device, DeviceGroup
+
+        group = DeviceGroup(id=uuid.uuid4(), name="Lobby")
+        db_session.add(group)
+        device = Device(
+            id="grp-002", name="Test", status=DeviceStatus.ADOPTED, group_id=group.id,
+        )
+        db_session.add(device)
+        await db_session.commit()
+
+        with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
+            resp = await client.patch(
+                "/api/devices/grp-002",
+                json={"group_id": None},
+            )
+            assert resp.status_code == 200
+            mock_sync.assert_called_once()
+            assert mock_sync.call_args[0][0] == "grp-002"
+
+    async def test_changing_group_id_pushes_sync(self, client, db_session):
+        from cms.models.device import Device, DeviceGroup
+
+        old_group = DeviceGroup(id=uuid.uuid4(), name="Lobby")
+        new_group = DeviceGroup(id=uuid.uuid4(), name="Cafeteria")
+        db_session.add_all([old_group, new_group])
+        device = Device(
+            id="grp-003", name="Test", status=DeviceStatus.ADOPTED, group_id=old_group.id,
+        )
+        db_session.add(device)
+        await db_session.commit()
+
+        with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
+            resp = await client.patch(
+                "/api/devices/grp-003",
+                json={"group_id": str(new_group.id)},
+            )
+            assert resp.status_code == 200
+            mock_sync.assert_called_once()
+            assert mock_sync.call_args[0][0] == "grp-003"
+
+    async def test_unrelated_patch_does_not_push_sync(self, client, db_session):
+        """PATCH that doesn't touch group_id/default_asset_id/timezone
+        should NOT push a sync (preserves existing behavior)."""
+        from cms.models.device import Device
+
+        device = Device(id="grp-004", name="OldName", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync:
+            resp = await client.patch(
+                "/api/devices/grp-004",
+                json={"name": "NewName"},
+            )
+            assert resp.status_code == 200
+            mock_sync.assert_not_called()
+
+    async def test_group_and_default_asset_together_single_full_sync(self, client, db_session):
+        """When both group_id and default_asset_id are in one PATCH, the
+        group_id branch wins (single full sync covers both)."""
+        from cms.models.asset import Asset
+        from cms.models.device import Device, DeviceGroup
+
+        group = DeviceGroup(id=uuid.uuid4(), name="Lobby")
+        asset_id = uuid.uuid4()
+        asset = Asset(id=asset_id, filename="t.mp4", asset_type="video", size_bytes=1, checksum="x")
+        db_session.add_all([group, asset])
+        device = Device(id="grp-005", name="Test", status=DeviceStatus.ADOPTED)
+        db_session.add(device)
+        await db_session.commit()
+
+        with patch("cms.routers.devices.push_sync_to_device", new_callable=AsyncMock) as mock_sync, \
+             patch("cms.routers.devices._push_default_asset", new_callable=AsyncMock) as mock_push_default:
+            resp = await client.patch(
+                "/api/devices/grp-005",
+                json={"group_id": str(group.id), "default_asset_id": str(asset_id)},
+            )
+            assert resp.status_code == 200
+            mock_sync.assert_called_once()
+            mock_push_default.assert_not_called()


### PR DESCRIPTION
When a device's `group_id` changes via PATCH, push a full sync immediately rather than waiting up to ~15s for the next scheduler tick.

## Why

The common scenario: a schedule has the `no-target` condition (it currently targets nothing). A device gets added to a group that schedule targets. Today, the device sits idle for an entire scheduler cycle before picking up the new assignment.

This change closes that gap. PATCHing `group_id` triggers `push_sync_to_device`, which sends the full device sync (schedules + inherited default asset). The device starts running the new content within a couple of seconds.

## Behavior

| PATCH body | Push |
|---|---|
| `{"group_id": "..."}` (set / change / clear) | full sync |
| `{"default_asset_id": "..."}` (no group_id) | existing default-asset push |
| `{"group_id": ..., "default_asset_id": ...}` | full sync (subsumes default-asset push) |
| `{"timezone": "..."}` (no group_id) | existing full sync |
| `{"name": "..."}` only | no push |

## Tests

5 new tests in `TestGroupChangePushSync` covering set / clear / change / unrelated / combined-with-default-asset.

All 16 tests in `tests/test_device_actions.py` pass locally.