### PR TITLE
fix(composed): add COMPOSED (uppercase) to assettype enum

### DIFF
--- a/alembic/versions/0038_composed_enum_uppercase.py
+++ b/alembic/versions/0038_composed_enum_uppercase.py
@@ -1,0 +1,40 @@
+"""Alembic migration 0038 — add ``COMPOSED`` to the assettype enum.
+
+Migration 0037 added ``'composed'`` (lowercase) to the Postgres
+``assettype`` enum, but the column is persisted using SQLAlchemy enum
+*names* (uppercase) — see the note at the top of migration 0015 for
+the convention.  The lowercase value never matches what SQLAlchemy
+sends, so every ``Asset(asset_type=AssetType.COMPOSED)`` insert fails
+with ``invalid input value for enum assettype: "COMPOSED"``.
+
+This migration adds the correctly-cased ``'COMPOSED'`` value.  The
+unused lowercase ``'composed'`` value from 0037 is left in place
+because Postgres can't drop a single enum value without rebuilding
+the type, and it's harmless.
+
+SQLite ignores enum constraints, so no-op there (matches 0015 /
+0037).
+
+Revision ID: 0038
+Revises: 0037
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0038"
+down_revision = "0037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'COMPOSED'")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0038 is not supported")


### PR DESCRIPTION
Hotfix for composed-slide create 500 in agoragwdev.

Migration 0037 added `'composed'` (lowercase) to the Postgres `assettype` enum, but the column persists SQLAlchemy enum **names** (uppercase) per the convention documented in 0015. Every `POST /composed/` failed with:

`invalid input value for enum assettype: "COMPOSED"`

Adds migration 0038 with the correctly-cased value. The unused lowercase `'composed'` from 0037 is left in place since Postgres can't drop a single enum value.

Verified by App Insights exception trace from agoragwdev replica `v1-38-91`.