### PR TITLE
composed: Phase 2 minimal manual editor + create/patch/publish API

### DIFF
--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -1,14 +1,22 @@
-"""Phase 1A: live preview endpoint for composed slides.
+"""Composed-slide HTTP API + Phase 1A live-preview endpoint.
 
-Renders the composed slide's current ``layout_json`` to a
-self-contained HTML document via the same bundle builder used at
-publish time, and serves it inline. No bundle is written to disk;
-this is the editor's "live preview" path.
+Routes:
 
-CSP is locked down: only the inline content the bundle builder
-generates is allowed; no external scripts, styles, fonts, or
-images. Frame ancestors are restricted to the CMS origin so the
-preview can render inside an editor ``<iframe>`` but cannot be
+* ``GET  /composed/{asset_id}/preview`` — live HTML render (Phase 1A).
+* ``POST /composed/`` — create a new draft composed-slide asset.
+* ``PATCH /composed/{asset_id}/layout`` — replace the layout JSON.
+* ``POST /composed/{asset_id}/publish`` — build the bundle and clear
+  ``is_draft``.
+
+All write routes require ``ASSETS_WRITE``. Visibility is enforced via
+``_verify_asset_access`` (the asset-library's shared visibility rule),
+and PATCH additionally checks that referenced assets are visible to
+the same audience as the composed slide (slideshow-style ACL).
+
+CSP is locked down on the preview response: only the inline content
+the bundle builder generates is allowed; no external scripts, styles,
+fonts, or images. Frame ancestors are restricted to the CMS origin so
+the preview can render inside an editor ``<iframe>`` but cannot be
 embedded elsewhere.
 """
 
@@ -16,19 +24,25 @@ from __future__ import annotations
 
 import logging
 import uuid
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cms.auth import require_auth
+from cms.auth import get_user_group_ids, require_auth, require_permission
 from cms.composed.bundle import BundleValidationError, build_bundle
 from cms.composed.registry import get_registry
-from cms.composed.schema import Layout
+from cms.composed.schema import Layout, empty_layout
+from cms.composed.validate import validate_layout
 from cms.database import get_db
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.models.group_asset import GroupAsset
+from cms.models.user import User
+from cms.permissions import ASSETS_WRITE
+from cms.services.audit_service import audit_log
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +64,149 @@ _PREVIEW_CSP = (
     "base-uri 'none'; "
     "form-action 'none'"
 )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def _load_composed_for_write(
+    asset_id: uuid.UUID, request: Request, db: AsyncSession,
+) -> tuple[Asset, ComposedSlide]:
+    """Look up the asset + backing composed-slide row, enforcing visibility.
+
+    Returns ``(asset, composed)`` or raises 404 / 403.
+    """
+    asset = await db.get(Asset, asset_id)
+    if asset is None or asset.asset_type != AssetType.COMPOSED or asset.deleted_at is not None:
+        raise HTTPException(status_code=404, detail="Composed slide not found")
+
+    # Visibility / ownership check. Reuse the assets router's helper so
+    # the rule stays single-sourced.
+    from cms.routers.assets import _verify_asset_access  # noqa: WPS433
+
+    await _verify_asset_access(asset_id, request, db)
+
+    cs_result = await db.execute(
+        select(ComposedSlide).where(ComposedSlide.asset_id == asset_id),
+    )
+    composed = cs_result.scalar_one_or_none()
+    if composed is None:
+        raise HTTPException(status_code=404, detail="Composed slide not found")
+    return asset, composed
+
+
+async def _check_referenced_asset_acl(
+    layout: Layout,
+    composed_asset: Asset,
+    db: AsyncSession,
+) -> None:
+    """Reject layouts that reference an asset the audience can't see.
+
+    Mirrors :func:`cms.routers.assets._validate_slideshow_acl` for the
+    composed case. Every asset declared by any widget in the layout
+    must be visible to a superset of the composed slide's audience:
+
+    * Composed slide is global → every referenced asset must also be global.
+    * Composed slide is group-scoped → every referenced asset must be
+      global, or shared with a superset of the composed slide's group set.
+    * Composed slide is personal (no groups, not global) → no extra
+      audience-widening check; visibility is already enforced via
+      ``_verify_asset_access``.
+    """
+    # Trigger widget registration so we can ask each widget for declared IDs.
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    registry = get_registry()
+    referenced: set[uuid.UUID] = set()
+    for inst in layout.widgets:
+        try:
+            widget = registry.get(inst.type)
+        except KeyError:
+            # Unknown widget type — leave it for validate_layout to
+            # surface a clean error.
+            continue
+        try:
+            cfg = widget.ConfigSchema.model_validate(inst.config)
+        except Exception:  # noqa: BLE001
+            # Config-shape errors are reported separately by
+            # validate_layout; ignore for ACL purposes.
+            continue
+        for aid in widget.declared_asset_ids(cfg):
+            referenced.add(aid)
+
+    if not referenced:
+        return
+
+    # Load each referenced asset + the groups it's shared with.
+    asset_rows = (await db.execute(
+        select(Asset).where(
+            Asset.id.in_(referenced), Asset.deleted_at.is_(None),
+        )
+    )).scalars().all()
+    found_ids = {a.id for a in asset_rows}
+    missing = referenced - found_ids
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Referenced asset(s) not found: "
+                + ", ".join(str(a) for a in sorted(missing))
+            ),
+        )
+
+    group_rows = (await db.execute(
+        select(GroupAsset.asset_id, GroupAsset.group_id).where(
+            GroupAsset.asset_id.in_(referenced),
+        )
+    )).all()
+    source_groups: dict[uuid.UUID, set[uuid.UUID]] = {}
+    for aid, gid in group_rows:
+        source_groups.setdefault(aid, set()).add(gid)
+
+    composed_group_rows = (await db.execute(
+        select(GroupAsset.group_id).where(GroupAsset.asset_id == composed_asset.id)
+    )).scalars().all()
+    composed_groups: set[uuid.UUID] = set(composed_group_rows)
+
+    if composed_asset.is_global:
+        not_global = sorted(a.filename for a in asset_rows if not a.is_global)
+        if not_global:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "A global composed slide can only reference global assets. "
+                    f"Not global: {', '.join(not_global)}. Mark these global first."
+                ),
+            )
+        return
+
+    if not composed_groups:
+        # Personal slide — visibility was already enforced upstream.
+        return
+
+    failures: list[str] = []
+    for a in asset_rows:
+        if a.is_global:
+            continue
+        sgroups = source_groups.get(a.id, set())
+        if not composed_groups.issubset(sgroups):
+            failures.append(a.filename)
+    if failures:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "These referenced assets are not shared with all of the composed "
+                f"slide's groups: {', '.join(sorted(failures))}. Share them (or "
+                "mark global) first."
+            ),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Routes
+# ─────────────────────────────────────────────────────────────────────
 
 
 @router.get("/{asset_id}/preview", response_class=HTMLResponse)
@@ -103,3 +260,253 @@ async def preview_composed_slide(
         "Cache-Control": "no-store",
     }
     return HTMLResponse(content=built.html_bytes, headers=headers)
+
+
+@router.post("/", status_code=201)
+async def create_composed_slide(
+    request: Request,
+    body: dict[str, Any] = Body(...),
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Create a new draft composed-slide asset with an empty layout.
+
+    Body:
+        ``name`` (str, required): user-facing display name; also used as
+            the unique ``Asset.filename`` (with a numeric suffix if a
+            conflict exists).
+        ``group_ids`` (list[str] | str, optional): group UUIDs to share
+            the asset with. Empty list + admin → global.
+
+    Returns the created asset's id and a redirect-friendly editor URL.
+    """
+    # Local imports keep this router off the assets.py hot path at startup.
+    from cms.routers.assets import _unique_filename  # noqa: WPS433
+
+    name_raw = body.get("name") or body.get("display_name")
+    if not name_raw or not str(name_raw).strip():
+        raise HTTPException(status_code=400, detail="name is required")
+    name = str(name_raw).strip()
+    if len(name) > 255:
+        raise HTTPException(status_code=400, detail="name must be ≤255 chars")
+
+    user_groups = await get_user_group_ids(user, db)
+    is_admin = user_groups is None
+
+    raw_ids = body.get("group_ids", [])
+    if isinstance(raw_ids, str):
+        raw_ids = [g.strip() for g in raw_ids.split(",") if g.strip()]
+    single = body.get("group_id")
+    if single and not raw_ids:
+        raw_ids = [single]
+
+    resolved_groups: list[uuid.UUID] = []
+    for gid in raw_ids:
+        try:
+            parsed_id = uuid.UUID(str(gid))
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"Invalid group_id: {gid}")
+        if not is_admin and parsed_id not in (user_groups or []):
+            raise HTTPException(status_code=403, detail="You are not a member of this group")
+        resolved_groups.append(parsed_id)
+
+    make_global = (not resolved_groups and is_admin)
+
+    filename = await _unique_filename(db, name)
+
+    asset = Asset(
+        filename=filename,
+        display_name=name,
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+        url=None,
+        is_global=make_global,
+        uploaded_by_user_id=user.id,
+    )
+    db.add(asset)
+    await db.flush()
+
+    for gid in resolved_groups:
+        db.add(GroupAsset(asset_id=asset.id, group_id=gid))
+
+    layout = empty_layout()
+    composed = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=layout.model_dump(mode="json"),
+        schema_version=layout.schema_version,
+        is_draft=True,
+    )
+    db.add(composed)
+
+    await audit_log(
+        db,
+        user=user,
+        action="asset.create_composed",
+        resource_type="asset",
+        resource_id=str(asset.id),
+        description=f"Created composed slide '{filename}'",
+        details={
+            "filename": filename,
+            "group_ids": [str(g) for g in resolved_groups],
+            "is_global": make_global,
+        },
+        request=request,
+    )
+    await db.commit()
+    await db.refresh(asset)
+    return {
+        "id": str(asset.id),
+        "filename": asset.filename,
+        "display_name": asset.display_name,
+        "edit_url": f"/assets/{asset.id}/composed",
+    }
+
+
+@router.patch("/{asset_id}/layout")
+async def patch_composed_layout(
+    asset_id: uuid.UUID,
+    request: Request,
+    body: dict[str, Any] = Body(...),
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Replace the layout JSON for a composed slide.
+
+    Body must be the full canonical ``Layout`` JSON (Pydantic shape).
+    The endpoint:
+
+    1. Validates Pydantic shape — 422 on failure.
+    2. Runs ``validate_layout`` (semantic: bounds, overlaps, unknown
+       widget types, per-widget ``validate_semantic``) — 422 on failure.
+    3. Checks referenced-asset ACL (audience widening) — 400 on failure.
+    4. Persists the canonical JSON via ``layout.model_dump(mode="json")``.
+    5. Sets ``is_draft=True`` so any previously-published bundle is
+       flagged stale until ``/publish`` is called again.
+    """
+    asset, composed = await _load_composed_for_write(asset_id, request, db)
+
+    # Trigger widget registration before validate_layout uses the registry.
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    try:
+        layout = Layout.model_validate(body)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "invalid_layout_shape", "message": str(e)},
+        ) from e
+
+    registry = get_registry()
+    errors = validate_layout(layout, registry)
+    if errors:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "invalid_layout",
+                "errors": [
+                    {
+                        "code": err.code,
+                        "message": err.message,
+                        "widget_id": err.widget_id,
+                    }
+                    for err in errors
+                ],
+            },
+        )
+
+    await _check_referenced_asset_acl(layout, asset, db)
+
+    composed.layout_json = layout.model_dump(mode="json")
+    composed.schema_version = layout.schema_version
+    composed.is_draft = True
+
+    await audit_log(
+        db,
+        user=user,
+        action="asset.update_composed_layout",
+        resource_type="asset",
+        resource_id=str(asset.id),
+        description=f"Updated composed-slide layout for '{asset.filename}'",
+        details={"widget_count": len(layout.widgets)},
+        request=request,
+    )
+    await db.commit()
+    return {
+        "id": str(asset.id),
+        "is_draft": True,
+        "widget_count": len(layout.widgets),
+    }
+
+
+@router.post("/{asset_id}/publish")
+async def publish_composed_endpoint(
+    asset_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Build the bundle for the composed slide and clear ``is_draft``.
+
+    Returns the bundle filename, size, and sha256. Errors map to:
+
+    * 422 — empty layout (need at least one widget).
+    * 422 — bundle/validation error (``PublishError``).
+    """
+    from cms.composed.publish import PublishError, publish_composed_slide  # noqa: WPS433
+
+    asset, composed = await _load_composed_for_write(asset_id, request, db)
+
+    # Cheap pre-check so the user gets a friendly error instead of the
+    # bundle builder's generic "nothing to render" message.
+    try:
+        layout = Layout.model_validate(composed.layout_json)
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "invalid_layout_shape", "message": str(e)},
+        ) from e
+    if not layout.widgets:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "empty_layout",
+                "message": "Add at least one widget before publishing.",
+            },
+        )
+
+    # Trigger widget registration before publish_composed_slide reads it.
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    try:
+        result = await publish_composed_slide(asset_id, db)
+    except PublishError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "publish_failed", "message": str(e)},
+        ) from e
+
+    await audit_log(
+        db,
+        user=user,
+        action="asset.publish_composed",
+        resource_type="asset",
+        resource_id=str(asset.id),
+        description=f"Published composed slide '{asset.filename}'",
+        details={
+            "filename": result.filename,
+            "size_bytes": result.size_bytes,
+            "checksum": result.checksum,
+        },
+        request=request,
+    )
+    await db.commit()
+    await db.refresh(asset)
+    return {
+        "id": str(asset.id),
+        "filename": result.filename,
+        "size_bytes": result.size_bytes,
+        "checksum": result.checksum,
+        "rebuilt": result.rebuilt,
+        "is_draft": False,
+    }

