### PR TITLE
composed: Phase 1B image/clock/ticker widgets + BundleContext contract

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -23,9 +23,11 @@ import base64
 import hashlib
 import html
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from cms.composed.registry import (
+    BundleContext,
     Widget,
     WidgetRegistry,
     WidgetRender,
@@ -63,6 +65,38 @@ class BuiltBundle:
     html_bytes: bytes
     sha256_hex: str
     source_asset_ids: list[uuid.UUID]
+
+
+# Callable that resolves an asset ID to ``(bytes, mime_type)``.  The
+# publish service builds one of these from a DB-bound closure (reads
+# the Asset row, opens the on-disk blob); tests pass a synchronous
+# dict-backed stub.
+AssetLoader = Callable[[uuid.UUID], tuple[bytes, str]]
+
+
+class MissingAssetLoaderError(BundleValidationError):
+    """Raised when a layout's widgets declared asset deps but the caller
+    didn't supply an :data:`AssetLoader`.
+
+    Subclasses :class:`BundleValidationError` so existing publish-side
+    error handling still catches it; the message specifically tells
+    the caller they forgot to wire the loader, which is a code bug
+    rather than a layout issue.
+    """
+
+    def __init__(self, missing_ids: list[uuid.UUID]) -> None:
+        ids = ", ".join(str(i) for i in missing_ids)
+        super().__init__(
+            [
+                ValidationError(
+                    code="missing_asset_loader",
+                    message=(
+                        f"layout references asset IDs {ids} but no "
+                        "asset_loader was supplied to build_bundle"
+                    ),
+                )
+            ]
+        )
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -120,8 +154,16 @@ def _resolve_widget(reg: WidgetRegistry, inst: WidgetInstance) -> Widget:
 def build_bundle(
     layout: Layout,
     registry: WidgetRegistry | None = None,
+    asset_loader: AssetLoader | None = None,
 ) -> BuiltBundle:
     """Render ``layout`` to a self-contained HTML bundle.
+
+    ``asset_loader``, if supplied, is called once per unique asset ID
+    declared by any widget (via :meth:`Widget.declared_asset_ids`) and
+    must return ``(bytes, mime_type)``.  Widgets receive the resolved
+    bytes through :class:`BundleContext`.  A layout whose widgets
+    declare any asset IDs but is built without a loader raises
+    :class:`MissingAssetLoaderError`.
 
     Raises :class:`BundleValidationError` if the layout fails
     :func:`~cms.composed.validate.validate_layout`.  The check is
@@ -136,23 +178,80 @@ def build_bundle(
     if errors:
         raise BundleValidationError(errors)
 
-    # 2. Render each widget, collecting css/js/static assets +
-    #    accumulated referenced asset IDs for staleness tracking.
-    rendered: list[tuple[WidgetInstance, WidgetRender]] = []
-    source_asset_ids: list[uuid.UUID] = []
-    seen_asset_ids: set[uuid.UUID] = set()
-
+    # 2a. Collect each widget's typed config + declared asset IDs in
+    #     a single pre-render pass.  Doing this first means we know
+    #     the full set of bytes we need before we render anything —
+    #     loader failures surface as one error block, not per-widget.
+    prepped: list[tuple[WidgetInstance, Widget, object, list[uuid.UUID]]] = []
+    all_declared_ids: list[uuid.UUID] = []
+    seen_declared: set[uuid.UUID] = set()
     for inst in layout.widgets:
         widget = _resolve_widget(reg, inst)
         # The validator already constructed + checked the config; re-do
         # it here so render_html gets a typed config object rather than
         # a raw dict.  Cheap (Pydantic is fast for small models).
         config = widget.ConfigSchema.model_validate(inst.config)
+        declared = list(widget.declared_asset_ids(config))
+        prepped.append((inst, widget, config, declared))
+        for aid in declared:
+            if aid not in seen_declared:
+                seen_declared.add(aid)
+                all_declared_ids.append(aid)
+
+    if all_declared_ids and asset_loader is None:
+        raise MissingAssetLoaderError(all_declared_ids)
+
+    # 2b. Pre-fetch every declared asset exactly once.
+    asset_bytes: dict[uuid.UUID, bytes] = {}
+    asset_mimes: dict[uuid.UUID, str] = {}
+    if asset_loader is not None:
+        for aid in all_declared_ids:
+            blob, mime = asset_loader(aid)
+            asset_bytes[aid] = blob
+            asset_mimes[aid] = mime
+
+    # 2c. Render each widget with a context scoped to *just* the assets
+    #     it declared.  Scoping (rather than handing every widget the
+    #     whole map) is the enforcement mechanism for the
+    #     "declare-before-reference" rule — a widget that tries to read
+    #     an undeclared ID gets a KeyError instead of silently working
+    #     because some other widget happened to declare the same asset.
+    rendered: list[tuple[WidgetInstance, WidgetRender]] = []
+    source_asset_ids: list[uuid.UUID] = []
+    seen_asset_ids: set[uuid.UUID] = set()
+
+    for inst, widget, config, declared in prepped:
+        ctx = BundleContext(
+            asset_bytes={aid: asset_bytes[aid] for aid in declared},
+            asset_mimes={aid: asset_mimes[aid] for aid in declared},
+        )
         render: WidgetRender = widget.render_html(
             config=config,
             cell=inst.cell,
             instance_id=_instance_id_str(inst),
+            ctx=ctx,
         )
+
+        # Enforce the declare-before-reference invariant: every ID a
+        # widget reports in WidgetRender.referenced_asset_ids must
+        # have been declared up front.
+        declared_set = set(declared)
+        for aid in render.referenced_asset_ids:
+            if aid not in declared_set:
+                raise BundleValidationError(
+                    [
+                        ValidationError(
+                            code="undeclared_referenced_asset",
+                            message=(
+                                f"widget {inst.id} ({inst.type}) referenced "
+                                f"asset {aid} in WidgetRender but did not "
+                                "return it from declared_asset_ids()"
+                            ),
+                            widget_id=str(inst.id),
+                        )
+                    ]
+                )
+
         rendered.append((inst, render))
 
         for aid in render.referenced_asset_ids:

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -23,10 +23,10 @@ one.
 
 from __future__ import annotations
 
+import mimetypes
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-
-import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -112,8 +112,68 @@ async def publish_composed_slide(
     import cms.composed.widgets  # noqa: F401
 
     registry = get_registry()
+
+    # Pre-fetch every asset declared by any widget in the layout.
+    # ``build_bundle`` runs sync, so we resolve all (bytes, mime) pairs
+    # here (async-friendly DB + disk reads) and hand the builder a
+    # dict-backed synchronous closure.  Widgets that declare an asset
+    # they can't legitimately reference will be caught by validation
+    # before we get here, but missing-on-disk slips through to this
+    # loop and surfaces as a PublishError.
+    from cms.auth import get_settings as _get_settings
+
+    storage_dir = _get_settings().asset_storage_path
+
+    declared_ids: list[uuid.UUID] = []
+    seen_declared: set[uuid.UUID] = set()
+    for inst in layout.widgets:
+        widget = registry.get(inst.type)
+        if widget is None:
+            # validate_layout (run inside build_bundle) will reject
+            # this with a clearer error; skip here so we don't crash
+            # before that gets a chance to run.
+            continue
+        cfg = widget.ConfigSchema.model_validate(inst.config)
+        for aid in widget.declared_asset_ids(cfg):
+            if aid not in seen_declared:
+                seen_declared.add(aid)
+                declared_ids.append(aid)
+
+    asset_payloads: dict[uuid.UUID, tuple[bytes, str]] = {}
+    if declared_ids:
+        rows = await db.execute(
+            select(Asset).where(Asset.id.in_(declared_ids)),
+        )
+        by_id = {a.id: a for a in rows.scalars().all()}
+        for aid in declared_ids:
+            ref = by_id.get(aid)
+            if ref is None:
+                raise PublishError(
+                    f"Composed slide references missing asset {aid}",
+                )
+            ref_path = storage_dir / ref.filename
+            try:
+                blob = ref_path.read_bytes()
+            except FileNotFoundError as e:
+                raise PublishError(
+                    f"Asset {aid} file missing on disk: {ref.filename}",
+                ) from e
+            mime, _ = mimetypes.guess_type(ref.filename)
+            asset_payloads[aid] = (blob, mime or "application/octet-stream")
+
+    def _asset_loader(aid: uuid.UUID) -> tuple[bytes, str]:
+        # build_bundle only calls this for IDs in ``declared_ids``,
+        # which is exactly what we pre-fetched above; a KeyError here
+        # would mean a widget bypassed declared_asset_ids() and is a
+        # programming error worth surfacing loudly.
+        return asset_payloads[aid]
+
     try:
-        built = build_bundle(layout, registry)
+        built = build_bundle(
+            layout,
+            registry,
+            asset_loader=_asset_loader if declared_ids else None,
+        )
     except BundleValidationError as e:
         raise PublishError(
             "Layout failed validation: "
@@ -122,8 +182,6 @@ async def publish_composed_slide(
 
     filename = _bundle_filename(asset_id, built.sha256_hex)
     storage = get_storage()
-    from cms.auth import get_settings as _get_settings
-    storage_dir = _get_settings().asset_storage_path
     storage_dir.mkdir(parents=True, exist_ok=True)
     dest = storage_dir / filename
 

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -29,6 +29,29 @@ from cms.composed.schema import Cell
 
 
 @dataclass
+class BundleContext:
+    """Per-build context passed into every widget's ``render_html``.
+
+    The bundle builder pre-fetches all bytes a layout needs (via the
+    asset loader supplied to :func:`cms.composed.bundle.build_bundle`)
+    and surfaces them here so widgets stay pure — they don't open files,
+    don't hit the DB, don't talk to the network.
+
+    ``asset_bytes`` and ``asset_mimes`` are keyed by the
+    ``uuid.UUID`` IDs the widget declared via
+    :meth:`Widget.declared_asset_ids`.  A widget that references an
+    asset MUST also declare it; the bundle builder rejects layouts
+    whose widgets reference undeclared assets at render time.
+
+    Empty default is intentional: trivial widgets (text, clock) that
+    never touch assets can ignore the parameter entirely.
+    """
+
+    asset_bytes: dict[uuid.UUID, bytes] = field(default_factory=dict)
+    asset_mimes: dict[uuid.UUID, str] = field(default_factory=dict)
+
+
+@dataclass
 class WidgetStaticAsset:
     """A binary or text asset the widget needs in the bundle.
 
@@ -84,7 +107,21 @@ class Widget:
         config: BaseModel,
         cell: Cell,
         instance_id: str,
+        ctx: BundleContext | None = None,
     ) -> WidgetRender:
