### PR TITLE
fix: composed editor weather + z-order preview nits

### DIFF
--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -399,8 +399,19 @@ async def preview_composed_slide(
             ),
         ) from e
 
+    # The weather widget is the only widget that makes a runtime network
+    # call (a keyless Open-Meteo forecast fetch). The locked-down preview
+    # CSP (default-src 'none', no connect-src) blocks that fetch, so the
+    # preview would show the widget's offline "Weather unavailable"
+    # fallback instead of live values. Allow exactly that one origin —
+    # and only when the slide actually contains a weather widget, so a
+    # plain text/image slide keeps the fully-locked CSP.
+    csp = _PREVIEW_CSP
+    if any(inst.type == "weather" for inst in layout.widgets):
+        csp = csp + "; connect-src https://api.open-meteo.com"
+
     headers = {
-        "Content-Security-Policy": _PREVIEW_CSP,
+        "Content-Security-Policy": csp,
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "no-store",
     }

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -588,11 +588,14 @@ function renderCanvas() {
         el.style.gridColumn = w.cell.col + " / span " + cs;
         el.style.gridRow = w.cell.row + " / span " + rs;
         // Stacking order == LAYOUT.widgets array order (later = on top),
-        // matching the published bundle. The selected widget is lifted
-        // above everything so its resize handles stay reachable even when
-        // it sits on a lower layer (editor-only; the Layers panel shows
-        // the true published order).
-        el.style.zIndex = (w.id === selectedWidgetId) ? 1000 : (i + 1);
+        // matching the published bundle and the live preview. We do NOT
+        // lift the selected widget above its true layer: doing so made
+        // bring-to-front / send-to-back appear to do nothing in the editor
+        // (the moved widget stays selected, so it stayed pinned on top
+        // until a reload cleared the selection). A covered widget is still
+        // selectable via the Layers panel and editable via the numeric
+        // Position/size inputs.
+        el.style.zIndex = i + 1;
         el.dataset.widgetId = w.id;
         const content = renderWidgetContent(w);
         content.style.pointerEvents = "none";
@@ -871,10 +874,6 @@ function buildWeatherPreview(cfg) {
         cond.style.fontSize = cqwFont((Number(cfg.font_size_px) || 64) * 0.45);
         wrap.appendChild(cond);
     }
-    const note = document.createElement("div");
-    note.className = "cw-prev-weather-note";
-    note.textContent = "Live on device";
-    wrap.appendChild(note);
     return wrap;
 }
 

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -25,6 +25,20 @@ def _text_layout(text: str = "hello preview") -> Layout:
     return layout
 
 
+def _weather_layout() -> Layout:
+    layout = empty_layout()
+    layout.widgets.append(
+        WidgetInstance(
+            id=uuid.uuid4(),
+            type="weather",
+            cell=Cell(row=1, col=1, rowspan=2, colspan=4),
+            config={},  # all-default (Seattle) config is valid
+            config_version=1,
+        )
+    )
+    return layout
+
+
 async def _make_composed(
     db_session, *, layout: Layout | None = None
 ) -> tuple[Asset, ComposedSlide]:
@@ -105,6 +119,25 @@ class TestComposedPreview:
         # No external script/style/img origins allowed.
         assert "http:" not in csp
         assert "https:" not in csp
+
+    async def test_csp_allows_open_meteo_for_weather_slide(
+        self, client, db_session
+    ):
+        # The weather widget fetches live conditions from Open-Meteo at
+        # runtime. A weather slide's preview must permit exactly that one
+        # connect-src so the preview shows live values instead of the
+        # offline "Weather unavailable" fallback — while every other
+        # directive stays locked down.
+        asset, _cs = await _make_composed(db_session, layout=_weather_layout())
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200
+        csp = resp.headers.get("content-security-policy", "")
+        assert "connect-src https://api.open-meteo.com" in csp
+        # Still locked down everywhere else; api.open-meteo.com is the
+        # only https origin that leaks into the policy.
+        assert "default-src 'none'" in csp
+        assert csp.count("https://") == 1
 
     async def test_no_cache_header_set(self, client, db_session):
         asset, _cs = await _make_composed(db_session)


### PR DESCRIPTION
Three small composer polish fixes from user review:

1. **Remove "Live on device" note** — the weather widget's editor mock showed a "Live on device" caption that read like real device state. Deleted; it was authoring chrome only.

2. **Live weather in Preview** — the preview's locked-down CSP (`default-src 'none'`, no `connect-src`) blocked the weather widget's runtime Open-Meteo fetch, so Preview showed the offline "Weather unavailable" fallback. Now the preview route appends `connect-src https://api.open-meteo.com` **only when the slide contains a weather widget**. Text/image/video slides keep the fully locked CSP.

3. **z-order updates live in the editor** — the canvas pinned the selected widget to `z-index: 1000`, which masked bring-to-front / send-to-back (the just-moved widget stayed selected → stayed on top until a page reload). Editor stacking now uses true array order (`i + 1`), matching the published bundle and the live preview. Covered widgets remain reachable via the Layers panel and the numeric Position inputs.

## Tests
- New: `test_csp_allows_open_meteo_for_weather_slide` — weather slide preview CSP grants exactly the Open-Meteo origin and nothing else.
- Existing locked-down + video CSP tests stay green (they use non-weather slides).
- Inline-JS syntax guard passes.
- `34 passed` locally (`tests/test_composed_preview.py` + `tests/test_template_inline_js_syntax.py`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>