### PR TITLE
feat(composed): guardrail unpublished composed slides (save vs publish UX)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -42,6 +42,7 @@ from cms.schemas.asset import (
 )
 from cms.schemas.tag import TagOut
 from cms.services.audit_service import audit_log, compute_diff
+from cms.services.asset_readiness import composed_unpublished_reason
 from cms.services.storage import get_storage
 
 logger = logging.getLogger(__name__)
@@ -496,6 +497,7 @@ def _asset_out_with_thumb(
     usage: dict[uuid.UUID, AssetUsage] | None = None,
 ) -> AssetOut:
     out = AssetOut.model_validate(asset)
+    out.unpublished = composed_unpublished_reason(asset) is not None
     if asset.id in thumbs:
         out.thumbnail_url = thumbs[asset.id]
     if tags is not None and asset.id in tags:

--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -21,7 +21,7 @@ from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.schemas.schedule import ScheduleCreate, ScheduleOut, ScheduleUpdate
 from cms.services.scheduler import push_sync_to_affected_devices, push_sync_to_device, _get_target_device_ids, skip_schedule_until, clear_schedule_skip, schedules_conflict, evaluate_schedules
 from cms.services.audit_service import audit_log, compute_diff
-from cms.services.asset_readiness import require_asset_ready
+from cms.services.asset_readiness import require_asset_ready, composed_unpublished_reason
 
 logger = logging.getLogger("agora.cms.schedules")
 
@@ -409,6 +409,18 @@ async def update_schedule(
         enabled=updates.get("enabled", schedule.enabled),
         end_date=updates.get("end_date", schedule.end_date),
     )
+
+    # Block landing on an unpublished composed slide whenever the resulting
+    # schedule would be enabled — covers re-enabling an existing schedule whose
+    # composed asset was never published (the asset-swap case is already gated
+    # by require_asset_ready above). Stale-but-published slides have a checksum
+    # and are not blocked.
+    if updates.get("enabled", schedule.enabled) and composed_unpublished_reason(target_asset):
+        raise HTTPException(
+            status_code=422,
+            detail="This composed slide hasn't been published yet. "
+            "Open it in the editor and click Publish before scheduling it.",
+        )
 
     # Webpage/live-stream assets cannot use loop_count
     if is_url_asset and updates.get("loop_count") is not None:

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -102,6 +102,10 @@ class AssetOut(BaseModel):
     capture_duration: Optional[int] = None
     tags: list[TagOut] = Field(default_factory=list)
     usage: Optional[AssetUsage] = None
+    # True for a composed slide that has never been published (no rendered
+    # bundle / checksum yet). Drives the "UNPUBLISHED" badge in the asset
+    # library so users see — before scheduling — that the slide isn't live.
+    unpublished: bool = False
 
 
 class AssetPageOut(BaseModel):

--- a/cms/services/asset_readiness.py
+++ b/cms/services/asset_readiness.py
@@ -20,6 +20,35 @@ from sqlalchemy.orm import selectinload
 
 from cms.models.asset import Asset
 from cms.services.variant_view import is_asset_ready
+from shared.models.asset import AssetType
+
+# Reason string surfaced when a composed slide has never been published
+# (no rendered bundle / checksum yet). Kept as a module constant so the UI
+# annotation (scheduler dropdown) and the server-side gate share one phrase.
+COMPOSED_UNPUBLISHED_REASON = "not published yet"
+
+
+def composed_unpublished_reason(asset: Asset | None) -> str | None:
+    """Return a reason when ``asset`` is a composed slide with no bundle yet.
+
+    A composed slide only becomes device-deliverable after **Publish**, which
+    renders the HTML bundle and stamps the bound Asset's ``checksum`` /
+    ``filename``. Until then there is no blob for the device to download, so
+    scheduling it 404s the device in a retry loop.
+
+    The check intentionally gates on the **checksum** (i.e. "has a published
+    bundle"), not on ``ComposedSlide.is_draft``. A slide that was published and
+    then edited is flagged ``is_draft=True`` but still has a valid checksum and
+    bundle, so the device can keep playing the last published version — that
+    case stays schedulable. Only *never-published* slides are blocked here.
+
+    Returns the reason string, or ``None`` when the asset is fine to schedule.
+    """
+    if asset is None:
+        return None
+    if getattr(asset, "asset_type", None) != AssetType.COMPOSED:
+        return None
+    return COMPOSED_UNPUBLISHED_REASON if not getattr(asset, "checksum", None) else None
 
 
 async def require_asset_ready(db: AsyncSession, asset_id: uuid.UUID) -> Asset:
