### PR TITLE
feat(composed): unified MediaWidget for image + video assets

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -155,15 +155,24 @@ def build_bundle(
     layout: Layout,
     registry: WidgetRegistry | None = None,
     asset_loader: AssetLoader | None = None,
+    sibling_asset_urls: dict[uuid.UUID, str] | None = None,
 ) -> BuiltBundle:
     """Render ``layout`` to a self-contained HTML bundle.
 
     ``asset_loader``, if supplied, is called once per unique asset ID
     declared by any widget (via :meth:`Widget.declared_asset_ids`) and
     must return ``(bytes, mime_type)``.  Widgets receive the resolved
-    bytes through :class:`BundleContext`.  A layout whose widgets
-    declare any asset IDs but is built without a loader raises
-    :class:`MissingAssetLoaderError`.
+    bytes through :class:`BundleContext`.
+
+    ``sibling_asset_urls`` maps declared asset IDs to *device-local*
+    URLs (e.g. ``/assets/videos/foo.mp4``) for assets that are
+    shipped to the device as siblings rather than inlined.  Used for
+    video assets — the bundle's ``<video src>`` points at these URLs
+    and the device cache layer fetches them separately.
+
+    A declared asset ID must be resolvable through *either* the
+    ``asset_loader`` path *or* the ``sibling_asset_urls`` mapping; if
+    it's in neither, :class:`MissingAssetLoaderError` is raised.
 
     Raises :class:`BundleValidationError` if the layout fails
     :func:`~cms.composed.validate.validate_layout`.  The check is
@@ -172,6 +181,9 @@ def build_bundle(
     """
 
     reg = registry if registry is not None else get_registry()
+    sib_urls: dict[uuid.UUID, str] = (
+        dict(sibling_asset_urls) if sibling_asset_urls else {}
+    )
 
     # 1. Defensive validation.
     errors = validate_layout(layout, reg)
