### PR TITLE
fix(composed): inline media assets when previewing a composed slide

### DIFF
--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -22,7 +22,10 @@ embedded elsewhere.
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import logging
+import mimetypes
 import uuid
 from typing import Any
 
@@ -31,7 +34,12 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cms.auth import get_user_group_ids, require_auth, require_permission
+from cms.auth import (
+    get_settings,
+    get_user_group_ids,
+    require_auth,
+    require_permission,
+)
 from cms.composed.bundle import BundleValidationError, build_bundle
 from cms.composed.registry import get_registry
 from cms.composed.schema import Layout, empty_layout
@@ -64,6 +72,20 @@ _PREVIEW_CSP = (
     "base-uri 'none'; "
     "form-action 'none'"
 )
+
+
+# Widgets allowed to render a VIDEO asset. The ImageWidget only knows
+# how to emit an <img> from inline bytes, so routing a video to it would
+# raise at render time (HTTP 500); restrict video to the media widget.
+_VIDEO_CAPABLE_SLUGS = {"media"}
+
+# Hard cap on a video inlined as a base64 data: URI in the *preview*
+# response. The locked-down preview CSP only permits ``media-src data:``,
+# so the device-local /assets/videos sibling URL the publish path uses
+# can't load in a browser — preview must inline the bytes. To avoid
+# reading an arbitrarily large file into memory (and base64-bloating it
+# by ~33%), refuse anything over this size with a clean 422.
+_MAX_INLINE_VIDEO_BYTES = 32 * 1024 * 1024
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -212,18 +234,36 @@ async def _check_referenced_asset_acl(
 @router.get("/{asset_id}/preview", response_class=HTMLResponse)
 async def preview_composed_slide(
     asset_id: uuid.UUID,
+    request: Request,
     db: AsyncSession = Depends(get_db),
+    settings=Depends(get_settings),
 ) -> HTMLResponse:
     """Live-render the composed slide bound to ``asset_id`` as HTML.
 
     Returns 404 if the asset doesn't exist or isn't a composed slide.
-    Returns 422 if the saved layout fails Pydantic shape validation
-    or the bundle builder's semantic validation. No disk writes;
-    no asset row mutations.
+    Returns 403 if the caller can't see the slide (or any asset it
+    references). Returns 422 if the saved layout fails validation, a
+    referenced asset is missing / the wrong type, or an inlined video
+    exceeds the preview size cap. No disk writes; no row mutations.
+
+    Unlike the publish path (which ships videos as device-local sibling
+    cache files), preview inlines every referenced image *and* video as
+    a base64 ``data:`` URI so the render works in an editor ``<iframe>``
+    under the locked-down preview CSP.
     """
     asset = await db.get(Asset, asset_id)
-    if asset is None or asset.asset_type != AssetType.COMPOSED:
+    if (
+        asset is None
+        or asset.asset_type != AssetType.COMPOSED
+        or asset.deleted_at is not None
+    ):
         raise HTTPException(status_code=404, detail="Composed slide not found")
+
+    # Visibility / ownership gate for the slide itself (was missing —
+    # preview previously had no per-asset access check at all).
+    from cms.routers.assets import _verify_asset_access  # noqa: WPS433
+
+    await _verify_asset_access(asset_id, request, db)
 
     cs_result = await db.execute(
         select(ComposedSlide).where(ComposedSlide.asset_id == asset_id),
@@ -239,12 +279,117 @@ async def preview_composed_slide(
             status_code=422, detail=f"Invalid layout JSON: {e}",
         ) from e
 
-    # Trigger auto-registration of all built-in widgets, then build.
+    # Trigger auto-registration of all built-in widgets.
     import cms.composed.widgets  # noqa: F401
 
     registry = get_registry()
+
+    # Run the semantic validator first so unknown widgets / bad configs
+    # surface a clean 422 before we start touching assets.
+    layout_errors = validate_layout(layout, registry)
+    if layout_errors:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Layout failed validation: "
+                + "; ".join(f"{err.code}: {err.message}" for err in layout_errors)
+            ),
+        )
+
+    # Collect every asset declared by the layout, tracking which widget
+    # slug(s) declared each so we can enforce type compatibility.
+    declared_ids: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    declaring_slugs: dict[uuid.UUID, set[str]] = {}
+    for inst in layout.widgets:
+        widget = registry.get(inst.type)
+        if widget is None:
+            continue
+        try:
+            cfg = widget.ConfigSchema.model_validate(inst.config)
+        except Exception:  # noqa: BLE001 — shape errors already 422'd above
+            continue
+        for aid in widget.declared_asset_ids(cfg):
+            if aid not in seen:
+                seen.add(aid)
+                declared_ids.append(aid)
+            declaring_slugs.setdefault(aid, set()).add(inst.type)
+
+    asset_payloads: dict[uuid.UUID, tuple[bytes, str]] = {}
+    sibling_asset_urls: dict[uuid.UUID, str] = {}
+
+    if declared_ids:
+        storage_dir = settings.asset_storage_path
+        rows = await db.execute(
+            select(Asset).where(
+                Asset.id.in_(declared_ids), Asset.deleted_at.is_(None),
+            ),
+        )
+        by_id = {a.id: a for a in rows.scalars().all()}
+
+        for aid in declared_ids:
+            ref = by_id.get(aid)
+            if ref is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Composed slide references missing asset {aid}",
+                )
+
+            # Per-referenced-asset visibility check — a viewer who can see
+            # the slide must not be able to inline an asset they can't see.
+            await _verify_asset_access(aid, request, db)
+
+            if ref.asset_type == AssetType.IMAGE:
+                blob = await _read_inline_asset(storage_dir, ref)
+                mime, _ = mimetypes.guess_type(ref.filename)
+                asset_payloads[aid] = (blob, mime or "application/octet-stream")
+            elif ref.asset_type == AssetType.VIDEO:
+                slugs = declaring_slugs.get(aid, set())
+                if not slugs.issubset(_VIDEO_CAPABLE_SLUGS):
+                    bad = sorted(slugs - _VIDEO_CAPABLE_SLUGS)
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Asset {aid} is a video but is used by widget(s) "
+                            f"{', '.join(bad)} that cannot render video"
+                        ),
+                    )
+                # Fast reject on recorded size before reading anything.
+                if (ref.size_bytes or 0) > _MAX_INLINE_VIDEO_BYTES:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Video asset {aid} is too large to preview "
+                            f"({ref.size_bytes} bytes; cap "
+                            f"{_MAX_INLINE_VIDEO_BYTES})"
+                        ),
+                    )
+                blob = await _read_inline_asset(
+                    storage_dir, ref, max_bytes=_MAX_INLINE_VIDEO_BYTES,
+                )
+                mime, _ = mimetypes.guess_type(ref.filename)
+                b64 = base64.b64encode(blob).decode("ascii")
+                sibling_asset_urls[aid] = f"data:{mime or 'video/mp4'};base64,{b64}"
+            else:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Composed slide references asset {aid} of type "
+                        f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
+                        "assets can be embedded in a composed slide"
+                    ),
+                )
+
+    def _asset_loader(aid: uuid.UUID) -> tuple[bytes, str]:
+        return asset_payloads[aid]
+
     try:
