### PR TITLE
feat(composed): allow overlapping widgets with z-order control

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -354,11 +354,15 @@ def build_bundle(
         )
 
     widget_html_blocks: list[str] = []
-    for inst, render in rendered:
+    for z_index, (inst, render) in enumerate(rendered):
         wid = _instance_id_str(inst)
+        # Stacking order == layout.widgets array order.  Emitting an
+        # explicit z-index (rather than relying on DOM paint order)
+        # makes overlap deterministic and stops a child widget's own
+        # z-index from interleaving with sibling cells.
         widget_html_blocks.append(
             f'<div class="cw-cell" data-widget-instance="{html.escape(wid)}" '
-            f'style="{_grid_area_style(inst)}">{render.html}</div>'
+            f'style="{_grid_area_style(inst)} z-index: {z_index};">{render.html}</div>'
         )
 
     doc = _DOC_TEMPLATE.format(

--- a/cms/composed/schema.py
+++ b/cms/composed/schema.py
@@ -10,8 +10,10 @@ v1 constraints (locked in 2026-06-03, see ``plan.md``):
 * Canvas is fixed at 1920×1080 (16:9).  Per-device profiles are
   deferred to a future major schema bump.
 * Grid is fixed at 12 columns × 8 rows.  Snap-to-cell editor.
-* No layering / z-index.  Cells must not overlap; the semantic
-  validator (:mod:`cms.composed.validate`) enforces this.
+* Widgets MAY overlap.  Stacking order is the ``widgets`` array
+  order (later entries paint on top), which the bundle builder
+  mirrors with an explicit ``z-index``.  The editor exposes
+  "Bring to Front / Send to Back" controls that reorder the array.
 
 The actual content of a widget's ``config`` dict is opaque at this
 layer — each widget defines its own ``ConfigSchema``.  The

--- a/cms/composed/validate.py
+++ b/cms/composed/validate.py
@@ -6,7 +6,6 @@ AI generate endpoint, and (defensively) the bundle builder all need:
 
 * Cells fit within grid bounds (also enforced by Pydantic for single
   cells, but rowspan/colspan can still push past the edge).
-* No overlapping cells (v1 has no z-index).
 * Every widget instance's ``type`` is in the registry.
 * Per-widget config validates against ``ConfigSchema`` and the
   widget's own ``validate_semantic`` hook.
@@ -32,21 +31,12 @@ class ValidationError:
     """One human-readable layout problem.
 
     ``widget_id`` is set when the problem is scoped to a specific
-    widget instance; ``None`` for layout-wide issues (e.g. overlaps).
+    widget instance; ``None`` for layout-wide issues.
     """
 
     code: str
     message: str
     widget_id: str | None = None
-
-
-def _cell_cells(cell: Cell) -> set[tuple[int, int]]:
-    """Expand a Cell into the set of (row, col) tuples it occupies."""
-    return {
-        (r, c)
-        for r in range(cell.row, cell.row + cell.rowspan)
-        for c in range(cell.col, cell.col + cell.colspan)
-    }
 
 
 def _cell_out_of_bounds(cell: Cell) -> bool:
@@ -113,10 +103,11 @@ def validate_layout(
             )
         seen_ids.add(wid)
 
-    # ── Per-widget bounds + per-cell ownership ──────────────────
-    # Map every occupied (row,col) → widget id so we can report
-    # *which* two widgets collide instead of just "something overlaps".
-    occupied: dict[tuple[int, int], str] = {}
+    # ── Per-widget bounds ───────────────────────────────────────
+    # Widgets MAY overlap: stacking order is the ``layout.widgets``
+    # array order (later = painted on top), mirrored by an explicit
+    # ``z-index`` in the bundle.  So the only cell-geometry rule left
+    # is that a widget must fit inside the grid.
     for inst in layout.widgets:
         wid = str(inst.id)
 
@@ -133,25 +124,6 @@ def validate_layout(
                     widget_id=wid,
                 )
             )
