### PR TITLE
fix: seed composed create-mode canvas from schema (422 on first save)

### DIFF
--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1856,6 +1856,15 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         for a in media_rows
     ]
 
+    # Seed the create-mode editor from the canonical schema default rather
+    # than a hand-written literal. A stale literal here previously seeded
+    # ``canvas: {w, h}`` (legacy keys), so the very first save of a brand-new
+    # slide PATCHed ``{w, h}`` and was rejected 422 ``extra_forbidden`` — the
+    # JS ``|| {width,height}`` fallback never heals it because the seeded
+    # canvas is already truthy. Sourcing from ``empty_layout`` keeps this in
+    # lock-step with ``cms.composed.schema`` forever.
+    from cms.composed.schema import empty_layout
+
     ctx = {
         "active_tab": "assets",
         "is_admin": is_admin,
@@ -1864,13 +1873,7 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         "asset": None,
         "asset_id": None,
         "asset_name": "",
-        "layout_json": {
-            "schema_version": 1,
-            "grid": {"rows": 8, "cols": 12},
-            "canvas": {"w": 1920, "h": 1080},
-            "background": {"color": "#000000"},
-            "widgets": [],
-        },
+        "layout_json": empty_layout().model_dump(mode="json"),
         "is_draft": True,
         "bundle_built_at": None,
         "schema_version": 1,

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -172,6 +172,25 @@ class TestComposedUI:
         text = resp.text.lower()
         assert "name" in text
 
+    async def test_new_page_seeds_schema_valid_layout(self, client):
+        # Regression: the create-mode page seeds ``let LAYOUT = {...}``
+        # straight from the server context. Earlier this hard-coded a legacy
+        # ``canvas: {w, h}`` literal, so the FIRST save of a brand-new slide
+        # PATCHed ``{w, h}`` and was rejected 422 ``extra_forbidden``. The JS
+        # ``|| {width,height}`` fallback (covered by TestEditorDefaultsMatch
+        # Schema) never fires here because the seeded canvas is already
+        # truthy — so the server seed itself must use schema keys.
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        m = re.search(r"let LAYOUT = (\{.*\});", resp.text)
+        assert m, "could not find seeded `let LAYOUT` object in new page"
+        seeded = json.loads(m.group(1))
+        assert seeded["canvas"] == {"width": 1920, "height": 1080}, seeded
+        assert "w" not in seeded["canvas"]
+        assert "h" not in seeded["canvas"]
+        # Exactly what the editor PATCHes before any widget is dropped.
+        Layout.model_validate(seeded)
+
     async def test_editor_renders_for_existing_composed(self, client, db_session):
         asset, _ = await _make_composed(db_session)
         resp = await client.get(f"/assets/{asset.id}/composed")


### PR DESCRIPTION
## Problem

Saving **any** composed slide created from scratch failed with:

`422 ... canvas.h / canvas.w Extra inputs are not permitted [extra_forbidden]`

even after PRs #716/#717. Those PRs fixed the editor JS fallback
literal (LAYOUT.canvas = LAYOUT.canvas || {width,height}), but that
fallback only fires when the canvas is **absent**.

## Root cause

The create-mode editor context in _composed_builder_context()
(cms/ui.py) hard-coded the seed layout with a legacy
`canvas: {w, h}`. The server therefore rendered
`let LAYOUT = { ... canvas: {w, h} ... }` for a brand-new slide.
Because the seeded canvas is already truthy, the JS || fallback
never runs, the `{w, h}` survives, and the first PATCH is rejected
422 by the Canvas schema (width/height, xtra="forbid").

Existing slides were fine because the asset row is minted by
POST /composed/ using mpty_layout() (correct {width,height}) —
only the **first save of a newly-created** slide hit the bad seed.

## Fix

- Seed layout_json from mpty_layout().model_dump(mode="json") so
  it tracks cms.composed.schema and can never drift again.
- Regression test 	est_new_page_seeds_schema_valid_layout asserts
  the **server-seeded** let LAYOUT uses {width,height} and
  validates against Layout. (The prior #716 tests only checked the
  JS fallback literal, not the server seed — which is why this slipped
  through.)

Mutation-verified: reverting the seed to {w,h} makes the new test
fail. Targeted suite green (17 passed).
