### PR TITLE
fix(composed): restore lost settings-panel template opener (editor broken)

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1347,6 +1347,8 @@ function renderSettings() {
                 Live temperature is fetched on the device. The preview shows placeholder values.
             </p>`;
     }
+
+    panel.innerHTML = `
         ${renderLayersHtml()}
         <h4 class="cw-sec">Arrange</h4>
         <div class="cw-zorder">


### PR DESCRIPTION
Editor JS broke at load time: a missing panel.innerHTML = ` opener in renderSettings (dropped by PR #714) left a block of \ expressions outside any template literal, throwing Uncaught SyntaxError: Unexpected token '{'. That aborted the whole script, so selecting any widget AND the unsaved-changes guard both stopped working. One-line restore of the opener; extracted script now passes node --check.
