### PR TITLE
ui(composer): drag widgets to move, drag handles to resize

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -163,8 +163,9 @@
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        cursor: pointer;
+        cursor: move;
         text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+        user-select: none;
     }
     .placed-widget.selected {
         background: rgba(34,197,94,0.28);
@@ -172,6 +173,22 @@
         outline: 2px solid #22c55e;
         outline-offset: -2px;
     }
+    .placed-widget.dragging { opacity: 0.7; }
+    .resize-handle {
+        position: absolute;
+        background: #22c55e;
+        border: 1px solid #064e3b;
+        z-index: 5;
+        box-sizing: border-box;
+    }
+    .resize-handle.h-e  { right: -5px; top: 50%; width: 10px; height: 18px; transform: translateY(-50%); cursor: ew-resize; border-radius: 2px; }
+    .resize-handle.h-w  { left: -5px;  top: 50%; width: 10px; height: 18px; transform: translateY(-50%); cursor: ew-resize; border-radius: 2px; }
+    .resize-handle.h-s  { bottom: -5px; left: 50%; width: 18px; height: 10px; transform: translateX(-50%); cursor: ns-resize; border-radius: 2px; }
+    .resize-handle.h-n  { top: -5px;    left: 50%; width: 18px; height: 10px; transform: translateX(-50%); cursor: ns-resize; border-radius: 2px; }
+    .resize-handle.h-se { right: -5px;  bottom: -5px; width: 12px; height: 12px; cursor: nwse-resize; border-radius: 2px; }
+    .resize-handle.h-sw { left: -5px;   bottom: -5px; width: 12px; height: 12px; cursor: nesw-resize; border-radius: 2px; }
+    .resize-handle.h-ne { right: -5px;  top: -5px;    width: 12px; height: 12px; cursor: nesw-resize; border-radius: 2px; }
+    .resize-handle.h-nw { left: -5px;   top: -5px;    width: 12px; height: 12px; cursor: nwse-resize; border-radius: 2px; }
     .settings label {
         display: block;
         font-size: 0.8rem;
@@ -319,10 +336,73 @@ function renderCanvas() {
         const rs = (w.cell && w.cell.rowspan) || 1;
         el.style.gridColumn = w.cell.col + " / span " + cs;
         el.style.gridRow = w.cell.row + " / span " + rs;
-        el.textContent = w.type + ": " + summarize(w);
+        el.dataset.widgetId = w.id;
+        const label = document.createElement("div");
+        label.textContent = w.type + ": " + summarize(w);
+        label.style.pointerEvents = "none";
+        el.appendChild(label);
         el.onclick = (e) => { e.stopPropagation(); selectWidget(w.id); };
+        el.addEventListener("pointerdown", (e) => beginDrag(e, w.id, "move"));
+        for (const dir of ["n","s","e","w","ne","nw","se","sw"]) {
+            const h = document.createElement("div");
+            h.className = "resize-handle h-" + dir;
+            h.addEventListener("pointerdown", (e) => beginDrag(e, w.id, dir));
+            el.appendChild(h);
+        }
         canvas.appendChild(el);
     }
+}
+
+function beginDrag(ev, widgetId, mode) {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const w = LAYOUT.widgets.find(x => x.id === widgetId);
+    if (!w) return;
+    selectWidget(widgetId);
+    const canvas = document.getElementById("canvas");
+    const rect = canvas.getBoundingClientRect();
+    const cellW = rect.width / 12;
+    const cellH = rect.height / 8;
+    const start = {
+        x: ev.clientX, y: ev.clientY,
+        row: w.cell.row, col: w.cell.col,
+        rs: w.cell.rowspan || 1, cs: w.cell.colspan || 1,
+    };
+    const widgetEl = ev.currentTarget.classList.contains("placed-widget")
+        ? ev.currentTarget : ev.currentTarget.parentElement;
+    if (widgetEl) widgetEl.classList.add("dragging");
+    const onMove = (e) => {
+        const dCol = Math.round((e.clientX - start.x) / cellW);
+        const dRow = Math.round((e.clientY - start.y) / cellH);
+        let row = start.row, col = start.col, rs = start.rs, cs = start.cs;
+        if (mode === "move") {
+            row = clampInt(start.row + dRow, 1, 8 - rs + 1);
+            col = clampInt(start.col + dCol, 1, 12 - cs + 1);
+        } else {
+            if (mode.includes("e")) cs = clampInt(start.cs + dCol, 1, 12 - start.col + 1);
+            if (mode.includes("s")) rs = clampInt(start.rs + dRow, 1, 8 - start.row + 1);
+            if (mode.includes("w")) {
+                const newCol = clampInt(start.col + dCol, 1, start.col + start.cs - 1);
+                cs = start.cs + (start.col - newCol);
+                col = newCol;
+            }
+            if (mode.includes("n")) {
+                const newRow = clampInt(start.row + dRow, 1, start.row + start.rs - 1);
+                rs = start.rs + (start.row - newRow);
+                row = newRow;
+            }
+        }
+        w.cell.row = row; w.cell.col = col;
+        w.cell.rowspan = rs; w.cell.colspan = cs;
+        renderCanvas();
+    };
+    const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        renderSettings();
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
 }
 
 function summarize(w) {
@@ -378,7 +458,10 @@ function renderSettings() {
     }
 
     const cellHtml = `
-        <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Position &amp; Size</h4>
+        <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Position</h4>
+        <p style="font-size:0.75rem; color:var(--text-muted); margin:0.25rem 0 0.5rem;">
+            Drag the widget to move. Drag edge or corner handles to resize.
+        </p>
         <div class="row">
             <div>
                 <label>Row (1–8)</label>
@@ -389,18 +472,6 @@ function renderSettings() {
                 <label>Col (1–12)</label>
                 <input type="number" min="1" max="12" value="${w.cell.col}"
                        oninput="updateSelected(x=>x.cell.col=clampInt(this.value,1,12))">
-            </div>
-        </div>
-        <div class="row">
-            <div>
-                <label>Rowspan</label>
-                <input type="number" min="1" max="8" value="${w.cell.rowspan||1}"
-                       oninput="updateSelected(x=>x.cell.rowspan=clampInt(this.value,1,8))">
-            </div>
-            <div>
-                <label>Colspan</label>
-                <input type="number" min="1" max="12" value="${w.cell.colspan||1}"
-                       oninput="updateSelected(x=>x.cell.colspan=clampInt(this.value,1,12))">
             </div>
         </div>`;
 


### PR DESCRIPTION
Final composer UI nit from the 2026-06-03 review: replace the row/col/rowspan/colspan number steppers with direct pointer manipulation.

## What changed

- Drag a placed widget's body to **move** it on the 12x8 grid (cell-snapped)
- Drag any of **8 edge/corner handles** to **resize** (cell-snapped)
- N/W handles adjust both position and span so the opposite edge stays pinned; E/S handles only change span
- Removed `rowspan` / `colspan` number inputs from the settings panel
- Row / Col number inputs kept for fine-tune typing
- Helper text added under canvas

## Why it's safe across re-renders

Pointer event handlers attach to `window` during a drag, so they survive `renderCanvas()` rebuilding the DOM between frames. The live widget object reference into `LAYOUT.widgets` is mutated in-place, so cell math stays consistent.

## Tests

- `tests/test_composed_routes_phase2.py` (11) — green
- No new JS-level tests; the route/template tests are sufficient for the backend contract. Manual smoke on dev after deploy.

Closes the 5/5 composer UI nits from the review (theme + back button + edit + unified create page + grips).