### PR TITLE
fix(composed): emit canvas {width,height} so saving a slide no longer 422s

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -527,7 +527,7 @@ function ensureLayoutShape() {
     if (!LAYOUT || typeof LAYOUT !== "object") LAYOUT = {};
     LAYOUT.schema_version = LAYOUT.schema_version || SCHEMA_VERSION || 1;
     LAYOUT.grid = LAYOUT.grid || {rows: 8, cols: 12};
-    LAYOUT.canvas = LAYOUT.canvas || {w: 1920, h: 1080};
+    LAYOUT.canvas = LAYOUT.canvas || {width: 1920, height: 1080};
     LAYOUT.background = LAYOUT.background || {color: "#000000"};
     LAYOUT.widgets = LAYOUT.widgets || [];
 }

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -16,13 +16,29 @@ Scope:
 
 from __future__ import annotations
 
+import json
+import re
 import uuid
+from pathlib import Path
 
 import pytest
 
-from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
+from cms.composed.schema import (
+    SCHEMA_VERSION,
+    Cell,
+    Layout,
+    WidgetInstance,
+    empty_layout,
+)
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+
+EDITOR_TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "cms"
+    / "templates"
+    / "composed_editor.html"
+)
 
 
 def _text_widget(text: str = "hi") -> WidgetInstance:
@@ -204,3 +220,73 @@ class TestComposedUI:
         )
         # The UI requires auth — accept either a redirect or a 401.
         assert resp.status_code in (302, 303, 401)
+
+
+# ───────────────── Editor ↔ schema contract (regression) ─────────────────
+
+
+def _js_object_literal_to_dict(literal: str) -> dict:
+    """Convert a simple JS object literal (identifier keys, int/string
+    values) into a Python dict via JSON. Only handles the flat literals
+    the editor's ``ensureLayoutShape`` emits."""
+    quoted = re.sub(r"([{,]\s*)([A-Za-z_]\w*)\s*:", r'\1"\2":', literal)
+    return json.loads(quoted)
+
+
+def _extract_default(field: str) -> dict:
+    """Pull the ``LAYOUT.<field> = LAYOUT.<field> || {...}`` default
+    object literal out of the editor template."""
+    src = EDITOR_TEMPLATE.read_text(encoding="utf-8")
+    m = re.search(
+        rf"LAYOUT\.{re.escape(field)}\s*=\s*LAYOUT\.{re.escape(field)}\s*\|\|\s*(\{{.*?\}})",
+        src,
+    )
+    assert m, f"could not find editor default literal for LAYOUT.{field}"
+    return _js_object_literal_to_dict(m.group(1))
+
+
+class TestEditorDefaultsMatchSchema:
+    """The empty-slide defaults the editor JS injects via
+    ``ensureLayoutShape`` MUST validate against the Pydantic ``Layout``
+    contract. This guards the canvas ``{w,h}`` vs ``{width,height}``
+    regression (a mismatch made every save fail with 422
+    ``extra_forbidden``) and any future drift in the editor's grid /
+    background / canvas key names.
+    """
+
+    def test_editor_canvas_default_uses_schema_keys(self):
+        canvas = _extract_default("canvas")
+        # Direct guard against the `{w, h}` regression.
+        assert set(canvas) == {"width", "height"}, canvas
+
+    def test_editor_empty_layout_validates_against_schema(self):
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "grid": _extract_default("grid"),
+            "canvas": _extract_default("canvas"),
+            "background": _extract_default("background"),
+            "widgets": [],
+        }
+        # Must not raise — this is exactly what the editor PATCHes on a
+        # brand-new slide before any widget is dropped.
+        Layout.model_validate(payload)
+
+
+@pytest.mark.asyncio
+class TestEditorEmptyLayoutSaves:
+    """End-to-end: the literal empty-slide shape the editor emits is
+    accepted by the save endpoint (200, not 422)."""
+
+    async def test_patch_editor_empty_layout_returns_200(
+        self, client, db_session
+    ):
+        asset, _ = await _make_composed(db_session)
+        body = {
+            "schema_version": SCHEMA_VERSION,
+            "grid": _extract_default("grid"),
+            "canvas": _extract_default("canvas"),
+            "background": _extract_default("background"),
+            "widgets": [],
+        }
+        resp = await client.patch(f"/composed/{asset.id}/layout", json=body)
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Problem

Saving **any** composed slide failed with a 422:

```
2 validation errors for Layout
canvas.h  Extra inputs are not permitted [type=extra_forbidden, input_value=1080]
canvas.w  Extra inputs are not permitted [type=extra_forbidden, input_value=1920]
```

## Root cause

The editor's `ensureLayoutShape()` defaulted `LAYOUT.canvas` to
`{w: 1920, h: 1080}`, but the Pydantic `Canvas` model uses
`width`/`height` with `extra="forbid"`. So `PATCH
/composed/{id}/layout` (`Layout.model_validate(body)`) rejected the
payload on every save. Introduced in PR #700 (Phase 2). Nothing reads
`.w`/`.h`, and no layout could ever have been saved with them, so
emitting `{width, height}` is safe for both save and load.

## Fix

- `composed_editor.html`: canvas default → `{width: 1920, height: 1080}`.

## Regression tests (`tests/test_composed_routes_phase2.py`)

- `test_editor_canvas_default_uses_schema_keys` — extracts the editor
  template's canvas default literal and asserts its keys are exactly
  `{width, height}` (direct guard against `{w,h}` drift).
- `test_editor_empty_layout_validates_against_schema` — the editor's
  full empty-slide defaults (grid/canvas/background) validate against
  `Layout`.
- `test_patch_editor_empty_layout_returns_200` — end-to-end PATCH of
  the editor's emitted shape returns 200.

Verified the new tests fail on the old `{w,h}` literal and pass on the fix.

After deploy, hard-reload the editor once.