### PR TITLE
feat(composed): analog clock and live weather widgets

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -9,6 +9,13 @@ to non-``data:`` URLs.  This is the file we ship to devices: the
 existing per-asset cache layer downloads it once and replays it
 offline-tolerantly.
 
+(The one bounded exception is the weather widget, which performs a
+runtime ``fetch()`` to Open-Meteo from its ``init_js``.  That URL lives
+only as a JS string literal — never as an HTML ``src=`` / ``href=``
+attribute — so the no-external-reference invariant above still holds
+for the static markup, and the widget degrades to a cached / "Weather
+unavailable" state when offline.  See :mod:`cms.composed.widgets.weather`.)
+
 Determinism: building the same layout twice yields byte-identical
 output (so :func:`hashlib.sha256` is a stable cache key).  We achieve
 this by iterating widgets in their layout order and de-duplicating

--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -19,19 +19,37 @@ global one.
 from __future__ import annotations
 
 from cms.composed.registry import get_registry
+from cms.composed.widgets.analog_clock import AnalogClockWidget
 from cms.composed.widgets.clock import ClockWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
+from cms.composed.widgets.weather import WeatherWidget
 
 _reg = get_registry()
 
 # Idempotent — guards against re-import edge cases (importlib.reload,
 # test session re-import) double-registering and tripping the
 # registry's "already registered" guard.
-for _widget_cls in (TextWidget, ImageWidget, MediaWidget, ClockWidget, TickerWidget):
+for _widget_cls in (
+    TextWidget,
+    ImageWidget,
+    MediaWidget,
+    ClockWidget,
+    AnalogClockWidget,
+    TickerWidget,
+    WeatherWidget,
+):
     if not _reg.has(_widget_cls.slug):
         _reg.register(_widget_cls())
 
-__all__ = ["ClockWidget", "ImageWidget", "MediaWidget", "TextWidget", "TickerWidget"]
+__all__ = [
+    "AnalogClockWidget",
+    "ClockWidget",
+    "ImageWidget",
+    "MediaWidget",
+    "TextWidget",
+    "TickerWidget",
+    "WeatherWidget",
+]

--- a/cms/composed/widgets/analog_clock.py
+++ b/cms/composed/widgets/analog_clock.py
@@ -1,0 +1,225 @@
+"""Analog clock widget — instance-scoped SVG face with live hands.
+
+Pure-JS, no asset dependencies.  Renders a fixed ``0 0 100 100`` SVG
+viewBox (so it scales cleanly to whatever cell it lands in) and rotates
+three hand groups once a second via ``setInterval``.  Like the digital
+:mod:`cms.composed.widgets.clock` widget it reads the browser ``Date``,
+so the displayed time follows the device OS clock + TZ.
+
+Instance scoping: every DOM ID + CSS class is suffixed with the widget
+instance UUID so two analog clocks in the same bundle don't collide.
+The hand groups carry stable per-instance IDs the init script looks up.
+
+Determinism: the SVG markup + init script are a pure function of the
+config + instance ID (no timestamps baked in at build time), so the
+bundle builder's byte-identical-rebuild guarantee holds.  The only
+runtime variability is the live clock, which is exactly the point.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+_HEX = r"^#[0-9a-fA-F]{6}$"
+
+
+class AnalogClockWidgetConfig(BaseModel):
+    """User-editable config for :class:`AnalogClockWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    face_color: str = Field(default="#111827", pattern=_HEX)
+    hand_color: str = Field(default="#ffffff", pattern=_HEX)
+    second_color: str = Field(default="#ef4444", pattern=_HEX)
+    show_seconds: bool = True
+    show_ticks: bool = True
+    show_numerals: bool = False
+
+
+# Per-instance init script.  ``$NAME`` placeholders (not ``{name}``) so
+# we don't have to brace-double every literal ``{`` in the JS body.
+_ANALOG_INIT_JS_TEMPLATE = """
+var hourEl = document.getElementById($HOUR_ID_LIT);
+var minEl = document.getElementById($MIN_ID_LIT);
+var secEl = $SEC_LOOKUP;
+function rot(el, deg) {
+  if (el) el.setAttribute('transform', 'rotate(' + deg + ' 50 50)');
+}
+function render() {
+  var d = new Date();
+  var s = d.getSeconds();
+  var m = d.getMinutes();
+  var h = d.getHours() % 12;
+  // Smooth coupling: minutes feed the hour hand, seconds feed the
+  // minute hand, so the dial reads accurately between ticks.
+  rot(hourEl, (h * 30) + (m * 0.5));
+  rot(minEl, (m * 6) + (s * 0.1));
+  if (secEl) rot(secEl, s * 6);
+}
+render();
+setInterval(render, 1000);
+""".strip()
+
+
+def _build_analog_init_js(*, hour_id: str, min_id: str, sec_id: str) -> str:
+    return (
+        _ANALOG_INIT_JS_TEMPLATE.replace("$HOUR_ID_LIT", f"'{hour_id}'")
+        .replace("$MIN_ID_LIT", f"'{min_id}'")
+        .replace(
+            "$SEC_LOOKUP",
+            f"document.getElementById('{sec_id}')" if sec_id else "null",
+        )
+    )
+
+
+def _tick_marks(css_class: str, *, hour: bool) -> str:
+    """Emit hour (or minute) tick ``<line>`` elements around the dial."""
+    out: list[str] = []
+    count = 12 if hour else 60
+    for i in range(count):
+        if hour and i % 1 != 0:  # always true for hour set; kept explicit
+            continue
+        if not hour and i % 5 == 0:
+            continue  # skip positions that already carry an hour tick
+        angle = i * (360 / count)
+        cls = f"{css_class}-tick-major" if hour else f"{css_class}-tick-minor"
+        # A vertical line near the top, rotated into place.
+        y2 = 8 if hour else 6
+        out.append(
+            f'<line x1="50" y1="2" x2="50" y2="{y2}" '
+            f'class="{cls}" transform="rotate({angle:.4f} 50 50)"/>'
+        )
+    return "".join(out)
+
+
+def _numerals(css_class: str) -> str:
+    """Emit 1–12 numerals positioned on a radius inside the dial."""
+    import math
+
+    out: list[str] = []
+    radius = 38.0
+    for n in range(1, 13):
+        angle = math.radians(n * 30)
+        x = 50 + radius * math.sin(angle)
+        y = 50 - radius * math.cos(angle)
+        out.append(
+            f'<text x="{x:.3f}" y="{y:.3f}" class="{css_class}-num" '
+            f'text-anchor="middle" dominant-baseline="central">{n}</text>'
+        )
+    return "".join(out)
+
+
+class AnalogClockWidget(Widget):
+    """Live analog wall-clock display (SVG)."""
+
+    slug: ClassVar[str] = "analog_clock"
+    display_name: ClassVar[str] = "Analog Clock"
+    icon: ClassVar[str] = "🕧"
+    ConfigSchema: ClassVar[type[BaseModel]] = AnalogClockWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "face_color": "#111827",
+            "hand_color": "#ffffff",
+            "second_color": "#ef4444",
+            "show_seconds": True,
+            "show_ticks": True,
+            "show_numerals": False,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/analog_clock.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        del ctx  # no asset deps
+        assert isinstance(config, AnalogClockWidgetConfig), (
+            "AnalogClockWidget.render_html expects an AnalogClockWidgetConfig"
+        )
+
+        css_class = f"cw-aclock-{instance_id}"
+        hour_id = f"cw-aclock-hour-{instance_id}"
+        min_id = f"cw-aclock-min-{instance_id}"
+        sec_id = f"cw-aclock-sec-{instance_id}"
+
+        ticks_html = ""
+        if config.show_ticks:
+            ticks_html = _tick_marks(css_class, hour=True) + _tick_marks(
+                css_class, hour=False
+            )
+        numerals_html = _numerals(css_class) if config.show_numerals else ""
+
+        # Hands point straight up at rotation 0 (12 o'clock).  Each hand
+        # is a group so the init script can rotate the whole group about
+        # the dial centre (50,50).
+        sec_hand = (
+            f'<g id="{sec_id}"><line x1="50" y1="54" x2="50" y2="14" '
+            f'class="{css_class}-sec"/></g>'
+            if config.show_seconds
+            else ""
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<svg class="{css_class}-svg" viewBox="0 0 100 100" '
+            f'preserveAspectRatio="xMidYMid meet">'
+            f'<circle cx="50" cy="50" r="48" class="{css_class}-face"/>'
+            f"{ticks_html}"
+            f"{numerals_html}"
+            f'<g id="{hour_id}"><line x1="50" y1="52" x2="50" y2="26" '
+            f'class="{css_class}-hour"/></g>'
+            f'<g id="{min_id}"><line x1="50" y1="53" x2="50" y2="16" '
+            f'class="{css_class}-min"/></g>'
+            f"{sec_hand}"
+            f'<circle cx="50" cy="50" r="2.2" class="{css_class}-pin"/>'
+            f"</svg>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"}}\n"
+            f".{css_class}-svg {{ width: 100%; height: 100%; }}\n"
+            f".{css_class}-face {{\n"
+            f"  fill: {config.face_color};\n"
+            f"  stroke: {config.hand_color};\n"
+            f"  stroke-width: 1;\n"
+            f"  stroke-opacity: 0.35;\n"
+            f"}}\n"
+            f".{css_class}-tick-major {{ stroke: {config.hand_color}; "
+            f"stroke-width: 1.4; }}\n"
+            f".{css_class}-tick-minor {{ stroke: {config.hand_color}; "
+            f"stroke-width: 0.5; stroke-opacity: 0.5; }}\n"
+            f".{css_class}-num {{ fill: {config.hand_color}; "
+            f"font-family: system-ui, sans-serif; font-size: 7px; }}\n"
+            f".{css_class}-hour {{ stroke: {config.hand_color}; "
+            f"stroke-width: 3; stroke-linecap: round; }}\n"
+            f".{css_class}-min {{ stroke: {config.hand_color}; "
+            f"stroke-width: 2; stroke-linecap: round; }}\n"
+            f".{css_class}-sec {{ stroke: {config.second_color}; "
+            f"stroke-width: 1; stroke-linecap: round; }}\n"
+            f".{css_class}-pin {{ fill: {config.second_color}; }}"
+        )
+
+        init_js = _build_analog_init_js(
+            hour_id=hour_id,
+            min_id=min_id,
+            sec_id=sec_id if config.show_seconds else "",
+        )
+
+        return WidgetRender(html=html_out, css=css_out, init_js=init_js)

--- a/cms/composed/widgets/weather.py
+++ b/cms/composed/widgets/weather.py
@@ -1,0 +1,375 @@
+"""Weather widget — live current conditions from Open-Meteo.
+
+Unlike every other v1 widget this one makes a **runtime network call**
+from the device: its ``init_js`` fetches current temperature + a WMO
+weather code from ``api.open-meteo.com`` (no API key required) and
+paints them into the cell.  Coordinates are *baked in at build time*
+(the editor geocodes a city name → lat/long via Open-Meteo's geocoding
+API and stores the result in config), so the device never needs the
+geocoding endpoint — only the lightweight forecast endpoint.
+
+This is a deliberate, bounded exception to the bundle's
+"offline-tolerant, zero-external-reference" property:
+
+* The fetch is wrapped in an ``AbortController`` timeout and a
+  ``try/catch`` so a network failure never throws — it falls back to a
+  ``localStorage`` cache (keyed by a config fingerprint) and, failing
+  that, a static "Weather unavailable" message.  The slide keeps
+  playing regardless.
+* The bundle's static markup still contains **no** ``src=`` / ``href=``
+  external references — the URL only exists as a JS string literal, so
+  the bundle's no-external-reference invariant (which only constrains
+  HTML attributes) is preserved.
+* The location label is rendered **server-side** with ``html.escape``;
+  no config-controlled string is ever interpolated into the emitted
+  JavaScript, so there's no script-injection surface here.
+
+Instance scoping: every DOM ID + CSS class is suffixed with the widget
+instance UUID.  The cache key is instance-scoped *and* carries a
+``{lat,lon,units}`` fingerprint so changing the location or units never
+shows stale cached weather.
+
+Determinism: the emitted HTML/CSS/JS is a pure function of config +
+instance ID.  The only non-deterministic runtime element is
+``Math.random()`` jitter on the refresh timer, which lives in the
+constant JS *source* — so byte-identical rebuilds still hold.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+_HEX = r"^#[0-9a-fA-F]{6}$"
+
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+# Default location so a freshly-dropped widget is immediately a *valid*
+# config (extra="forbid" + required coords would otherwise make a
+# just-placed widget fail save/publish validation before the user picks
+# a city).  Seattle — matches the deployment's locale; users change it
+# via the editor's city search.
+_DEFAULT_LAT = 47.6062
+_DEFAULT_LON = -122.3321
+_DEFAULT_LABEL = "Seattle"
+
+
+def _js_str(s: str) -> str:
+    """Serialise a Python string as a JS string literal, HTML-safe.
+
+    ``json.dumps`` handles quote/backslash/control-char escaping; we
+    additionally escape ``<>&`` so a stray ``</script>`` can never
+    terminate the embedded script block.  (In practice the only values
+    passed here are URLs / fingerprints / UUIDs, but stay defensive.)
+    """
+    return (
+        json.dumps(s)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+class WeatherWidgetConfig(BaseModel):
+    """User-editable config for :class:`WeatherWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    latitude: float = Field(default=_DEFAULT_LAT, ge=-90.0, le=90.0)
+    longitude: float = Field(default=_DEFAULT_LON, ge=-180.0, le=180.0)
+    location_label: str = Field(default=_DEFAULT_LABEL, max_length=80)
+    units: Literal["imperial", "metric"] = "imperial"
+    show_condition: bool = True
+    show_location: bool = True
+    color: str = Field(default="#ffffff", pattern=_HEX)
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=64, ge=8, le=512)
+    # Open-Meteo asks for a courteous refresh interval; current
+    # conditions update at most a few times an hour upstream, so a
+    # 10-minute floor is plenty and keeps us a good citizen.
+    refresh_seconds: int = Field(default=900, ge=600, le=86400)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+
+# WMO weather interpretation codes → (label, emoji).  Compact map of
+# the documented codes; unknown codes fall back to a neutral label at
+# runtime so an upstream addition never breaks rendering.
+# https://open-meteo.com/en/docs (WMO Weather interpretation codes)
+_WMO: dict[int, tuple[str, str]] = {
+    0: ("Clear", "\u2600\ufe0f"),
+    1: ("Mainly clear", "\U0001f324\ufe0f"),
+    2: ("Partly cloudy", "\u26c5"),
+    3: ("Overcast", "\u2601\ufe0f"),
+    45: ("Fog", "\U0001f32b\ufe0f"),
+    48: ("Rime fog", "\U0001f32b\ufe0f"),
+    51: ("Light drizzle", "\U0001f326\ufe0f"),
+    53: ("Drizzle", "\U0001f326\ufe0f"),
+    55: ("Heavy drizzle", "\U0001f326\ufe0f"),
+    56: ("Freezing drizzle", "\U0001f327\ufe0f"),
+    57: ("Freezing drizzle", "\U0001f327\ufe0f"),
+    61: ("Light rain", "\U0001f327\ufe0f"),
+    63: ("Rain", "\U0001f327\ufe0f"),
+    65: ("Heavy rain", "\U0001f327\ufe0f"),
+    66: ("Freezing rain", "\U0001f327\ufe0f"),
+    67: ("Freezing rain", "\U0001f327\ufe0f"),
+    71: ("Light snow", "\u2744\ufe0f"),
+    73: ("Snow", "\u2744\ufe0f"),
+    75: ("Heavy snow", "\u2744\ufe0f"),
+    77: ("Snow grains", "\u2744\ufe0f"),
+    80: ("Rain showers", "\U0001f326\ufe0f"),
+    81: ("Rain showers", "\U0001f326\ufe0f"),
+    82: ("Violent rain showers", "\u26c8\ufe0f"),
+    85: ("Snow showers", "\U0001f328\ufe0f"),
+    86: ("Snow showers", "\U0001f328\ufe0f"),
+    95: ("Thunderstorm", "\u26c8\ufe0f"),
+    96: ("Thunderstorm w/ hail", "\u26c8\ufe0f"),
+    99: ("Thunderstorm w/ hail", "\u26c8\ufe0f"),
+}
+
+
+def _wmo_js_object() -> str:
+    """Render :data:`_WMO` as a deterministic JS object literal."""
+    parts: list[str] = []
+    for code in sorted(_WMO):
+        label, emoji = _WMO[code]
+        parts.append(f"{code}:{{l:{_js_str(label)},e:{_js_str(emoji)}}}")
+    return "{" + ",".join(parts) + "}"
+
+
+_WEATHER_INIT_JS_TEMPLATE = """
+var root = document.getElementById($ROOT_ID_LIT);
+var tempEl = document.getElementById($TEMP_ID_LIT);
+var condEl = $COND_LOOKUP;
+var FORECAST_URL = $URL_LIT;
+var SYMBOL = $SYMBOL_LIT;
+var CFG_FP = $CFG_FP_LIT;
+var CACHE_KEY = $CACHE_KEY_LIT;
+var REFRESH_MS = $REFRESH_MS;
+var WMO = $WMO_OBJ;
+function lsGet() {
+  try {
+    var raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) { return null; }
+    var o = JSON.parse(raw);
+    if (!o || o.fp !== CFG_FP) { return null; }
+    return o;
+  } catch (e) { return null; }
+}
+function lsSet(temp, code) {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({fp: CFG_FP, t: temp, c: code}));
+  } catch (e) {}
+}
+function paint(temp, code) {
+  if (tempEl && temp !== null && temp !== undefined) {
+    tempEl.textContent = Math.round(temp) + SYMBOL;
+  }
+  if (condEl) {
+    var w = WMO[code];
+    condEl.textContent = w ? ((w.e ? w.e + ' ' : '') + w.l) : '';
+  }
+}
+function fallback() {
+  var c = lsGet();
+  if (c) { paint(c.t, c.c); return; }
+  if (tempEl) { tempEl.textContent = '--' + SYMBOL; }
+  if (condEl) { condEl.textContent = 'Weather unavailable'; }
+}
+function schedule() {
+  if (!root || !document.body.contains(root)) { return; }
+  setTimeout(refresh, REFRESH_MS + Math.floor(Math.random() * 30000));
+}
+function refresh() {
+  if (!root || !document.body.contains(root)) { return; }
+  var ctrl = new AbortController();
+  var to = setTimeout(function () { ctrl.abort(); }, 8000);
+  fetch(FORECAST_URL, {signal: ctrl.signal})
+    .then(function (r) { if (!r.ok) { throw new Error('http ' + r.status); } return r.json(); })
+    .then(function (d) {
+      var cur = d && d.current ? d.current : null;
+      var t = cur ? cur.temperature_2m : null;
+      if (t === null || t === undefined) { throw new Error('bad shape'); }
+      paint(t, cur.weather_code);
+      lsSet(t, cur.weather_code);
+    })
+    .catch(function () { fallback(); })
+    .then(function () { clearTimeout(to); schedule(); });
+}
+fallback();
+refresh();
+""".strip()
+
+
+def _forecast_url(lat: float, lon: float, units: str) -> str:
+    unit_param = "fahrenheit" if units == "imperial" else "celsius"
+    return (
+        "https://api.open-meteo.com/v1/forecast"
+        f"?latitude={lat}&longitude={lon}"
+        "&current=temperature_2m,weather_code"
+        f"&temperature_unit={unit_param}"
+    )
+
+
+def _build_weather_init_js(
+    *,
+    root_id: str,
+    temp_id: str,
+    cond_id: str,
+    url: str,
+    symbol: str,
+    cfg_fp: str,
+    cache_key: str,
+    refresh_ms: int,
+) -> str:
+    cond_lookup = (
+        f"document.getElementById({_js_str(cond_id)})" if cond_id else "null"
+    )
+    return (
+        _WEATHER_INIT_JS_TEMPLATE.replace("$ROOT_ID_LIT", _js_str(root_id))
+        .replace("$TEMP_ID_LIT", _js_str(temp_id))
+        .replace("$COND_LOOKUP", cond_lookup)
+        .replace("$URL_LIT", _js_str(url))
+        .replace("$SYMBOL_LIT", _js_str(symbol))
+        .replace("$CFG_FP_LIT", _js_str(cfg_fp))
+        .replace("$CACHE_KEY_LIT", _js_str(cache_key))
+        .replace("$REFRESH_MS", str(refresh_ms))
+        .replace("$WMO_OBJ", _wmo_js_object())
+    )
+
+
+class WeatherWidget(Widget):
+    """Live current-conditions weather (Open-Meteo, no API key)."""
+
+    slug: ClassVar[str] = "weather"
+    display_name: ClassVar[str] = "Weather"
+    icon: ClassVar[str] = "\u26c5"
+    ConfigSchema: ClassVar[type[BaseModel]] = WeatherWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "latitude": _DEFAULT_LAT,
+            "longitude": _DEFAULT_LON,
+            "location_label": _DEFAULT_LABEL,
+            "units": "imperial",
+            "show_condition": True,
+            "show_location": True,
+            "color": "#ffffff",
+            "font_family": "sans",
+            "font_size_px": 64,
+            "refresh_seconds": 900,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/weather.html"
+
+    def validate_semantic(self, config: BaseModel) -> list[str]:
+        assert isinstance(config, WeatherWidgetConfig)
+        errors: list[str] = []
+        if config.show_location and not config.location_label.strip():
+            errors.append(
+                "location_label must not be blank when show_location is on"
+            )
+        return errors
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        del ctx  # weather fetches at runtime; no build-time asset deps
+        assert isinstance(config, WeatherWidgetConfig), (
+            "WeatherWidget.render_html expects a WeatherWidgetConfig instance"
+        )
+
+        css_class = f"cw-weather-{instance_id}"
+        root_id = f"cw-weather-root-{instance_id}"
+        temp_id = f"cw-weather-temp-{instance_id}"
+        cond_id = f"cw-weather-cond-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+        symbol = "\u00b0F" if config.units == "imperial" else "\u00b0C"
+
+        # Location label is the ONLY config-controlled string in the
+        # markup — escaped here, never passed into JS.
+        loc_html = (
+            f'<div class="{css_class}-loc">'
+            f"{html.escape(config.location_label)}</div>"
+            if config.show_location
+            else ""
+        )
+        cond_html = (
+            f'<div id="{cond_id}" class="{css_class}-cond"></div>'
+            if config.show_condition
+            else ""
+        )
+        html_out = (
+            f'<div id="{root_id}" class="{css_class}">'
+            f"{loc_html}"
+            f'<div id="{temp_id}" class="{css_class}-temp">--{symbol}</div>'
+            f"{cond_html}"
+            f"</div>"
+        )
+
+        loc_size = max(8, int(config.font_size_px * 0.4))
+        cond_size = max(8, int(config.font_size_px * 0.45))
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  text-align: center;\n"
+            f"}}\n"
+            f".{css_class}-loc {{\n"
+            f"  font-size: {loc_size}px;\n"
+            f"  opacity: 0.85;\n"
+            f"  margin-bottom: 0.1em;\n"
+            f"}}\n"
+            f".{css_class}-temp {{\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1;\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"}}\n"
+            f".{css_class}-cond {{\n"
+            f"  font-size: {cond_size}px;\n"
+            f"  opacity: 0.9;\n"
+            f"  margin-top: 0.1em;\n"
+            f"}}"
+        )
+
+        cfg_fp = f"{config.latitude},{config.longitude},{config.units}"
+        init_js = _build_weather_init_js(
+            root_id=root_id,
+            temp_id=temp_id,
+            cond_id=cond_id if config.show_condition else "",
+            url=_forecast_url(config.latitude, config.longitude, config.units),
+            symbol=symbol,
+            cfg_fp=cfg_fp,
+            cache_key=f"cw-weather-{instance_id}",
+            refresh_ms=config.refresh_seconds * 1000,
+        )
+
+        return WidgetRender(html=html_out, css=css_out, init_js=init_js)

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -73,7 +73,9 @@
             <button type="button" class="palette-btn" data-type="text" onclick="selectPaletteType('text')">🅰 Text</button>
             <button type="button" class="palette-btn" data-type="media" onclick="selectPaletteType('media')">🎬 Media</button>
             <button type="button" class="palette-btn" data-type="clock" onclick="selectPaletteType('clock')">🕒 Clock</button>
