### PR TITLE
feat(composed): emit per-device siblings in FETCH_ASSET

### DIFF
--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -182,8 +182,12 @@ async def publish_composed_slide(
                 # produce a valid src attribute.
                 import urllib.parse as _urlparse
 
+                # ``safe=""`` so '/' in a hypothetical filename gets
+                # percent-encoded too — without it, urllib leaves '/'
+                # alone (the default ``safe="/"``) and a malicious or
+                # buggy filename could break out of the videos/ dir.
                 sibling_asset_urls[aid] = (
-                    f"/assets/videos/{_urlparse.quote(ref.filename)}"
+                    f"/assets/videos/{_urlparse.quote(ref.filename, safe='')}"
                 )
                 video_count += 1
             else:

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -35,6 +35,17 @@ SUPPORTED_PROTOCOL_VERSIONS = frozenset({1, 2})
 # is gated out of slideshow scheduling / default-asset assignment.
 CAPABILITY_SLIDESHOW_V1 = "slideshow_v1"
 
+# ``composed_siblings_v1`` indicates the device's os_updater pre-fetches
+# the source assets (videos / images) embedded in a Composed Slide bundle
+# before swapping the bundle into the active cache.  When the CMS sends a
+# ``FETCH_ASSET`` for a COMPOSED asset and the device advertises this
+# capability, the message carries an extra ``siblings`` list of resolved
+# per-device variants for every asset referenced by the bundle.  Older
+# firmware never sees ``siblings`` and just renders the bundle on top of
+# whatever the local /assets cache already contains.  Pairs with agora
+# firmware PR #253 (APT 1.11.95).
+CAPABILITY_COMPOSED_SIBLINGS_V1 = "composed_siblings_v1"
+
 # Slideshow manifest schema version (semver, additive minor bumps).  The
 # wire format of the slideshow manifest is independent of the
 # higher-level ``PROTOCOL_VERSION``: protocol bumps describe the WS
@@ -279,6 +290,15 @@ class FetchAssetMessage(BaseMessage):
     # the CMS having to tell each device a different start time.
     # Optional / additive; v1.0 devices ignore it.
     started_at: Optional[str] = None
+    # Composed-slide sibling dependencies (Phase 1D of agora#253).  Only
+    # present (non-None) when ``asset_type`` is ``composed`` AND the device
+    # advertises ``composed_siblings_v1``.  Each entry describes one
+    # source asset (video / image / saved_stream) embedded in the bundle
+    # so the device's os_updater can pre-fetch it into the local
+    # /assets/<dir>/<filename> cache before swapping the bundle in.  Empty
+    # / None means "no siblings declared" (e.g. a composed slide that is
+    # all text + clock widgets, or a draft with no referenced assets).
+    siblings: Optional[list["Sibling"]] = None
 
 
 class SlideDescriptor(BaseModel):
@@ -328,7 +348,50 @@ class SlideDescriptor(BaseModel):
         return self
 
 
-# Resolve forward reference now that ``SlideDescriptor`` is defined.
+class Sibling(BaseModel):
+    """One source-asset dependency of a Composed Slide bundle.
+
+    The device uses ``name`` as the on-disk filename under
+    ``/opt/agora/assets/<videos|images>/`` (matching the ``src``
+    attributes baked into the bundle HTML by
+    :mod:`cms.composed.publish`), and downloads from ``download_url``
+    verifying against ``checksum`` and ``size_bytes``.  When the source
+    asset has a profile-matched READY :class:`AssetVariant`, the CMS
+    populates the variant's URL / checksum / size here so the device
+    receives an already-transcoded file; ``name`` always stays as the
+    source asset filename so it lines up with the bundle's HTML refs.
+    """
+
+    name: str
+    asset_type: str  # "video" | "image" | "saved_stream"
+    download_url: str
+    checksum: str
+    size_bytes: int
+
+    @model_validator(mode="after")
+    def _validate_invariants(self) -> "Sibling":
+        if self.asset_type not in ("video", "image", "saved_stream"):
+            raise ValueError(
+                "Sibling.asset_type must be one of "
+                "('video', 'image', 'saved_stream'), got "
+                f"{self.asset_type!r}"
+            )
+        # ``name`` lands on the device filesystem under /opt/agora/assets/<dir>/<name>;
+        # reject path-traversal shapes outright so a compromised CMS row
+        # (or future migration bug) can't escape the cache directory.
+        if not self.name or self.name in (".", "..") or "/" in self.name or "\\" in self.name:
+            raise ValueError(
+                f"Sibling.name must be a bare filename (no path separators); got {self.name!r}"
+            )
+        if self.size_bytes < 0:
+            raise ValueError(
+                f"Sibling.size_bytes must be non-negative, got {self.size_bytes}"
+            )
+        return self
+
+
+# Resolve forward references now that ``SlideDescriptor`` and ``Sibling``
+# are defined.
 FetchAssetMessage.model_rebuild()
 
 

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -28,9 +28,11 @@ from cms.models.device_event import DeviceEventType
 from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLogEvent
 from cms.schemas.protocol import (
+    CAPABILITY_COMPOSED_SIBLINGS_V1,
     ConfigMessage,
     FetchAssetMessage,
     MessageType,
+    Sibling,
 )
 from cms.services.alert_service import alert_service
 from cms.services.scheduler import (
@@ -92,37 +94,26 @@ class InboundContext:
     received_at: datetime | None = None
 
 
-async def _resolve_asset_for_device(
-    asset: Asset, device: Device, base_url: str, db: AsyncSession,
-) -> FetchAssetMessage | None:
-    """Build a FetchAssetMessage using the best variant for the device's profile.
+async def _resolve_variant_or_source(
+    asset: Asset, device: Device, base_url: str, db: AsyncSession, storage,
+) -> tuple[str, str, int, str] | None:
+    """Resolve one asset to (download_url, checksum, size_bytes, asset_type_value).
 
-    For video and image assets with a profile:
-      - If a READY variant exists → use variant download URL
-      - If variant exists but not ready → return None (not available yet)
-    For devices without a profile → use source asset directly.
-    For slideshow assets → resolve the slide list to a manifest; return
-    None if any slide source can't be served (see
-    :mod:`cms.services.slideshow_resolver`).
+    "Latest-READY-wins" variant lookup for VIDEO / IMAGE / SAVED_STREAM
+    when the device has a profile; falls back to the source asset
+    otherwise.  Returns ``None`` when a non-terminal variant exists for
+    this (asset, profile) pair but no READY variant is available yet —
+    the caller MUST treat that as "skip this fetch for now" (mirrors the
+    in-flight short-circuit in :func:`_resolve_asset_for_device`).
+
+    Extracted so both the top-level single-asset path and the composed
+    siblings path can share the same variant selection rules.
     """
-    if asset.asset_type == AssetType.SLIDESHOW:
-        # Lazy import — avoids a circular reference at module import time.
-        from cms.services.slideshow_resolver import build_fetch_for_slideshow
-        return await build_fetch_for_slideshow(asset, device, base_url, db)
-
-    storage = get_storage()
-
-    # Saved streams behave like videos for download purposes
-    is_file_asset = asset.asset_type in (AssetType.VIDEO, AssetType.IMAGE, AssetType.SAVED_STREAM)
+    is_file_asset = asset.asset_type in (
+        AssetType.VIDEO, AssetType.IMAGE, AssetType.SAVED_STREAM,
+    )
 
     if is_file_asset and device.profile_id:
-        # "Latest-READY-wins": with the variant-swap model multiple variant
-        # rows may exist transiently for the same (asset, profile) pair.
-        # Pick the most recently created READY non-deleted variant so devices
-        # always get the freshest completed transcode.  If no READY variant
-        # exists yet, we must still signal "not available" (rather than
-        # falling through to the untranscoded source) when there IS a
-        # non-terminal variant in flight.
         ready_result = await db.execute(
             select(AssetVariant)
             .where(
@@ -140,15 +131,13 @@ async def _resolve_asset_for_device(
             download_url = await storage.get_device_download_url(
                 f"variants/{variant.filename}", api_url,
             )
-            return FetchAssetMessage(
-                asset_name=asset.filename,
-                download_url=download_url,
-                checksum=variant.checksum,
-                size_bytes=variant.size_bytes,
-                asset_type=asset.asset_type.value,
+            return (
+                download_url,
+                variant.checksum,
+                variant.size_bytes,
+                asset.asset_type.value,
             )
 
-        # No READY variant — check if any non-deleted variant is in flight.
         inflight = await db.execute(
             select(AssetVariant.id)
             .where(
@@ -159,18 +148,146 @@ async def _resolve_asset_for_device(
             .limit(1)
         )
         if inflight.scalar_one_or_none() is not None:
-            # Variant exists but not ready — skip for now
             return None
 
-    # No profile or no variant → use source
     api_url = f"{base_url}/api/assets/{asset.id}/download"
     download_url = await storage.get_device_download_url(asset.filename, api_url)
+    return (
+        download_url,
+        asset.checksum,
+        asset.size_bytes,
+        asset.asset_type.value,
+    )
+
+
+async def _build_composed_siblings(
+    composed_asset: Asset, device: Device, base_url: str, db: AsyncSession, storage,
+) -> list[Sibling] | None:
+    """Build the per-device ``siblings`` payload for a Composed Slide.
+
+    Returns:
+      * ``None`` if the bundle declares no source assets (e.g. an
+        all-text composed slide, or a draft with an empty
+        ``bundle_source_asset_ids``).  The caller emits a
+        ``FetchAssetMessage`` with ``siblings=None`` — equivalent on the
+        wire to "no siblings field" for v1.0 firmware.
+      * ``None`` (sentinel via second-arm) if any sibling has an
+        in-flight variant — caller MUST treat as "skip whole fetch for
+        now", same as the single-asset in-flight rule.  Distinguished
+        from the empty-bundle case by returning the string sentinel
+        ``"INFLIGHT"`` (callers branch on identity).
+      * A list of :class:`Sibling` entries otherwise; missing (deleted)
+        siblings are logged and skipped per spec — the bundle plays
+        with a broken <video> tag on the device, same as today's
+        pre-sibling behaviour.
+    """
+    # Lazy import — avoids module-import cycle with cms.composed.
+    from cms.models.composed_slide import ComposedSlide
+
+    cs_row = (
+        await db.execute(
+            select(ComposedSlide).where(ComposedSlide.asset_id == composed_asset.id)
+        )
+    ).scalars().first()
+
+    raw_declared = list(cs_row.bundle_source_asset_ids or []) if cs_row else []
+    if not raw_declared:
+        return None
+
+    # publish.py stores these as str(uuid) so the value round-trips through
+    # both PG UUID[] and the SQLite JSON fallback.  Coerce back to uuid.UUID
+    # so the IN clause and the by_id dict lookup hit the same Asset.id type.
+    declared: list[uuid.UUID] = [
+        aid if isinstance(aid, uuid.UUID) else uuid.UUID(str(aid))
+        for aid in raw_declared
+    ]
+
+    rows = await db.execute(
+        select(Asset).where(
+            Asset.id.in_(declared),
+            Asset.deleted_at.is_(None),
+        )
+    )
+    by_id = {a.id: a for a in rows.scalars().all()}
+
+    siblings: list[Sibling] = []
+    for aid in declared:
+        ref = by_id.get(aid)
+        if ref is None:
+            logger.warning(
+                "Composed asset %s references missing/deleted sibling asset %s; "
+                "device will play bundle with broken media reference",
+                composed_asset.id, aid,
+            )
+            continue
+        resolved = await _resolve_variant_or_source(ref, device, base_url, db, storage)
+        if resolved is None:
+            # Sibling has a non-terminal variant in flight — skip the
+            # whole FetchAssetMessage same as the single-asset path.
+            return "INFLIGHT"  # type: ignore[return-value]
+        download_url, checksum, size_bytes, type_value = resolved
+        siblings.append(
+            Sibling(
+                name=ref.filename,
+                asset_type=type_value,
+                download_url=download_url,
+                checksum=checksum,
+                size_bytes=size_bytes,
+            )
+        )
+
+    return siblings
+
+
+async def _resolve_asset_for_device(
+    asset: Asset, device: Device, base_url: str, db: AsyncSession,
+) -> FetchAssetMessage | None:
+    """Build a FetchAssetMessage using the best variant for the device's profile.
+
+    For video and image assets with a profile:
+      - If a READY variant exists → use variant download URL
+      - If variant exists but not ready → return None (not available yet)
+    For devices without a profile → use source asset directly.
+    For slideshow assets → resolve the slide list to a manifest; return
+    None if any slide source can't be served (see
+    :mod:`cms.services.slideshow_resolver`).
+    For composed assets, if the device advertises
+    ``composed_siblings_v1`` (Phase 1D, agora#253), additionally resolve
+    every asset referenced by the bundle into a ``siblings[]`` list so
+    the device can pre-fetch them into the local cache before the
+    bundle swap.  Returns None if any sibling variant is still in
+    flight.
+    """
+    if asset.asset_type == AssetType.SLIDESHOW:
+        # Lazy import — avoids a circular reference at module import time.
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+        return await build_fetch_for_slideshow(asset, device, base_url, db)
+
+    storage = get_storage()
+
+    resolved = await _resolve_variant_or_source(asset, device, base_url, db, storage)
+    if resolved is None:
+        # In-flight variant — caller must skip this FetchAssetMessage.
+        return None
+    download_url, checksum, size_bytes, type_value = resolved
+
+    siblings: list[Sibling] | None = None
+    if (
+        asset.asset_type == AssetType.COMPOSED
+        and CAPABILITY_COMPOSED_SIBLINGS_V1 in (device.capabilities or [])
+    ):
+        built = await _build_composed_siblings(asset, device, base_url, db, storage)
+        if built == "INFLIGHT":
+            return None
+        siblings = built
+
     return FetchAssetMessage(
         asset_name=asset.filename,
         download_url=download_url,
-        checksum=asset.checksum,
-        size_bytes=asset.size_bytes,
-        asset_type=asset.asset_type.value,
+        checksum=checksum,
+        size_bytes=size_bytes,
+        asset_type=type_value,
+        siblings=siblings,
     )
 
 

--- a/tests/test_composed_siblings_cms.py
+++ b/tests/test_composed_siblings_cms.py
@@ -1,0 +1,326 @@
+"""Phase 1D: ``siblings`` payload on FETCH_ASSET for COMPOSED assets.
+
+Pairs with agora firmware PR #253 (APT 1.11.95) which adds the
+``composed_siblings_v1`` capability so the device's os_updater can
+pre-fetch every video / image referenced by a composed bundle before
+swapping it into the active cache.
+
+These tests exercise ``_resolve_asset_for_device`` end-to-end against
+the in-memory test DB (sqlite via conftest), only mocking
+``get_storage`` to keep S3 / presigned URLs out of the picture.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+from cms.models.composed_slide import ComposedSlide
+from cms.models.device import Device, DeviceStatus
+from cms.models.device_profile import DeviceProfile
+from cms.schemas.protocol import CAPABILITY_COMPOSED_SIBLINGS_V1
+from cms.services.device_inbound import _resolve_asset_for_device
+
+
+# ---------------------------------------------------------------------------
+# Local seed helpers (mirror test_slideshow_resolver.py patterns)
+# ---------------------------------------------------------------------------
+
+async def _seed_image(db, *, filename, checksum="img-sha", size=100):
+    a = Asset(
+        filename=filename, asset_type=AssetType.IMAGE,
+        size_bytes=size, checksum=checksum, is_global=True,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+async def _seed_video(db, *, filename, checksum="vid-sha", size=200):
+    a = Asset(
+        filename=filename, asset_type=AssetType.VIDEO,
+        size_bytes=size, checksum=checksum, is_global=True,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+async def _seed_profile(db, name="px"):
+    p = DeviceProfile(name=name)
+    db.add(p)
+    await db.commit()
+    await db.refresh(p)
+    return p
+
+
+async def _seed_variant(db, *, source, profile, status=VariantStatus.READY,
+                        checksum="v-sha", size=50, ext="mp4"):
+    v = AssetVariant(
+        source_asset_id=source.id,
+        profile_id=profile.id,
+        filename=f"{uuid.uuid4()}.{ext}",
+        status=status, checksum=checksum, size_bytes=size,
+    )
+    db.add(v)
+    await db.commit()
+    await db.refresh(v)
+    return v
+
+
+async def _seed_device(db, *, did="dev-1", profile=None, capabilities=None):
+    d = Device(
+        id=did, name=did, status=DeviceStatus.ADOPTED,
+        capabilities=list(capabilities or []),
+        profile_id=profile.id if profile else None,
+    )
+    db.add(d)
+    await db.commit()
+    await db.refresh(d)
+    return d
+
+
+async def _seed_composed(db, *, filename="composed-x.html", checksum="cmp-sha",
+                         size=4096, source_asset_ids=None):
+    a = Asset(
+        filename=filename, asset_type=AssetType.COMPOSED,
+        size_bytes=size, checksum=checksum, is_global=True,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    cs = ComposedSlide(
+        asset_id=a.id,
+        layout_json={"widgets": []},
+        is_draft=False,
+        bundle_source_asset_ids=(
+            None if source_asset_ids is None
+            else [str(aid) for aid in source_asset_ids]
+        ),
+    )
+    db.add(cs)
+    await db.commit()
+    return a
+
+
+def _fake_storage(url_prefix="https://cdn"):
+    s = AsyncMock()
+
+    async def _url(path, _api):
+        return f"{url_prefix}/{path}"
+
+    s.get_device_download_url = AsyncMock(side_effect=_url)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestComposedSiblings:
+    """Verifies the per-device ``siblings`` payload contract."""
+
+    async def test_capability_off_omits_siblings_field(self, db_session):
+        """Device without ``composed_siblings_v1`` MUST get
+        ``siblings=None`` (legacy fetch shape) even when the bundle
+        declares source assets — this is the firmware-back-compat gate.
+        """
+        vid = await _seed_video(db_session, filename="v.mp4")
+        composed = await _seed_composed(db_session, source_asset_ids=[vid.id])
+        device = await _seed_device(db_session, capabilities=[])
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None
+        assert fetch.asset_type == "composed"
+        assert fetch.siblings is None
+
+    async def test_capability_on_emits_siblings(self, db_session):
+        """Device WITH the capability gets one Sibling per declared
+        source asset; without a profile each sibling carries the source
+        asset's filename / checksum / size_bytes."""
+        vid = await _seed_video(db_session, filename="hello.mp4",
+                                checksum="VVV", size=222)
+        img = await _seed_image(db_session, filename="logo.png",
+                                checksum="III", size=111)
+        composed = await _seed_composed(
+            db_session, source_asset_ids=[vid.id, img.id],
+        )
+        device = await _seed_device(
+            db_session, capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None and fetch.siblings is not None
+        assert len(fetch.siblings) == 2
+        # Order preserved from bundle_source_asset_ids
+        sib_v, sib_i = fetch.siblings
+        assert sib_v.name == "hello.mp4"
+        assert sib_v.asset_type == "video"
+        assert sib_v.checksum == "VVV"
+        assert sib_v.size_bytes == 222
+        assert "hello.mp4" in sib_v.download_url
+        assert sib_i.name == "logo.png"
+        assert sib_i.asset_type == "image"
+        assert sib_i.checksum == "III"
+        assert sib_i.size_bytes == 111
+
+    async def test_sibling_uses_profile_variant_when_ready(self, db_session):
+        """Per-device variant lookup: a READY variant for the sibling's
+        (asset, device.profile) pair MUST be reflected in the Sibling's
+        URL / checksum / size — but ``name`` stays as the SOURCE
+        filename so the bundle's hard-coded
+        ``/assets/videos/<filename>`` ref still resolves on disk."""
+        profile = await _seed_profile(db_session, "hevc")
+        vid = await _seed_video(db_session, filename="hello.mp4",
+                                checksum="SRC", size=999)
+        variant = await _seed_variant(
+            db_session, source=vid, profile=profile,
+            checksum="HEVC", size=333, ext="mp4",
+        )
+        composed = await _seed_composed(db_session, source_asset_ids=[vid.id])
+        device = await _seed_device(
+            db_session, profile=profile,
+            capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None and fetch.siblings is not None
+        assert len(fetch.siblings) == 1
+        sib = fetch.siblings[0]
+        assert sib.name == "hello.mp4"           # SOURCE filename
+        assert sib.checksum == "HEVC"             # variant
+        assert sib.size_bytes == 333              # variant
+        assert variant.filename in sib.download_url  # variant URL
+
+    async def test_inflight_sibling_variant_returns_none(self, db_session):
+        """If ANY sibling has a non-terminal variant in flight for this
+        device's profile, the entire FetchAssetMessage MUST be skipped
+        (mirrors the single-asset rule — we never serve a stale fetch
+        racing a still-transcoding variant)."""
+        profile = await _seed_profile(db_session, "hevc")
+        vid = await _seed_video(db_session, filename="hello.mp4")
+        await _seed_variant(
+            db_session, source=vid, profile=profile,
+            status=VariantStatus.PROCESSING, ext="mp4",
+        )
+        composed = await _seed_composed(db_session, source_asset_ids=[vid.id])
+        device = await _seed_device(
+            db_session, profile=profile,
+            capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is None
+
+    async def test_deleted_sibling_is_skipped_with_warning(
+        self, db_session, caplog,
+    ):
+        """A sibling whose source asset has been soft-deleted is dropped
+        from the list with a WARNING log; the bundle is still served —
+        the device will hit a broken <video> tag for that filename but
+        that's the same behaviour as today (pre-siblings) and matches
+        the spec ("don't fail the whole message")."""
+        import logging
+        caplog.set_level(logging.WARNING, logger="cms.services.device_inbound")
+
+        good = await _seed_video(db_session, filename="kept.mp4",
+                                 checksum="KEEP", size=11)
+        gone = await _seed_video(db_session, filename="gone.mp4")
+        # Soft-delete the second sibling.
+        from datetime import datetime, timezone
+        gone.deleted_at = datetime.now(timezone.utc)
+        await db_session.commit()
+
+        composed = await _seed_composed(
+            db_session, source_asset_ids=[good.id, gone.id],
+        )
+        device = await _seed_device(
+            db_session, capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None and fetch.siblings is not None
+        assert [s.name for s in fetch.siblings] == ["kept.mp4"]
+        assert any(
+            "missing/deleted sibling" in r.message
+            for r in caplog.records
+        )
+
+    async def test_empty_bundle_source_asset_ids_yields_none(self, db_session):
+        """A composed slide with an empty bundle_source_asset_ids list
+        (e.g. all-text/clock widgets) MUST emit ``siblings=None`` — NOT
+        an empty list — so the wire stays stable for the "no deps"
+        case."""
+        composed = await _seed_composed(db_session, source_asset_ids=[])
+        device = await _seed_device(
+            db_session, capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None
+        assert fetch.siblings is None
+
+    async def test_null_bundle_source_asset_ids_yields_none(self, db_session):
+        """A draft composed slide whose bundle hasn't been built yet has
+        ``bundle_source_asset_ids = NULL`` — same wire result as the
+        empty case (``siblings=None``)."""
+        composed = await _seed_composed(db_session, source_asset_ids=None)
+        device = await _seed_device(
+            db_session, capabilities=[CAPABILITY_COMPOSED_SIBLINGS_V1],
+        )
+
+        with patch("cms.services.device_inbound.get_storage",
+                   return_value=_fake_storage()):
+            fetch = await _resolve_asset_for_device(
+                composed, device, "https://cms", db_session,
+            )
+
+        assert fetch is not None
+        assert fetch.siblings is None
+
+    async def test_quote_safe_empty_in_publish(self):
+        """Direct unit test for the publish.py quote-safe fix: filenames
+        with '/' must percent-encode the slash (default urllib
+        ``safe='/'`` would leave it alone and let a malicious filename
+        escape the /assets/videos/ directory)."""
+        from urllib.parse import quote
+        # Mirror the call site: f"/assets/videos/{quote(name, safe='')}"
+        encoded = quote("evil/../etc/passwd", safe="")
+        assert "/" not in encoded
+        assert encoded == "evil%2F..%2Fetc%2Fpasswd"


### PR DESCRIPTION
Phase 1D of composed-slide feature. Pairs with already-merged agora firmware PR #253 (APT 1.11.95).

## What
- Adds Sibling schema in cms/schemas/protocol.py with capability constant composed_siblings_v1.
- New _build_composed_siblings helper in cms/services/device_inbound.py resolves per-device variants for each declared bundle source asset, gated on the device capability.
- publish.py stringifies UUIDs for SQLite JSON fallback compatibility; device_inbound now coerces back to uuid.UUID on read.
- 8 new test cases in tests/test_composed_siblings_cms.py covering capability on/off, profile-variant resolution, in-flight skip sentinel, and missing-sibling warning.

## Test results
- 8/8 new sibling tests pass.
- 40/40 broader composed tests pass (siblings + device_sync + publish + staleness).
- 73/73 device contract + devices tests pass.

## Deploy
- Dev-only via deploy-goodwill-dev on main.