+        """Render a single widget instance.
+
+        ``ctx`` is the per-build :class:`BundleContext` populated by
+        the bundle builder.  Widgets that don't need pre-fetched
+        bytes can ignore it; widgets that do (image, video) read
+        from ``ctx.asset_bytes`` / ``ctx.asset_mimes`` keyed by the
+        IDs they returned from :meth:`declared_asset_ids`.
+
+        The parameter defaults to ``None`` so unit tests and trivial
+        widgets can call ``render_html(cfg, cell, "id")`` directly;
+        production calls from the bundle builder always pass a real
+        :class:`BundleContext`.
+        """
         raise NotImplementedError
 
     def editor_template(self) -> str:
@@ -107,6 +144,25 @@ class Widget:
         renames, removals, or required-field additions.
         """
         return raw
+
+    def declared_asset_ids(self, config: BaseModel) -> list[uuid.UUID]:
+        """Asset IDs this widget instance will reference at render time.
+
+        Returning an ID here means the bundle builder will pre-fetch
+        the asset's bytes + MIME and stash them in :class:`BundleContext`
+        before calling :meth:`render_html`.  Used both to populate the
+        render context AND as the canonical staleness-tracking input
+        (the bundle records the union of declared IDs as
+        ``bundle_source_asset_ids``).
+
+        Default: no asset dependencies.
+
+        IMPORTANT: a widget that emits ``referenced_asset_ids`` in its
+        :class:`WidgetRender` MUST also have declared those same IDs
+        here.  The bundle builder asserts this invariant so it can't be
+        silently broken by a copy-paste bug.
+        """
+        return []
 
     def validate_semantic(self, config: BaseModel) -> list[str]:
         """Cross-field / external checks beyond Pydantic shape.

--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -19,14 +19,18 @@ global one.
 from __future__ import annotations
 
 from cms.composed.registry import get_registry
+from cms.composed.widgets.clock import ClockWidget
+from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.text import TextWidget
+from cms.composed.widgets.ticker import TickerWidget
 
 _reg = get_registry()
 
 # Idempotent — guards against re-import edge cases (importlib.reload,
 # test session re-import) double-registering and tripping the
 # registry's "already registered" guard.
-if not _reg.has(TextWidget.slug):
-    _reg.register(TextWidget())
+for _widget_cls in (TextWidget, ImageWidget, ClockWidget, TickerWidget):
+    if not _reg.has(_widget_cls.slug):
+        _reg.register(_widget_cls())
 
-__all__ = ["TextWidget"]
+__all__ = ["ClockWidget", "ImageWidget", "TextWidget", "TickerWidget"]