@@ -48,5 +77,15 @@ async def require_asset_ready(db: AsyncSession, asset_id: uuid.UUID) -> Asset:
         raise HTTPException(
             status_code=422,
             detail=f"Asset is not ready for assignment ({reason}).",
+        )
+
+    # Composed slides must be published before they can be scheduled — an
+    # unpublished slide has no bundle for the device to download (404 loop).
+    composed_reason = composed_unpublished_reason(asset)
+    if composed_reason:
+        raise HTTPException(
+            status_code=422,
+            detail="This composed slide hasn't been published yet. "
+            "Open it in the editor and click Publish before scheduling it.",
         )
     return asset

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -1104,6 +1104,23 @@ async def build_device_sync(
                 # Pre-resolve slideshow checksum so the entry's
                 # asset_checksum reflects per-profile variant choice.
                 await _get_slideshow_checksum(s.asset)
+            # Backstop: never emit a composed slide that has no published
+            # bundle (no checksum). Without a bundle the device 404s in a
+            # fetch loop. The UI/API gates should prevent this from ever
+            # being scheduled, but this guarantees a bad row can't reach the
+            # device's schedule.json regardless of how it got enabled. Shares
+            # the predicate with the scheduling gate (single source of truth).
+            from cms.services.asset_readiness import composed_unpublished_reason
+            if composed_unpublished_reason(s.asset):
+                logger.warning(
+                    "Skipping composed schedule %s (asset %s '%s') for device %s: "
+                    "no published bundle (checksum is empty); slide must be published first",
+                    s.id,
+                    s.asset.id,
+                    s.asset.filename,
+                    device_id,
+                )
+                continue
             entries.append(_schedule_to_entry(s, variant_checksums, slideshow_checksums))
 
     # Per-device timezone overrides the CMS global timezone

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -216,7 +216,9 @@
                     {% endif %}
                 </td>
                 <td data-live-variants="{{ a.id }}">
-                    {% if a.asset_type.value == 'webpage' or a.asset_type.value == 'stream' %}
+                    {% if a.asset_type.value == 'composed' and not a.checksum %}
+                    <span class="has-tooltip"><span class="badge badge-failed">⚠ Unpublished</span><span class="tooltip">This composed slide has not been published — it will not appear on devices until you open it and click Publish.</span></span>
+                    {% elif a.asset_type.value == 'webpage' or a.asset_type.value == 'stream' %}
                     —
                     {% elif a.asset_type.value == 'slideshow' %}
                         {% if a.slide_count is defined and a.slide_count > 0 %}

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -700,6 +700,10 @@
     };
 
     function buildVariantBadge(a) {
+        if (a.unpublished) {
+            return '<span class="has-tooltip"><span class="badge badge-failed">⚠ Unpublished</span>' +
+                '<span class="tooltip">This composed slide has not been published — it will not appear on devices until you open it and click Publish.</span></span>';
+        }
         if (a.asset_type === 'slideshow') {
             const n = a.slide_count || 0;
             if (n > 0) {
@@ -1249,6 +1253,7 @@ function fallbackCopy(text, onSuccess) {
                     : _typeIcon(a.asset_type)) +
                 '<input type="checkbox" class="bulk-select-grid" data-asset-id="' + a.id + '" onclick="event.stopPropagation()" style="position:absolute; top:6px; left:6px; transform:scale(1.2);">' +
                 (a.is_global ? '<span class="badge badge-ready" style="position:absolute; top:6px; right:6px; font-size:0.7rem;">Global</span>' : '') +
+                (a.unpublished ? '<span title="This composed slide has not been published — it will not appear on devices until you open it and click Publish." style="position:absolute; bottom:6px; left:6px; background:#dc2626; color:#fff; font-size:0.65rem; font-weight:700; letter-spacing:0.03em; padding:0.15rem 0.4rem; border-radius:4px;">⚠ UNPUBLISHED</span>' : '') +
             '</div>' +
             '<div style="padding:0.5rem;">' +
                 '<div class="asset-grid-name" title="' + _escHtml(name) + '" style="font-size:0.85rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">' + _escHtml(name) + '</div>' +

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -64,6 +64,25 @@
 
     <div id="msg-box" style="margin-top:0.5rem; display:none; padding:0.5rem 0.75rem; border-radius:6px;"></div>
 
+    <!-- Persistent publish-state banner. Non-flashing (no animation) so it's
+         clearly visible without being annoying. Server renders the initial
+         state; markDraft()/markPublished() update it live as the user edits. -->
+    <div id="publish-banner" role="status"
+         style="margin-top:0.5rem; display:{% if edit_mode and is_draft %}block{% else %}none{% endif %};
+                padding:0.6rem 0.85rem; border-radius:8px; font-size:0.9rem;
+                border-left:5px solid
+                {% if edit_mode and is_draft and not bundle_built_at %}#dc2626{% else %}#f59e0b{% endif %};
+                background:
+                {% if edit_mode and is_draft and not bundle_built_at %}#fef2f2;color:#991b1b{% else %}#fffbeb;color:#92400e{% endif %};">
+        {% if edit_mode and is_draft and not bundle_built_at %}
+        <strong>⚠ Not published.</strong> This slide will <strong>not appear on any device</strong>
+        until you click <strong>Publish</strong>. Saving only stores a draft.
+        {% elif edit_mode and is_draft %}
+        <strong>⚠ Unpublished changes.</strong> Devices are still showing the
+        <strong>last published version</strong>. Click <strong>Publish</strong> to push your edits.
+        {% endif %}
+    </div>
+
     <div class="composed-editor">
         <aside class="palette">
             <h3>Palette</h3>
@@ -459,6 +478,9 @@
 <script>
 let ASSET_ID = {% if asset_id %}"{{ asset_id }}"{% else %}null{% endif %};
 const EDIT_MODE = {% if edit_mode %}true{% else %}false{% endif %};
+// Whether a published bundle has ever been built for this slide. Drives the
+// "never published" (red) vs "unpublished changes" (amber) banner variant.
+let BUNDLE_EVER_BUILT = {% if bundle_built_at %}true{% else %}false{% endif %};
 const SCHEMA_VERSION = {{ schema_version|tojson }};
 let LAYOUT = {{ layout_json|tojson }};
 let selectedPaletteType = null;
@@ -1452,7 +1474,7 @@ async function saveLayout(opts) {
             flash(msg, false);
             return false;
         }
-        flash("Saved.", true);
+        flash("Saved as draft — not live on devices yet. Click Publish to push it.", true);
         markDraft();
         clearDirty();
         if (isCreate && !opts.skipRedirect) {
@@ -1502,11 +1524,40 @@ async function publishLayout() {
     }
 }
 
+function setPublishBanner(state) {
+    // state: "never" (red, no bundle yet), "stale" (amber, edited since
+    // publish), or "published" (hidden).
+    const banner = document.getElementById("publish-banner");
+    if (!banner) return;
+    if (state === "published") {
+        banner.style.display = "none";
+        return;
+    }
+    if (state === "never") {
+        banner.style.display = "block";
+        banner.style.borderLeft = "5px solid #dc2626";
+        banner.style.background = "#fef2f2";
+        banner.style.color = "#991b1b";
+        banner.innerHTML = "<strong>\u26a0 Not published.</strong> This slide will " +
+            "<strong>not appear on any device</strong> until you click " +
+            "<strong>Publish</strong>. Saving only stores a draft.";
+    } else {
+        banner.style.display = "block";
+        banner.style.borderLeft = "5px solid #f59e0b";
+        banner.style.background = "#fffbeb";
+        banner.style.color = "#92400e";
+        banner.innerHTML = "<strong>\u26a0 Unpublished changes.</strong> Devices are " +
+            "still showing the <strong>last published version</strong>. Click " +
+            "<strong>Publish</strong> to push your edits.";
+    }
+}
+
 function markDraft() {
     const pill = document.getElementById("status-pill");
     pill.textContent = "Draft";
     pill.style.background = "#fef3c7";
     pill.style.color = "#92400e";
+    setPublishBanner(BUNDLE_EVER_BUILT ? "stale" : "never");
 }
 
 function markPublished() {
@@ -1514,6 +1565,8 @@ function markPublished() {
     pill.textContent = "Published";
     pill.style.background = "#dcfce7";
     pill.style.color = "#166534";
+    BUNDLE_EVER_BUILT = true;
+    setPublishBanner("published");
 }
 
 // ── Unsaved-changes navigation guard ────────────────────────────────

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1172,8 +1172,12 @@ async def devices_page(request: Request, db: AsyncSession = Depends(get_db)):
     # Annotate each asset with a readiness flag for the splash dropdowns
     # (issue #201). Assets that aren't fully ready are shown but disabled.
     from cms.services.variant_view import is_asset_ready as _is_asset_ready
+    from cms.services.asset_readiness import composed_unpublished_reason as _composed_unpub
     for a in assets_early:
         ready, reason = _is_asset_ready(a.variants)
+        composed_reason = _composed_unpub(a)
+        if ready and composed_reason:
+            ready, reason = False, composed_reason
         a.ready_for_selection = ready
         a.not_ready_reason = reason
     for d in devices:
@@ -2033,8 +2037,12 @@ async def schedules_page(request: Request, db: AsyncSession = Depends(get_db)):
         a._group_ids_json = asset_group_map.get(str(a.id), [])
     # Readiness flag for schedule asset picker (issue #201).
     from cms.services.variant_view import is_asset_ready as _is_asset_ready
+    from cms.services.asset_readiness import composed_unpublished_reason as _composed_unpub
     for a in assets:
         ready, reason = _is_asset_ready(a.variants)
+        composed_reason = _composed_unpub(a)
+        if ready and composed_reason:
+            ready, reason = False, composed_reason
         a.ready_for_selection = ready
         a.not_ready_reason = reason
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4487,6 +4487,10 @@ components:
           anyOf:
           - $ref: '#/components/schemas/AssetUsage'
           - type: 'null'
+        unpublished:
+          type: boolean
+          title: Unpublished
+          default: false
       type: object
       required:
       - id

--- a/tests/test_asset_readiness_helpers.py
+++ b/tests/test_asset_readiness_helpers.py
@@ -12,7 +12,11 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 from cms.services.variant_view import collapse_to_ready, is_asset_ready
-from shared.models.asset import VariantStatus
+from cms.services.asset_readiness import (
+    COMPOSED_UNPUBLISHED_REASON,
+    composed_unpublished_reason,
+)
+from shared.models.asset import AssetType, VariantStatus
 
 
 @dataclass
@@ -177,3 +181,48 @@ class TestIsAssetReady:
             _mk(p2, VariantStatus.PROCESSING, deleted=True),
         ]
         assert is_asset_ready(vs) == (True, None)
+
+
+@dataclass
+class _FakeAsset:
+    """Minimal stand-in for Asset — only the columns the composed gate reads."""
+
+    asset_type: AssetType
+    checksum: str | None = None
+
+
+class TestComposedUnpublishedReason:
+    """``composed_unpublished_reason`` gates scheduling/sync of composed slides
+    that have never been published (no rendered bundle → device 404 loop).
+
+    The gate keys on the **checksum**, not ``is_draft``: a published-then-edited
+    slide keeps its old bundle/checksum and stays schedulable (devices play the
+    last published version), so only never-published slides are blocked.
+    """
+
+    def test_none_asset_is_ok(self):
+        assert composed_unpublished_reason(None) is None
+
+    def test_non_composed_is_ok(self):
+        # A video asset with no checksum is not our concern here.
+        a = _FakeAsset(asset_type=AssetType.VIDEO, checksum=None)
+        assert composed_unpublished_reason(a) is None
+
+    def test_composed_without_checksum_is_blocked(self):
+        a = _FakeAsset(asset_type=AssetType.COMPOSED, checksum=None)
+        assert composed_unpublished_reason(a) == COMPOSED_UNPUBLISHED_REASON
+
+    def test_composed_empty_string_checksum_is_blocked(self):
+        a = _FakeAsset(asset_type=AssetType.COMPOSED, checksum="")
+        assert composed_unpublished_reason(a) == COMPOSED_UNPUBLISHED_REASON
+
+    def test_published_composed_is_ok(self):
+        # Has a bundle checksum → published at least once → schedulable.
+        a = _FakeAsset(asset_type=AssetType.COMPOSED, checksum="abc123")
+        assert composed_unpublished_reason(a) is None
+
+    def test_stale_but_published_composed_is_ok(self):
+        """Published-then-edited slide: checksum still present (old bundle),
+        so it must stay schedulable even though it's a draft again."""
+        a = _FakeAsset(asset_type=AssetType.COMPOSED, checksum="oldbundle")
+        assert composed_unpublished_reason(a) is None

--- a/tests/test_composed_publish_gate.py
+++ b/tests/test_composed_publish_gate.py
@@ -1,0 +1,142 @@
+"""Server-side gate: a composed slide can't be scheduled until it's published.
+
+The user-facing bug this guards against: a composed slide was saved + scheduled
+but never **published**, so no HTML bundle/checksum existed and the device 404'd
+forever trying to download it. ``require_asset_ready`` now rejects an
+unpublished composed asset (no checksum) with 422, while leaving a
+published-then-edited (stale-but-published) slide schedulable because its old
+bundle/checksum still serves the device.
+
+These are DB-integration tests against the real ``require_asset_ready``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from cms.models.asset import Asset, AssetType
+from cms.services.asset_readiness import require_asset_ready
+
+
+@pytest.mark.asyncio
+async def test_unpublished_composed_is_rejected(db_session):
+    """COMPOSED asset with no checksum (never published) → 422."""
+    asset = Asset(
+        filename="New Slide",
+        asset_type=AssetType.COMPOSED,
+        checksum=None,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    with pytest.raises(HTTPException) as ei:
+        await require_asset_ready(db_session, asset.id)
+    assert ei.value.status_code == 422
+    assert "published" in str(ei.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_published_composed_is_allowed(db_session):
+    """COMPOSED asset with a bundle checksum → passes the gate."""
+    asset = Asset(
+        filename="composed-deadbeef.html",
+        asset_type=AssetType.COMPOSED,
+        checksum="abc123def456",
+        size_bytes=2048,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    out = await require_asset_ready(db_session, asset.id)
+    assert out.id == asset.id
+
+
+@pytest.mark.asyncio
+async def test_stale_but_published_composed_is_allowed(db_session):
+    """Published-then-edited slide: checksum still present from the last
+    published bundle → must stay schedulable (device plays last version)."""
+    asset = Asset(
+        filename="composed-cafe.html",
+        asset_type=AssetType.COMPOSED,
+        checksum="oldbundlechecksum",
+        size_bytes=4096,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    out = await require_asset_ready(db_session, asset.id)
+    assert out.id == asset.id
+
+
+@pytest.mark.asyncio
+async def test_non_composed_without_variants_is_allowed(db_session):
+    """A plain URL-style asset (no variants, not composed) is unaffected."""
+    asset = Asset(
+        filename="https://example.com",
+        asset_type=AssetType.WEBPAGE,
+        url="https://example.com",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    out = await require_asset_ready(db_session, asset.id)
+    assert out.id == asset.id
+
+
+def test_asset_out_marks_unpublished_composed():
+    """Library serializer flags a never-published composed slide so the
+    'UNPUBLISHED' badge renders in the asset grid/table."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+    from cms.routers.assets import _asset_out_with_thumb
+
+    asset = Asset(
+        id=_uuid.uuid4(),
+        filename="New Slide",
+        asset_type=AssetType.COMPOSED,
+        checksum="",
+        size_bytes=0,
+        uploaded_at=datetime.now(timezone.utc),
+        is_global=False,
+    )
+    out = _asset_out_with_thumb(asset, {})
+    assert out.unpublished is True
+
+
+def test_asset_out_published_composed_not_flagged():
+    """A published composed slide (has a bundle checksum) is not flagged."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+    from cms.routers.assets import _asset_out_with_thumb
+
+    asset = Asset(
+        id=_uuid.uuid4(),
+        filename="composed-deadbeef.html",
+        asset_type=AssetType.COMPOSED,
+        checksum="abc123",
+        size_bytes=2048,
+        uploaded_at=datetime.now(timezone.utc),
+        is_global=False,
+    )
+    out = _asset_out_with_thumb(asset, {})
+    assert out.unpublished is False
+
+
+def test_asset_out_non_composed_not_flagged():
+    """Non-composed assets never carry the unpublished badge."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+    from cms.routers.assets import _asset_out_with_thumb
+
+    asset = Asset(
+        id=_uuid.uuid4(),
+        filename="clip.mp4",
+        asset_type=AssetType.VIDEO,
+        checksum="",
+        size_bytes=1024,
+        uploaded_at=datetime.now(timezone.utc),
+        is_global=False,
+    )
+    out = _asset_out_with_thumb(asset, {})
+    assert out.unpublished is False


### PR DESCRIPTION
## Why

A composed slide that was **saved + scheduled but never published** has no rendered HTML bundle/checksum, so the device 404s forever and nothing in the UI warns the user. (This is exactly what bit the Pi100.) Saving vs Publishing was also not obvious.

## What

Layered guardrails so an unpublished composed slide is **impossible to ship** and **obvious** to the user:

- **Server gate** (`require_asset_ready`): a never-published composed asset (no checksum) → 422. Gates on `checksum`, **never** `is_draft`, so a published-then-edited *stale-but-published* slide stays schedulable (device keeps playing the last good bundle).
- **Schedule re-enable gate** (`update_schedule`): 422 when re-enabling/editing a schedule pointed at an unpublished composed asset. Create path covered automatically by `require_asset_ready`.
- **Sync backstop** (`build_device_sync`): belt-and-suspenders — skips any unpublished composed slide so a bad row can never reach `schedule.json`.
- **Scheduler dropdowns** (devices + schedules pages): unpublished composed slides are disabled + annotated with the reason.
- **Editor banner**: persistent, non-flashing banner — red *Not published* (never published) / amber *Unpublished changes* (stale). Live-updated on edit/publish. Save flash reworded to make draft-vs-live explicit. (No flashing Publish button, per request.)
- **Library badge**: new `AssetOut.unpublished` flag drives an **UNPUBLISHED** badge in both the grid (corner ribbon) and table (variant cell), server-rendered + live-refreshed.

## Tests

Helper unit tests, `require_asset_ready` DB tests, `AssetOut` serializer tests, plus existing schedules / device-sync / phase2 suites — **100 passing** locally (`-p no:timeout`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