-        built = build_bundle(layout, registry)
+        built = build_bundle(
+            layout,
+            registry,
+            asset_loader=_asset_loader if asset_payloads else None,
+            sibling_asset_urls=sibling_asset_urls or None,
+        )
     except BundleValidationError as e:
         raise HTTPException(
             status_code=422,
@@ -260,6 +405,66 @@ async def preview_composed_slide(
         "Cache-Control": "no-store",
     }
     return HTMLResponse(content=built.html_bytes, headers=headers)
+
+
+async def _read_inline_asset(
+    storage_dir, ref: Asset, *, max_bytes: int | None = None,
+) -> bytes:
+    """Read a referenced asset's bytes for inlining into a preview.
+
+    Enforces that the resolved path stays under ``storage_dir``
+    (defense-in-depth against a crafted filename) and, for videos, that
+    the on-disk size — checked via ``stat`` *before* reading — is within
+    ``max_bytes``. Raises 422 on any read / size problem.
+    """
+    base = storage_dir.resolve()
+    path = (storage_dir / ref.filename).resolve()
+    if not path.is_relative_to(base):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Asset {ref.id} has an invalid storage path",
+        )
+    try:
+        if max_bytes is not None:
+            actual = path.stat().st_size
+            if actual > max_bytes:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Video asset {ref.id} is too large to preview "
+                        f"({actual} bytes; cap {max_bytes})"
+                    ),
+                )
+            # Bounded read closes the stat→read TOCTOU window: if the file
+            # grew/was swapped after the stat, refuse rather than inline
+            # more than the cap.
+            blob = await asyncio.to_thread(_read_capped, path, max_bytes)
+            if blob is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Video asset {ref.id} is too large to preview "
+                        f"(exceeds cap {max_bytes})"
+                    ),
+                )
+            return blob
+        return await asyncio.to_thread(path.read_bytes)
+    except HTTPException:
+        raise
+    except OSError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Asset {ref.id} file missing or unreadable: {ref.filename}",
+        ) from e
+
+
+def _read_capped(path, max_bytes: int) -> bytes | None:
+    """Read up to ``max_bytes``; return None if the file is larger."""
+    with path.open("rb") as fh:
+        data = fh.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        return None
+    return data
 
 
 @router.post("/", status_code=201)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -207,9 +207,15 @@ paths:
         Live-render the composed slide bound to ``asset_id`` as HTML.
 
         Returns 404 if the asset doesn't exist or isn't a composed slide.