--- a/cms/composed/widgets/clock.py
+++ b/cms/composed/widgets/clock.py
@@ -1,0 +1,202 @@
+"""Clock widget — wall-clock display using the device's local time.
+
+Pure-JS, no asset dependencies.  Updates every second via
+``setInterval``.  Uses the browser's ``Date`` object so the displayed
+time follows whatever the OS clock + TZ are set to on the device —
+intentional for Phase 1B (no CMS-side TZ config yet; per-device TZ
+becomes meaningful in Phase 5+ when slides start carrying timezone
+metadata).
+
+Instance scoping: every DOM ID + CSS class is suffixed with the
+widget instance UUID so two clock widgets in the same bundle don't
+collide.  The init script captures ``instanceId`` from the per-init
+closure the bundle builder wraps each ``init_js`` block in
+(see :mod:`cms.composed.bundle`).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+
+# Font-family allowlist — kept local to this widget so the clock and
+# text widget can evolve typography independently.
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+
+class ClockWidgetConfig(BaseModel):
+    """User-editable config for :class:`ClockWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    format: Literal["12h", "24h"] = "24h"
+    show_seconds: bool = True
+    show_date: bool = False
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=96, ge=8, le=512)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+
+# Per-instance init script.  Placeholders use ``$NAME`` rather than
+# ``{name}`` so we don't have to brace-double every literal ``{`` in
+# the JS body (much easier to read + edit).
+_CLOCK_INIT_JS_TEMPLATE = """
+var timeEl = document.getElementById($TIME_ID_LIT);
+var dateEl = $DATE_LOOKUP;
+function pad2(n) { return n < 10 ? '0' + n : '' + n; }
+function render() {
+  var d = new Date();
+  var hours = d.getHours();
+  var minutes = d.getMinutes();
+  var seconds = d.getSeconds();
+  var suffix = '';
+  if ('$FORMAT' === '12h') {
+    suffix = hours >= 12 ? ' PM' : ' AM';
+    hours = hours % 12;
+    if (hours === 0) hours = 12;
+  }
+  var t = ('$FORMAT' === '24h' ? pad2(hours) : ('' + hours)) + ':' + pad2(minutes);
+  if ($SHOW_SECONDS) t += ':' + pad2(seconds);
+  t += suffix;
+  if (timeEl) timeEl.textContent = t;
+  if (dateEl && $SHOW_DATE) {
+    dateEl.textContent = d.toLocaleDateString(undefined, {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+    });
+  }
+}
+render();
+setInterval(render, 1000);
+""".strip()
+
+
+def _build_clock_init_js(
+    *,
+    time_id: str,
+    date_id: str,
+    format_: str,
+    show_seconds: bool,
+    show_date: bool,
+) -> str:
+    return (
+        _CLOCK_INIT_JS_TEMPLATE
+        .replace("$TIME_ID_LIT", f"'{time_id}'")
+        .replace(
+            "$DATE_LOOKUP",
+            f"document.getElementById('{date_id}')" if date_id else "null",
+        )
+        .replace("$FORMAT", format_)
+        .replace("$SHOW_SECONDS", "true" if show_seconds else "false")
+        .replace("$SHOW_DATE", "true" if show_date else "false")
+    )
+
+
+class ClockWidget(Widget):
+    """Live wall-clock display."""
+
+    slug: ClassVar[str] = "clock"
+    display_name: ClassVar[str] = "Clock"
+    icon: ClassVar[str] = "🕒"
+    ConfigSchema: ClassVar[type[BaseModel]] = ClockWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "format": "24h",
+            "show_seconds": True,
+            "show_date": False,
+            "color": "#ffffff",
+            "font_family": "sans",
+            "font_size_px": 96,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/clock.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # Clock has no asset deps; ctx is ignored.
+        del ctx
+        assert isinstance(config, ClockWidgetConfig), (
+            "ClockWidget.render_html expects a ClockWidgetConfig instance"
+        )
+
+        css_class = f"cw-clock-{instance_id}"
+        time_id = f"cw-clock-time-{instance_id}"
+        date_id = f"cw-clock-date-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        date_html = (
+            f'<div id="{date_id}" class="{css_class}-date"></div>'
+            if config.show_date
+            else ""
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{time_id}" class="{css_class}-time"></div>'
+            f"{date_html}"
+            f"</div>"
+        )
+
+        # Subordinate date font sized at 40% of the time font.  Picked
+        # by eye in the 1B mocks; reads cleanly on 1080p preview.
+        date_size = max(8, int(config.font_size_px * 0.4))
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"}}\n"
+            f".{css_class}-time {{\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1;\n"
+            f"}}\n"
+            f".{css_class}-date {{\n"
+            f"  font-size: {date_size}px;\n"
+            f"  opacity: 0.8;\n"
+            f"  margin-top: 0.25em;\n"
+            f"}}"
+        )
+
+        init_js = _build_clock_init_js(
+            time_id=time_id,
+            date_id=date_id if config.show_date else "",
+            format_=config.format,
+            show_seconds=config.show_seconds,
+            show_date=config.show_date,
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            init_js=init_js,
+        )

--- a/cms/composed/widgets/image.py
+++ b/cms/composed/widgets/image.py
@@ -1,0 +1,163 @@
+"""Image widget — embeds a single Asset (type=IMAGE) into the bundle.
+
+Pulls the asset's bytes from the per-build :class:`BundleContext`
+that the bundle builder pre-fetches via the ``asset_loader`` callback
+(see :mod:`cms.composed.bundle`).  The image is inlined as a base64
+``data:`` URI inside an ``<img>`` tag so the rendered bundle stays
+self-contained (no external network fetches at playback time).
+
+Sizing model: the widget always fills its grid cell.  ``object_fit``
+controls how the source image is scaled inside that cell:
+
+* ``cover``  — fill cell, crop overflow (default; matches CMS asset
+  thumbnail behaviour)
+* ``contain`` — fit fully inside cell, letterbox the gaps
+* ``fill``   — stretch to cell ignoring aspect ratio
+
+Future work (Phase 2+): server-side resize-on-publish to avoid
+shipping a 4K photo through a data URI for a 200px cell.  For 1B,
+we just warn on bundles where any single image exceeds 2 MiB.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import uuid
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+
+log = logging.getLogger(__name__)
+
+
+# Soft warning threshold for inlined image size.  Above this the
+# widget logs a warning so we have a breadcrumb in the publish logs
+# when a bundle explodes in size.  Not a hard cap — the editor will
+# surface this in Phase 2.
+_LARGE_IMAGE_WARN_BYTES: int = 2 * 1024 * 1024
+
+
+class ImageWidgetConfig(BaseModel):
+    """User-editable config for :class:`ImageWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: uuid.UUID
+    # Mirrors the CSS ``object-fit`` allowlist we actually support.
+    # The CSS ``object-position: center`` default is fine for v1.
+    object_fit: Literal["cover", "contain", "fill"] = "cover"
+    # Optional human-readable alt text for accessibility / debug.
+    # Always HTML-escaped before emission.
+    alt: str = Field(default="", max_length=512)
+
+
+class ImageWidget(Widget):
+    """Single image asset, inlined as a data URI."""
+
+    slug: ClassVar[str] = "image"
+    display_name: ClassVar[str] = "Image"
+    icon: ClassVar[str] = "🖼"
+    ConfigSchema: ClassVar[type[BaseModel]] = ImageWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        # The editor will replace ``asset_id`` immediately upon drop;
+        # the all-zero UUID is just a placeholder that validates
+        # shape-wise but will fail :func:`validate_layout` (because the
+        # referenced asset doesn't exist).  This is intentional — it
+        # forces the user to pick an asset before save.
+        return {
+            "asset_id": "00000000-0000-0000-0000-000000000000",
+            "object_fit": "cover",
+            "alt": "",
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/image.html"
+
+    def declared_asset_ids(self, config: BaseModel) -> list[uuid.UUID]:
+        assert isinstance(config, ImageWidgetConfig)
+        return [config.asset_id]
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        assert isinstance(config, ImageWidgetConfig), (
+            "ImageWidget.render_html expects an ImageWidgetConfig instance"
+        )
+        if ctx is None:
+            # Bundle builder always passes one; the only way to hit this
+            # is to call render_html directly without going through
+            # build_bundle (e.g., a unit test that forgot the ctx arg).
+            raise RuntimeError(
+                "ImageWidget.render_html requires a BundleContext "
+                "with asset bytes pre-loaded"
+            )
+
+        asset_id = config.asset_id
+        try:
+            blob = ctx.asset_bytes[asset_id]
+            mime = ctx.asset_mimes[asset_id]
+        except KeyError:
+            # The bundle builder enforces declare-before-reference; if
+            # we end up here it means the loader silently returned
+            # nothing or a widget bypassed declared_asset_ids().  Bail
+            # loudly rather than emit a broken data: URI.
+            raise RuntimeError(
+                f"ImageWidget instance {instance_id}: asset {asset_id} "
+                "missing from BundleContext"
+            ) from None
+
+        if len(blob) > _LARGE_IMAGE_WARN_BYTES:
+            log.warning(
+                "composed image widget %s: asset %s is %d bytes (>%d) — "
+                "inlined bundle will be large",
+                instance_id,
+                asset_id,
+                len(blob),
+                _LARGE_IMAGE_WARN_BYTES,
+            )
+
+        css_class = f"cw-image-{instance_id}"
+        b64 = base64.b64encode(blob).decode("ascii")
+        data_uri = f"data:{mime};base64,{b64}"
+
+        # Use ``html.escape`` via Pydantic-validated alt + the fact
+        # that ``data_uri`` is hex-only base64 — no special chars to
+        # escape in the attribute.  alt may contain user input though.
+        import html as _html
+
+        alt_escaped = _html.escape(config.alt)
+
+        html_out = (
+            f'<img class="{css_class}" '
+            f'src="{data_uri}" '
+            f'alt="{alt_escaped}" '
+            f'draggable="false" />'
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: block;\n"
+            f"  object-fit: {config.object_fit};\n"
+            f"  object-position: center;\n"
+            f"  user-select: none;\n"
+            f"}}"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            referenced_asset_ids=[asset_id],
+        )

--- a/cms/composed/widgets/text.py
+++ b/cms/composed/widgets/text.py
@@ -22,7 +22,7 @@ from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from cms.composed.registry import Widget, WidgetRender
+from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
 
 
@@ -84,7 +84,10 @@ class TextWidget(Widget):
         config: BaseModel,
         cell: Cell,
         instance_id: str,
+        ctx: BundleContext | None = None,
     ) -> WidgetRender:
+        # text widget has no asset dependencies; ctx is ignored.
+        del ctx
         # The base class typing uses BaseModel; narrow for attr access.
         # validate_layout always calls ConfigSchema.model_validate before
         # forwarding, so this assertion guards against direct misuse.

--- a/cms/composed/widgets/ticker.py
+++ b/cms/composed/widgets/ticker.py
@@ -1,0 +1,179 @@
+"""Ticker widget — horizontal/vertical scrolling marquee, CSS-only.
+
+Uses an instance-scoped ``@keyframes`` so two ticker widgets in the
+same bundle scroll independently.  The animation runs entirely in CSS
+(no JS, no ``init_js``) so it survives JS errors elsewhere in the
+bundle and is dead-cheap on the Pi GPU.
+
+Phase 1B scope: ``scroll`` mode only (text loops continuously in one
+direction).  A ``bounce`` mode is planned as a Round-2 *variant* PR
+to validate that the plugin contract supports new behaviours without
+core changes.
+
+Instance scoping is mandatory — the bundle builder rejects any
+widget whose CSS isn't scoped to ``instance_id``.  Here that means
+both the wrapper class (``cw-ticker-{instance_id}``) AND the
+keyframe name (``ticker-scroll-{instance_id}``) include the UUID.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+
+class TickerWidgetConfig(BaseModel):
+    """User-editable config for :class:`TickerWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(..., min_length=1, max_length=4096)
+    # Pixels per second the marquee advances.  20–500 covers
+    # "barely-moving billboard" through "Wall-Street-style stock
+    # ticker" without giving the editor a footgun.
+    speed_px_per_sec: int = Field(default=100, ge=20, le=500)
+    direction: Literal["left", "right"] = "left"
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    background: str = Field(default="#000000", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=48, ge=8, le=512)
+    # Spacing (px) between the end of one copy and the start of the
+    # next.  Lets long messages "breathe" before they repeat.
+    gap_px: int = Field(default=100, ge=0, le=2000)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+
+class TickerWidget(Widget):
+    """Continuous-scroll text marquee."""
+
+    slug: ClassVar[str] = "ticker"
+    display_name: ClassVar[str] = "Scrolling Ticker"
+    icon: ClassVar[str] = "📰"
+    ConfigSchema: ClassVar[type[BaseModel]] = TickerWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "text": "Breaking news goes here",
+            "speed_px_per_sec": 100,
+            "direction": "left",
+            "color": "#ffffff",
+            "background": "#000000",
+            "font_family": "sans",
+            "font_size_px": 48,
+            "gap_px": 100,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/ticker.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # Ticker has no asset deps; ctx is ignored.
+        del ctx
+        assert isinstance(config, TickerWidgetConfig), (
+            "TickerWidget.render_html expects a TickerWidgetConfig instance"
+        )
+
+        wrapper_class = f"cw-ticker-{instance_id}"
+        track_class = f"cw-ticker-track-{instance_id}"
+        item_class = f"cw-ticker-item-{instance_id}"
+        kf_name = f"ticker-scroll-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        escaped_text = html.escape(config.text)
+
+        # Two copies of the text inside the track so we can translate
+        # the track by exactly -50% and have the next copy appear
+        # seamlessly in the gap.  The animation duration is computed
+        # from a *symbolic* viewport-width approximation; for the Pi's
+        # fixed 1920px canvas this lands in the same pixels/sec ballpark
+        # the editor advertises (close enough for v1).
+        #
+        # The classic CSS-only marquee trick: copy the content N times
+        # in markup so the track is wider than the viewport, then
+        # translateX it cyclically.  Two copies is sufficient when each
+        # copy is at least as wide as the viewport (and our cells are
+        # 160px wide at minimum on the 12-col grid, so even short text
+        # at 48px is fine for the demo; long text trivially fits).
+        track_html = (
+            f'<span class="{item_class}">{escaped_text}</span>'
+            f'<span class="{item_class}" aria-hidden="true">{escaped_text}</span>'
+        )
+
+        html_out = (
+            f'<div class="{wrapper_class}">'
+            f'<div class="{track_class}">{track_html}</div>'
+            f"</div>"
+        )
+
+        # Duration in seconds for one full cycle.  We base it on the
+        # 1920-px canvas width (the only canvas size in v1) so the
+        # editor's "speed_px_per_sec" maps to a stable real-world
+        # speed regardless of the widget's actual cell width.
+        # Phase 5+ (per-device canvas sizes) will revisit this.
+        duration_s = max(1.0, 1920.0 / max(1, config.speed_px_per_sec))
+
+        # Direction: ``left`` scrolls content right-to-left (track
+        # moves in negative X), ``right`` is the reverse via
+        # ``animation-direction``.
+        anim_dir = "normal" if config.direction == "left" else "reverse"
+
+        css_out = (
+            f".{wrapper_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  overflow: hidden;\n"
+            f"  background: {config.background};\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  white-space: nowrap;\n"
+            f"}}\n"
+            f".{track_class} {{\n"
+            f"  display: inline-flex;\n"
+            f"  flex-wrap: nowrap;\n"
+            f"  gap: {config.gap_px}px;\n"
+            f"  animation: {kf_name} {duration_s:.3f}s linear infinite {anim_dir};\n"
+            f"  will-change: transform;\n"
+            f"}}\n"
+            f".{item_class} {{\n"
+            f"  flex: 0 0 auto;\n"
+            f"  padding-right: {config.gap_px}px;\n"
+            f"}}\n"
+            f"@keyframes {kf_name} {{\n"
+            f"  from {{ transform: translateX(0); }}\n"
+            f"  to {{ transform: translateX(-50%); }}\n"
+            f"}}"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+        )

--- a/tests/test_composed_bundle.py
+++ b/tests/test_composed_bundle.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from typing import ClassVar
 
 import pytest
 from pydantic import BaseModel, Field
@@ -208,7 +209,8 @@ class _StaticAssetWidget(Widget):
     def editor_template(self):
         return "n/a"
 
-    def render_html(self, config, cell, instance_id):
+    def render_html(self, config, cell, instance_id, ctx=None):
+        del ctx
         return WidgetRender(
             html=f'<span id="x-{instance_id}">x</span>',
             css=f"#x-{instance_id} {{color:red;}}",
@@ -274,3 +276,261 @@ class TestRegistryWiring:
         # And it actually works end-to-end (regression).
         result = build_bundle(_text_layout())
         assert b"cw-text-" in result.html_bytes
+
+
+# ── Tests: BundleContext / asset_loader contract (Phase 1B) ──────────
+
+
+class _AssetConfig(BaseModel):
+    """Synthetic 'declares-an-asset' widget config."""
+
+    asset_id: uuid.UUID
+
+
+class _AssetWidget(Widget):
+    """Synthetic widget that both declares AND references an asset id.
+
+    Lets us drive the bundle's pre-fetch / scoped-context plumbing
+    without depending on the real ImageWidget implementation.
+    """
+
+    slug = "asset_test"
+    display_name = "Asset Test"
+    icon = "x"
+    ConfigSchema = _AssetConfig
+    config_version = 1
+
+    def default_config(self):
+        return {"asset_id": "00000000-0000-0000-0000-000000000000"}
+
+    def editor_template(self):
+        return "n/a"
+
+    def declared_asset_ids(self, config):
+        return [config.asset_id]
+
+    def render_html(self, config, cell, instance_id, ctx=None):
+        assert ctx is not None, "_AssetWidget requires a BundleContext"
+        blob = ctx.asset_bytes[config.asset_id]
+        mime = ctx.asset_mimes[config.asset_id]
+        return WidgetRender(
+            html=f'<span id="a-{instance_id}" data-mime="{mime}" data-len="{len(blob)}">x</span>',
+            referenced_asset_ids=[config.asset_id],
+        )
+
+
+class _BadReferenceWidget(Widget):
+    """Synthetic widget that 'forgets' to declare what it references.
+
+    Used to verify the bundle builder catches the contract violation.
+    """
+
+    slug = "bad_ref_test"
+    display_name = "Bad Ref"
+    icon = "x"
+    ConfigSchema = _AssetConfig
+    config_version = 1
+
+    def default_config(self):
+        return {"asset_id": "00000000-0000-0000-0000-000000000000"}
+
+    def editor_template(self):
+        return "n/a"
+
+    def declared_asset_ids(self, config):
+        # Intentionally does NOT declare config.asset_id even though
+        # render_html references it below.
+        return []
+
+    def render_html(self, config, cell, instance_id, ctx=None):
+        del ctx
+        return WidgetRender(
+            html=f'<span id="bad-{instance_id}">x</span>',
+            referenced_asset_ids=[config.asset_id],
+        )
+
+
+class _LeakyContextWidget(Widget):
+    """Widget that records which asset ids it can see in its context.
+
+    Lets the scoping test assert that a widget's BundleContext only
+    contains assets *this* widget declared, not ones declared by
+    neighbouring widgets in the same layout.
+    """
+
+    slug = "leaky_ctx_test"
+    display_name = "Leaky Ctx"
+    icon = "x"
+    ConfigSchema = _AssetConfig
+    config_version = 1
+
+    # Class-level capture point so test code can inspect what the
+    # builder handed each instance.
+    seen: ClassVar = []  # type: ignore[var-annotated]
+
+    def default_config(self):
+        return {"asset_id": "00000000-0000-0000-0000-000000000000"}
+
+    def editor_template(self):
+        return "n/a"
+
+    def declared_asset_ids(self, config):
+        return [config.asset_id]
+
+    def render_html(self, config, cell, instance_id, ctx=None):
+        assert ctx is not None
+        self.__class__.seen.append((instance_id, sorted(ctx.asset_bytes.keys())))
+        return WidgetRender(
+            html=f'<span id="leaky-{instance_id}">x</span>',
+            referenced_asset_ids=[config.asset_id],
+        )
+
+
+class TestBundleAssetLoaderContract:
+    def test_missing_loader_raises_when_widgets_declare_assets(self):
+        from cms.composed.bundle import MissingAssetLoaderError
+
+        reg = WidgetRegistry()
+        reg.register(_AssetWidget())
+        aid = uuid.uuid4()
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="asset_test",
+                    cell=Cell(row=1, col=1),
+                    config={"asset_id": str(aid)},
+                ),
+            ],
+        )
+        with pytest.raises(MissingAssetLoaderError):
+            build_bundle(layout, registry=reg)  # no asset_loader
+
+    def test_no_loader_needed_when_no_assets_declared(self):
+        # The text-only layout never declares any assets; building
+        # without a loader must keep working (1A regression check).
+        result = build_bundle(_text_layout())
+        assert isinstance(result, BuiltBundle)
+
+    def test_loader_called_once_per_unique_id(self):
+        reg = WidgetRegistry()
+        reg.register(_AssetWidget())
+        aid = uuid.uuid4()
+        # Same asset referenced by two widgets.
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="asset_test",
+                    cell=Cell(row=1, col=1),
+                    config={"asset_id": str(aid)},
+                ),
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="asset_test",
+                    cell=Cell(row=2, col=1),
+                    config={"asset_id": str(aid)},
+                ),
+            ],
+        )
+        calls: list[uuid.UUID] = []
+
+        def loader(asset_id):
+            calls.append(asset_id)
+            return (b"BYTES", "image/png")
+
+        result = build_bundle(layout, registry=reg, asset_loader=loader)
+        assert calls == [aid]  # exactly one call, despite two widgets
+        # Both widgets still received the bytes (rendered with the
+        # data-len attribute) — verify both spans are present.
+        html_text = result.html_bytes.decode("utf-8")
+        assert html_text.count('data-len="5"') == 2
+
+    def test_undeclared_referenced_asset_raises(self):
+        reg = WidgetRegistry()
+        reg.register(_BadReferenceWidget())
+        aid = uuid.uuid4()
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="bad_ref_test",
+                    cell=Cell(row=1, col=1),
+                    config={"asset_id": str(aid)},
+                ),
+            ],
+        )
+
+        # No loader needed because the widget declares nothing — the
+        # builder catches the violation in pass 2.
+        with pytest.raises(BundleValidationError) as ei:
+            build_bundle(layout, registry=reg)
+        assert any(
+            e.code == "undeclared_referenced_asset" for e in ei.value.errors
+        )
+
+    def test_each_widget_only_sees_its_own_declared_assets(self):
+        _LeakyContextWidget.seen.clear()
+        reg = WidgetRegistry()
+        reg.register(_LeakyContextWidget())
+
+        aid_a = uuid.uuid4()
+        aid_b = uuid.uuid4()
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    type="leaky_ctx_test",
+                    cell=Cell(row=1, col=1),
+                    config={"asset_id": str(aid_a)},
+                ),
+                WidgetInstance(
+                    id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                    type="leaky_ctx_test",
+                    cell=Cell(row=2, col=1),
+                    config={"asset_id": str(aid_b)},
+                ),
+            ],
+        )
+
+        def loader(asset_id):
+            return (b"x", "image/png")
+
+        build_bundle(layout, registry=reg, asset_loader=loader)
+
+        # Two widgets rendered, each saw only its own asset id.
+        assert len(_LeakyContextWidget.seen) == 2
+        for _instance_id, seen_ids in _LeakyContextWidget.seen:
+            assert len(seen_ids) == 1
+        # And the two widgets' contexts were genuinely different.
+        sets = {tuple(s) for _, s in _LeakyContextWidget.seen}
+        assert sets == {(aid_a,), (aid_b,)}
+
+    def test_source_asset_ids_flow_through_to_built_bundle(self):
+        reg = WidgetRegistry()
+        reg.register(_AssetWidget())
+        aid_a = uuid.uuid4()
+        aid_b = uuid.uuid4()
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="asset_test",
+                    cell=Cell(row=1, col=1),
+                    config={"asset_id": str(aid_a)},
+                ),
+                WidgetInstance(
+                    id=uuid.uuid4(),
+                    type="asset_test",
+                    cell=Cell(row=2, col=1),
+                    config={"asset_id": str(aid_b)},
+                ),
+            ],
+        )
+
+        def loader(asset_id):
+            return (b"x", "image/png")
+
+        result = build_bundle(layout, registry=reg, asset_loader=loader)
+        # Both ids surface in source_asset_ids (order = first-appearance).
+        assert set(result.source_asset_ids) == {aid_a, aid_b}

--- a/tests/test_composed_clock_widget.py
+++ b/tests/test_composed_clock_widget.py
@@ -1,0 +1,139 @@
+"""Tests for cms.composed.widgets.clock.ClockWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.clock import ClockWidget, ClockWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestClockWidgetConfig:
+    def test_defaults(self):
+        c = ClockWidgetConfig()
+        assert c.format == "24h"
+        assert c.show_seconds is True
+        assert c.show_date is False
+        assert c.color == "#ffffff"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 96
+
+    def test_format_allowlist(self):
+        ClockWidgetConfig(format="12h")
+        ClockWidgetConfig(format="24h")
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(format="48h")  # type: ignore[arg-type]
+
+    def test_font_allowlist(self):
+        for ok in ("sans", "serif", "mono"):
+            ClockWidgetConfig(font_family=ok)
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(font_family="comic-sans")
+
+    def test_color_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(color="red")
+
+    def test_font_size_bounds(self):
+        ClockWidgetConfig(font_size_px=8)
+        ClockWidgetConfig(font_size_px=512)
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(font_size_px=7)
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(font_size_px=513)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            ClockWidgetConfig(timezone="UTC")  # type: ignore[call-arg]
+
+
+class TestClockWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("clock")
+        assert isinstance(w, ClockWidget)
+        assert w.slug == "clock"
+
+
+class TestClockWidgetRender:
+    def test_no_declared_assets(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig()
+        assert w.declared_asset_ids(cfg) == []
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig()
+
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+
+        assert "cw-clock-inst-A" in r1.html
+        assert "cw-clock-inst-A" in r1.css
+        assert "cw-clock-time-inst-A" in r1.html
+        assert "cw-clock-inst-B" in r2.html
+        # No cross-contamination
+        assert "cw-clock-inst-B" not in r1.html
+        assert "cw-clock-inst-A" not in r2.html
+
+    def test_init_js_references_time_element_id(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig()
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert "cw-clock-time-abc" in r.init_js
+        assert "setInterval" in r.init_js
+
+    def test_12h_format_includes_am_pm_branch(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig(format="12h")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert "'12h'" in r.init_js
+        assert "PM" in r.init_js and "AM" in r.init_js
+
+    def test_24h_format_no_am_pm_substitution(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig(format="24h")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        # 24h branch keeps suffix empty
+        assert "'12h'" in r.init_js  # the literal branch check is still there
+        assert "'24h'" in r.init_js
+
+    def test_show_seconds_flag_present(self):
+        w = ClockWidget()
+        r_on = w.render_html(ClockWidgetConfig(show_seconds=True), _cell(), "a")
+        r_off = w.render_html(ClockWidgetConfig(show_seconds=False), _cell(), "b")
+        assert "if (true)" in r_on.init_js  # type: ignore[operator]
+        assert "if (false)" in r_off.init_js  # type: ignore[operator]
+
+    def test_show_date_adds_date_element(self):
+        w = ClockWidget()
+        r_off = w.render_html(ClockWidgetConfig(show_date=False), _cell(), "a")
+        r_on = w.render_html(ClockWidgetConfig(show_date=True), _cell(), "b")
+
+        assert "cw-clock-date-a" not in r_off.html
+        assert "cw-clock-date-b" in r_on.html
+        # The init_js date branch should be wired up only when on.
+        assert r_off.init_js is not None and r_on.init_js is not None
+        assert "dateEl = null" in r_off.init_js
+        assert "dateEl = document.getElementById('cw-clock-date-b')" in r_on.init_js
+
+    def test_color_propagates_to_css(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig(color="#abcdef")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "color: #abcdef" in r.css
+
+    def test_font_size_propagates_to_css(self):
+        w = ClockWidget()
+        cfg = ClockWidgetConfig(font_size_px=128)
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "font-size: 128px" in r.css

--- a/tests/test_composed_image_widget.py
+++ b/tests/test_composed_image_widget.py
@@ -1,0 +1,177 @@
+"""Tests for cms.composed.widgets.image.ImageWidget.
+
+Covers config validation, render output, instance scoping, and the
+declared/referenced asset contract.  The widget reads bytes from
+:class:`BundleContext`; tests construct one synthetically rather than
+going through ``build_bundle`` so failures point at the widget
+implementation itself, not the pipeline.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+# Side-effect import: triggers global registry population
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import BundleContext, get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.image import (
+    ImageWidget,
+    ImageWidgetConfig,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+def _ctx_for(aid: uuid.UUID, blob: bytes, mime: str = "image/png") -> BundleContext:
+    return BundleContext(
+        asset_bytes={aid: blob},
+        asset_mimes={aid: mime},
+    )
+
+
+# A trivial 1x1 transparent PNG — enough to exercise the data-URI path.
+_TINY_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c63600100000005000168cb6e6d0000000049454e44ae426082"
+)
+
+
+class TestImageWidgetConfig:
+    def test_minimum_valid_config(self):
+        aid = uuid.uuid4()
+        c = ImageWidgetConfig(asset_id=aid)
+        assert c.asset_id == aid
+        assert c.object_fit == "cover"
+        assert c.alt == ""
+
+    def test_asset_id_required(self):
+        with pytest.raises(ValidationError):
+            ImageWidgetConfig()  # type: ignore[call-arg]
+
+    def test_object_fit_allowlist(self):
+        for ok in ("cover", "contain", "fill"):
+            ImageWidgetConfig(asset_id=uuid.uuid4(), object_fit=ok)
+        with pytest.raises(ValidationError):
+            ImageWidgetConfig(asset_id=uuid.uuid4(), object_fit="scale-down")
+
+    def test_alt_max_length(self):
+        with pytest.raises(ValidationError):
+            ImageWidgetConfig(asset_id=uuid.uuid4(), alt="x" * 513)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            ImageWidgetConfig(asset_id=uuid.uuid4(), unknown="nope")  # type: ignore[call-arg]
+
+
+class TestImageWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("image")
+        assert isinstance(w, ImageWidget)
+        assert w.slug == "image"
+        assert w.config_version == 1
+
+
+class TestImageWidgetDeclaredAssetIds:
+    def test_returns_single_asset_id(self):
+        aid = uuid.uuid4()
+        w = ImageWidget()
+        cfg = ImageWidgetConfig(asset_id=aid)
+        assert w.declared_asset_ids(cfg) == [aid]
+
+
+class TestImageWidgetRender:
+    def test_requires_ctx(self):
+        # Calling without a BundleContext is a programmer bug — it
+        # would silently emit a broken data: URI without this guard.
+        w = ImageWidget()
+        cfg = ImageWidgetConfig(asset_id=uuid.uuid4())
+        with pytest.raises(RuntimeError, match="BundleContext"):
+            w.render_html(cfg, _cell(), "id-1", ctx=None)
+
+    def test_missing_asset_in_ctx_raises(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid)
+        # Pass an empty ctx — widget should bail loudly rather than
+        # render an <img> with no src.
+        with pytest.raises(RuntimeError, match="missing from BundleContext"):
+            w.render_html(cfg, _cell(), "id-1", ctx=BundleContext())
+
+    def test_renders_data_uri_with_b64_content(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid, alt="cat")
+        ctx = _ctx_for(aid, _TINY_PNG, "image/png")
+
+        r = w.render_html(cfg, _cell(), "abc", ctx=ctx)
+
+        b64 = base64.b64encode(_TINY_PNG).decode("ascii")
+        assert f'src="data:image/png;base64,{b64}"' in r.html
+        assert 'alt="cat"' in r.html
+
+    def test_referenced_asset_ids_match_declared(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid)
+        ctx = _ctx_for(aid, _TINY_PNG)
+        r = w.render_html(cfg, _cell(), "abc", ctx=ctx)
+        assert r.referenced_asset_ids == [aid]
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid)
+        ctx = _ctx_for(aid, _TINY_PNG)
+
+        r1 = w.render_html(cfg, _cell(), "inst-A", ctx=ctx)
+        r2 = w.render_html(cfg, _cell(), "inst-B", ctx=ctx)
+
+        assert "cw-image-inst-A" in r1.html
+        assert "cw-image-inst-A" in r1.css
+        assert "cw-image-inst-B" in r2.html
+        assert "cw-image-inst-B" in r2.css
+        # No cross-contamination
+        assert "cw-image-inst-B" not in r1.html
+        assert "cw-image-inst-A" not in r2.html
+
+    def test_alt_text_is_html_escaped(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid, alt='</alt><script>bad()</script>')
+        ctx = _ctx_for(aid, _TINY_PNG)
+
+        r = w.render_html(cfg, _cell(), "abc", ctx=ctx)
+
+        # The literal payload must NOT escape the alt attribute.
+        assert "<script>" not in r.html
+        assert "&lt;script&gt;" in r.html
+        assert "&lt;/alt&gt;" in r.html
+
+    def test_object_fit_propagates_to_css(self):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        ctx = _ctx_for(aid, _TINY_PNG)
+        for fit in ("cover", "contain", "fill"):
+            cfg = ImageWidgetConfig(asset_id=aid, object_fit=fit)  # type: ignore[arg-type]
+            r = w.render_html(cfg, _cell(), "abc", ctx=ctx)
+            assert f"object-fit: {fit}" in r.css
+
+    def test_large_image_logs_warning(self, caplog):
+        w = ImageWidget()
+        aid = uuid.uuid4()
+        cfg = ImageWidgetConfig(asset_id=aid)
+        big = b"\x00" * (3 * 1024 * 1024)  # 3 MiB > 2 MiB threshold
+        ctx = _ctx_for(aid, big, "image/png")
+
+        with caplog.at_level(logging.WARNING, logger="cms.composed.widgets.image"):
+            w.render_html(cfg, _cell(), "big", ctx=ctx)
+
+        assert any("inlined bundle will be large" in rec.message for rec in caplog.records)

--- a/tests/test_composed_ticker_widget.py
+++ b/tests/test_composed_ticker_widget.py
@@ -1,0 +1,173 @@
+"""Tests for cms.composed.widgets.ticker.TickerWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.ticker import TickerWidget, TickerWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=8, col=1, rowspan=1, colspan=12)
+
+
+class TestTickerWidgetConfig:
+    def test_minimum_valid_config(self):
+        c = TickerWidgetConfig(text="hi")
+        assert c.text == "hi"
+        assert c.direction == "left"
+        assert c.speed_px_per_sec == 100
+
+    def test_text_required(self):
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig()  # type: ignore[call-arg]
+
+    def test_text_min_length(self):
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="")
+
+    def test_text_max_length(self):
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="x" * 4097)
+
+    def test_speed_bounds(self):
+        TickerWidgetConfig(text="hi", speed_px_per_sec=20)
+        TickerWidgetConfig(text="hi", speed_px_per_sec=500)
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="hi", speed_px_per_sec=19)
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="hi", speed_px_per_sec=501)
+
+    def test_direction_allowlist(self):
+        TickerWidgetConfig(text="hi", direction="left")
+        TickerWidgetConfig(text="hi", direction="right")
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="hi", direction="up")  # type: ignore[arg-type]
+
+    def test_font_allowlist(self):
+        for ok in ("sans", "serif", "mono"):
+            TickerWidgetConfig(text="hi", font_family=ok)
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="hi", font_family="cursive")
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            TickerWidgetConfig(text="hi", scrolling=True)  # type: ignore[call-arg]
+
+
+class TestTickerWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("ticker")
+        assert isinstance(w, TickerWidget)
+        assert w.slug == "ticker"
+
+
+class TestTickerWidgetRender:
+    def test_no_declared_assets(self):
+        w = TickerWidget()
+        cfg = TickerWidgetConfig(text="hi")
+        assert w.declared_asset_ids(cfg) == []
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = TickerWidget()
+        cfg = TickerWidgetConfig(text="news")
+
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+
+        for cls in (
+            "cw-ticker-inst-A",
+            "cw-ticker-track-inst-A",
+            "cw-ticker-item-inst-A",
+        ):
+            assert cls in r1.html, f"{cls} should be in html"
+            assert cls in r1.css, f"{cls} should be in css"
+
+        # @keyframes name is also instance-scoped so two tickers can
+        # coexist with different animation durations.
+        assert "ticker-scroll-inst-A" in r1.css
+        assert "ticker-scroll-inst-B" in r2.css
+        assert "ticker-scroll-inst-B" not in r1.css
+        assert "ticker-scroll-inst-A" not in r2.css
+
+    def test_text_is_html_escaped_and_duplicated(self):
+        w = TickerWidget()
+        cfg = TickerWidgetConfig(text="<b>hi</b> & bye")
+        r = w.render_html(cfg, _cell(), "abc")
+
+        assert "<b>hi</b>" not in r.html
+        # The duplicate-content marquee trick: text appears twice
+        assert r.html.count("&lt;b&gt;hi&lt;/b&gt;") == 2
+        assert "&amp;" in r.html
+        # Second copy is aria-hidden to avoid duplicate-announcement
+        assert 'aria-hidden="true"' in r.html
+
+    def test_direction_left_is_normal_anim(self):
+        w = TickerWidget()
+        r = w.render_html(
+            TickerWidgetConfig(text="x", direction="left"),
+            _cell(),
+            "a",
+        )
+        assert "animation:" in r.css
+        assert " normal" in r.css.replace("\n", " ")
+
+    def test_direction_right_is_reverse_anim(self):
+        w = TickerWidget()
+        r = w.render_html(
+            TickerWidgetConfig(text="x", direction="right"),
+            _cell(),
+            "a",
+        )
+        assert "reverse" in r.css
+
+    def test_speed_affects_duration(self):
+        # 1920-px canvas; 100 px/s → 19.2 s, 200 px/s → 9.6 s.
+        w = TickerWidget()
+        r_slow = w.render_html(
+            TickerWidgetConfig(text="x", speed_px_per_sec=100),
+            _cell(),
+            "a",
+        )
+        r_fast = w.render_html(
+            TickerWidgetConfig(text="x", speed_px_per_sec=200),
+            _cell(),
+            "b",
+        )
+        assert "19.200s" in r_slow.css
+        assert "9.600s" in r_fast.css
+
+    def test_gap_propagates_to_css(self):
+        w = TickerWidget()
+        r = w.render_html(
+            TickerWidgetConfig(text="x", gap_px=250),
+            _cell(),
+            "a",
+        )
+        assert "gap: 250px" in r.css
+        assert "padding-right: 250px" in r.css
+
+    def test_color_and_background_propagate(self):
+        w = TickerWidget()
+        r = w.render_html(
+            TickerWidgetConfig(
+                text="x", color="#abcdef", background="#123456",
+            ),
+            _cell(),
+            "a",
+        )
+        assert "color: #abcdef" in r.css
+        assert "background: #123456" in r.css
+
+    def test_no_init_js_pure_css_marquee(self):
+        # The CSS-only marquee survives JS errors elsewhere in the
+        # bundle.  If we ever switch to JS-driven scrolling we want to
+        # know about it loudly.
+        w = TickerWidget()
+        r = w.render_html(TickerWidgetConfig(text="x"), _cell(), "a")
+        assert r.init_js is None
+        assert r.js == ""


### PR DESCRIPTION
# Composed slide Phase 1B — image / clock / ticker widgets + BundleContext contract

Implements three new widgets and the asset-handling contract change
that the Phase 1A plan committed to before the Round-3 extensibility
freeze.

## Widgets

| Widget | Mechanism | Asset deps |
|---|---|---|
| `ImageWidget` (`cw-image-*`) | base64 data URI inlined into HTML | declares 1 asset id |
| `ClockWidget` (`cw-clock-*`) | `setInterval` JS, 12h/24h, optional date | none |
| `TickerWidget` (`cw-ticker-*`) | CSS-only `@keyframes` marquee, instance-scoped | none |

All three follow the existing instance-scoping rule (every CSS
selector and DOM id contains `{instance_id}`) so the
bundle-builder's collision guard accepts them and two instances of
the same widget on one slide don't cross-style each other.

## Contract change — `BundleContext` (registry.py / bundle.py)

`Widget.render_html` gains a new keyword arg:

```python
def render_html(self, config, cell, instance_id, ctx: BundleContext | None = None) -> WidgetRender: ...
```

`BundleContext` is a tiny dataclass holding `asset_bytes` +
`asset_mimes`, scoped per-widget — a widget only sees ids it
declared via the new `Widget.declared_asset_ids(config)` method.

The bundle builder now runs in two passes:

1. Walk every widget, collect+dedup declared asset ids, fail loud
   (`MissingAssetLoaderError`) if anything is declared but no
   `asset_loader` was provided.
2. Pre-fetch each unique id exactly once via the loader, then render
   widgets with a scoped `BundleContext`. After each render the
   builder verifies `referenced_asset_ids ⊆ declared_asset_ids` and
   raises `BundleValidationError(code="undeclared_referenced_asset")`
   on a violation.

`publish.py` is updated to walk the layout, resolve declared assets
in a single DB query, and pass a sync closure to `build_bundle`.

`ctx` defaults to `None` so the text widget's old 3-arg form still
works as a positional call — backward compatible for any external
custom widgets that may exist.

## Tests

- `tests/test_composed_image_widget.py` (15 tests) — config
  validation, data URI assembly, alt escaping, missing-asset guard,
  large-image warning, ctx-required error
- `tests/test_composed_clock_widget.py` (16 tests) — config,
  12/24h format substitution, show_seconds + show_date flag
  propagation, instance scoping of ids/classes
- `tests/test_composed_ticker_widget.py` (18 tests) — config,
  duplication for seamless loop, direction → animation-direction,
  speed → 1920/speed duration, gap_px in CSS, scoping
- `tests/test_composed_bundle.py` — 6 new tests covering:
  - `MissingAssetLoaderError` when widgets declare without loader
  - No loader needed when no assets declared (1A regression)
  - Loader called exactly once per unique id (dedup)
  - `undeclared_referenced_asset` raised on contract violation
  - Per-widget context scoping (widget A can't see widget B's ids)
  - `source_asset_ids` flow-through to `BuiltBundle`

Full composed suite: **154 passed**.

## Out of scope

- Editor templates for the new widgets (Phase 2)
- Stale-bundle detection UI (Phase 2)
- Video widget (Phase 1C)
- The `bounce` ticker variant (Round-2 extensibility proof)

## Validation status

- [x] Local full composed suite passes
- [ ] CI tests-changed + full PR pipeline (this PR)
- [ ] Manual Pi100 smoke (tonight — text-widget end-to-end; image
      smoke deferred to Phase 2 when the editor lets a user actually
      build one)