@@ -198,14 +210,23 @@ def build_bundle(
                 seen_declared.add(aid)
                 all_declared_ids.append(aid)
 
-    if all_declared_ids and asset_loader is None:
-        raise MissingAssetLoaderError(all_declared_ids)
+    # An ID counts as "satisfied" if we have either bytes-channel
+    # coverage (asset_loader) OR a sibling-URL mapping for it.  Only
+    # IDs with no coverage from either channel are missing.
+    needs_loader = [aid for aid in all_declared_ids if aid not in sib_urls]
+    if needs_loader and asset_loader is None:
+        raise MissingAssetLoaderError(needs_loader)
 
-    # 2b. Pre-fetch every declared asset exactly once.
+    # 2b. Pre-fetch every declared asset exactly once.  Skip IDs
+    #     that the publish layer routed to the sibling-URLs channel
+    #     (videos, etc.) — those don't get inlined and don't need
+    #     bytes loaded.
     asset_bytes: dict[uuid.UUID, bytes] = {}
     asset_mimes: dict[uuid.UUID, str] = {}
     if asset_loader is not None:
         for aid in all_declared_ids:
+            if aid in sib_urls:
+                continue
             blob, mime = asset_loader(aid)
             asset_bytes[aid] = blob
             asset_mimes[aid] = mime
@@ -222,8 +243,15 @@ def build_bundle(
 
     for inst, widget, config, declared in prepped:
         ctx = BundleContext(
-            asset_bytes={aid: asset_bytes[aid] for aid in declared},
-            asset_mimes={aid: asset_mimes[aid] for aid in declared},
+            asset_bytes={
+                aid: asset_bytes[aid] for aid in declared if aid in asset_bytes
+            },
+            asset_mimes={
+                aid: asset_mimes[aid] for aid in declared if aid in asset_mimes
+            },
+            sibling_asset_urls={
+                aid: sib_urls[aid] for aid in declared if aid in sib_urls
+            },
         )
         render: WidgetRender = widget.render_html(
             config=config,

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -139,7 +139,20 @@ async def publish_composed_slide(
                 seen_declared.add(aid)
                 declared_ids.append(aid)
 
+    # Bucket each declared asset by its AssetType:
+    #   IMAGE → inline as base64 data URI (bytes channel, asset_loader)
+    #   VIDEO → ship as a sibling cache entry; bundle's <video src>
+    #           points at the device-local /assets/videos/<filename>
+    #           URL.  Phase 1C scope: no firmware sibling-fetch wiring
+    #           yet (deferred to Phase 1D) — until that ships, videos
+    #           used in composed slides must be independently assigned
+    #           to the same device groups so they land in the device's
+    #           video cache through the existing per-asset sync path.
+    #   anything else → reject (e.g. a composed slide can't embed
+    #           another composed slide, a webpage asset, or a slideshow)
     asset_payloads: dict[uuid.UUID, tuple[bytes, str]] = {}
+    sibling_asset_urls: dict[uuid.UUID, str] = {}
+    video_count = 0
     if declared_ids:
         rows = await db.execute(
             select(Asset).where(Asset.id.in_(declared_ids)),
@@ -151,20 +164,54 @@ async def publish_composed_slide(
                 raise PublishError(
                     f"Composed slide references missing asset {aid}",
                 )
-            ref_path = storage_dir / ref.filename
-            try:
-                blob = ref_path.read_bytes()
-            except FileNotFoundError as e:
+            if ref.asset_type == AssetType.IMAGE:
+                ref_path = storage_dir / ref.filename
+                try:
+                    blob = ref_path.read_bytes()
+                except FileNotFoundError as e:
+                    raise PublishError(
+                        f"Asset {aid} file missing on disk: {ref.filename}",
+                    ) from e
+                mime, _ = mimetypes.guess_type(ref.filename)
+                asset_payloads[aid] = (blob, mime or "application/octet-stream")
+            elif ref.asset_type == AssetType.VIDEO:
+                # Device-local URL served by the Pi shell's HTTP server
+                # (port 8780, FastAPI StaticFiles mount on /assets →
+                # /opt/agora/assets/).  URL-encode the filename so files
+                # with spaces / special chars (e.g. "my video (final).mp4")
+                # produce a valid src attribute.
+                import urllib.parse as _urlparse
+
+                sibling_asset_urls[aid] = (
+                    f"/assets/videos/{_urlparse.quote(ref.filename)}"
+                )
+                video_count += 1
+            else:
                 raise PublishError(
-                    f"Asset {aid} file missing on disk: {ref.filename}",
-                ) from e
-            mime, _ = mimetypes.guess_type(ref.filename)
-            asset_payloads[aid] = (blob, mime or "application/octet-stream")
+                    f"Composed slide references asset {aid} of type "
+                    f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
+                    "assets can be embedded in a composed slide",
+                )
+
+    if video_count > 1:
+        # No hard cap — multiple muted autoplay videos technically work
+        # on Chromium, but on a Pi Zero 2 W the H.264 decoder can
+        # struggle with concurrent streams.  Leave a breadcrumb in the
+        # publish log so it's findable if a slide misbehaves on-device.
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "composed slide %s declares %d video widgets; multiple "
+            "concurrent decodes may stutter on lower-end Pi hardware",
+            asset_id,
+            video_count,
+        )
 
     def _asset_loader(aid: uuid.UUID) -> tuple[bytes, str]:
-        # build_bundle only calls this for IDs in ``declared_ids``,
-        # which is exactly what we pre-fetched above; a KeyError here
-        # would mean a widget bypassed declared_asset_ids() and is a
+        # build_bundle only calls this for IDs in the bytes channel
+        # (IMAGE assets we pre-fetched above); a KeyError here would
+        # mean a widget bypassed declared_asset_ids() or the bundle
+        # builder ignored the sibling-URLs channel — either is a
         # programming error worth surfacing loudly.
         return asset_payloads[aid]
 
@@ -172,7 +219,8 @@ async def publish_composed_slide(
         built = build_bundle(
             layout,
             registry,
-            asset_loader=_asset_loader if declared_ids else None,
+            asset_loader=_asset_loader if asset_payloads else None,
+            sibling_asset_urls=sibling_asset_urls or None,
         )
     except BundleValidationError as e:
         raise PublishError(
@@ -197,7 +245,12 @@ async def publish_composed_slide(
     now = datetime.now(timezone.utc)
     composed.is_draft = False
     composed.bundle_built_at = now
-    composed.bundle_source_asset_ids = list(built.source_asset_ids)
+    # Stringify for storage portability: on Postgres prod the column is
+    # ARRAY(UUID) and accepts string-form UUIDs (cast), and on the
+    # SQLite test variant it degrades to JSON which can't serialize raw
+    # UUID objects.  Stringifying here gives both backends a working
+    # value without a custom type decorator.
+    composed.bundle_source_asset_ids = [str(aid) for aid in built.source_asset_ids]
 
     await db.flush()
 

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -43,12 +43,25 @@ class BundleContext:
     asset MUST also declare it; the bundle builder rejects layouts
     whose widgets reference undeclared assets at render time.
 
-    Empty default is intentional: trivial widgets (text, clock) that
+    ``sibling_asset_urls`` is the parallel channel for assets the
+    bundle should *reference by URL* rather than inline as bytes.
+    Used for VIDEO assets in Phase 1C onward — videos are way too big
+    to inline as data URIs, so the publish layer registers them as
+    sibling assets on the device cache and the bundle's ``<video>``
+    tag just points at the device-local URL (e.g.
+    ``/assets/videos/foo.mp4``).  Keyed by the same declared asset ID.
+
+    A given asset ID appears in *either* the bytes channel *or* the
+    sibling-URLs channel, never both — the publish layer buckets by
+    ``asset_type``.
+
+    Empty defaults are intentional: trivial widgets (text, clock) that
     never touch assets can ignore the parameter entirely.
     """
 
     asset_bytes: dict[uuid.UUID, bytes] = field(default_factory=dict)
     asset_mimes: dict[uuid.UUID, str] = field(default_factory=dict)
+    sibling_asset_urls: dict[uuid.UUID, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/cms/composed/staleness.py
+++ b/cms/composed/staleness.py
@@ -121,9 +121,16 @@ def compute_staleness(
         )
 
     current_ids = _compute_current_asset_ids(layout, registry)
-    bundle_ids = set(slide.bundle_source_asset_ids or [])
-    added = current_ids - bundle_ids
-    removed = bundle_ids - current_ids
+    # Normalize both sides to strings: on Postgres prod the column is
+    # ARRAY(UUID) and reads back as UUID objects; on the SQLite test
+    # variant it degrades to JSON and reads back as strings.  Compare
+    # by string form so set arithmetic is correct on either backend.
+    current_str = {str(x) for x in current_ids}
+    bundle_str = {str(x) for x in (slide.bundle_source_asset_ids or [])}
+    added_str = current_str - bundle_str
+    removed_str = bundle_str - current_str
+    added = {uuid.UUID(s) for s in added_str}
+    removed = {uuid.UUID(s) for s in removed_str}
 
     if added or removed:
         return StaleBundleReport(

--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from cms.composed.registry import get_registry
 from cms.composed.widgets.clock import ClockWidget
 from cms.composed.widgets.image import ImageWidget
+from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
 
@@ -29,8 +30,8 @@ _reg = get_registry()
 # Idempotent — guards against re-import edge cases (importlib.reload,
 # test session re-import) double-registering and tripping the
 # registry's "already registered" guard.
-for _widget_cls in (TextWidget, ImageWidget, ClockWidget, TickerWidget):
+for _widget_cls in (TextWidget, ImageWidget, MediaWidget, ClockWidget, TickerWidget):
     if not _reg.has(_widget_cls.slug):
         _reg.register(_widget_cls())
 
-__all__ = ["ClockWidget", "ImageWidget", "TextWidget", "TickerWidget"]
+__all__ = ["ClockWidget", "ImageWidget", "MediaWidget", "TextWidget", "TickerWidget"]

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -1,0 +1,191 @@
+"""Media widget — embeds a single Asset (IMAGE or VIDEO) into the bundle.
+
+A unified palette tile that handles both image and video assets so
+the editor doesn't have to expose two near-identical widgets.  The
+publish layer (see :mod:`cms.composed.publish`) buckets each
+declared asset ID into one of two parallel channels on the
+:class:`BundleContext`:
+
+* :attr:`BundleContext.asset_bytes` — for IMAGE assets, loaded from
+  disk and inlined as a base64 ``data:`` URI inside an ``<img>``
+  tag.  Same shape as the older :class:`~cms.composed.widgets.image.ImageWidget`.
+* :attr:`BundleContext.sibling_asset_urls` — for VIDEO assets, the
+  publish layer registers the video as a *sibling* asset on the
+  device cache and stores the device-local URL here.  The rendered
+  bundle's ``<video src>`` points at that URL; the device cache
+  layer downloads the file separately.
+
+Inlining a multi-megabyte MP4 as a base64 data URI is a non-starter
+(payload bloat, decode pressure on the Pi); the sibling-URL channel
+keeps the bundle small and lets the device cache do its job.
+
+Sizing model mirrors :class:`~cms.composed.widgets.image.ImageWidget`:
+the widget always fills its grid cell, and ``object_fit`` controls
+how the source is scaled inside the cell.
+
+Phase 1C scope: the firmware sibling-fetch protocol that wires
+declared-but-not-yet-cached VIDEO assets into the device's
+``/assets/videos/`` directory is deferred to Phase 1D.  Until then,
+videos used in composed slides must be independently assigned to the
+same device groups so they land in the device's video cache through
+the existing per-asset sync path.
+"""
+
+from __future__ import annotations
+
+import base64
+import html as _html
+import logging
+import uuid
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+
+log = logging.getLogger(__name__)
+
+
+# Soft warning threshold for inlined image size.  Matches the
+# ImageWidget threshold — we hit this on a re-uploaded 4K photo that
+# someone dropped into a 200px cell.
+_LARGE_IMAGE_WARN_BYTES: int = 2 * 1024 * 1024
+
+
+class MediaWidgetConfig(BaseModel):
+    """User-editable config for :class:`MediaWidget`.
+
+    A single ``asset_id`` points at either an IMAGE or a VIDEO asset;
+    which one is determined at publish time (the publish layer looks
+    up the Asset row and routes by ``asset_type``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: uuid.UUID
+    # Mirrors the CSS ``object-fit`` allowlist we actually support.
+    # Applied to both ``<img>`` and ``<video>``; both honour it.
+    object_fit: Literal["cover", "contain", "fill"] = "cover"
+    # Optional alt text for images / accessibility hint for videos.
+    # Always HTML-escaped before emission.
+    alt: str = Field(default="", max_length=512)
+
+
+class MediaWidget(Widget):
+    """Single image OR video asset; publish layer picks the channel."""
+
+    slug: ClassVar[str] = "media"
+    display_name: ClassVar[str] = "Media"
+    icon: ClassVar[str] = "🎬"
+    ConfigSchema: ClassVar[type[BaseModel]] = MediaWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        # All-zero UUID placeholder is intentional — the editor will
+        # replace it as soon as the user picks an asset.  validate_layout
+        # rejects it because the referenced asset doesn't exist, forcing
+        # an explicit pick before save.
+        return {
+            "asset_id": "00000000-0000-0000-0000-000000000000",
+            "object_fit": "cover",
+            "alt": "",
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/media.html"
+
+    def declared_asset_ids(self, config: BaseModel) -> list[uuid.UUID]:
+        assert isinstance(config, MediaWidgetConfig)
+        return [config.asset_id]
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        assert isinstance(config, MediaWidgetConfig), (
+            "MediaWidget.render_html expects a MediaWidgetConfig instance"
+        )
+        if ctx is None:
+            raise RuntimeError(
+                "MediaWidget.render_html requires a BundleContext "
+                "with the declared asset routed into either "
+                "asset_bytes (image) or sibling_asset_urls (video)"
+            )
+
+        asset_id = config.asset_id
+        css_class = f"cw-media-{instance_id}"
+        alt_escaped = _html.escape(config.alt)
+
+        # Video branch: publish layer routed this ID to the sibling
+        # URL channel.  Emit a <video> tag pointing at the device-local
+        # URL; the bundle stays small and the device cache fetches the
+        # MP4 through the existing per-asset sync path.
+        if asset_id in ctx.sibling_asset_urls:
+            src = ctx.sibling_asset_urls[asset_id]
+            # The publish layer is responsible for URL-encoding the
+            # filename.  Escape for HTML attribute safety here.
+            src_escaped = _html.escape(src, quote=True)
+            html_out = (
+                f'<video class="{css_class}" '
+                f'src="{src_escaped}" '
+                f'muted loop autoplay playsinline '
+                f'aria-label="{alt_escaped}"></video>'
+            )
+        elif asset_id in ctx.asset_bytes:
+            # Image branch: inline as base64 data URI.  Mirrors the
+            # ImageWidget shape exactly so existing image rendering
+            # behaviour is unchanged.
+            blob = ctx.asset_bytes[asset_id]
+            mime = ctx.asset_mimes[asset_id]
+
+            if len(blob) > _LARGE_IMAGE_WARN_BYTES:
+                log.warning(
+                    "composed media widget %s: image asset %s is %d bytes "
+                    "(>%d) — inlined bundle will be large",
+                    instance_id,
+                    asset_id,
+                    len(blob),
+                    _LARGE_IMAGE_WARN_BYTES,
+                )
+
+            b64 = base64.b64encode(blob).decode("ascii")
+            data_uri = f"data:{mime};base64,{b64}"
+            html_out = (
+                f'<img class="{css_class}" '
+                f'src="{data_uri}" '
+                f'alt="{alt_escaped}" '
+                f'draggable="false" />'
+            )
+        else:
+            # Bundle builder enforces declare-before-reference and the
+            # publish layer always routes a declared ID into one of the
+            # two channels — getting here means a regression in that
+            # contract.  Fail loudly rather than emit a broken tag.
+            raise RuntimeError(
+                f"MediaWidget instance {instance_id}: asset {asset_id} "
+                "missing from BundleContext (neither asset_bytes nor "
+                "sibling_asset_urls)"
+            )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: block;\n"
+            f"  object-fit: {config.object_fit};\n"
+            f"  object-position: center;\n"
+            f"  user-select: none;\n"
+            f"  background: #000;\n"
+            f"}}"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            referenced_asset_ids=[asset_id],
+        )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -71,6 +71,7 @@
                 Click a widget below, then click a grid cell to place it.
             </p>
             <button type="button" class="palette-btn" data-type="text" onclick="selectPaletteType('text')">🅰 Text</button>
+            <button type="button" class="palette-btn" data-type="media" onclick="selectPaletteType('media')">🎬 Media</button>
             <button type="button" class="palette-btn" data-type="clock" onclick="selectPaletteType('clock')">🕒 Clock</button>
             <button type="button" class="palette-btn" data-type="ticker" onclick="selectPaletteType('ticker')">📰 Ticker</button>
             <div id="palette-status" style="margin-top:0.5rem; font-size:0.85rem; color:var(--text-muted);">
@@ -251,9 +252,12 @@ let selectedPaletteType = null;
 let selectedWidgetId = null;
 
 const FONT_OPTIONS = ["sans","serif","mono","display"];
+const MEDIA_ASSETS = {{ media_assets|tojson }};
+const NULL_UUID = "00000000-0000-0000-0000-000000000000";
 
 const DEFAULTS = {
     text: {text:"Text", color:"#ffffff", font_size_px:48, font_family:"sans", bold:false, italic:false},
+    media: {asset_id: NULL_UUID, object_fit:"cover", alt:""},
     clock: {format:"24h", show_seconds:true, show_date:false, color:"#ffffff", font_family:"sans", font_size_px:96},
     ticker: {text:"Breaking news...", speed_px_per_sec:100, direction:"left", mode:"scroll",
              color:"#ffffff", background:"#000000", font_family:"sans", font_size_px:48, gap_px:100},
@@ -409,6 +413,12 @@ function summarize(w) {
     if (w.type === "text") return (w.config.text || "").slice(0, 24);
     if (w.type === "clock") return w.config.format || "24h";
     if (w.type === "ticker") return (w.config.text || "").slice(0, 24);
+    if (w.type === "media") {
+        const aid = w.config.asset_id;
+        if (!aid || aid === NULL_UUID) return "(no asset)";
+        const a = MEDIA_ASSETS.find(x => x.id === aid);
+        return a ? a.name : "(missing)";
+    }
     return "";
 }
 
@@ -507,6 +517,30 @@ function renderSettings() {
                         oninput="updateSelected(x=>x.config.italic=this.checked)"> Italic
                 </label>
             </div>`;
+    } else if (w.type === "media") {
+        const currentId = w.config.asset_id || NULL_UUID;
+        const opts = [`<option value="${NULL_UUID}" ${currentId===NULL_UUID?"selected":""}>— pick an image or video —</option>`]
+            .concat(MEDIA_ASSETS.map(a => {
+                const label = `${a.asset_type === "video" ? "🎞" : "🖼"} ${escapeHtml(a.name)}`;
+                return `<option value="${a.id}" ${a.id===currentId?"selected":""}>${label}</option>`;
+            }))
+            .join("");
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Media widget</h4>
+            <label>Asset</label>
+            <select oninput="updateSelected(x=>x.config.asset_id=this.value)">${opts}</select>
+            <label style="margin-top:0.5rem;">Fit</label>
+            <select oninput="updateSelected(x=>x.config.object_fit=this.value)">
+                <option value="cover" ${w.config.object_fit==="cover"?"selected":""}>Cover (crop to fill)</option>
+                <option value="contain" ${w.config.object_fit==="contain"?"selected":""}>Contain (letterbox)</option>
+                <option value="fill" ${w.config.object_fit==="fill"?"selected":""}>Fill (stretch)</option>
+            </select>
+            <label style="margin-top:0.5rem;">Alt text</label>
+            <input type="text" maxlength="512" value="${escapeHtml(w.config.alt||"")}"
+                   oninput="updateSelected(x=>x.config.alt=this.value)">
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                For videos: assign the asset to the same device groups so it lands in the device's video cache.
+            </p>`;
     } else if (w.type === "clock") {
         configHtml = `
             <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Clock widget</h4>

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1803,6 +1803,49 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         groups_q = None
     user_groups = groups_q.scalars().all() if groups_q else []
 
+    # Query IMAGE + VIDEO assets the user can pick in the editor's
+    # media-widget asset picker.  Visibility filter mirrors the
+    # schedules-page pattern: globals + group-assigned + own uploads
+    # (not yet assigned to any group).  Admins see everything.
+    media_q = (
+        select(Asset)
+        .where(Asset.deleted_at.is_(None))
+        .where(Asset.asset_type.in_((AssetType.IMAGE, AssetType.VIDEO)))
+        .order_by(Asset.filename)
+    )
+    if not is_admin:
+        global_ids = set(
+            (await db.execute(select(Asset.id).where(Asset.is_global.is_(True)))).scalars().all()
+        )
+        ga_ids = set()
+        if group_ids:
+            ga_ids = set(
+                (await db.execute(
+                    select(GroupAsset.asset_id).where(GroupAsset.group_id.in_(group_ids))
+                )).scalars().all()
+            )
+        own_ids = set()
+        if user:
+            own_ids = set(
+                (await db.execute(
+                    select(Asset.id)
+                    .where(Asset.uploaded_by_user_id == user.id)
+                    .where(~Asset.id.in_(select(GroupAsset.asset_id)))
+                )).scalars().all()
+            )
+        visible = list(global_ids | ga_ids | own_ids)
+        media_q = media_q.where(Asset.id.in_(visible))
+    media_rows = (await db.execute(media_q)).scalars().all()
+    media_assets = [
+        {
+            "id": str(a.id),
+            "name": a.display_name or a.original_filename or a.filename,
+            "asset_type": a.asset_type.value,
+            "filename": a.filename,
+        }
+        for a in media_rows
+    ]
+
     ctx = {
         "active_tab": "assets",
         "is_admin": is_admin,
@@ -1823,6 +1866,7 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         "schema_version": 1,
         "asset_groups": [],
         "asset_is_global": False,
+        "media_assets": media_assets,
     }
 
     if asset_id is not None:

--- a/tests/test_composed_extensibility_round2.py
+++ b/tests/test_composed_extensibility_round2.py
@@ -304,7 +304,7 @@ class TestExtensibilityContractGuardrail:
     def test_bundle_context_fields_pinned(self):
         assert is_dataclass(BundleContext)
         names = {f.name for f in fields(BundleContext)}
-        assert names == {"asset_bytes", "asset_mimes"}, (
+        assert names == {"asset_bytes", "asset_mimes", "sibling_asset_urls"}, (
             f"BundleContext fields drifted: {names!r}. Adding fields "
             "may be OK — explicitly update this pin and the contract docs."
         )

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -1,0 +1,214 @@
+"""Tests for cms.composed.widgets.media.MediaWidget.
+
+Covers config validation, render output (both image and video
+branches), instance scoping, and the declared/referenced asset
+contract.  Construction of :class:`BundleContext` is done directly
+rather than via ``build_bundle`` so failures point at the widget
+implementation itself.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+# Side-effect import: triggers global registry population
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import BundleContext, get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.media import (
+    MediaWidget,
+    MediaWidgetConfig,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+def _img_ctx(aid: uuid.UUID, blob: bytes, mime: str = "image/png") -> BundleContext:
+    return BundleContext(
+        asset_bytes={aid: blob},
+        asset_mimes={aid: mime},
+    )
+
+
+def _vid_ctx(aid: uuid.UUID, url: str) -> BundleContext:
+    return BundleContext(sibling_asset_urls={aid: url})
+
+
+# Trivial 1x1 transparent PNG — enough for the data-URI branch.
+_TINY_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c63600100000005000168cb6e6d0000000049454e44ae426082"
+)
+
+
+class TestMediaWidgetConfig:
+    def test_minimum_valid_config(self):
+        aid = uuid.uuid4()
+        c = MediaWidgetConfig(asset_id=aid)
+        assert c.asset_id == aid
+        assert c.object_fit == "cover"
+        assert c.alt == ""
+
+    def test_asset_id_required(self):
+        with pytest.raises(ValidationError):
+            MediaWidgetConfig()  # type: ignore[call-arg]
+
+    def test_object_fit_allowlist(self):
+        for ok in ("cover", "contain", "fill"):
+            MediaWidgetConfig(asset_id=uuid.uuid4(), object_fit=ok)
+        with pytest.raises(ValidationError):
+            MediaWidgetConfig(asset_id=uuid.uuid4(), object_fit="scale-down")
+
+    def test_alt_max_length(self):
+        with pytest.raises(ValidationError):
+            MediaWidgetConfig(asset_id=uuid.uuid4(), alt="x" * 513)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            MediaWidgetConfig(asset_id=uuid.uuid4(), unknown="nope")  # type: ignore[call-arg]
+
+
+class TestMediaWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("media")
+        assert isinstance(w, MediaWidget)
+        assert w.slug == "media"
+        assert w.config_version == 1
+        assert w.display_name == "Media"
+
+
+class TestMediaWidgetDeclaredAssetIds:
+    def test_returns_single_asset_id(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        assert MediaWidget().declared_asset_ids(cfg) == [aid]
+
+
+class TestMediaWidgetRender:
+    def test_requires_ctx(self):
+        cfg = MediaWidgetConfig(asset_id=uuid.uuid4())
+        with pytest.raises(RuntimeError, match="BundleContext"):
+            MediaWidget().render_html(cfg, _cell(), "id-1", ctx=None)
+
+    def test_missing_from_both_channels_raises(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        with pytest.raises(RuntimeError, match="missing from BundleContext"):
+            MediaWidget().render_html(cfg, _cell(), "id-1", ctx=BundleContext())
+
+
+class TestMediaWidgetImageBranch:
+    def test_renders_data_uri_with_b64_content(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid, alt="cat")
+        ctx = _img_ctx(aid, _TINY_PNG, "image/png")
+
+        r = MediaWidget().render_html(cfg, _cell(), "abc", ctx=ctx)
+
+        b64 = base64.b64encode(_TINY_PNG).decode("ascii")
+        assert f'src="data:image/png;base64,{b64}"' in r.html
+        assert '<img ' in r.html
+        assert 'alt="cat"' in r.html
+
+    def test_referenced_asset_ids_match_declared(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        ctx = _img_ctx(aid, _TINY_PNG)
+        r = MediaWidget().render_html(cfg, _cell(), "abc", ctx=ctx)
+        assert r.referenced_asset_ids == [aid]
+
+    def test_alt_text_is_html_escaped(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid, alt='</alt><script>bad()</script>')
+        ctx = _img_ctx(aid, _TINY_PNG)
+        r = MediaWidget().render_html(cfg, _cell(), "abc", ctx=ctx)
+        assert "<script>" not in r.html
+        assert "&lt;script&gt;" in r.html
+
+    def test_large_image_logs_warning(self, caplog):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        big = b"\x00" * (3 * 1024 * 1024)
+        ctx = _img_ctx(aid, big, "image/png")
+        with caplog.at_level(logging.WARNING, logger="cms.composed.widgets.media"):
+            MediaWidget().render_html(cfg, _cell(), "big", ctx=ctx)
+        assert any("inlined bundle will be large" in rec.message for rec in caplog.records)
+
+
+class TestMediaWidgetVideoBranch:
+    def test_renders_video_tag_with_sibling_url(self):
+        aid = uuid.uuid4()
+        url = "/assets/videos/clip.mp4"
+        cfg = MediaWidgetConfig(asset_id=aid, alt="promo")
+        ctx = _vid_ctx(aid, url)
+
+        r = MediaWidget().render_html(cfg, _cell(), "v1", ctx=ctx)
+
+        assert '<video ' in r.html
+        assert f'src="{url}"' in r.html
+        # autoplay/muted/loop/playsinline required for kiosk playback
+        assert 'muted' in r.html
+        assert 'loop' in r.html
+        assert 'autoplay' in r.html
+        assert 'playsinline' in r.html
+        assert 'aria-label="promo"' in r.html
+        # No data URI for videos — sibling URL only
+        assert 'data:' not in r.html
+
+    def test_video_url_with_special_chars_is_html_escaped(self):
+        aid = uuid.uuid4()
+        # publish layer URL-encodes the filename, but the widget must
+        # still HTML-escape the resulting attribute value defensively.
+        url = "/assets/videos/my%20clip%20%26%20more.mp4"
+        cfg = MediaWidgetConfig(asset_id=aid)
+        ctx = _vid_ctx(aid, url)
+        r = MediaWidget().render_html(cfg, _cell(), "v2", ctx=ctx)
+        # %26 stays %26 (HTML escape converts to &amp;... wait, & becomes &amp;)
+        # The URL already contains literal %26, no & to escape, so it round-trips.
+        assert "/assets/videos/my%20clip%20%26%20more.mp4" in r.html
+
+    def test_video_referenced_asset_ids(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        ctx = _vid_ctx(aid, "/assets/videos/x.mp4")
+        r = MediaWidget().render_html(cfg, _cell(), "v3", ctx=ctx)
+        assert r.referenced_asset_ids == [aid]
+
+
+class TestMediaWidgetScoping:
+    def test_html_and_css_are_instance_scoped(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid)
+        ctx = _img_ctx(aid, _TINY_PNG)
+
+        r1 = MediaWidget().render_html(cfg, _cell(), "inst-A", ctx=ctx)
+        r2 = MediaWidget().render_html(cfg, _cell(), "inst-B", ctx=ctx)
+
+        assert "cw-media-inst-A" in r1.html
+        assert "cw-media-inst-A" in r1.css
+        assert "cw-media-inst-B" in r2.html
+        assert "cw-media-inst-B" in r2.css
+        assert "cw-media-inst-B" not in r1.html
+        assert "cw-media-inst-A" not in r2.html
+
+    def test_object_fit_propagates_to_css(self):
+        aid = uuid.uuid4()
+        ctx = _img_ctx(aid, _TINY_PNG)
+        for fit in ("cover", "contain", "fill"):
+            cfg = MediaWidgetConfig(asset_id=aid, object_fit=fit)  # type: ignore[arg-type]
+            r = MediaWidget().render_html(cfg, _cell(), "abc", ctx=ctx)
+            assert f"object-fit: {fit}" in r.css
+
+    def test_object_fit_applies_to_video_branch_too(self):
+        aid = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=aid, object_fit="contain")
+        ctx = _vid_ctx(aid, "/assets/videos/x.mp4")
+        r = MediaWidget().render_html(cfg, _cell(), "vid", ctx=ctx)
+        assert "object-fit: contain" in r.css

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -316,7 +316,7 @@ async def test_publish_image_via_media_widget_inlines_bytes(db_session, mock_sto
     assert "/assets/videos/" not in bundle_html
 
     await db_session.refresh(cs)
-    assert str(img.id) in cs.bundle_source_asset_ids
+    assert str(img.id) in [str(x) for x in cs.bundle_source_asset_ids]
     assert result.rebuilt is True
 
 
@@ -335,7 +335,7 @@ async def test_publish_video_via_media_widget_emits_sibling_url(db_session, mock
     assert "data:video" not in bundle_html
 
     await db_session.refresh(cs)
-    assert str(vid.id) in cs.bundle_source_asset_ids
+    assert str(vid.id) in [str(x) for x in cs.bundle_source_asset_ids]
 
 
 @pytest.mark.asyncio
@@ -452,4 +452,4 @@ async def test_publish_mixed_image_and_video_uses_both_channels(
     assert "/assets/videos/clip.mp4" in bundle_html
 
     await db_session.refresh(cs)
-    assert set(cs.bundle_source_asset_ids) == {str(img.id), str(vid.id)}
+    assert {str(x) for x in cs.bundle_source_asset_ids} == {str(img.id), str(vid.id)}

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -246,3 +246,210 @@ async def test_publish_raises_on_validation_failure(db_session, mock_storage_and
 
     with pytest.raises(PublishError, match="failed validation"):
         await publish_composed_slide(asset.id, db_session)
+
+
+# ---------------------------------------------------------------------------
+# MediaWidget bucketing tests (Phase 1C)
+# ---------------------------------------------------------------------------
+#
+# These exercise the publish-layer split: each declared asset is routed
+# to one of three fates based on its AssetType.  IMAGE → inlined as a
+# data URI (bytes channel).  VIDEO → emitted as a sibling URL the device
+# resolves against its local /assets cache.  Anything else → PublishError.
+
+
+def _media_layout(asset_id: uuid.UUID, *, cell: Cell | None = None) -> Layout:
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="media",
+            cell=cell or Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(asset_id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        )
+    )
+    return layout
+
+
+async def _make_image_asset(db_session, tmp_path, filename: str = "pic.png") -> Asset:
+    # MediaWidget's image branch inlines the file bytes — the publish
+    # layer reads from disk via asset_storage_path, so the file must
+    # actually exist at tmp_path / filename.
+    img = Asset(
+        filename=filename,
+        asset_type=AssetType.IMAGE,
+        size_bytes=8,
+        checksum="x",
+    )
+    db_session.add(img)
+    await db_session.flush()
+    (tmp_path / filename).write_bytes(b"\x89PNG\r\n\x1a\n")
+    return img
+
+
+async def _make_video_asset(db_session, filename: str = "clip.mp4") -> Asset:
+    # Videos go through the sibling-URL channel — publish doesn't touch
+    # the file bytes, so we don't need to write anything to disk.
+    vid = Asset(
+        filename=filename,
+        asset_type=AssetType.VIDEO,
+        size_bytes=1024,
+        checksum="y",
+    )
+    db_session.add(vid)
+    await db_session.flush()
+    return vid
+
+
+@pytest.mark.asyncio
+async def test_publish_image_via_media_widget_inlines_bytes(db_session, mock_storage_and_dir):
+    _, tmp_path = mock_storage_and_dir
+    img = await _make_image_asset(db_session, tmp_path)
+    asset, cs = await _make_composed(db_session, layout=_media_layout(img.id))
+
+    result = await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # IMAGE went through the bytes channel — emitted as a data URI
+    assert "data:image/png;base64," in bundle_html
+    assert "/assets/videos/" not in bundle_html
+
+    await db_session.refresh(cs)
+    assert str(img.id) in cs.bundle_source_asset_ids
+    assert result.rebuilt is True
+
+
+@pytest.mark.asyncio
+async def test_publish_video_via_media_widget_emits_sibling_url(db_session, mock_storage_and_dir):
+    _, tmp_path = mock_storage_and_dir
+    vid = await _make_video_asset(db_session, "clip.mp4")
+    asset, cs = await _make_composed(db_session, layout=_media_layout(vid.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # VIDEO went through the sibling URL channel — no inlined bytes
+    assert "<video " in bundle_html
+    assert "/assets/videos/clip.mp4" in bundle_html
+    assert "data:video" not in bundle_html
+
+    await db_session.refresh(cs)
+    assert str(vid.id) in cs.bundle_source_asset_ids
+
+
+@pytest.mark.asyncio
+async def test_publish_video_filename_is_url_encoded(db_session, mock_storage_and_dir):
+    _, tmp_path = mock_storage_and_dir
+    # Spaces, parens, ampersand — all need URL-encoding to form a valid
+    # src attribute.  The HTML attribute value still needs to round-trip
+    # safely (no double-escape that breaks the path on-device).
+    vid = await _make_video_asset(db_session, "my video (final) & cut.mp4")
+    asset, _ = await _make_composed(db_session, layout=_media_layout(vid.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # urllib.parse.quote default-safe set leaves "/" alone; everything
+    # else interesting gets percent-encoded.
+    assert "my%20video%20%28final%29%20%26%20cut.mp4" in bundle_html
+    # Sanity: the raw form did NOT leak through
+    assert "my video (final)" not in bundle_html
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_non_media_asset_type(db_session, mock_storage_and_dir):
+    # A webpage asset has no business being targeted by MediaWidget —
+    # the publish layer is the second line of defense (the first being
+    # the UI filter on the editor).
+    web = Asset(
+        filename="page.url",
+        asset_type=AssetType.WEBPAGE,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(web)
+    await db_session.flush()
+    asset, _ = await _make_composed(db_session, layout=_media_layout(web.id))
+
+    with pytest.raises(PublishError, match="only IMAGE and VIDEO"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_missing_asset_reference(db_session, mock_storage_and_dir):
+    # User deleted the asset between save and publish — publish must
+    # surface this as a clean PublishError, not a 500.
+    ghost = uuid.uuid4()
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ghost))
+
+    with pytest.raises(PublishError, match="missing asset"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_warns_when_multiple_video_widgets_declared(
+    db_session, mock_storage_and_dir, caplog
+):
+    vid1 = await _make_video_asset(db_session, "a.mp4")
+    vid2 = await _make_video_asset(db_session, "b.mp4")
+    layout = empty_layout()
+    layout.widgets.extend([
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="media",
+            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(vid1.id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        ),
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="media",
+            cell=Cell(row=3, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(vid2.id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        ),
+    ])
+    asset, _ = await _make_composed(db_session, layout=layout)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="cms.composed.publish"):
+        await publish_composed_slide(asset.id, db_session)
+
+    assert any("video widgets" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_publish_mixed_image_and_video_uses_both_channels(
+    db_session, mock_storage_and_dir
+):
+    _, tmp_path = mock_storage_and_dir
+    img = await _make_image_asset(db_session, tmp_path, "pic.png")
+    vid = await _make_video_asset(db_session, "clip.mp4")
+    layout = empty_layout()
+    layout.widgets.extend([
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="media",
+            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(img.id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        ),
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="media",
+            cell=Cell(row=3, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(vid.id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        ),
+    ])
+    asset, cs = await _make_composed(db_session, layout=layout)
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    assert "data:image/png;base64," in bundle_html
+    assert "/assets/videos/clip.mp4" in bundle_html
+
+    await db_session.refresh(cs)
+    assert set(cs.bundle_source_asset_ids) == {str(img.id), str(vid.id)}


### PR DESCRIPTION
Phase 1C of composed-slide feature: a single `Media` palette tile that handles both IMAGE and VIDEO assets.

## What changed

- **New `MediaWidget`** (`cms/composed/widgets/media.py`) — single tile in the palette; picks the renderer branch by where the asset ID landed in the bundle context.
- **Publish-layer bucketing** (`cms/composed/publish.py`):
  - IMAGE → inlined into the bundle as a data URI (existing `asset_bytes` channel).
  - VIDEO → emitted as a sibling URL `/assets/videos/<urlquoted_filename>` (new `sibling_asset_urls` channel on `BundleContext`). The Pi shell HTTP server serves these from the local asset cache.
  - Non-media asset types → `PublishError`.
  - More than one video widget per slide → warning.
- **Existing ImageWidget kept**; MediaWidget is additive. The widget contract is unchanged — both widgets declare asset IDs and let the publish layer route.
- **Editor template** wired to expose the unified Media palette tile.

## Latent bug fixed along the way

`ComposedSlide.bundle_source_asset_ids` was being assigned raw `list[UUID]`. On Postgres prod the column is `ARRAY(UUID)` and accepted it; on the SQLite test variant the column degrades to JSON and `json.dumps` blew up the moment any non-empty list was published. The text-only Phase 1A/1B tests never exercised the non-empty path so it stayed hidden. Fixed by stringifying at write; staleness comparison normalizes both sides so set arithmetic works on either backend.

## Phase 1C limitation (firmware sibling-fetch is Phase 1D)

Until the Phase 1D firmware sibling-fetch protocol ships, **any video asset referenced by a composed slide must independently be assigned to the same device groups** so it lands in the device's `/assets/videos/` cache. Otherwise the `<video>` tag will 404 against the local shell server. UI/copy nudge for editor users tracked as a Phase 2-polish follow-up.

## Tests

- `tests/test_composed_media_widget.py` (NEW) — direct widget tests: registry, config validation, render-html branches (image + video), instance scoping, alt escaping, large-image warning, object_fit propagation.
- `tests/test_composed_publish.py` — 7 new bucketing tests: image inlining, sibling-URL emission, filename URL-encoding, non-media rejection, missing-ref rejection, multiple-video warning, mixed image+video.
- `tests/test_composed_extensibility_round2.py` — BundleContext pin updated to include `sibling_asset_urls` (intentional contract change).

267 composed-related tests passing locally.

## Out of scope

- Composed_resolver / FetchAssetMessage.siblings protocol / firmware sibling handling (Phase 1D).
- Editor-side validation/copy that warns "this video must also be assigned to the group" (Phase 2 polish).