### PR TITLE
composed: stale-bundle detection service (Phase 1B follow-up)

### DIFF
--- a/cms/composed/staleness.py
+++ b/cms/composed/staleness.py
@@ -1,0 +1,136 @@
+"""Stale-bundle detection for composed slides.
+
+The bundle builder records the union of every widget's declared asset
+dependencies in ``ComposedSlide.bundle_source_asset_ids`` at build
+time (see ``cms/composed/bundle.py``).  Once a slide is published,
+the user can continue editing the draft layout — adding widgets,
+removing them, swapping referenced assets — and the published bundle
+gradually drifts out of sync with what the layout now says.
+
+This module exposes :func:`compute_staleness` so the editor can
+surface "your bundle is stale, rebuild?" affordances and the publish
+endpoint can skip a no-op rebuild when the bundle is already fresh.
+
+What this catches (v1):
+    * Bundle was never built (``bundle_built_at`` is None).
+    * The layout now references asset IDs the bundle doesn't have
+      ("added") — e.g. user dropped a new image widget after publish.
+    * The bundle references asset IDs the layout no longer mentions
+      ("removed") — e.g. user deleted a widget after publish.
+
+What this does NOT catch (v1):
+    * Same asset ID, different bytes (user re-uploaded an image in
+      place).  Detecting this requires recording per-asset checksums
+      at build time, which means a schema bump.  Tracked as a
+      follow-up; for now editors should treat "I changed the source
+      file" as a manual-rebuild trigger.
+
+This service is intentionally read-only and side-effect-free: callers
+choose whether to act on the report (show a banner, gate a publish,
+auto-trigger a rebuild, etc.).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+from pydantic import ValidationError as PydanticValidationError
+
+from cms.composed.registry import WidgetRegistry
+from cms.composed.schema import Layout
+
+StalenessReason = Literal[
+    "fresh",
+    "never_built",
+    "asset_ids_drift",
+    "layout_unloadable",
+]
+
+
+@dataclass
+class StaleBundleReport:
+    """Result of :func:`compute_staleness`.
+
+    ``is_stale`` is the single-bit answer the UI cares about; the
+    other fields explain *why* so the editor can render a useful
+    message and tests can assert specific drift modes.
+    """
+
+    is_stale: bool
+    reason: StalenessReason
+    added: set[uuid.UUID] = field(default_factory=set)
+    removed: set[uuid.UUID] = field(default_factory=set)
+    # Set when reason == "layout_unloadable": the Pydantic error
+    # message.  Callers usually surface this as "layout itself is
+    # broken; fix that before worrying about staleness".
+    layout_error: str | None = None
+
+
+def _compute_current_asset_ids(
+    layout: Layout, registry: WidgetRegistry
+) -> set[uuid.UUID]:
+    """Re-derive the union of ``declared_asset_ids`` over every widget
+    instance in ``layout``.  Mirrors the loop the bundle builder runs
+    at build time (see ``bundle.py``), minus the rendering side.
+
+    Unknown widget slugs and per-widget config-validation failures are
+    swallowed silently here: the dedicated layout validator
+    (``validate_layout``) is the right place to surface those.  A
+    staleness check whose only "issue" is that a config doesn't
+    validate cleanly should still report on whatever IS resolvable.
+    """
+    current: set[uuid.UUID] = set()
+    for inst in layout.widgets:
+        widget = registry.get(inst.type)
+        if widget is None:
+            continue
+        try:
+            typed = widget.ConfigSchema.model_validate(inst.config)
+        except PydanticValidationError:
+            continue
+        current.update(widget.declared_asset_ids(typed))
+    return current
+
+
+def compute_staleness(
+    slide,  # ComposedSlide ORM row (not imported to keep this module test-friendly)
+    registry: WidgetRegistry,
+) -> StaleBundleReport:
+    """Compare the slide's current layout against its last bundle.
+
+    Returns a :class:`StaleBundleReport`.  Does not touch the database
+    and does not mutate ``slide``.
+    """
+    if slide.bundle_built_at is None:
+        return StaleBundleReport(is_stale=True, reason="never_built")
+
+    layout_json = slide.layout_json or {}
+    try:
+        layout = Layout.model_validate(layout_json)
+    except PydanticValidationError as e:
+        # Defensive: a previously-published slide whose draft layout
+        # has since been corrupted (or hand-edited via the DB) can
+        # still hit staleness checks from the editor.  Treat that as
+        # "needs attention" so callers don't quietly mark it fresh.
+        return StaleBundleReport(
+            is_stale=True,
+            reason="layout_unloadable",
+            layout_error=str(e),
+        )
+
+    current_ids = _compute_current_asset_ids(layout, registry)
+    bundle_ids = set(slide.bundle_source_asset_ids or [])
+    added = current_ids - bundle_ids
+    removed = bundle_ids - current_ids
+
+    if added or removed:
+        return StaleBundleReport(
+            is_stale=True,
+            reason="asset_ids_drift",
+            added=added,
+            removed=removed,
+        )
+
+    return StaleBundleReport(is_stale=False, reason="fresh")

--- a/tests/test_composed_staleness.py
+++ b/tests/test_composed_staleness.py
@@ -1,0 +1,405 @@
+"""Tests for ``cms.composed.staleness.compute_staleness``.
+
+The staleness service compares a slide's current draft layout against
+the asset IDs the last bundle was built from.  It's pure / read-only,
+so we can exercise it with a hand-rolled ``SimpleNamespace`` slide
+stub instead of standing up real ORM rows — the function never
+touches the session.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+# Side-effect import: registers built-in widgets (text, image, ...)
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.staleness import (
+    StaleBundleReport,
+    compute_staleness,
+)
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def _layout_with_text(text: str = "hello") -> dict:
+    """A minimal valid layout containing a single text widget (no
+    asset deps).  Used when we want a layout that's loadable but
+    declares zero asset IDs.
+    """
+    return {
+        "schema_version": 1,
+        "background": {"color": "#000000"},
+        "widgets": [
+            {
+                "id": str(uuid.uuid4()),
+                "type": "text",
+                "cell": {"row": 1, "col": 1, "rowspan": 1, "colspan": 1},
+                "config_version": 1,
+                "config": {
+                    "text": text,
+                    "color": "#ffffff",
+                    "font_size_px": 48,
+                    "font_family": "sans-serif",
+                },
+            },
+        ],
+    }
+
+
+def _layout_with_image(asset_id: uuid.UUID) -> dict:
+    """A minimal valid layout containing a single image widget that
+    declares ``asset_id`` as its dependency.
+    """
+    return {
+        "schema_version": 1,
+        "background": {"color": "#000000"},
+        "widgets": [
+            {
+                "id": str(uuid.uuid4()),
+                "type": "image",
+                "cell": {"row": 1, "col": 1, "rowspan": 2, "colspan": 2},
+                "config_version": 1,
+                "config": {"asset_id": str(asset_id), "object_fit": "contain"},
+            },
+        ],
+    }
+
+
+def _layout_with_images(*asset_ids: uuid.UUID) -> dict:
+    """Layout containing N image widgets, one per asset ID."""
+    widgets = []
+    for i, aid in enumerate(asset_ids):
+        widgets.append(
+            {
+                "id": str(uuid.uuid4()),
+                "type": "image",
+                "cell": {"row": 1 + i, "col": 1, "rowspan": 1, "colspan": 1},
+                "config_version": 1,
+                "config": {"asset_id": str(aid), "object_fit": "contain"},
+            }
+        )
+    return {
+        "schema_version": 1,
+        "background": {"color": "#000000"},
+        "widgets": widgets,
+    }
+
+
+def _slide(
+    *,
+    layout_json: dict | None = None,
+    bundle_built_at: datetime | None = None,
+    bundle_source_asset_ids: list[uuid.UUID] | None = None,
+) -> SimpleNamespace:
+    """Build a minimal slide-shaped object for the staleness function.
+
+    ``compute_staleness`` only reads ``bundle_built_at``,
+    ``bundle_source_asset_ids``, and ``layout_json`` — we use
+    SimpleNamespace so the test doesn't depend on the SQLAlchemy
+    model surface.
+    """
+    return SimpleNamespace(
+        layout_json=layout_json or _layout_with_text(),
+        bundle_built_at=bundle_built_at,
+        bundle_source_asset_ids=bundle_source_asset_ids,
+    )
+
+
+# ---------------------------------------------------------------------
+# never_built path
+# ---------------------------------------------------------------------
+
+
+class TestNeverBuilt:
+    def test_no_bundle_built_yet_is_stale(self):
+        registry = get_registry()
+        slide = _slide(bundle_built_at=None)
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.reason == "never_built"
+        assert report.added == set()
+        assert report.removed == set()
+
+    def test_never_built_short_circuits_before_layout_parse(self):
+        """A slide that's never been built returns ``never_built``
+        even if its layout would otherwise fail to load.  This keeps
+        the message accurate for the editor — telling someone their
+        layout is broken when the real issue is "you haven't hit
+        publish yet" would be confusing.
+        """
+        registry = get_registry()
+        slide = _slide(layout_json={"not": "valid"}, bundle_built_at=None)
+        report = compute_staleness(slide, registry)
+        assert report.reason == "never_built"
+
+
+# ---------------------------------------------------------------------
+# fresh path
+# ---------------------------------------------------------------------
+
+
+class TestFresh:
+    def test_no_asset_widgets_no_bundle_ids_is_fresh(self):
+        registry = get_registry()
+        slide = _slide(
+            layout_json=_layout_with_text(),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is False
+        assert report.reason == "fresh"
+
+    def test_no_asset_widgets_none_bundle_ids_is_fresh(self):
+        """``bundle_source_asset_ids`` is nullable in the schema; the
+        bundle builder leaves it None for slides without asset deps.
+        Treat None and [] equivalently.
+        """
+        registry = get_registry()
+        slide = _slide(
+            layout_json=_layout_with_text(),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=None,
+        )
+        report = compute_staleness(slide, registry)
+        assert report.reason == "fresh"
+
+    def test_matching_single_asset_id_is_fresh(self):
+        registry = get_registry()
+        aid = uuid.uuid4()
+        slide = _slide(
+            layout_json=_layout_with_image(aid),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[aid],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is False
+        assert report.reason == "fresh"
+
+    def test_matching_multi_asset_ids_is_fresh(self):
+        registry = get_registry()
+        aids = [uuid.uuid4() for _ in range(3)]
+        slide = _slide(
+            layout_json=_layout_with_images(*aids),
+            bundle_built_at=datetime.now(timezone.utc),
+            # Different ordering than the layout's — set semantics.
+            bundle_source_asset_ids=list(reversed(aids)),
+        )
+        report = compute_staleness(slide, registry)
+        assert report.reason == "fresh"
+
+
+# ---------------------------------------------------------------------
+# asset_ids_drift path
+# ---------------------------------------------------------------------
+
+
+class TestAssetIdsDrift:
+    def test_added_asset_marks_stale(self):
+        registry = get_registry()
+        aid = uuid.uuid4()
+        slide = _slide(
+            layout_json=_layout_with_image(aid),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.reason == "asset_ids_drift"
+        assert report.added == {aid}
+        assert report.removed == set()
+
+    def test_removed_asset_marks_stale(self):
+        registry = get_registry()
+        old_aid = uuid.uuid4()
+        slide = _slide(
+            # Layout no longer references any assets…
+            layout_json=_layout_with_text(),
+            bundle_built_at=datetime.now(timezone.utc),
+            # …but the bundle was built when it did.
+            bundle_source_asset_ids=[old_aid],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.reason == "asset_ids_drift"
+        assert report.added == set()
+        assert report.removed == {old_aid}
+
+    def test_swapped_asset_marks_both_added_and_removed(self):
+        registry = get_registry()
+        old_aid = uuid.uuid4()
+        new_aid = uuid.uuid4()
+        slide = _slide(
+            layout_json=_layout_with_image(new_aid),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[old_aid],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.reason == "asset_ids_drift"
+        assert report.added == {new_aid}
+        assert report.removed == {old_aid}
+
+    def test_partial_overlap_only_lists_drift(self):
+        registry = get_registry()
+        kept = uuid.uuid4()
+        removed = uuid.uuid4()
+        added = uuid.uuid4()
+        slide = _slide(
+            layout_json=_layout_with_images(kept, added),
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[kept, removed],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.added == {added}
+        assert report.removed == {removed}
+
+
+# ---------------------------------------------------------------------
+# layout_unloadable path
+# ---------------------------------------------------------------------
+
+
+class TestLayoutUnloadable:
+    def test_corrupt_layout_reports_layout_error(self):
+        """If a published slide's draft layout has been corrupted
+        (e.g. via direct DB edit), staleness should report it rather
+        than crash or silently claim fresh.
+        """
+        registry = get_registry()
+        slide = _slide(
+            layout_json={"schema_version": 1, "widgets": "not-a-list"},
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is True
+        assert report.reason == "layout_unloadable"
+        assert report.layout_error is not None
+        assert "widgets" in report.layout_error.lower()
+
+
+# ---------------------------------------------------------------------
+# Unknown widget / config-validation edge cases
+# ---------------------------------------------------------------------
+
+
+class TestUnknownWidget:
+    def test_unknown_widget_type_does_not_crash(self):
+        """If the layout references an unregistered widget type, the
+        function should skip it for the staleness comparison — the
+        layout validator owns that error.  We still want a usable
+        report on the rest of the widgets.
+
+        We construct this layout by bypassing Layout.model_validate
+        (which the WidgetInstance type-validator would reject), and
+        instead feed compute_staleness raw JSON via the model_dump
+        path used by real callers.
+        """
+        registry = get_registry()
+        known_aid = uuid.uuid4()
+        # Hand-crafted layout JSON with one valid widget and one
+        # unknown-typed widget.  Layout.model_validate accepts unknown
+        # slugs at parse time (the slug validator only checks shape:
+        # lowercase alphanumeric after stripping underscores); the
+        # registry lookup is what rejects them.
+        layout_json = {
+            "schema_version": 1,
+            "background": {"color": "#000000"},
+            "widgets": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "type": "image",
+                    "cell": {"row": 1, "col": 1, "rowspan": 1, "colspan": 1},
+                    "config_version": 1,
+                    "config": {
+                        "asset_id": str(known_aid),
+                        "object_fit": "contain",
+                    },
+                },
+                {
+                    "id": str(uuid.uuid4()),
+                    "type": "totallymadeup",
+                    "cell": {
+                        "row": 2,
+                        "col": 1,
+                        "rowspan": 1,
+                        "colspan": 1,
+                    },
+                    "config_version": 1,
+                    "config": {"anything": "goes"},
+                },
+            ],
+        }
+        slide = _slide(
+            layout_json=layout_json,
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[known_aid],
+        )
+        report = compute_staleness(slide, registry)
+        # Image widget's asset matches bundle; unknown widget skipped.
+        assert report.is_stale is False
+        assert report.reason == "fresh"
+
+    def test_invalid_widget_config_does_not_crash(self):
+        """A widget whose config fails Pydantic validation is silently
+        skipped for staleness purposes — the layout validator surfaces
+        that error elsewhere.
+        """
+        registry = get_registry()
+        kept_aid = uuid.uuid4()
+        layout_json = {
+            "schema_version": 1,
+            "background": {"color": "#000000"},
+            "widgets": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "type": "image",
+                    "cell": {"row": 1, "col": 1, "rowspan": 1, "colspan": 1},
+                    "config_version": 1,
+                    "config": {"asset_id": str(kept_aid), "object_fit": "contain"},
+                },
+                # Image widget with garbage config — model_validate will
+                # raise inside compute_staleness; should be caught.
+                {
+                    "id": str(uuid.uuid4()),
+                    "type": "image",
+                    "cell": {"row": 2, "col": 1, "rowspan": 1, "colspan": 1},
+                    "config_version": 1,
+                    "config": {"asset_id": "not-a-uuid", "object_fit": "contain"},
+                },
+            ],
+        }
+        slide = _slide(
+            layout_json=layout_json,
+            bundle_built_at=datetime.now(timezone.utc),
+            bundle_source_asset_ids=[kept_aid],
+        )
+        report = compute_staleness(slide, registry)
+        assert report.is_stale is False
+        assert report.reason == "fresh"
+
+
+# ---------------------------------------------------------------------
+# Dataclass behaviour
+# ---------------------------------------------------------------------
+
+
+class TestReportShape:
+    def test_default_added_removed_are_distinct_sets(self):
+        """Regression guard: ``set`` default args used to silently
+        share state across instances back when dataclasses were less
+        strict.  Use the explicit factory and verify."""
+        a = StaleBundleReport(is_stale=False, reason="fresh")
+        b = StaleBundleReport(is_stale=False, reason="fresh")
+        a.added.add(uuid.uuid4())
+        assert b.added == set()


### PR DESCRIPTION
## Why

Phase 1B widget contract is shipped (#697) and schema migration on read (#699) handles old bundles. This adds the **detector** that flags when a composed slide's *current layout* has drifted from the *last published bundle* -- the input a future UI affordance will use to nudge the user to republish.

## What

* New module `cms/composed/staleness.py` with `compute_staleness(slide, registry)` returning a `StaleBundleReport` whose `reason` is one of:
  * `never_built` -- bundle has never been built
  * `fresh` -- layout matches the last bundle (asset-id-set comparison)
  * `asset_ids_drift` -- widgets reference different asset IDs than the last bundle
  * `layout_unloadable` -- layout can't be parsed (treat as stale, surface details)
* Pure / read-only / no DB access. Slide is consumed as a duck-typed stub so callers pass either a real ORM row or a SimpleNamespace.

## Scope (intentional v1 limitation)

ID-set drift only. This detects added / removed / swapped widgets, but **NOT** re-uploads of the same asset ID with different bytes (Asset has no `updated_at` and we don't record per-asset checksums at bundle time). Per-asset checksum tracking is deferred to a follow-up that would add a JSONB column + migration.

## Out of scope

* UI affordance ("Stale -- republish" pill on the editor) -- separate PR
* Per-asset checksum tracking -- separate PR (needs schema change)
* Calling the detector from any route -- this PR is the building block only

## Tests

14 unit tests across 6 classes. All green locally (`pytest tests/test_composed_staleness.py` -- 0.51s).