-            # Don't try to mark cells for an out-of-bounds widget —
-            # we'd just generate noise.  Move on.
-            continue
-
-        for rc in _cell_cells(inst.cell):
-            existing = occupied.get(rc)
-            if existing is not None and existing != wid:
-                errors.append(
-                    ValidationError(
-                        code="cells_overlap",
-                        message=(
-                            f"widgets {existing} and {wid} both occupy "
-                            f"cell ({rc[0]},{rc[1]})"
-                        ),
-                        widget_id=wid,
-                    )
-                )
-            else:
-                occupied[rc] = wid
 
     # ── Per-widget config validation via registry ───────────────
     for inst in layout.widgets:

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -582,7 +582,7 @@ async def patch_composed_layout(
     The endpoint:
 
     1. Validates Pydantic shape — 422 on failure.
-    2. Runs ``validate_layout`` (semantic: bounds, overlaps, unknown
+    2. Runs ``validate_layout`` (semantic: bounds, unknown
        widget types, per-widget ``validate_semantic``) — 422 on failure.
     3. Checks referenced-asset ACL (audience widening) — 400 on failure.
     4. Persists the canonical JSON via ``layout.model_dump(mode="json")``.

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -275,6 +275,49 @@
         box-sizing: border-box;
     }
     .cw-prev-placeholder .icon { font-size: 1.2rem; line-height: 1; }
+    .cw-sec { margin:0.9rem 0 0.3rem; font-size:0.85rem; }
+    .cw-hint { font-size:0.78rem; color:var(--text-muted); margin:0.25rem 0; }
+    .cw-layers {
+        display:flex;
+        flex-direction:column;
+        gap:2px;
+        max-height:9rem;
+        overflow-y:auto;
+        border:1px solid var(--border, rgba(255,255,255,0.12));
+        border-radius:6px;
+        padding:3px;
+    }
+    .cw-layer {
+        display:flex;
+        align-items:center;
+        gap:0.4rem;
+        width:100%;
+        text-align:left;
+        background:transparent;
+        border:1px solid transparent;
+        border-radius:4px;
+        color:var(--text, #e6e6e6);
+        font-size:0.78rem;
+        padding:0.25rem 0.4rem;
+        cursor:pointer;
+        overflow:hidden;
+    }
+    .cw-layer:hover { background:rgba(99,179,237,0.18); }
+    .cw-layer.sel { background:rgba(34,197,94,0.22); border-color:#22c55e; }
+    .cw-layer-icon { flex:0 0 auto; }
+    .cw-layer-label { flex:1 1 auto; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .cw-zorder { display:flex; gap:4px; flex-wrap:wrap; }
+    .cw-zorder button {
+        flex:1 1 auto;
+        font-size:0.75rem;
+        padding:0.3rem 0.2rem;
+        background:var(--bg, #1a1a2e);
+        color:var(--text, #e6e6e6);
+        border:1px solid var(--border, rgba(255,255,255,0.18));
+        border-radius:5px;
+        cursor:pointer;
+    }
+    .cw-zorder button:hover { background:rgba(99,179,237,0.2); }
     .resize-handle {
         position: absolute;
         background: #22c55e;
@@ -449,13 +492,19 @@ function renderCanvas() {
         }
     }
 
-    for (const w of LAYOUT.widgets) {
+    LAYOUT.widgets.forEach((w, i) => {
         const el = document.createElement("div");
         el.className = "placed-widget" + (w.id === selectedWidgetId ? " selected" : "");
         const cs = (w.cell && w.cell.colspan) || 1;
         const rs = (w.cell && w.cell.rowspan) || 1;
         el.style.gridColumn = w.cell.col + " / span " + cs;
         el.style.gridRow = w.cell.row + " / span " + rs;
+        // Stacking order == LAYOUT.widgets array order (later = on top),
+        // matching the published bundle. The selected widget is lifted
+        // above everything so its resize handles stay reachable even when
+        // it sits on a lower layer (editor-only; the Layers panel shows
+        // the true published order).
+        el.style.zIndex = (w.id === selectedWidgetId) ? 1000 : (i + 1);
         el.dataset.widgetId = w.id;
         const content = renderWidgetContent(w);
         content.style.pointerEvents = "none";
@@ -470,7 +519,7 @@ function renderCanvas() {
             el.appendChild(h);
         }
         canvas.appendChild(el);
-    }
+    });
 }
 
 // ── Live in-editor widget previews ──────────────────────────────────
@@ -732,11 +781,58 @@ function updateSelected(patcher) {
     renderCanvas();
 }
 
+// ── Z-order (stacking) ──────────────────────────────────────────────
+// Stacking order is simply the LAYOUT.widgets array order: the last
+// entry paints on top (matches the published bundle). These ops move
+// the selected widget within that array.
+function moveSelectedZ(op) {
+    const w = getSelected();
+    if (!w) return;
+    const i = LAYOUT.widgets.indexOf(w);
+    if (i < 0) return;
+    LAYOUT.widgets.splice(i, 1);
+    let j;
+    if (op === "front") j = LAYOUT.widgets.length;
+    else if (op === "back") j = 0;
+    else if (op === "forward") j = Math.min(LAYOUT.widgets.length, i + 1);
+    else j = Math.max(0, i - 1); // backward
+    LAYOUT.widgets.splice(j, 0, w);
+    renderCanvas();
+    renderSettings();
+}
+
+const LAYER_ICONS = {text:"🅰", media:"🎬", clock:"🕒", ticker:"📰"};
+
+// Build the always-visible layer list (front → back). This is the
+// authoritative way to select a widget that is fully covered by
+// another on the canvas.
+function renderLayersHtml() {
+    if (!LAYOUT.widgets.length) {
+        return "<h4 class='cw-sec'>Layers</h4>" +
+            "<p class='cw-hint'>No widgets yet.</p>";
+    }
+    // End of the array is the front-most widget, so reverse for display.
+    const rows = LAYOUT.widgets.slice().reverse().map((w) => {
+        const sel = w.id === selectedWidgetId;
+        const icon = LAYER_ICONS[w.type] || "▪";
+        const sum = summarize(w);
+        const label = escapeHtml(w.type + (sum ? " · " + sum : ""));
+        return `<button type="button" class="cw-layer${sel ? " sel" : ""}"
+            onclick="selectWidget('${w.id}')" title="${label}">
+            <span class="cw-layer-icon">${icon}</span>
+            <span class="cw-layer-label">${label}</span></button>`;
+    }).join("");
+    return "<h4 class='cw-sec'>Layers (front → back)</h4>" +
+        `<div class="cw-layers">${rows}</div>`;
+}
+
 function renderSettings() {
     const panel = document.getElementById("settings-panel");
     const w = getSelected();
     if (!w) {
-        panel.innerHTML = "<h3>Settings</h3><p class='text-muted' style='font-size:0.85rem;'>Click a placed widget to edit it.</p>";
+        panel.innerHTML = "<h3>Settings</h3>" + renderLayersHtml() +
+            "<p class='text-muted' style='font-size:0.85rem; margin-top:0.5rem;'>" +
+            "Click a placed widget (or a layer above) to edit it.</p>";
         return;
     }
 
@@ -901,7 +997,15 @@ function renderSettings() {
     }
 
     panel.innerHTML = `<h3>Settings</h3>
-        <div style="font-size:0.75rem; color:var(--text-muted,#57606a); word-break:break-all;">${w.id}</div>
+        ${renderLayersHtml()}
+        <h4 class="cw-sec">Arrange</h4>
+        <div class="cw-zorder">
+            <button type="button" onclick="moveSelectedZ('front')" title="Bring to front">⤒ Front</button>
+            <button type="button" onclick="moveSelectedZ('forward')" title="Bring forward">↑ Fwd</button>
+            <button type="button" onclick="moveSelectedZ('backward')" title="Send backward">↓ Back</button>
+            <button type="button" onclick="moveSelectedZ('back')" title="Send to back">⤓ Bottom</button>
+        </div>
+        <div style="font-size:0.75rem; color:var(--text-muted,#57606a); word-break:break-all; margin-top:0.5rem;">${w.id}</div>
         ${cellHtml}
         ${configHtml}
         <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>`;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -290,7 +290,7 @@ paths:
         The endpoint:
 
         1. Validates Pydantic shape — 422 on failure.
-        2. Runs ``validate_layout`` (semantic: bounds, overlaps, unknown
+        2. Runs ``validate_layout`` (semantic: bounds, unknown
            widget types, per-widget ``validate_semantic``) — 422 on failure.
         3. Checks referenced-asset ACL (audience widening) — 400 on failure.
         4. Persists the canonical JSON via ``layout.model_dump(mode="json")``.

--- a/tests/test_composed_bundle.py
+++ b/tests/test_composed_bundle.py
@@ -151,6 +151,47 @@ class TestDeterminism:
         assert a.sha256_hex != b.sha256_hex
 
 
+class TestZIndexStacking:
+    """Overlapping widgets stack by ``layout.widgets`` array order:
+    later entries paint on top via an explicit z-index."""
+
+    def _two_overlapping(self) -> Layout:
+        return Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    type="text",
+                    cell=Cell(row=1, col=1, rowspan=2, colspan=2),
+                    config={"text": "back"},
+                ),
+                WidgetInstance(
+                    id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                    type="text",
+                    cell=Cell(row=1, col=1, rowspan=2, colspan=2),
+                    config={"text": "front"},
+                ),
+            ],
+        )
+
+    def test_overlapping_widgets_build_without_error(self):
+        # Overlap used to fail validation; it must now succeed.
+        result = build_bundle(self._two_overlapping())
+        assert isinstance(result, BuiltBundle)
+
+    def test_array_order_maps_to_ascending_z_index(self):
+        html = build_bundle(self._two_overlapping()).html_bytes.decode("utf-8")
+        i_back = html.index("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        i_front = html.index("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        # First array entry renders first and gets the lower z-index.
+        assert i_back < i_front
+        assert "z-index: 0;" in html
+        assert "z-index: 1;" in html
+        # The lower z-index belongs to the earlier (back) widget.
+        z0 = html.index("z-index: 0;")
+        z1 = html.index("z-index: 1;")
+        assert z0 < z1
+
+
 # ── Tests: validation handoff ───────────────────────────────────────
 
 

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -222,23 +222,15 @@ async def test_publish_raises_on_invalid_layout(db_session, mock_storage_and_dir
 
 @pytest.mark.asyncio
 async def test_publish_raises_on_validation_failure(db_session, mock_storage_and_dir):
-    # Two overlapping widgets — passes Pydantic shape, fails validate_layout.
+    # Out-of-bounds widget — passes Pydantic shape, fails validate_layout.
+    # (Overlap is allowed now, so it can no longer be the failure trigger.)
     layout = empty_layout()
     layout.widgets.append(
         WidgetInstance(
             id=uuid.uuid4(),
             type="text",
-            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            cell=Cell(row=2, col=1, rowspan=8, colspan=1),
             config={"text": "a"},
-            config_version=1,
-        )
-    )
-    layout.widgets.append(
-        WidgetInstance(
-            id=uuid.uuid4(),
-            type="text",
-            cell=Cell(row=2, col=2, rowspan=2, colspan=2),
-            config={"text": "b"},
             config_version=1,
         )
     )

--- a/tests/test_composed_validate.py
+++ b/tests/test_composed_validate.py
@@ -133,10 +133,12 @@ def test_colspan_extending_past_grid_is_rejected():
     assert any(e.code == "cell_out_of_bounds" for e in errors)
 
 
-# ── Overlap detection ────────────────────────────────────────────────
+# ── Overlap is now allowed (z-order = array order) ───────────────────
 
 
-def test_overlap_reports_both_widget_ids():
+def test_overlapping_widgets_are_allowed():
+    """Overlap is a feature: stacking order is the widgets array order,
+    so the validator must NOT report a cells_overlap error."""
     a = uuid.uuid4()
     b = uuid.uuid4()
     layout = Layout(
@@ -145,14 +147,19 @@ def test_overlap_reports_both_widget_ids():
             _wi(wid=b, cell=Cell(row=2, col=2, rowspan=2, colspan=2)),
         ]
     )
-    errors = [e for e in validate_layout(layout, _registry()) if e.code == "cells_overlap"]
-    assert errors, "expected cells_overlap"
-    msg = errors[0].message
-    assert str(a) in msg
-    assert str(b) in msg
+    errors = validate_layout(layout, _registry())
+    assert not any(e.code == "cells_overlap" for e in errors)
+    # Fully-overlapping (identical) cells are fine too.
+    layout2 = Layout(
+        widgets=[
+            _wi(wid=a, cell=Cell(row=1, col=1, rowspan=2, colspan=2)),
+            _wi(wid=b, cell=Cell(row=1, col=1, rowspan=2, colspan=2)),
+        ]
+    )
+    assert validate_layout(layout2, _registry()) == []
 
 
-def test_adjacent_widgets_do_not_overlap():
+def test_adjacent_widgets_validate_clean():
     layout = Layout(
         widgets=[
             _wi(cell=Cell(row=1, col=1, colspan=6)),


### PR DESCRIPTION
## What

Composed-slide widgets can now **overlap**, with PowerPoint-style
z-order control. Stacking order is the `layout.widgets` array order
(later = on top), applied consistently on the device bundle and in
the editor.

This is the first of three PRs for the composed-editor feature batch
(this = overlap + z-order; next = unsaved-changes guard; then =
analog clock + weather widgets).

## Backend

- **validate.py** — removed the `cells_overlap` check and the unused
  `_cell_cells` helper. Overlap is now a supported feature, not a
  validation error. Bounds / uniqueness / per-widget semantic checks
  are unchanged.
- **bundle.py** — each `.cw-cell` now gets an explicit
  `z-index: <array index>`, making stacking deterministic and
  preventing a child widget's own z-index from interleaving with
  sibling cells.
- **schema.py / routers/composed.py** — doc updates (overlap allowed).

## Editor (`composed_editor.html`)

- `renderCanvas` stacks widgets by array index; the **selected**
  widget is lifted above everything so its drag/resize handles stay
  reachable while editing.
- New **Arrange** controls in the settings panel: Bring to Front /
  Forward / Backward / Send to Back (`moveSelectedZ` reorders
  `LAYOUT.widgets`).
- New always-visible **Layers** panel (front → back), so a widget
  that is fully covered on the canvas can still be selected by
  clicking its layer row.
- Supporting CSS for the layers list and arrange buttons.

## Tests

- Overlapping widgets now **validate clean** (previously rejected);
  identical/fully-overlapping cells too.
- New bundle tests: overlapping layout builds, and array order maps
  to ascending `z-index`.
- The publish validation-failure test now uses an out-of-bounds
  (rowspan overflow) trigger, since overlap is no longer a failure.

Targeted composed suite: **288 passed** locally. Full suite runs in
CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