--- a/cms/templates/assets_new.html
+++ b/cms/templates/assets_new.html
@@ -27,20 +27,16 @@
                 </p>
             </div>
         </a>
-        <div class="builder-tile builder-tile-disabled" aria-disabled="true"
-             title="Coming soon">
+        <a href="/assets/new/composed" class="builder-tile">
             <div class="builder-tile-icon" aria-hidden="true">🧩</div>
             <div class="builder-tile-body">
-                <h3 class="builder-tile-title">
-                    Composed Slide
-                    <span class="builder-tile-badge">Coming soon</span>
-                </h3>
+                <h3 class="builder-tile-title">Composed Slide</h3>
                 <p class="builder-tile-desc">
-                    Layer images, video, and widgets like tickers and clocks
-                    onto a single canvas.
+                    Layer text, clocks, and tickers onto a single canvas;
+                    publish as a self-contained slide.
                 </p>
             </div>
-        </div>
+        </a>
     </div>
 </div>
 

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1,0 +1,570 @@
+{% extends "base.html" %}
+{% block title %}Edit Composed Slide — Agora CMS{% endblock %}
+{% block content %}
+<h1>Assets</h1>
+<div class="sub-tabs">
+    <a href="/assets" class="sub-tab active">Library</a>
+    <a href="/assets/new" class="sub-tab">Create</a>
+    <a href="/profiles" class="sub-tab">Playback Profiles</a>
+</div>
+
+<div class="card">
+    <div style="display:flex; align-items:baseline; gap:1rem; flex-wrap:wrap;">
+        <h2 style="margin:0;">{{ asset_name }}</h2>
+        <span id="status-pill"
+              style="font-size:0.8rem; padding:0.15rem 0.55rem; border-radius:999px;
+                     background:{% if is_draft %}#fef3c7;color:#92400e{% else %}#dcfce7;color:#166534{% endif %};">
+            {% if is_draft %}Draft{% else %}Published{% endif %}
+        </span>
+        <span style="font-size:0.8rem; color:var(--text-muted,#57606a);">
+            {% if bundle_built_at %}Bundle built {{ bundle_built_at.strftime("%Y-%m-%d %H:%M UTC") }}{% else %}Never published{% endif %}
+        </span>
+        <div style="margin-left:auto; display:flex; gap:0.5rem;">
+            <button type="button" class="btn" onclick="saveLayout()">Save</button>
+            <button type="button" class="btn" onclick="openPreview()">Preview</button>
+            <button type="button" class="btn btn-primary" onclick="publishLayout()">Publish</button>
+        </div>
+    </div>
+
+    <div id="msg-box" style="margin-top:0.5rem; display:none; padding:0.5rem 0.75rem; border-radius:6px;"></div>
+
+    <div class="composed-editor">
+        <aside class="palette">
+            <h3>Palette</h3>
+            <p class="text-muted" style="font-size:0.85rem;">
+                Click a widget below, then click a grid cell to place it.
+            </p>
+            <button type="button" class="palette-btn" data-type="text" onclick="selectPaletteType('text')">🅰 Text</button>
+            <button type="button" class="palette-btn" data-type="clock" onclick="selectPaletteType('clock')">🕒 Clock</button>
+            <button type="button" class="palette-btn" data-type="ticker" onclick="selectPaletteType('ticker')">📰 Ticker</button>
+            <div id="palette-status" style="margin-top:0.5rem; font-size:0.85rem; color:var(--text-muted,#57606a);">
+                None selected.
+            </div>
+
+            <h3 style="margin-top:1.5rem;">Background</h3>
+            <label style="display:block; font-size:0.85rem;">Color</label>
+            <input type="color" id="bg-color" value="#000000" oninput="setBgColor(this.value)">
+        </aside>
+
+        <div class="canvas-wrap">
+            <div class="canvas" id="canvas" aria-label="Composed slide canvas"></div>
+            <p class="text-muted" style="font-size:0.8rem; margin-top:0.5rem;">
+                12 cols × 8 rows. Aspect ratio 16:9 (1920×1080 at full size).
+            </p>
+        </div>
+
+        <aside class="settings" id="settings-panel">
+            <h3>Settings</h3>
+            <p class="text-muted" style="font-size:0.85rem;">Click a placed widget to edit it.</p>
+        </aside>
+    </div>
+</div>
+
+<style>
+    .composed-editor {
+        display: grid;
+        grid-template-columns: 200px 1fr 280px;
+        gap: 1rem;
+        margin-top: 1rem;
+        align-items: start;
+    }
+    .palette, .settings {
+        padding: 0.75rem;
+        border: 1px solid var(--border-color,#d0d7de);
+        border-radius: 6px;
+        background: var(--card-bg,#fff);
+    }
+    .palette h3, .settings h3 { margin: 0 0 0.5rem; font-size: 1rem; }
+    .palette-btn {
+        display: block;
+        width: 100%;
+        text-align: left;
+        padding: 0.45rem 0.65rem;
+        margin-bottom: 0.35rem;
+        border: 1px solid var(--border-color,#d0d7de);
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 0.9rem;
+    }
+    .palette-btn.active {
+        border-color: var(--accent-color,#0969da);
+        background: #ddebff;
+    }
+    .canvas-wrap {
+        min-width: 0;
+    }
+    .canvas {
+        position: relative;
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: repeat(8, 1fr);
+        gap: 1px;
+        background: #1a1a1a;
+        aspect-ratio: 16 / 9;
+        border: 2px solid #1a1a1a;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+    .grid-cell {
+        background: rgba(255,255,255,0.04);
+        cursor: pointer;
+        transition: background .08s;
+    }
+    .grid-cell:hover { background: rgba(99,179,237,0.25); }
+    .placed-widget {
+        position: relative;
+        background: rgba(59,130,246,0.18);
+        border: 1px solid rgba(59,130,246,0.65);
+        color: #fff;
+        font-size: 0.7rem;
+        padding: 0.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        cursor: pointer;
+        text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+    }
+    .placed-widget.selected {
+        background: rgba(34,197,94,0.28);
+        border-color: #22c55e;
+        outline: 2px solid #22c55e;
+        outline-offset: -2px;
+    }
+    .settings label {
+        display: block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        margin-top: 0.6rem;
+    }
+    .settings input[type=text],
+    .settings input[type=number],
+    .settings textarea,
+    .settings select {
+        width: 100%;
+        padding: 0.35rem 0.45rem;
+        border: 1px solid var(--border-color,#d0d7de);
+        border-radius: 4px;
+        font-size: 0.85rem;
+        box-sizing: border-box;
+    }
+    .settings textarea { min-height: 60px; resize: vertical; }
+    .settings .row { display: flex; gap: 0.5rem; }
+    .settings .row > div { flex: 1; min-width: 0; }
+    .settings .delete-btn {
+        margin-top: 1rem;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid #dc2626;
+        background: #fff;
+        color: #dc2626;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.85rem;
+    }
+</style>
+
+<script>
+const ASSET_ID = "{{ asset_id }}";
+const SCHEMA_VERSION = {{ schema_version|tojson }};
+let LAYOUT = {{ layout_json|tojson }};
+let selectedPaletteType = null;
+let selectedWidgetId = null;
+
+const FONT_OPTIONS = ["sans","serif","mono","display"];
+
+const DEFAULTS = {
+    text: {text:"Text", color:"#ffffff", font_size_px:48, font_family:"sans", bold:false, italic:false},
+    clock: {format:"24h", show_seconds:true, show_date:false, color:"#ffffff", font_family:"sans", font_size_px:96},
+    ticker: {text:"Breaking news...", speed_px_per_sec:100, direction:"left", mode:"scroll",
+             color:"#ffffff", background:"#000000", font_family:"sans", font_size_px:48, gap_px:100},
+};
+
+function flash(msg, ok) {
+    const box = document.getElementById("msg-box");
+    box.style.display = "block";
+    box.style.background = ok ? "#dcfce7" : "#fee2e2";
+    box.style.color     = ok ? "#166534" : "#991b1b";
+    box.textContent = msg;
+    if (ok) setTimeout(() => { box.style.display = "none"; }, 2500);
+}
+
+function uuid4() {
+    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c/4).toString(16));
+}
+
+function ensureLayoutShape() {
+    if (!LAYOUT || typeof LAYOUT !== "object") LAYOUT = {};
+    LAYOUT.schema_version = LAYOUT.schema_version || SCHEMA_VERSION || 1;
+    LAYOUT.grid = LAYOUT.grid || {rows: 8, cols: 12};
+    LAYOUT.canvas = LAYOUT.canvas || {w: 1920, h: 1080};
+    LAYOUT.background = LAYOUT.background || {color: "#000000"};
+    LAYOUT.widgets = LAYOUT.widgets || [];
+}
+
+function selectPaletteType(t) {
+    selectedPaletteType = t;
+    document.querySelectorAll(".palette-btn").forEach(b => {
+        b.classList.toggle("active", b.dataset.type === t);
+    });
+    document.getElementById("palette-status").textContent = "Placing: " + t + ". Click a cell.";
+}
+
+function setBgColor(c) {
+    ensureLayoutShape();
+    LAYOUT.background.color = c;
+    renderCanvas();
+}
+
+function renderCanvas() {
+    ensureLayoutShape();
+    const canvas = document.getElementById("canvas");
+    canvas.innerHTML = "";
+    canvas.style.background = LAYOUT.background.color || "#000";
+    document.getElementById("bg-color").value = LAYOUT.background.color || "#000000";
+
+    // Build an occupancy map so empty cells are still clickable.
+    const occupied = {};
+    for (const w of LAYOUT.widgets) {
+        const cs = (w.cell && w.cell.colspan) || 1;
+        const rs = (w.cell && w.cell.rowspan) || 1;
+        for (let r = w.cell.row; r < w.cell.row + rs; r++) {
+            for (let c = w.cell.col; c < w.cell.col + cs; c++) {
+                occupied[r + "," + c] = w.id;
+            }
+        }
+    }
+
+    for (let r = 1; r <= 8; r++) {
+        for (let c = 1; c <= 12; c++) {
+            if (occupied[r + "," + c]) continue;
+            const cell = document.createElement("div");
+            cell.className = "grid-cell";
+            cell.style.gridColumn = c;
+            cell.style.gridRow = r;
+            cell.dataset.row = r;
+            cell.dataset.col = c;
+            cell.onclick = () => placeAt(r, c);
+            canvas.appendChild(cell);
+        }
+    }
+
+    for (const w of LAYOUT.widgets) {
+        const el = document.createElement("div");
+        el.className = "placed-widget" + (w.id === selectedWidgetId ? " selected" : "");
+        const cs = (w.cell && w.cell.colspan) || 1;
+        const rs = (w.cell && w.cell.rowspan) || 1;
+        el.style.gridColumn = w.cell.col + " / span " + cs;
+        el.style.gridRow = w.cell.row + " / span " + rs;
+        el.textContent = w.type + ": " + summarize(w);
+        el.onclick = (e) => { e.stopPropagation(); selectWidget(w.id); };
+        canvas.appendChild(el);
+    }
+}
+
+function summarize(w) {
+    if (w.type === "text") return (w.config.text || "").slice(0, 24);
+    if (w.type === "clock") return w.config.format || "24h";
+    if (w.type === "ticker") return (w.config.text || "").slice(0, 24);
+    return "";
+}
+
+function placeAt(row, col) {
+    if (!selectedPaletteType) {
+        flash("Pick a widget type from the palette first.", false);
+        return;
+    }
+    ensureLayoutShape();
+    const id = uuid4();
+    const cfg = JSON.parse(JSON.stringify(DEFAULTS[selectedPaletteType]));
+    LAYOUT.widgets.push({
+        id,
+        type: selectedPaletteType,
+        cell: {row, col, rowspan: 1, colspan: 1},
+        config: cfg,
+        config_version: 1,
+    });
+    selectedWidgetId = id;
+    renderCanvas();
+    renderSettings();
+}
+
+function selectWidget(id) {
+    selectedWidgetId = id;
+    renderCanvas();
+    renderSettings();
+}
+
+function getSelected() {
+    return LAYOUT.widgets.find(w => w.id === selectedWidgetId) || null;
+}
+
+function updateSelected(patcher) {
+    const w = getSelected();
+    if (!w) return;
+    patcher(w);
+    renderCanvas();
+}
+
+function renderSettings() {
+    const panel = document.getElementById("settings-panel");
+    const w = getSelected();
+    if (!w) {
+        panel.innerHTML = "<h3>Settings</h3><p class='text-muted' style='font-size:0.85rem;'>Click a placed widget to edit it.</p>";
+        return;
+    }
+
+    const cellHtml = `
+        <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Position &amp; Size</h4>
+        <div class="row">
+            <div>
+                <label>Row (1–8)</label>
+                <input type="number" min="1" max="8" value="${w.cell.row}"
+                       oninput="updateSelected(x=>x.cell.row=clampInt(this.value,1,8))">
+            </div>
+            <div>
+                <label>Col (1–12)</label>
+                <input type="number" min="1" max="12" value="${w.cell.col}"
+                       oninput="updateSelected(x=>x.cell.col=clampInt(this.value,1,12))">
+            </div>
+        </div>
+        <div class="row">
+            <div>
+                <label>Rowspan</label>
+                <input type="number" min="1" max="8" value="${w.cell.rowspan||1}"
+                       oninput="updateSelected(x=>x.cell.rowspan=clampInt(this.value,1,8))">
+            </div>
+            <div>
+                <label>Colspan</label>
+                <input type="number" min="1" max="12" value="${w.cell.colspan||1}"
+                       oninput="updateSelected(x=>x.cell.colspan=clampInt(this.value,1,12))">
+            </div>
+        </div>`;
+
+    let configHtml = "";
+    if (w.type === "text") {
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Text widget</h4>
+            <label>Text</label>
+            <textarea oninput="updateSelected(x=>x.config.text=this.value)">${escapeHtml(w.config.text||"")}</textarea>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||48}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <label>Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>
+            <div class="row" style="margin-top:0.5rem;">
+                <label style="font-weight:400;">
+                    <input type="checkbox" ${w.config.bold?"checked":""}
+                        oninput="updateSelected(x=>x.config.bold=this.checked)"> Bold
+                </label>
+                <label style="font-weight:400;">
+                    <input type="checkbox" ${w.config.italic?"checked":""}
+                        oninput="updateSelected(x=>x.config.italic=this.checked)"> Italic
+                </label>
+            </div>`;
+    } else if (w.type === "clock") {
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Clock widget</h4>
+            <label>Format</label>
+            <select oninput="updateSelected(x=>x.config.format=this.value)">
+                <option value="24h" ${w.config.format==="24h"?"selected":""}>24-hour</option>
+                <option value="12h" ${w.config.format==="12h"?"selected":""}>12-hour</option>
+            </select>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.show_seconds?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_seconds=this.checked)"> Show seconds
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_date?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_date=this.checked)"> Show date
+            </label>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <label>Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>`;
+    } else if (w.type === "ticker") {
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Ticker widget</h4>
+            <label>Text</label>
+            <textarea oninput="updateSelected(x=>x.config.text=this.value)">${escapeHtml(w.config.text||"")}</textarea>
+            <div class="row">
+                <div>
+                    <label>Speed (px/s)</label>
+                    <input type="number" min="20" max="500" value="${w.config.speed_px_per_sec||100}"
+                           oninput="updateSelected(x=>x.config.speed_px_per_sec=clampInt(this.value,20,500))">
+                </div>
+                <div>
+                    <label>Gap (px)</label>
+                    <input type="number" min="0" max="2000" value="${w.config.gap_px||100}"
+                           oninput="updateSelected(x=>x.config.gap_px=clampInt(this.value,0,2000))">
+                </div>
+            </div>
+            <label>Direction</label>
+            <select oninput="updateSelected(x=>x.config.direction=this.value)">
+                <option value="left" ${w.config.direction==="left"?"selected":""}>Left</option>
+                <option value="right" ${w.config.direction==="right"?"selected":""}>Right</option>
+            </select>
+            <label>Mode</label>
+            <select oninput="updateSelected(x=>x.config.mode=this.value)">
+                <option value="scroll" ${w.config.mode==="scroll"?"selected":""}>Scroll (loop)</option>
+                <option value="bounce" ${w.config.mode==="bounce"?"selected":""}>Bounce</option>
+            </select>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Background</label>
+                    <input type="color" value="${w.config.background||"#000000"}"
+                           oninput="updateSelected(x=>x.config.background=this.value)">
+                </div>
+            </div>
+            <div class="row">
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||48}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+                <div>
+                    <label>Font</label>
+                    <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                        ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+                    </select>
+                </div>
+            </div>`;
+    }
+
+    panel.innerHTML = `<h3>Settings</h3>
+        <div style="font-size:0.75rem; color:var(--text-muted,#57606a); word-break:break-all;">${w.id}</div>
+        ${cellHtml}
+        ${configHtml}
+        <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>`;
+}
+
+function clampInt(v, lo, hi) {
+    let n = parseInt(v, 10);
+    if (isNaN(n)) n = lo;
+    return Math.max(lo, Math.min(hi, n));
+}
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+        "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"
+    }[c]));
+}
+
+function deleteSelected() {
+    if (!selectedWidgetId) return;
+    LAYOUT.widgets = LAYOUT.widgets.filter(w => w.id !== selectedWidgetId);
+    selectedWidgetId = null;
+    renderCanvas();
+    renderSettings();
+}
+
+async function saveLayout() {
+    ensureLayoutShape();
+    try {
+        const resp = await fetch("/composed/" + ASSET_ID + "/layout", {
+            method: "PATCH",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(LAYOUT),
+        });
+        if (!resp.ok) {
+            const txt = await resp.text();
+            let msg = "Save failed.";
+            try {
+                const j = JSON.parse(txt);
+                if (j.detail && j.detail.errors) {
+                    msg = "Save failed: " + j.detail.errors.map(e => e.message).join("; ");
+                } else if (j.detail) {
+                    msg = "Save failed: " + (typeof j.detail === "string" ? j.detail : (j.detail.message || JSON.stringify(j.detail)));
+                }
+            } catch (_) {}
+            flash(msg, false);
+            return false;
+        }
+        flash("Saved.", true);
+        markDraft();
+        return true;
+    } catch (e) {
+        flash("Network error: " + e, false);
+        return false;
+    }
+}
+
+async function openPreview() {
+    const ok = await saveLayout();
+    if (!ok) return;
+    window.open("/composed/" + ASSET_ID + "/preview", "_blank");
+}
+
+async function publishLayout() {
+    const ok = await saveLayout();
+    if (!ok) return;
+    try {
+        const resp = await fetch("/composed/" + ASSET_ID + "/publish", {method: "POST"});
+        if (!resp.ok) {
+            const txt = await resp.text();
+            let msg = "Publish failed.";
+            try {
+                const j = JSON.parse(txt);
+                if (j.detail) {
+                    msg = "Publish failed: " + (typeof j.detail === "string" ? j.detail : (j.detail.message || JSON.stringify(j.detail)));
+                }
+            } catch (_) {}
+            flash(msg, false);
+            return;
+        }
+        const body = await resp.json();
+        flash("Published. Bundle: " + body.filename + " (" + body.size_bytes + " bytes)", true);
+        markPublished();
+    } catch (e) {
+        flash("Network error: " + e, false);
+    }
+}
+
+function markDraft() {
+    const pill = document.getElementById("status-pill");
+    pill.textContent = "Draft";
+    pill.style.background = "#fef3c7";
+    pill.style.color = "#92400e";
+}
+
+function markPublished() {
+    const pill = document.getElementById("status-pill");
+    pill.textContent = "Published";
+    pill.style.background = "#dcfce7";
+    pill.style.color = "#166534";
+}
+
+ensureLayoutShape();
+renderCanvas();
+renderSettings();
+</script>
+{% endblock %}

--- a/cms/templates/composed_new.html
+++ b/cms/templates/composed_new.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+{% block title %}New Composed Slide — Agora CMS{% endblock %}
+{% block content %}
+<h1>Assets</h1>
+<div class="sub-tabs">
+    <a href="/assets" class="sub-tab">Library</a>
+    <a href="/assets/new" class="sub-tab active">Create</a>
+    <a href="/profiles" class="sub-tab">Playback Profiles</a>
+</div>
+
+<div class="card">
+    <h2 style="margin-top:0;">New Composed Slide</h2>
+    <p class="text-muted">
+        Give your slide a name and pick which groups can see it.
+        You'll be dropped straight into the editor.
+    </p>
+
+    <form id="composed-new-form" onsubmit="return submitComposedNew(event);" style="max-width:560px;">
+        <label for="composed-name" style="display:block; margin-top:1rem; font-weight:600;">Name</label>
+        <input type="text" id="composed-name" name="name" required maxlength="255"
+               placeholder="e.g. Lobby welcome"
+               style="width:100%; padding:0.5rem; border:1px solid var(--border-color,#d0d7de); border-radius:6px;">
+
+        {% if is_admin %}
+        <label style="display:block; margin-top:1rem;">
+            <input type="checkbox" id="composed-global" name="is_global" checked>
+            Visible to everyone (global)
+        </label>
+        {% endif %}
+
+        {% if user_groups %}
+        <fieldset style="margin-top:1rem; border:1px solid var(--border-color,#d0d7de); border-radius:6px; padding:0.75rem;">
+            <legend style="font-weight:600;">{% if is_admin %}Or share with specific groups{% else %}Share with groups{% endif %}</legend>
+            {% for g in user_groups %}
+            <label style="display:block; padding:0.15rem 0;">
+                <input type="checkbox" name="group_ids" value="{{ g.id }}"> {{ g.name }}
+            </label>
+            {% endfor %}
+        </fieldset>
+        {% endif %}
+
+        <div id="composed-new-error" style="color:#b91c1c; margin-top:0.75rem; display:none;"></div>
+
+        <div style="margin-top:1.25rem; display:flex; gap:0.5rem;">
+            <button type="submit" class="btn btn-primary">Create &amp; open editor</button>
+            <a href="/assets/new" class="btn">Cancel</a>
+        </div>
+    </form>
+</div>
+
+<script>
+async function submitComposedNew(ev) {
+    ev.preventDefault();
+    const form = ev.target;
+    const errBox = document.getElementById("composed-new-error");
+    errBox.style.display = "none";
+    errBox.textContent = "";
+
+    const name = form.querySelector("#composed-name").value.trim();
+    if (!name) {
+        errBox.textContent = "Name is required.";
+        errBox.style.display = "block";
+        return false;
+    }
+
+    const isGlobalEl = form.querySelector("#composed-global");
+    const wantsGlobal = isGlobalEl ? isGlobalEl.checked : false;
+    const groupIds = Array.from(form.querySelectorAll("input[name='group_ids']:checked"))
+        .map((el) => el.value);
+
+    const payload = { name };
+    if (!wantsGlobal && groupIds.length) {
+        payload.group_ids = groupIds;
+    }
+
+    try {
+        const resp = await fetch("/composed/", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(payload),
+        });
+        if (!resp.ok) {
+            const txt = await resp.text();
+            let msg = "Could not create composed slide.";
+            try { msg = (JSON.parse(txt).detail) || msg; } catch (_) {}
+            errBox.textContent = msg;
+            errBox.style.display = "block";
+            return false;
+        }
+        const body = await resp.json();
+        window.location.href = body.edit_url || ("/assets/" + body.id + "/composed");
+    } catch (e) {
+        errBox.textContent = "Network error: " + e;
+        errBox.style.display = "block";
+    }
+    return false;
+}
+</script>
+{% endblock %}

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1782,6 +1782,94 @@ async def slideshow_builder_edit(
     return templates.TemplateResponse(request, "slideshow_builder.html", ctx)
 
 
+@router.get(
+    "/assets/new/composed",
+    response_class=HTMLResponse,
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
+)
+async def composed_builder_new(request: Request, db: AsyncSession = Depends(get_db)):
+    """Show the 'create composed slide' form (name + group picker).
+
+    The form POSTs to ``/composed/`` which creates the asset + an empty
+    draft layout and returns the editor URL.
+    """
+    user: User | None = getattr(request.state, "user", None)
+    group_ids = await get_user_group_ids(user, db) if user else []
+    is_admin = group_ids is None
+    if group_ids is None:
+        groups_q = await db.execute(select(DeviceGroup).order_by(DeviceGroup.name))
+    elif group_ids:
+        groups_q = await db.execute(
+            select(DeviceGroup).where(DeviceGroup.id.in_(group_ids)).order_by(DeviceGroup.name)
+        )
+    else:
+        groups_q = None
+    user_groups = groups_q.scalars().all() if groups_q else []
+    return templates.TemplateResponse(request, "composed_new.html", {
+        "active_tab": "assets",
+        "is_admin": is_admin,
+        "user_groups": user_groups,
+    })
+
+
+@router.get(
+    "/assets/{asset_id}/composed",
+    response_class=HTMLResponse,
+    dependencies=[Depends(require_permission(ASSETS_WRITE))],
+)
+async def composed_builder_edit(
+    asset_id: str, request: Request, db: AsyncSession = Depends(get_db),
+):
+    """Open the composed-slide editor for an existing asset.
+
+    Loads the asset + the backing composed-slide row's
+    ``layout_json`` and hands them to the editor template. The editor
+    is HTMX-driven and talks to ``/composed/{id}/layout`` (PATCH),
+    ``/composed/{id}/publish`` (POST), and
+    ``/composed/{id}/preview`` (iframe GET) for round-trips.
+    """
+    import uuid as _uuid
+
+    try:
+        aid = _uuid.UUID(asset_id)
+    except ValueError:
+        return RedirectResponse("/assets", status_code=303)
+
+    asset = (await db.execute(
+        select(Asset).where(
+            Asset.id == aid,
+            Asset.deleted_at.is_(None),
+            Asset.asset_type == AssetType.COMPOSED,
+        )
+    )).scalar_one_or_none()
+    if asset is None:
+        return RedirectResponse("/assets", status_code=303)
+
+    from cms.models.composed_slide import ComposedSlide
+
+    composed = (await db.execute(
+        select(ComposedSlide).where(ComposedSlide.asset_id == aid)
+    )).scalar_one_or_none()
+    if composed is None:
+        return RedirectResponse("/assets", status_code=303)
+
+    user: User | None = getattr(request.state, "user", None)
+    group_ids = await get_user_group_ids(user, db) if user else []
+    is_admin = group_ids is None
+
+    return templates.TemplateResponse(request, "composed_editor.html", {
+        "active_tab": "assets",
+        "is_admin": is_admin,
+        "asset": asset,
+        "asset_id": str(asset.id),
+        "asset_name": asset.display_name or asset.original_filename or asset.filename,
+        "layout_json": composed.layout_json,
+        "is_draft": composed.is_draft,
+        "bundle_built_at": composed.bundle_built_at,
+        "schema_version": composed.schema_version,
+    })
+
+
 # ── Schedules ──
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -232,6 +232,132 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /composed/:
+    post:
+      tags:
+      - composed
+      summary: Create Composed Slide
+      description: |-
+        Create a new draft composed-slide asset with an empty layout.
+
+        Body:
+            ``name`` (str, required): user-facing display name; also used as
+                the unique ``Asset.filename`` (with a numeric suffix if a
+                conflict exists).
+            ``group_ids`` (list[str] | str, optional): group UUIDs to share
+                the asset with. Empty list + admin → global.
+
+        Returns the created asset's id and a redirect-friendly editor URL.
+      operationId: create_composed_slide_composed__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Body
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Create Composed Slide Composed  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /composed/{asset_id}/layout:
+    patch:
+      tags:
+      - composed
+      summary: Patch Composed Layout
+      description: |-
+        Replace the layout JSON for a composed slide.
+
+        Body must be the full canonical ``Layout`` JSON (Pydantic shape).
+        The endpoint:
+
+        1. Validates Pydantic shape — 422 on failure.
+        2. Runs ``validate_layout`` (semantic: bounds, overlaps, unknown
+           widget types, per-widget ``validate_semantic``) — 422 on failure.
+        3. Checks referenced-asset ACL (audience widening) — 400 on failure.
+        4. Persists the canonical JSON via ``layout.model_dump(mode="json")``.
+        5. Sets ``is_draft=True`` so any previously-published bundle is
+           flagged stale until ``/publish`` is called again.
+      operationId: patch_composed_layout_composed__asset_id__layout_patch
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Body
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Patch Composed Layout Composed  Asset Id  Layout Patch
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /composed/{asset_id}/publish:
+    post:
+      tags:
+      - composed
+      summary: Publish Composed Endpoint
+      description: |-
+        Build the bundle for the composed slide and clear ``is_draft``.
+
+        Returns the bundle filename, size, and sha256. Errors map to:
+
+        * 422 — empty layout (need at least one widget).
+        * 422 — bundle/validation error (``PublishError``).
+      operationId: publish_composed_endpoint_composed__asset_id__publish_post
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Publish Composed Endpoint Composed  Asset Id  Publish Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/check-updates:
     post:
       summary: Check For Updates

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -1,0 +1,177 @@
+"""Phase 2 tests for the composed-slide write/publish routes and the
+UI builder routes.
+
+Scope:
+
+* ``POST /composed/`` — admin create round-trip; missing-name 400.
+* ``PATCH /composed/{id}/layout`` — sets ``is_draft=True`` even after
+  publish; invalid layout shape returns 422 (not 500).
+* ``POST /composed/{id}/publish`` — empty-layout returns a friendly 422.
+* Auth: unauth user gets redirected (303/302) to /login on UI routes
+  and 401 on the JSON API routes.
+* UI: ``GET /assets/new/composed`` renders for an authed user; the
+  editor route renders for an existing composed asset and 303s to
+  /assets for a missing one.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+
+def _text_widget(text: str = "hi") -> WidgetInstance:
+    return WidgetInstance(
+        id=uuid.uuid4(),
+        type="text",
+        cell=Cell(row=1, col=1, rowspan=1, colspan=4),
+        config={"text": text, "font_size_px": 64},
+        config_version=1,
+    )
+
+
+async def _make_composed(
+    db_session, *, layout: Layout | None = None, is_draft: bool = True,
+) -> tuple[Asset, ComposedSlide]:
+    asset = Asset(
+        filename=f"composed-{uuid.uuid4()}",
+        display_name="Test composed",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=(layout or empty_layout()).model_dump(mode="json"),
+        is_draft=is_draft,
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    return asset, cs
+
+
+# ─────────────────────────── API: create ───────────────────────────
+
+
+@pytest.mark.asyncio
+class TestComposedCreate:
+    async def test_admin_can_create(self, client):
+        resp = await client.post(
+            "/composed/", json={"name": "Lobby welcome"}
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["display_name"] == "Lobby welcome"
+        assert body["edit_url"].startswith("/assets/")
+        assert body["edit_url"].endswith("/composed")
+        # The id round-trips as a UUID.
+        uuid.UUID(body["id"])
+
+    async def test_missing_name_is_400(self, client):
+        resp = await client.post("/composed/", json={})
+        assert resp.status_code == 400
+
+    async def test_unauth_is_401(self, unauthed_client):
+        resp = await unauthed_client.post("/composed/", json={"name": "x"})
+        # The API is JSON, so it does NOT redirect — it returns 401.
+        assert resp.status_code in (401, 403)
+
+
+# ─────────────────────────── API: patch ────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestComposedPatch:
+    async def test_invalid_layout_shape_is_422_not_500(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        # Send a totally bogus body — not a Layout shape.
+        resp = await client.patch(
+            f"/composed/{asset.id}/layout", json={"hello": "world"}
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, dict)
+        assert detail["error"] in ("invalid_layout_shape", "invalid_layout")
+
+    async def test_patch_after_publish_re_drafts(self, client, db_session):
+        """Once published (is_draft=False), a PATCH must set is_draft=True
+        again so the device-facing bundle is flagged stale until republished.
+        """
+        layout = empty_layout()
+        layout.widgets.append(_text_widget("hi"))
+        asset, cs = await _make_composed(db_session, layout=layout, is_draft=False)
+        assert cs.is_draft is False
+
+        new_layout = empty_layout()
+        new_layout.widgets.append(_text_widget("updated"))
+
+        resp = await client.patch(
+            f"/composed/{asset.id}/layout",
+            json=new_layout.model_dump(mode="json"),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["is_draft"] is True
+
+        await db_session.refresh(cs)
+        assert cs.is_draft is True
+
+
+# ─────────────────────────── API: publish ──────────────────────────
+
+
+@pytest.mark.asyncio
+class TestComposedPublish:
+    async def test_empty_layout_returns_friendly_422(self, client, db_session):
+        asset, _ = await _make_composed(db_session)  # default empty layout
+        resp = await client.post(f"/composed/{asset.id}/publish")
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, dict)
+        assert detail["error"] == "empty_layout"
+        assert "widget" in detail["message"].lower()
+
+    async def test_publish_missing_asset_404(self, client):
+        resp = await client.post(f"/composed/{uuid.uuid4()}/publish")
+        assert resp.status_code == 404
+
+
+# ─────────────────────────── UI routes ─────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestComposedUI:
+    async def test_new_page_renders_for_authed_user(self, client):
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        # Some breadcrumb of the form is present.
+        text = resp.text.lower()
+        assert "name" in text
+
+    async def test_editor_renders_for_existing_composed(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await client.get(f"/assets/{asset.id}/composed")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    async def test_editor_redirects_for_missing_asset(self, client):
+        resp = await client.get(
+            f"/assets/{uuid.uuid4()}/composed", follow_redirects=False
+        )
+        assert resp.status_code in (302, 303)
+        assert resp.headers["location"] == "/assets"
+
+    async def test_unauth_ui_redirects_to_login(self, unauthed_client):
+        resp = await unauthed_client.get(
+            "/assets/new/composed", follow_redirects=False
+        )
+        # The UI requires auth — accept either a redirect or a 401.
+        assert resp.status_code in (302, 303, 401)


### PR DESCRIPTION
## Why

Phase 1A delivery (bundle -> device cache -> playback) needs end-to-end validation on a real Pi. The seed-script approach for hand-creating a composed asset proved fiddly, so this PR ships the **smallest usable web UI** to hand-build one instead. Once merged + deployed to agoragwdev, the user can create a composed slide in a browser, assign it to Pi100, and close out Phase 1A.

## What

**Backend (`cms/routers/composed.py`):**
* `POST /composed/` -- create a draft composed asset (name + groups, admin-with-no-groups => global)
* `PATCH /composed/{id}/layout` -- replace layout, sets `is_draft=True` so any previously-published bundle is flagged stale
* `POST /composed/{id}/publish` -- build bundle, clear `is_draft`
* All gated by `ASSETS_WRITE` and scoped via `_verify_asset_access`
* Friendly 422s for invalid layout shape, empty-on-publish, ACL widening

**UI:**
* `GET /assets/new/composed` -- name + groups form, JS posts to `/composed/` and redirects
* `GET /assets/{id}/composed` -- 12x8 grid editor:
  * Palette (text / clock / ticker) -- auto-built per-type defaults
  * Click-palette-then-click-cell placement (no drag-and-drop in v1)
  * Per-widget settings panel (position + rowspan/colspan + type-specific fields)
  * Save / Preview (opens `/composed/{id}/preview` in a new tab) / Publish
  * Draft-vs-Published pill + bundle timestamp

**Tests (`tests/test_composed_routes_phase2.py` -- 11, all green locally):**
* Create round-trip, missing-name 400, unauth 401
* PATCH invalid shape -> 422 (not 500)
* PATCH after publish re-drafts
* Publish empty -> friendly 422 with `error: empty_layout`
* UI new + editor render; missing asset -> 303 to `/assets`

## Trade-offs

* **No drag-and-drop.** Click-palette-then-click-cell is much simpler and works on touch. Resize via rowspan/colspan number inputs.
* **Settings forms are hardcoded per widget type in JS**, not auto-generated from `ConfigSchema.model_json_schema()`. Decision call: auto-gen wasn't worth the effort for v1.
* **Widget defaults are duplicated in the editor's `DEFAULTS` JS object.** Acceptable drift risk for v1; if a widget adds a new default, this file must be updated.

## Out of scope (intentional)

* Image / video widgets (Phase 1C)
* AI-generated layouts (Phase 3)
* Stale-bundle UI affordance (separate, on `composed-1b-stale-bundle` branch)
* Schema migration on read (separate, PR #699)

## Verify

After auto-merge + deploy to agoragwdev:
1. Log in, click 'New asset' -> 'Composed Slide'
2. Name it, optionally scope to a group, hit Create
3. Drop a Text widget, edit content, hit Publish
4. Assign to Pi100, watch it render