+            <button type="button" class="palette-btn" data-type="analog_clock" onclick="selectPaletteType('analog_clock')">🕧 Analog Clock</button>
             <button type="button" class="palette-btn" data-type="ticker" onclick="selectPaletteType('ticker')">📰 Ticker</button>
+            <button type="button" class="palette-btn" data-type="weather" onclick="selectPaletteType('weather')">⛅ Weather</button>
             <div id="palette-status" style="margin-top:0.5rem; font-size:0.85rem; color:var(--text-muted);">
                 None selected.
             </div>
@@ -243,6 +245,39 @@
         from { transform: translateX(0); }
         to   { transform: translateX(-100%); }
     }
+    .cw-prev-aclock { width: 100%; height: 100%; display: block; }
+    .cw-prev-weather {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        text-align: center;
+        line-height: 1.05;
+    }
+    .cw-prev-weather-temp { line-height: 1; white-space: nowrap; }
+    .cw-prev-weather-loc { opacity: 0.85; white-space: nowrap; }
+    .cw-prev-weather-cond { opacity: 0.85; margin-top: 0.1em; }
+    .cw-prev-weather-note {
+        margin-top: 0.35em;
+        font-size: 0.6rem;
+        opacity: 0.55;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+    .wx-results { display: flex; flex-direction: column; gap: 0.2rem; margin: 0.25rem 0; }
+    .wx-result {
+        text-align: left;
+        background: var(--bg-subtle, #f6f8fa);
+        border: 1px solid var(--border, #d0d7de);
+        border-radius: 5px;
+        padding: 0.3rem 0.5rem;
+        font-size: 0.8rem;
+        cursor: pointer;
+    }
+    .wx-result:hover { background: var(--bg-hover, #eaeef2); }
     .cw-prev-media { width: 100%; height: 100%; position: relative; }
     .cw-prev-media img { width: 100%; height: 100%; display: block; }
     .cw-prev-media-badge {
@@ -437,6 +472,11 @@ function markDirty() { _dirty = true; }
 function clearDirty() { _dirty = false; }
 
 const FONT_OPTIONS = ["sans","serif","mono","display"];
+// New widgets (analog clock, weather) only support the three font
+// stacks the server actually ships (_FONT_STACKS in the widget .py).
+// FONT_OPTIONS keeps "display"/"handwritten" for legacy widgets whose
+// server side historically tolerated them; do not extend that here.
+const SAFE_FONT_OPTIONS = ["sans","serif","mono"];
 // Mirror of the server-side _FONT_STACKS (cms/composed/widgets/*.py) so
 // in-editor previews use the same font stacks the device bundle will.
 const FONT_STACKS = {
@@ -460,8 +500,13 @@ const DEFAULTS = {
     text: {text:"Text", color:"#ffffff", font_size_px:48, font_family:"sans", bold:false, italic:false},
     media: {asset_id: NULL_UUID, object_fit:"cover", alt:""},
     clock: {format:"24h", show_seconds:true, show_date:false, color:"#ffffff", font_family:"sans", font_size_px:96},
+    analog_clock: {face_color:"#111827", hand_color:"#ffffff", second_color:"#ef4444",
+             show_seconds:true, show_ticks:true, show_numerals:false},
     ticker: {text:"Breaking news...", speed_px_per_sec:100, direction:"left", mode:"scroll",
              color:"#ffffff", background:"#000000", font_family:"sans", font_size_px:48, gap_px:100},
+    weather: {latitude:47.6062, longitude:-122.3321, location_label:"Seattle", units:"imperial",
+             show_condition:true, show_location:true, color:"#ffffff", font_family:"sans",
+             font_size_px:64, refresh_seconds:900},
 };
 
 function flash(msg, ok) {
@@ -605,6 +650,10 @@ function renderWidgetContent(w) {
             root.appendChild(c);
             updateClockEl(timeEl);
             if (cfg.show_date) updateClockDateEl(c.querySelector(".cw-prev-clock-date"));
+        } else if (w.type === "analog_clock") {
+            root.appendChild(buildAnalogSvg(cfg));
+        } else if (w.type === "weather") {
+            root.appendChild(buildWeatherPreview(cfg));
         } else if (w.type === "ticker") {
             const strip = document.createElement("div");
             strip.className = "cw-prev-ticker";
@@ -713,6 +762,7 @@ function updateClockDateEl(el) {
 function tickClocks() {
     document.querySelectorAll(".cw-prev-clock-time").forEach(updateClockEl);
     document.querySelectorAll(".cw-prev-clock-date").forEach(updateClockDateEl);
+    document.querySelectorAll(".cw-prev-aclock").forEach(updateAnalogEl);
 }
 
 let _clockTimerStarted = false;
@@ -720,6 +770,178 @@ function startClockTimer() {
     if (_clockTimerStarted) return;
     _clockTimerStarted = true;
     setInterval(tickClocks, 1000);
+}
+
+// ── Analog clock preview ────────────────────────────────────────────
+const SVGNS = "http://www.w3.org/2000/svg";
+function svgEl(name, attrs) {
+    const e = document.createElementNS(SVGNS, name);
+    for (const k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+}
+function buildAnalogSvg(cfg) {
+    const hand = cfg.hand_color || "#ffffff";
+    const sec = cfg.second_color || "#ef4444";
+    const svg = svgEl("svg", {
+        viewBox: "0 0 100 100", preserveAspectRatio: "xMidYMid meet",
+        class: "cw-prev-aclock",
+    });
+    svg.dataset.showSeconds = cfg.show_seconds ? "1" : "0";
+    svg.appendChild(svgEl("circle", {
+        cx: 50, cy: 50, r: 48, fill: cfg.face_color || "#111827",
+        stroke: hand, "stroke-width": 1, "stroke-opacity": 0.35,
+    }));
+    if (cfg.show_ticks) {
+        for (let i = 0; i < 12; i++) {
+            svg.appendChild(svgEl("line", {
+                x1: 50, y1: 2, x2: 50, y2: 8, stroke: hand, "stroke-width": 1.4,
+                transform: `rotate(${i * 30} 50 50)`,
+            }));
+        }
+        for (let i = 0; i < 60; i++) {
+            if (i % 5 === 0) continue;
+            svg.appendChild(svgEl("line", {
+                x1: 50, y1: 2, x2: 50, y2: 6, stroke: hand,
+                "stroke-width": 0.5, "stroke-opacity": 0.5,
+                transform: `rotate(${i * 6} 50 50)`,
+            }));
+        }
+    }
+    if (cfg.show_numerals) {
+        for (let n = 1; n <= 12; n++) {
+            const a = (n * 30) * Math.PI / 180;
+            const t = svgEl("text", {
+                x: (50 + 38 * Math.sin(a)).toFixed(2),
+                y: (50 - 38 * Math.cos(a)).toFixed(2),
+                fill: hand, "font-size": 7, "text-anchor": "middle",
+                "dominant-baseline": "central",
+            });
+            t.textContent = n;
+            svg.appendChild(t);
+        }
+    }
+    const gh = svgEl("g", {class: "cw-prev-aclock-hour"});
+    gh.appendChild(svgEl("line", {x1:50,y1:52,x2:50,y2:26,stroke:hand,"stroke-width":3,"stroke-linecap":"round"}));
+    const gm = svgEl("g", {class: "cw-prev-aclock-min"});
+    gm.appendChild(svgEl("line", {x1:50,y1:53,x2:50,y2:16,stroke:hand,"stroke-width":2,"stroke-linecap":"round"}));
+    svg.appendChild(gh); svg.appendChild(gm);
+    if (cfg.show_seconds) {
+        const gs = svgEl("g", {class: "cw-prev-aclock-sec"});
+        gs.appendChild(svgEl("line", {x1:50,y1:54,x2:50,y2:14,stroke:sec,"stroke-width":1,"stroke-linecap":"round"}));
+        svg.appendChild(gs);
+    }
+    svg.appendChild(svgEl("circle", {cx:50,cy:50,r:2.2,fill:sec}));
+    updateAnalogEl(svg);
+    return svg;
+}
+function updateAnalogEl(svg) {
+    const d = new Date();
+    const s = d.getSeconds(), m = d.getMinutes(), h = d.getHours() % 12;
+    const setRot = (sel, deg) => {
+        const g = svg.querySelector(sel);
+        if (g) g.setAttribute("transform", `rotate(${deg} 50 50)`);
+    };
+    setRot(".cw-prev-aclock-hour", h * 30 + m * 0.5);
+    setRot(".cw-prev-aclock-min", m * 6 + s * 0.1);
+    if (svg.dataset.showSeconds === "1") setRot(".cw-prev-aclock-sec", s * 6);
+}
+
+// ── Weather preview (static mock; live values only render on device) ─
+function buildWeatherPreview(cfg) {
+    const wrap = document.createElement("div");
+    wrap.className = "cw-prev-weather";
+    wrap.style.color = cfg.color || "#ffffff";
+    wrap.style.fontFamily = fontStack(cfg.font_family);
+    if (cfg.show_location) {
+        const loc = document.createElement("div");
+        loc.className = "cw-prev-weather-loc";
+        loc.textContent = cfg.location_label || "";
+        loc.style.fontSize = cqwFont((Number(cfg.font_size_px) || 64) * 0.4);
+        wrap.appendChild(loc);
+    }
+    const temp = document.createElement("div");
+    temp.className = "cw-prev-weather-temp";
+    temp.textContent = "72" + (cfg.units === "metric" ? "°C" : "°F");
+    temp.style.fontSize = cqwFont(cfg.font_size_px);
+    wrap.appendChild(temp);
+    if (cfg.show_condition) {
+        const cond = document.createElement("div");
+        cond.className = "cw-prev-weather-cond";
+        cond.textContent = "⛅ Partly cloudy";
+        cond.style.fontSize = cqwFont((Number(cfg.font_size_px) || 64) * 0.45);
+        wrap.appendChild(cond);
+    }
+    const note = document.createElement("div");
+    note.className = "cw-prev-weather-note";
+    note.textContent = "Live on device";
+    wrap.appendChild(note);
+    return wrap;
+}
+
+// ── Weather city search → Open-Meteo geocoding (editor-only) ─────────
+// Coordinates are baked into config here so the device never needs the
+// geocoding endpoint. Debounced + abortable; failures are non-blocking
+// and never clear the widget's existing coords.
+let _wxAbort = null;
+let _wxTimer = null;
+function weatherSearchDebounced(q) {
+    if (_wxTimer) clearTimeout(_wxTimer);
+    _wxTimer = setTimeout(() => weatherGeocode(q), 400);
+}
+function weatherGeocode(q) {
+    const status = document.getElementById("wx-status");
+    const results = document.getElementById("wx-results");
+    if (!results || !status) return;
+    const query = String(q || "").trim();
+    results.replaceChildren();
+    if (query.length < 2) { status.textContent = ""; return; }
+    if (_wxAbort) { try { _wxAbort.abort(); } catch (e) {} }
+    _wxAbort = new AbortController();
+    const ctrl = _wxAbort;
+    const to = setTimeout(() => { try { ctrl.abort(); } catch (e) {} }, 8000);
+    status.textContent = "Searching…";
+    const url = "https://geocoding-api.open-meteo.com/v1/search?count=5&name="
+        + encodeURIComponent(query);
+    fetch(url, {signal: ctrl.signal})
+        .then(r => { if (!r.ok) throw new Error("http " + r.status); return r.json(); })
+        .then(d => {
+            if (ctrl !== _wxAbort) return; // superseded
+            const list = (d && Array.isArray(d.results)) ? d.results : [];
+            if (!list.length) { status.textContent = "No matches."; return; }
+            status.textContent = "";
+            list.forEach(item => {
+                const parts = [item.name, item.admin1, item.country].filter(Boolean);
+                const label = parts.join(", ");
+                const btn = document.createElement("button");
+                btn.type = "button";
+                btn.className = "wx-result";
+                btn.textContent = label;
+                btn.onclick = () => pickWeatherLocation(
+                    item.latitude, item.longitude, item.name || label);
+                results.appendChild(btn);
+            });
+        })
+        .catch(() => {
+            if (ctrl !== _wxAbort) return;
+            status.textContent = "Search failed — keeping current location.";
+        })
+        .then(() => { clearTimeout(to); });
+}
+function pickWeatherLocation(lat, lon, label) {
+    updateSelected(x => {
+        x.config.latitude = Number(lat);
+        x.config.longitude = Number(lon);
+        x.config.location_label = label;
+    });
+    const cur = document.getElementById("wx-current");
+    if (cur) cur.textContent = label + "  (" + Number(lat).toFixed(3)
+        + ", " + Number(lon).toFixed(3) + ")";
+    const results = document.getElementById("wx-results");
+    if (results) results.replaceChildren();
+    const status = document.getElementById("wx-status");
+    if (status) status.textContent = "Location set.";
+    const labelInput = document.getElementById("wx-label");
+    if (labelInput) labelInput.value = label;
 }
 
 function beginDrag(ev, widgetId, mode) {
@@ -780,7 +1002,9 @@ function beginDrag(ev, widgetId, mode) {
 function summarize(w) {
     if (w.type === "text") return (w.config.text || "").slice(0, 24);
     if (w.type === "clock") return w.config.format || "24h";
+    if (w.type === "analog_clock") return "analog";
     if (w.type === "ticker") return (w.config.text || "").slice(0, 24);
+    if (w.type === "weather") return (w.config.location_label || "weather").slice(0, 24);
     if (w.type === "media") {
         const aid = w.config.asset_id;
         if (!aid || aid === NULL_UUID) return "(no asset)";
@@ -850,7 +1074,7 @@ function moveSelectedZ(op) {
     renderSettings();
 }
 
-const LAYER_ICONS = {text:"🅰", media:"🎬", clock:"🕒", ticker:"📰"};
+const LAYER_ICONS = {text:"🅰", media:"🎬", clock:"🕒", analog_clock:"🕧", ticker:"📰", weather:"⛅"};
 
 // Build the always-visible layer list (front → back). This is the
 // authoritative way to select a widget that is fully covered by
@@ -1043,9 +1267,86 @@ function renderSettings() {
                     </select>
                 </div>
             </div>`;
+    } else if (w.type === "analog_clock") {
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Analog clock widget</h4>
+            <div class="row">
+                <div>
+                    <label>Face color</label>
+                    <input type="color" value="${w.config.face_color||"#111827"}"
+                           oninput="updateSelected(x=>x.config.face_color=this.value)">
+                </div>
+                <div>
+                    <label>Hand color</label>
+                    <input type="color" value="${w.config.hand_color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.hand_color=this.value)">
+                </div>
+            </div>
+            <label>Second-hand color</label>
+            <input type="color" value="${w.config.second_color||"#ef4444"}"
+                   oninput="updateSelected(x=>x.config.second_color=this.value)">
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.show_seconds?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_seconds=this.checked)"> Show second hand
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_ticks?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_ticks=this.checked)"> Show tick marks
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_numerals?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_numerals=this.checked)"> Show numerals
+            </label>`;
+    } else if (w.type === "weather") {
+        const lat = Number(w.config.latitude), lon = Number(w.config.longitude);
+        const curTxt = `${escapeHtml(w.config.location_label||"")}  (${lat.toFixed(3)}, ${lon.toFixed(3)})`;
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Weather widget</h4>
+            <label>Search city</label>
+            <input id="wx-q" type="text" placeholder="e.g. Seattle"
+                   oninput="weatherSearchDebounced(this.value)">
+            <div id="wx-status" style="font-size:0.75rem; color:var(--text-muted); min-height:1rem;"></div>
+            <div id="wx-results" class="wx-results"></div>
+            <label style="margin-top:0.5rem;">Location label</label>
+            <input id="wx-label" type="text" maxlength="80" value="${escapeHtml(w.config.location_label||"")}"
+                   oninput="updateSelected(x=>x.config.location_label=this.value)">
+            <div id="wx-current" style="font-size:0.72rem; color:var(--text-muted); margin-top:0.25rem; word-break:break-all;">${curTxt}</div>
+            <label style="margin-top:0.5rem;">Units</label>
+            <select oninput="updateSelected(x=>x.config.units=this.value)">
+                <option value="imperial" ${w.config.units==="imperial"?"selected":""}>Fahrenheit (°F)</option>
+                <option value="metric" ${w.config.units==="metric"?"selected":""}>Celsius (°C)</option>
+            </select>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.show_location?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_location=this.checked)"> Show location label
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_condition?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_condition=this.checked)"> Show condition
+            </label>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||64}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <label>Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${SAFE_FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>
+            <label style="margin-top:0.5rem;">Refresh (seconds, 600–86400)</label>
+            <input type="number" min="600" max="86400" value="${w.config.refresh_seconds||900}"
+                   oninput="updateSelected(x=>x.config.refresh_seconds=clampInt(this.value,600,86400))">
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                Live temperature is fetched on the device. The preview shows placeholder values.
+            </p>`;
     }
-
-    panel.innerHTML = `<h3>Settings</h3>
         ${renderLayersHtml()}
         <h4 class="cw-sec">Arrange</h4>
         <div class="cw-zorder">

--- a/tests/test_composed_analog_clock_widget.py
+++ b/tests/test_composed_analog_clock_widget.py
@@ -1,0 +1,138 @@
+"""Tests for cms.composed.widgets.analog_clock.AnalogClockWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.analog_clock import (
+    AnalogClockWidget,
+    AnalogClockWidgetConfig,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestAnalogClockWidgetConfig:
+    def test_defaults(self):
+        c = AnalogClockWidgetConfig()
+        assert c.face_color == "#111827"
+        assert c.hand_color == "#ffffff"
+        assert c.second_color == "#ef4444"
+        assert c.show_seconds is True
+        assert c.show_ticks is True
+        assert c.show_numerals is False
+
+    def test_default_config_matches_schema(self):
+        # The editor's DEFAULTS map must round-trip through the schema
+        # with extra="forbid" — otherwise a freshly-placed widget fails
+        # save/publish validation.
+        w = AnalogClockWidget()
+        AnalogClockWidgetConfig(**w.default_config())
+
+    def test_color_must_be_hex_6(self):
+        for field in ("face_color", "hand_color", "second_color"):
+            with pytest.raises(ValidationError):
+                AnalogClockWidgetConfig(**{field: "red"})
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            AnalogClockWidgetConfig(timezone="UTC")  # type: ignore[call-arg]
+
+
+class TestAnalogClockWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("analog_clock")
+        assert isinstance(w, AnalogClockWidget)
+        assert w.slug == "analog_clock"
+        assert w.display_name == "Analog Clock"
+
+
+class TestAnalogClockWidgetRender:
+    def test_no_declared_assets(self):
+        w = AnalogClockWidget()
+        assert w.declared_asset_ids(AnalogClockWidgetConfig()) == []
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = AnalogClockWidget()
+        cfg = AnalogClockWidgetConfig()
+
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+
+        assert "cw-aclock-inst-A" in r1.html
+        assert "cw-aclock-inst-A" in r1.css
+        assert "cw-aclock-inst-B" in r2.html
+        # No cross-contamination.
+        assert "inst-B" not in r1.html
+        assert "inst-A" not in r2.html
+
+    def test_svg_viewbox_present(self):
+        w = AnalogClockWidget()
+        r = w.render_html(AnalogClockWidgetConfig(), _cell(), "abc")
+        assert 'viewBox="0 0 100 100"' in r.html
+        assert "<svg" in r.html
+
+    def test_three_hand_groups_when_seconds_on(self):
+        w = AnalogClockWidget()
+        r = w.render_html(AnalogClockWidgetConfig(show_seconds=True), _cell(), "abc")
+        assert 'id="cw-aclock-hour-abc"' in r.html
+        assert 'id="cw-aclock-min-abc"' in r.html
+        assert 'id="cw-aclock-sec-abc"' in r.html
+
+    def test_second_hand_omitted_when_off(self):
+        w = AnalogClockWidget()
+        r = w.render_html(AnalogClockWidgetConfig(show_seconds=False), _cell(), "abc")
+        assert 'id="cw-aclock-hour-abc"' in r.html
+        assert 'id="cw-aclock-min-abc"' in r.html
+        assert 'id="cw-aclock-sec-abc"' not in r.html
+        # init_js must not look up the missing second hand.
+        assert r.init_js is not None
+        assert "cw-aclock-sec-abc" not in r.init_js
+        assert "secEl = null" in r.init_js
+
+    def test_init_js_rotates_and_ticks(self):
+        w = AnalogClockWidget()
+        r = w.render_html(AnalogClockWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        assert "cw-aclock-hour-abc" in r.init_js
+        assert "setInterval" in r.init_js
+        assert "rotate(" in r.init_js
+
+    def test_ticks_toggle(self):
+        w = AnalogClockWidget()
+        on = w.render_html(AnalogClockWidgetConfig(show_ticks=True), _cell(), "a")
+        off = w.render_html(AnalogClockWidgetConfig(show_ticks=False), _cell(), "b")
+        assert "cw-aclock-a-tick-major" in on.html
+        assert "tick-major" not in off.html
+
+    def test_numerals_toggle(self):
+        w = AnalogClockWidget()
+        on = w.render_html(AnalogClockWidgetConfig(show_numerals=True), _cell(), "a")
+        off = w.render_html(AnalogClockWidgetConfig(show_numerals=False), _cell(), "b")
+        assert "cw-aclock-a-num" in on.html
+        assert "-num" not in off.html
+
+    def test_colors_propagate_to_css(self):
+        w = AnalogClockWidget()
+        cfg = AnalogClockWidgetConfig(
+            face_color="#010203", hand_color="#040506", second_color="#070809"
+        )
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "fill: #010203" in r.css
+        assert "stroke: #040506" in r.css
+        assert "stroke: #070809" in r.css
+
+    def test_deterministic_render(self):
+        w = AnalogClockWidget()
+        cfg = AnalogClockWidgetConfig()
+        a = w.render_html(cfg, _cell(), "abc")
+        b = w.render_html(cfg, _cell(), "abc")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.init_js == b.init_js

--- a/tests/test_composed_bundle.py
+++ b/tests/test_composed_bundle.py
@@ -133,6 +133,27 @@ class TestNoExternalReferences:
         html = build_bundle(empty_layout()).html_bytes.decode("utf-8")
         assert self.EXTERNAL_RE.search(html) is None
 
+    def test_weather_widget_bundle_has_no_external_attr_refs(self):
+        # The weather widget makes a runtime fetch, but the Open-Meteo
+        # URL must only ever exist as a JS string literal — never as a
+        # src=/href= attribute that a strict offline check would flag.
+        layout = Layout(
+            widgets=[
+                WidgetInstance(
+                    id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+                    type="weather",
+                    cell=Cell(row=1, col=1, rowspan=2, colspan=3),
+                    config={},
+                ),
+            ],
+        )
+        html = build_bundle(layout).html_bytes.decode("utf-8")
+        # The forecast endpoint is present (baked into init_js)…
+        assert "open-meteo.com/v1/forecast" in html
+        # …but never as an external src=/href= attribute.
+        match = self.EXTERNAL_RE.search(html)
+        assert match is None, f"unexpected external reference: {match!r}"
+
 
 class TestDeterminism:
     def test_same_layout_produces_same_sha_and_bytes(self):

--- a/tests/test_composed_weather_widget.py
+++ b/tests/test_composed_weather_widget.py
@@ -1,0 +1,196 @@
+"""Tests for cms.composed.widgets.weather.WeatherWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.weather import (
+    WeatherWidget,
+    WeatherWidgetConfig,
+    _DEFAULT_LABEL,
+    _DEFAULT_LAT,
+    _DEFAULT_LON,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestWeatherWidgetConfig:
+    def test_defaults(self):
+        c = WeatherWidgetConfig()
+        assert c.latitude == _DEFAULT_LAT
+        assert c.longitude == _DEFAULT_LON
+        assert c.location_label == _DEFAULT_LABEL
+        assert c.units == "imperial"
+        assert c.show_condition is True
+        assert c.show_location is True
+        assert c.color == "#ffffff"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 64
+        assert c.refresh_seconds == 900
+
+    def test_default_config_matches_schema(self):
+        # A freshly-placed widget must immediately be a valid config.
+        w = WeatherWidget()
+        WeatherWidgetConfig(**w.default_config())
+
+    def test_units_allowlist(self):
+        WeatherWidgetConfig(units="imperial")
+        WeatherWidgetConfig(units="metric")
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(units="kelvin")  # type: ignore[arg-type]
+
+    def test_font_allowlist(self):
+        for ok in ("sans", "serif", "mono"):
+            WeatherWidgetConfig(font_family=ok)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(font_family="display")
+
+    def test_latitude_bounds(self):
+        WeatherWidgetConfig(latitude=-90.0)
+        WeatherWidgetConfig(latitude=90.0)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(latitude=90.1)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(longitude=-180.1)
+
+    def test_refresh_floor(self):
+        WeatherWidgetConfig(refresh_seconds=600)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(refresh_seconds=599)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(refresh_seconds=86401)
+
+    def test_label_max_length(self):
+        WeatherWidgetConfig(location_label="x" * 80)
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(location_label="x" * 81)
+
+    def test_color_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(color="blue")
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            WeatherWidgetConfig(api_key="secret")  # type: ignore[call-arg]
+
+
+class TestWeatherWidgetSemantic:
+    def test_blank_label_with_show_location_flagged(self):
+        w = WeatherWidget()
+        errors = w.validate_semantic(
+            WeatherWidgetConfig(show_location=True, location_label="   ")
+        )
+        assert errors and "location_label" in errors[0]
+
+    def test_blank_label_ok_when_location_hidden(self):
+        w = WeatherWidget()
+        errors = w.validate_semantic(
+            WeatherWidgetConfig(show_location=False, location_label="")
+        )
+        assert errors == []
+
+
+class TestWeatherWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("weather")
+        assert isinstance(w, WeatherWidget)
+        assert w.slug == "weather"
+        assert w.display_name == "Weather"
+
+
+class TestWeatherWidgetRender:
+    def test_no_declared_assets(self):
+        w = WeatherWidget()
+        assert w.declared_asset_ids(WeatherWidgetConfig()) == []
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = WeatherWidget()
+        cfg = WeatherWidgetConfig()
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+        assert "cw-weather-inst-A" in r1.html
+        assert "cw-weather-inst-A" in r1.css
+        assert "cw-weather-inst-B" in r2.html
+        assert "inst-B" not in r1.html
+        assert "inst-A" not in r2.html
+
+    def test_init_js_has_fetch_and_cache_and_abort(self):
+        w = WeatherWidget()
+        r = w.render_html(WeatherWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        js = r.init_js
+        assert "fetch(" in js
+        assert "localStorage" in js
+        assert "AbortController" in js
+        assert "open-meteo.com/v1/forecast" in js
+
+    def test_baked_coords_and_units_in_url(self):
+        w = WeatherWidget()
+        cfg = WeatherWidgetConfig(latitude=40.5, longitude=-74.25, units="metric")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert "latitude=40.5" in r.init_js
+        assert "longitude=-74.25" in r.init_js
+        assert "temperature_unit=celsius" in r.init_js
+
+    def test_imperial_url_uses_fahrenheit(self):
+        w = WeatherWidget()
+        r = w.render_html(WeatherWidgetConfig(units="imperial"), _cell(), "abc")
+        assert r.init_js is not None
+        assert "temperature_unit=fahrenheit" in r.init_js
+
+    def test_wmo_map_present(self):
+        w = WeatherWidget()
+        r = w.render_html(WeatherWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        # WMO code object literal — clear-sky code 0 should be present.
+        assert "var WMO =" in r.init_js
+        assert "0:{" in r.init_js
+
+    def test_label_html_escaped_not_in_js(self):
+        w = WeatherWidget()
+        cfg = WeatherWidgetConfig(location_label="<b>Town</b> & Co")
+        r = w.render_html(cfg, _cell(), "abc")
+        # Escaped in markup.
+        assert "&lt;b&gt;Town&lt;/b&gt; &amp; Co" in r.html
+        assert "<b>Town</b>" not in r.html
+        # Never interpolated into JS.
+        assert r.init_js is not None
+        assert "Town" not in r.init_js
+
+    def test_condition_element_toggle(self):
+        w = WeatherWidget()
+        on = w.render_html(WeatherWidgetConfig(show_condition=True), _cell(), "a")
+        off = w.render_html(WeatherWidgetConfig(show_condition=False), _cell(), "b")
+        assert "cw-weather-cond-a" in on.html
+        assert "cw-weather-cond-b" not in off.html
+
+    def test_location_element_toggle(self):
+        w = WeatherWidget()
+        on = w.render_html(WeatherWidgetConfig(show_location=True), _cell(), "a")
+        off = w.render_html(WeatherWidgetConfig(show_location=False), _cell(), "b")
+        assert "cw-weather-a-loc" in on.html
+        assert "-loc" not in off.html
+
+    def test_cache_key_fingerprint_changes_with_location(self):
+        w = WeatherWidget()
+        a = w.render_html(WeatherWidgetConfig(latitude=10.0), _cell(), "abc")
+        b = w.render_html(WeatherWidgetConfig(latitude=20.0), _cell(), "abc")
+        # Fingerprint embeds lat/lon/units, so the two init scripts differ.
+        assert a.init_js != b.init_js
+
+    def test_deterministic_render(self):
+        w = WeatherWidget()
+        cfg = WeatherWidgetConfig()
+        a = w.render_html(cfg, _cell(), "abc")
+        b = w.render_html(cfg, _cell(), "abc")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.init_js == b.init_js


### PR DESCRIPTION
## What

Adds two new composed-slide widgets and full editor support for them.

### Backend widgets
- **Analog Clock** (`analog_clock`): SVG clock face with hour/minute/
  second hands. Config: face/hand/second colors, and toggles for
  seconds, ticks, and numerals. JS-driven from the device clock.
  Instance-scoped CSS classes and element IDs.
- **Weather** (`weather`): runtime fetch from the free
  [Open-Meteo](https://open-meteo.com) forecast API (current temp +
  WMO weather code). Baked latitude/longitude/units; `localStorage`
  cache keyed by a `{lat},{lon},{units}` fingerprint so a config
  change busts the cache; `AbortController` + WMO→label map. The
  forecast URL only ever appears as a **JS string literal**, never as
  a `src=`/`href=` attribute — covered by a new assertion in
  `TestNoExternalReferences`. `location_label` is `html.escape`'d and
  is never injected into JS.

### Editor (`composed_editor.html`)
- Palette tiles, `DEFAULTS`, `summarize`, and `LAYER_ICONS` entries
  for both widgets.
- **Live in-editor previews**: a ticking analog SVG clock, and a
  static weather mock with a "Live on device" note.
- Weather settings panel includes an Open-Meteo **city search**
  (debounced, abortable, non-blocking error UX, result buttons built
  via DOM `textContent` not `innerHTML`).
- `SAFE_FONT_OPTIONS` limits the new widgets' font picker to the three
  font stacks the backend actually ships (`sans`/`serif`/`mono`).

## Tests
- `tests/test_composed_analog_clock_widget.py` — defaults/validation,
  registry, render (instance scoping, viewBox, hand groups, toggles,
  color propagation, determinism).
- `tests/test_composed_weather_widget.py` — defaults/validation,
  `validate_semantic`, registry, render (fetch/localStorage/Abort,
  baked coords+units, WMO map, label escaping, cache fingerprint,
  determinism).
- `tests/test_composed_bundle.py` — weather-bundle no-external-refs
  assertion.

61 new tests + existing composed suites (schema/validate/publish/
extensibility/bundle) all green locally on Windows. Full suite runs in
CI.

## Notes
- No router changes → `docs/openapi.yaml` untouched.
- Follows the widget plugin contract: no edits to base `Widget` /
  `WidgetRender` / registry / bundle builder were needed.
