### PR TITLE
ci: add tests-changed early-warning job + concurrency cancel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   workflow_call:
 
+# Cancel any in-flight run on the same ref when a new commit lands.
+# Saves CI minutes when devs push fix-ups to a PR that already had a
+# long-running test job underway. ``cancel-in-progress: true`` is
+# safe here because we never care about an intermediate commit's
+# result once a newer one exists -- the newer commit's run supersedes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect whether the PR touches code/tests that warrant running the
   # unit and e2e suites. Pure docs/nightly/workflow-only PRs skip the
@@ -36,6 +45,121 @@ jobs:
             broker:
               - 'local-broker/**'
               - '.github/workflows/tests.yml'
+
+  # Early-warning job: runs ONLY the test files changed in this PR,
+  # sequentially with -x (fail-fast), no coverage, no xdist overhead.
+  # Goal: surface failures in newly added / edited tests in 1-3 min
+  # instead of waiting ~30 min for the full xdist suite. Mirrors the
+  # ``test`` job's environment (postgres service + ffmpeg + libheif)
+  # so a green result here genuinely predicts a green result there
+  # for the same files.
+  #
+  # NOT added to ci-gate -- the full ``test`` job remains the required
+  # check. This is purely a developer-feedback signal.
+  tests-changed:
+    name: tests-changed (early-warning)
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: agora_test
+          POSTGRES_PASSWORD: agora_test
+          POSTGRES_DB: agora_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U agora_test -d agora_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      AGORA_CMS_DATABASE_URL: postgresql+asyncpg://agora_test:agora_test@localhost:5432/agora_test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need history for ``git diff`` against the PR base ref.
+          fetch-depth: 0
+
+      - name: Determine changed test files
+        id: changed
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE_SHA" ]; then
+            echo "No PR base SHA; skipping."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Three-dot: tests in HEAD that differ from the merge-base
+          # with base (i.e. only what THIS PR adds/changes, not
+          # everything ``main`` has moved on since branch).
+          FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- 'tests/**/*.py' 'tests_e2e/**/*.py' \
+            | grep -v '^tests/nightly/' \
+            | grep -v '^tests/e2e/' \
+            | grep -v '^tests_e2e/' \
+            | tr '\n' ' ' \
+            | sed 's/[[:space:]]*$//')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "No changed unit-test files in this PR."
+          else
+            echo "Changed test files:"
+            for f in $FILES; do echo "  - $f"; done
+          fi
+
+      - name: Skip if no changed test files
+        if: steps.changed.outputs.files == ''
+        run: echo "Nothing to run. Full ``test`` job will still execute."
+
+      - uses: actions/setup-python@v5
+        if: steps.changed.outputs.files != ''
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-shared.txt
+
+      - name: Cache FFmpeg
+        if: steps.changed.outputs.files != ''
+        id: ffmpeg-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/ffmpeg
+            /usr/local/bin/ffprobe
+          key: ffmpeg-8.1-${{ runner.arch }}
+
+      - name: Install FFmpeg
+        if: steps.changed.outputs.files != '' && steps.ffmpeg-cache.outputs.cache-hit != 'true'
+        run: |
+          ARCH=$(dpkg --print-architecture)
+          case "$ARCH" in
+            arm64|aarch64) FFARCH=linuxarm64 ;;
+            *)             FFARCH=linux64 ;;
+          esac
+          curl -fSL "https://github.com/sslivins/agora-cms/releases/download/ffmpeg-8.1/ffmpeg-${FFARCH}.tar.xz" | \
+            sudo tar -xJ --strip-components=1 -C /usr/local
+
+      - name: Install system dependencies
+        if: steps.changed.outputs.files != ''
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libheif-examples libheif-plugin-x265 mtools parted xz-utils
+
+      - name: Install dependencies
+        if: steps.changed.outputs.files != ''
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-timeout pytest-cov pytest-xdist httpx aiosqlite psycopg2-binary
+
+      - name: Run changed tests (fail-fast, sequential, no coverage)
+        if: steps.changed.outputs.files != ''
+        run: |
+          python -m pytest ${{ steps.changed.outputs.files }} \
+            -x -p no:xdist -p no:timeout \
+            --tb=short -q -rs
 
   test:
     needs: changes


### PR DESCRIPTION
## What

Adds a new `tests-changed` CI job that runs **only the test files this PR touches**, sequentially, fail-fast, no coverage, no xdist overhead. Mirrors the full `test` job's environment (postgres service, ffmpeg, libheif) so a green result here genuinely predicts a green result there for those files.

Also adds a top-level `concurrency` block to cancel in-flight runs on the same ref when fix-up commits land.

## Why

Today's pain: full suite is xdist + ~30 min, new tests run last, so a broken new test surfaces ~28 min into a run. Most of that time is spent re-validating hundreds of tests we already know pass.

Goal: surface failures in newly-added / changed tests in **1-3 min** while the long suite is still going.

## How it works

- Reads `github.event.pull_request.base.sha`, three-dot diff against HEAD to get files added/modified in this PR
- Filters to `tests/**/*.py`, excludes `tests/nightly/`, `tests/e2e/`, `tests_e2e/`
- If empty → friendly skip message, job ends green
- Else → installs the same env the full `test` job uses, runs `pytest <files> -x -p no:xdist -p no:timeout`

## Not a required check

**`tests-changed` is NOT added to `ci-gate`.** The full `test` job remains the required check for merge. This is purely a developer-feedback signal — fast, advisory, fails loud when something obviously broke.

## Concurrency cancel

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Safe: we never care about an intermediate commit's result once a newer one exists on the same branch. Saves CI minutes on rapid fix-up pushes.

## Validation

This PR is itself a meaningful first test: it touches the workflow (so `changes.code == true`) but adds no test files, so `tests-changed` should hit the no-files path and skip cleanly.

After merge I'll cut throwaway branches to validate the other paths (passing-test, failing-test, concurrency-cancel).