-        Returns 422 if the saved layout fails Pydantic shape validation
-        or the bundle builder's semantic validation. No disk writes;
-        no asset row mutations.
+        Returns 403 if the caller can't see the slide (or any asset it
+        references). Returns 422 if the saved layout fails validation, a
+        referenced asset is missing / the wrong type, or an inlined video
+        exceeds the preview size cap. No disk writes; no row mutations.
+
+        Unlike the publish path (which ships videos as device-local sibling
+        cache files), preview inlines every referenced image *and* video as
+        a base64 ``data:`` URI so the render works in an editor ``<iframe>``
+        under the locked-down preview CSP.
       operationId: preview_composed_slide_composed__asset_id__preview_get
       parameters:
       - name: asset_id

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -129,3 +129,248 @@ class TestComposedPreview:
 
         resp = await client.get(f"/composed/{asset.id}/preview")
         assert resp.status_code == 422
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Media-asset preview (image + video) — regression for the
+# missing_asset_loader 422 (composed slide referencing a media asset
+# could not be previewed at all).
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _media_layout(asset_id: uuid.UUID, *, widget_type: str = "media") -> Layout:
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type=widget_type,
+            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={"asset_id": str(asset_id), "object_fit": "cover", "alt": ""},
+            config_version=1,
+        )
+    )
+    return layout
+
+
+def _storage_dir(tmp_path):
+    # Mirrors the conftest ``app`` fixture: asset_storage_path = tmp_path/"assets".
+    d = tmp_path / "assets"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# A 1x1 PNG (valid header is enough for preview — we only inline bytes).
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+)
+
+
+@pytest.mark.asyncio
+class TestComposedPreviewMedia:
+    async def _make_composed_with(self, db_session, layout: Layout):
+        asset = Asset(
+            filename=f"composed-{uuid.uuid4()}",
+            asset_type=AssetType.COMPOSED,
+            size_bytes=0,
+            checksum="",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+        cs = ComposedSlide(
+            asset_id=asset.id, layout_json=layout.model_dump(mode="json")
+        )
+        db_session.add(cs)
+        await db_session.commit()
+        return asset
+
+    async def test_media_widget_image_inlines_data_uri(
+        self, client, db_session, tmp_path
+    ):
+        storage = _storage_dir(tmp_path)
+        (storage / "pic.png").write_bytes(_PNG_BYTES)
+        img = Asset(
+            filename="pic.png",
+            asset_type=AssetType.IMAGE,
+            size_bytes=len(_PNG_BYTES),
+            checksum="x",
+        )
+        db_session.add(img)
+        await db_session.flush()
+        asset = await self._make_composed_with(db_session, _media_layout(img.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert "data:image/png;base64," in body
+        # No device-local sibling path should leak into a preview.
+        assert "/assets/videos/" not in body
+
+    async def test_media_widget_video_inlines_data_uri(
+        self, client, db_session, tmp_path
+    ):
+        storage = _storage_dir(tmp_path)
+        (storage / "clip.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        vid = Asset(
+            filename="clip.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=12,
+            checksum="y",
+        )
+        db_session.add(vid)
+        await db_session.flush()
+        asset = await self._make_composed_with(db_session, _media_layout(vid.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert "<video " in body
+        # Preview inlines the video as a data: URI so it renders in-browser
+        # under the locked-down CSP (no device-local /assets path).
+        assert "src=\"data:video/mp4;base64," in body
+        assert "/assets/videos/" not in body
+
+    async def test_preview_csp_unchanged_for_video(
+        self, client, db_session, tmp_path
+    ):
+        storage = _storage_dir(tmp_path)
+        (storage / "clip2.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        vid = Asset(
+            filename="clip2.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=12,
+            checksum="y",
+        )
+        db_session.add(vid)
+        await db_session.flush()
+        asset = await self._make_composed_with(db_session, _media_layout(vid.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        csp = resp.headers.get("content-security-policy", "")
+        assert "media-src data:" in csp
+        assert "http:" not in csp
+        assert "https:" not in csp
+
+    async def test_image_widget_referencing_video_is_clean_422(
+        self, client, db_session, tmp_path
+    ):
+        # ImageWidget can only render bytes (<img>); a VIDEO routed to it
+        # must produce a clean 422, not a 500 RuntimeError.
+        _storage_dir(tmp_path)
+        vid = Asset(
+            filename="badwidget.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=12,
+            checksum="y",
+        )
+        db_session.add(vid)
+        await db_session.flush()
+        asset = await self._make_composed_with(
+            db_session, _media_layout(vid.id, widget_type="image")
+        )
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+
+    async def test_missing_referenced_asset_is_422(
+        self, client, db_session, tmp_path
+    ):
+        _storage_dir(tmp_path)
+        asset = await self._make_composed_with(
+            db_session, _media_layout(uuid.uuid4())
+        )
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+
+    async def test_deleted_referenced_asset_is_422(
+        self, client, db_session, tmp_path
+    ):
+        from datetime import datetime, timezone
+
+        storage = _storage_dir(tmp_path)
+        (storage / "gone.png").write_bytes(_PNG_BYTES)
+        img = Asset(
+            filename="gone.png",
+            asset_type=AssetType.IMAGE,
+            size_bytes=len(_PNG_BYTES),
+            checksum="x",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(img)
+        await db_session.flush()
+        asset = await self._make_composed_with(db_session, _media_layout(img.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+
+    async def test_oversized_video_is_422(self, client, db_session, tmp_path):
+        # Metadata says the video is far larger than the inline cap; the
+        # endpoint must refuse before reading it into memory.
+        _storage_dir(tmp_path)
+        vid = Asset(
+            filename="huge.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=64 * 1024 * 1024,
+            checksum="y",
+        )
+        db_session.add(vid)
+        await db_session.flush()
+        asset = await self._make_composed_with(db_session, _media_layout(vid.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+
+    async def test_video_via_two_widgets_one_incapable_is_422(
+        self, client, db_session, tmp_path
+    ):
+        # Same video asset declared by a media widget AND an image widget;
+        # the image widget can't render video so the whole preview must
+        # 422 (not slip through on the valid media declaration).
+        storage = _storage_dir(tmp_path)
+        (storage / "shared.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        vid = Asset(
+            filename="shared.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=12,
+            checksum="y",
+        )
+        db_session.add(vid)
+        await db_session.flush()
+        layout = empty_layout()
+        layout.widgets.append(
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="media",
+                cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+                config={"asset_id": str(vid.id), "object_fit": "cover", "alt": ""},
+                config_version=1,
+            )
+        )
+        layout.widgets.append(
+            WidgetInstance(
+                id=uuid.uuid4(),
+                type="image",
+                cell=Cell(row=3, col=1, rowspan=2, colspan=4),
+                config={"asset_id": str(vid.id), "object_fit": "cover", "alt": ""},
+                config_version=1,
+            )
+        )
+        asset = await self._make_composed_with(db_session, layout)
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+
+    async def test_unauthorized_user_cannot_preview(
+        self, operator_client, client, db_session, tmp_path
+    ):
+        # A non-admin Operator with no group memberships can only see
+        # global assets; a personal/un-shared composed slide must 403.
+        _storage_dir(tmp_path)
+        asset = await self._make_composed_with(db_session, _text_layout("secret"))
+
+        resp = await operator_client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code in (403, 404), resp.text
+        # Admin can still see it (sanity).
+        ok = await client.get(f"/composed/{asset.id}/preview")
+        assert ok.status_code == 200, ok.text


### PR DESCRIPTION
## Problem

Previewing a composed slide that references a media (image or video) asset returned **HTTP 422 `missing_asset_loader`**. The user hit this with:

```
{"detail":"Layout failed validation: missing_asset_loader: layout references asset IDs ce4826bd-... but no asset_loader was supplied to build_bundle"}
```

Root cause: `preview_composed_slide` called `build_bundle(layout, registry)` with **no asset channels**, so any layout that declares an asset failed validation.

## Fix

Resolve declared assets the same way the publish path (`cms/composed/publish.py`) does, with one deliberate difference: **videos inline as base64 `data:` URIs** instead of device-local sibling URLs. The preview CSP only allows `media-src data:`, and a `/assets/videos/...` path doesn't resolve in an editor iframe — so the preview must embed the bytes.

While in here, closed several latent gaps the preview endpoint had:

- **Access control:** added `_verify_asset_access` for the slide *and* each referenced asset (preview previously had **no** visibility check).
- **Soft-deleted / missing / wrong-type refs:** clean 422.
- **ImageWidget × video → 500:** `ImageWidget` only reads inline bytes; a video routed to it raised a `RuntimeError` (HTTP 500). Now a type-compat guard returns a clean 422.
- **Inline-video size cap (32 MiB):** fast-reject on `size_bytes`, then a bounded read (`max_bytes+1`) that closes the stat→read TOCTOU window.
- **Path containment:** resolved-path `is_relative_to(storage_dir)` check on the asset filename.

CSP is unchanged.

## Tests

New `TestComposedPreviewMedia` in `tests/test_composed_preview.py`:
- MediaWidget image → 200, inlined `data:image/...`
- MediaWidget video → 200, `<video src="data:video/mp4;base64,...">`
- preview CSP still locked down (no `http:`/`https:`)
- ImageWidget × video → 422 (not 500)
- video shared by a media + image widget → 422 (can't slip past via the valid declaration)
- missing / soft-deleted referenced asset → 422
- oversized video → 422
- unauthorized (non-admin, no groups) user → 403; admin still 200

16 tests in `test_composed_preview.py` pass; 61 related composed tests pass locally.

> Reviewed with a rubber-duck pass: tightened the video size guard to a bounded read (TOCTOU) and added the mixed-slug regression test.

⚠️ Per request: review on **dev** first — **do not deploy to production.**
