### PR TITLE
fix(schedules): clear per-device End Now skip when a schedule is edited

### DIFF
--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -16,6 +16,7 @@ from cms.permissions import SCHEDULES_READ, SCHEDULES_WRITE
 from cms.models.asset import Asset, AssetType
 from cms.models.device import Device, DeviceStatus
 from cms.models.schedule import Schedule
+from cms.models.schedule_device_skip import ScheduleDeviceSkip
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.schemas.schedule import ScheduleCreate, ScheduleOut, ScheduleUpdate
 from cms.services.scheduler import push_sync_to_affected_devices, push_sync_to_device, _get_target_device_ids, skip_schedule_until, clear_schedule_skip, schedules_conflict, evaluate_schedules
@@ -443,8 +444,20 @@ async def update_schedule(
 
     for field, value in updates.items():
         setattr(schedule, field, value)
-    # Clear any active "End Now" skip so the schedule is re-evaluated
+    # Clear any active "End Now" skip so the schedule is re-evaluated.
+    # Editing a schedule is a deliberate "run this" action, so BOTH skip
+    # scopes must be cleared: the schedule-wide ``skipped_until`` AND any
+    # per-device ``ScheduleDeviceSkip`` rows.  Previously only the
+    # schedule-wide skip was cleared, so a per-device End Now (the
+    # dashboard tile button) left an orphaned skip row that kept the
+    # schedule suppressed for that device until its original end_time —
+    # making a restarted schedule silently fail to appear on the device.
     schedule.skipped_until = None
+    await db.execute(
+        ScheduleDeviceSkip.__table__.delete().where(
+            ScheduleDeviceSkip.schedule_id == schedule_id
+        )
+    )
     await _check_conflicts(schedule, db, exclude_id=schedule_id)
     # NB: compute diff against the CURRENT (post-mutation) schedule by
     # comparing against the old snapshot is messier here because end_time

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -710,6 +710,81 @@ class TestEndNowClearedOnEdit:
         )).scalar_one()
         assert row is None
 
+    async def test_patch_clears_per_device_end_now_skip(self, client, db_session):
+        """Regression (per-device End Now): editing a schedule must also delete
+        any ``ScheduleDeviceSkip`` rows, not just the schedule-wide
+        ``skipped_until``.
+
+        Previously, clicking End Now on a single device's dashboard tile wrote
+        a per-device skip row, and editing the schedule (e.g. "set time to now"
+        to restart it) cleared only the schedule-wide skip.  The orphaned
+        per-device row kept ``build_device_sync`` dropping the schedule from
+        that device's payload until the original end_time, so the restarted
+        schedule silently never appeared on the device.
+        """
+        from sqlalchemy import select
+        from cms.models.schedule import Schedule
+        from cms.models.schedule_device_skip import ScheduleDeviceSkip
+        from cms.services.scheduler import build_device_sync
+        import uuid
+
+        group_id, asset_id = await self._seed(db_session)
+        device_id = "end-now-pi"  # the device seeded into the group
+
+        create = await client.post("/api/schedules", json={
+            "name": "Per-Device End Now",
+            "group_id": group_id,
+            "asset_id": asset_id,
+            "start_time": "00:00",
+            "end_time": "23:59",
+        })
+        assert create.status_code == 201
+        sched_id = create.json()["id"]
+
+        # End it now for THIS device only (per-device skip → ScheduleDeviceSkip).
+        resp = await client.post(
+            f"/api/schedules/{sched_id}/end-now", json={"device_id": device_id},
+        )
+        assert resp.status_code == 200
+
+        # The per-device skip row must exist, and the device's sync must drop
+        # the schedule while the skip is active.
+        db_session.expire_all()
+        skip = (await db_session.execute(
+            select(ScheduleDeviceSkip).where(
+                ScheduleDeviceSkip.schedule_id == uuid.UUID(sched_id)
+            )
+        )).scalar_one_or_none()
+        assert skip is not None, "per-device End Now should write a skip row"
+
+        sync = await build_device_sync(device_id, db_session)
+        assert sync is not None
+        assert all(s.name != "Per-Device End Now" for s in sync.schedules), (
+            "schedule should be suppressed for the device while skip is active"
+        )
+
+        # Restart the schedule by editing it (mirrors "set time to now").
+        resp = await client.patch(
+            f"/api/schedules/{sched_id}", json={"start_time": "00:00"},
+        )
+        assert resp.status_code == 200
+
+        # The per-device skip row must be gone...
+        db_session.expire_all()
+        skip = (await db_session.execute(
+            select(ScheduleDeviceSkip).where(
+                ScheduleDeviceSkip.schedule_id == uuid.UUID(sched_id)
+            )
+        )).scalar_one_or_none()
+        assert skip is None, "PATCH must delete orphaned per-device skip rows"
+
+        # ...and the schedule must be back in the device's sync payload.
+        sync = await build_device_sync(device_id, db_session)
+        assert sync is not None
+        assert any(s.name == "Per-Device End Now" for s in sync.schedules), (
+            "schedule should reappear for the device after edit clears the skip"
+        )
+
 
 @pytest.mark.asyncio
 class TestEndNowPerDevice:


### PR DESCRIPTION
## Problem

On a device's dashboard tile, clicking **End Now** writes a *per-device* `ScheduleDeviceSkip` row (not a schedule-wide skip). Editing that schedule afterward — e.g. restarting it by setting the time to `now` — only cleared the schedule-wide `Schedule.skipped_until`. The orphaned per-device skip row kept `build_device_sync` dropping the schedule from that device's sync payload until the schedule's original `end_time`.

Symptom (reproduced live on Pi100): a restarted composed-slide schedule showed **nothing** on screen and **no 'currently playing'** entry, while other devices were unaffected.

## Fix

`update_schedule` now also deletes every `ScheduleDeviceSkip` row for the schedule, alongside clearing `skipped_until`. This matches the existing code intent (the comment already said *'clear any active End Now skip so the schedule is re-evaluated'* — it just only did the schedule-wide half).

## Test

Adds `TestEndNowClearedOnEdit::test_patch_clears_per_device_end_now_skip`: per-device End Now -> assert sync drops the schedule -> PATCH the schedule -> assert the skip row is deleted AND `build_device_sync` includes the schedule again. Verified it fails without the fix.

Targeted suites green locally (`test_schedules.py::TestEndNowClearedOnEdit` + `test_end_now_per_device.py`).