### PR TITLE
feat(composed): AI-assistant draft-layout endpoints + MCP tools + editor-mode tool scoping

### DIFF
--- a/alembic/versions/0039_chat_thread_mode.py
+++ b/alembic/versions/0039_chat_thread_mode.py
@@ -1,0 +1,45 @@
+"""Alembic migration 0039 — composed-editor mode on chat threads.
+
+Adds ``mode`` to ``chat_threads`` so a thread can select which tool
+profile the assistant runs with.  ``"general"`` (the default and the
+only value any existing thread has) keeps the full read + approval-gated
+fleet tools; ``"composed_editor"`` exposes only the small composed-slide
+editor tool profile (see
+:mod:`cms.services.assistant.mcp_client` for ``tools_for_mode``).
+
+The column is NOT NULL with a ``"general"`` server default so every
+pre-existing row backfills to general mode automatically.  Editor-mode
+threads are created server-side by the composed-slide editor (a later
+PR); the public chat-thread create endpoint never sets a non-general
+mode, so a client cannot self-select the editor profile.
+
+Revision ID: 0039
+Revises: 0038
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0039"
+down_revision = "0038"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_threads",
+        sa.Column(
+            "mode",
+            sa.String(length=32),
+            nullable=False,
+            server_default="general",
+        ),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0039 is not supported")

--- a/cms/models/chat_thread.py
+++ b/cms/models/chat_thread.py
@@ -39,6 +39,12 @@ class ChatThread(Base):
     title: Mapped[str] = mapped_column(
         String(200), nullable=False, default="", server_default=""
     )
+    mode: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="general",
+        server_default="general",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -42,7 +42,14 @@ from cms.auth import (
 )
 from cms.composed.bundle import BundleValidationError, build_bundle
 from cms.composed.registry import get_registry
-from cms.composed.schema import Layout, empty_layout
+from cms.composed.schema import (
+    CANVAS_HEIGHT,
+    CANVAS_WIDTH,
+    GRID_COLS,
+    GRID_ROWS,
+    Layout,
+    empty_layout,
+)
 from cms.composed.validate import validate_layout
 from cms.database import get_db
 from cms.models.asset import Asset, AssetType
@@ -122,20 +129,35 @@ async def _load_composed_for_write(
 async def _check_referenced_asset_acl(
     layout: Layout,
     composed_asset: Asset,
+    request: Request,
     db: AsyncSession,
 ) -> None:
     """Reject layouts that reference an asset the audience can't see.
 
-    Mirrors :func:`cms.routers.assets._validate_slideshow_acl` for the
-    composed case. Every asset declared by any widget in the layout
-    must be visible to a superset of the composed slide's audience:
+    Two independent checks are applied to every asset declared by any
+    widget in the layout:
 
-    * Composed slide is global → every referenced asset must also be global.
-    * Composed slide is group-scoped → every referenced asset must be
-      global, or shared with a superset of the composed slide's group set.
-    * Composed slide is personal (no groups, not global) → no extra
-      audience-widening check; visibility is already enforced via
-      ``_verify_asset_access``.
+    1. **Caller visibility.** The current user must be able to see each
+       referenced asset (global, shared with one of their groups, or
+       their own unshared upload). A referenced asset the caller cannot
+       see is reported indistinguishably from a missing one so we don't
+       disclose the existence of another user's private asset. This is
+       what stops a personal composed slide from inlining someone
+       else's private asset by guessing its UUID.
+
+    2. **Audience widening.** Mirrors
+       :func:`cms.routers.assets._validate_slideshow_acl` for the
+       composed case — a referenced asset must be visible to a superset
+       of the composed slide's *delivery* audience:
+
+       * Composed slide is global → every referenced asset must also be
+         global.
+       * Composed slide is group-scoped → every referenced asset must be
+         global, or shared with a superset of the composed slide's group
+         set.
+       * Composed slide is personal (no groups, not global) → no extra
+         audience-widening check (it isn't delivered to a wider audience
+         than the author).
     """
     # Trigger widget registration so we can ask each widget for declared IDs.
     import cms.composed.widgets  # noqa: F401, WPS433
@@ -161,12 +183,24 @@ async def _check_referenced_asset_acl(
     if not referenced:
         return
 
+    # Caller-visibility gate: scope the existence query to the assets the
+    # current user can actually see. A referenced asset that exists but
+    # isn't visible to the caller then falls into ``missing`` below and is
+    # reported as "not found" — closing the cross-user private-asset leak
+    # without disclosing that the asset exists.
+    from cms.routers.assets import _visible_asset_ids  # noqa: WPS433
+
+    user = getattr(request.state, "user", None)
+    visible = await _visible_asset_ids(user, db) if user is not None else None
+
+    asset_query = select(Asset).where(
+        Asset.id.in_(referenced), Asset.deleted_at.is_(None),
+    )
+    if visible is not None:
+        asset_query = asset_query.where(Asset.id.in_(visible))
+
     # Load each referenced asset + the groups it's shared with.
-    asset_rows = (await db.execute(
-        select(Asset).where(
-            Asset.id.in_(referenced), Asset.deleted_at.is_(None),
-        )
-    )).scalars().all()
+    asset_rows = (await db.execute(asset_query)).scalars().all()
     found_ids = {a.id for a in asset_rows}
     missing = referenced - found_ids
     if missing:
@@ -205,7 +239,9 @@ async def _check_referenced_asset_acl(
         return
 
     if not composed_groups:
-        # Personal slide — visibility was already enforced upstream.
+        # Personal slide — caller-visibility was enforced by the gate
+        # above; no audience-widening check needed (it isn't delivered to
+        # a wider audience than the author).
         return
 
     failures: list[str] = []
@@ -224,6 +260,191 @@ async def _check_referenced_asset_acl(
                 "mark global) first."
             ),
         )
+
+
+def _build_widget_types() -> list[dict[str, Any]]:
+    """Introspect the widget registry into LLM-friendly type descriptors.
+
+    Each entry carries the widget's config JSON-schema, defaults, the
+    required field names, and a ``references_asset`` flag so an AI
+    caller knows which widgets need a real ``asset_id`` from the asset
+    library. This is the source of truth the assistant consults before
+    placing widgets, preventing hallucinated types / config fields.
+    """
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    registry = get_registry()
+    out: list[dict[str, Any]] = []
+    for widget in registry.all():
+        schema = widget.ConfigSchema.model_json_schema()
+        props = schema.get("properties", {})
+        out.append(
+            {
+                "type": widget.slug,
+                "display_name": widget.display_name,
+                "icon": widget.icon,
+                "config_version": widget.config_version,
+                "references_asset": "asset_id" in props,
+                "required_fields": schema.get("required", []),
+                "default_config": widget.default_config(),
+                "config_schema": schema,
+            }
+        )
+    return out
+
+
+def _friendly_to_layout_dict(
+    widgets_in: Any,
+    background_color: str | None,
+    current_layout: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Translate the friendly widget list into a canonical Layout dict.
+
+    The friendly shape hides the parts of the canonical ``Layout`` that
+    are either locked (canvas 1920x1080, grid 12x8) or machine-managed
+    (per-widget UUID ``id``, ``config_version``). Each friendly widget
+    is ``{type, row, col, rowspan?, colspan?, config?, id?}``. A missing
+    ``id`` gets a fresh ``uuid4``; a supplied ``id`` is preserved so
+    edits keep widget identity. ``config_version`` is taken from the
+    registered widget when the type is known.
+
+    The returned dict is fed straight to ``Layout.model_validate`` so
+    all shape/bounds errors surface through the same 422 path as the
+    canonical PATCH endpoint. Raises 422 only for structurally
+    impossible input (non-list widgets, non-object entries, malformed
+    ``id``).
+    """
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    registry = get_registry()
+
+    if not isinstance(widgets_in, list):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "invalid_widgets",
+                "message": "widgets must be a list",
+            },
+        )
+
+    widgets_out: list[dict[str, Any]] = []
+    for idx, w in enumerate(widgets_in):
+        if not isinstance(w, dict):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error": "invalid_widget",
+                    "message": f"widget at index {idx} must be an object",
+                },
+            )
+        raw_id = w.get("id")
+        if raw_id is not None:
+            try:
+                widget_id = str(uuid.UUID(str(raw_id)))
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "invalid_widget_id",
+                        "message": (
+                            f"widget at index {idx} has a malformed id: "
+                            f"{raw_id!r}"
+                        ),
+                    },
+                ) from exc
+        else:
+            widget_id = str(uuid.uuid4())
+
+        wtype = w.get("type")
+        known = registry.get(wtype) if isinstance(wtype, str) else None
+        config_version = known.config_version if known is not None else 1
+
+        widgets_out.append(
+            {
+                "id": widget_id,
+                "type": wtype,
+                "cell": {
+                    "row": w.get("row"),
+                    "col": w.get("col"),
+                    "rowspan": w.get("rowspan", 1),
+                    "colspan": w.get("colspan", 1),
+                },
+                "config": w.get("config", {}),
+                "config_version": config_version,
+            }
+        )
+
+    if background_color is not None:
+        bg_color = background_color
+    elif current_layout:
+        bg_color = (current_layout.get("background") or {}).get(
+            "color", "#000000"
+        )
+    else:
+        bg_color = "#000000"
+
+    return {
+        "background": {"color": bg_color},
+        "widgets": widgets_out,
+    }
+
+
+async def _validate_persist_layout(
+    asset: Asset,
+    composed: ComposedSlide,
+    layout: Layout,
+    user: User,
+    request: Request,
+    db: AsyncSession,
+    *,
+    action: str,
+) -> dict[str, Any]:
+    """Run semantic + ACL validation, then persist the layout as a draft.
+
+    Shared by the canonical PATCH endpoint and the friendly PUT endpoint
+    so the validate -> ACL -> persist -> audit sequence lives in one
+    place. Raises 422 (semantic) / 400 (ACL) exactly as the PATCH path.
+    """
+    registry = get_registry()
+    errors = validate_layout(layout, registry)
+    if errors:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "invalid_layout",
+                "errors": [
+                    {
+                        "code": err.code,
+                        "message": err.message,
+                        "widget_id": err.widget_id,
+                    }
+                    for err in errors
+                ],
+            },
+        )
+
+    await _check_referenced_asset_acl(layout, asset, request, db)
+
+    composed.layout_json = layout.model_dump(mode="json")
+    composed.schema_version = layout.schema_version
+    composed.is_draft = True
+
+    await audit_log(
+        db,
+        user=user,
+        action=action,
+        resource_type="asset",
+        resource_id=str(asset.id),
+        description=f"Updated composed-slide layout for '{asset.filename}'",
+        details={"widget_count": len(layout.widgets)},
+        request=request,
+    )
+    await db.commit()
+    return {
+        "id": str(asset.id),
+        "is_draft": True,
+        "widget_count": len(layout.widgets),
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -613,46 +834,15 @@ async def patch_composed_layout(
             detail={"error": "invalid_layout_shape", "message": str(e)},
         ) from e
 
-    registry = get_registry()
-    errors = validate_layout(layout, registry)
-    if errors:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "invalid_layout",
-                "errors": [
-                    {
-                        "code": err.code,
-                        "message": err.message,
-                        "widget_id": err.widget_id,
-                    }
-                    for err in errors
-                ],
-            },
-        )
-
-    await _check_referenced_asset_acl(layout, asset, db)
-
-    composed.layout_json = layout.model_dump(mode="json")
-    composed.schema_version = layout.schema_version
-    composed.is_draft = True
-
-    await audit_log(
+    return await _validate_persist_layout(
+        asset,
+        composed,
+        layout,
+        user,
+        request,
         db,
-        user=user,
         action="asset.update_composed_layout",
-        resource_type="asset",
-        resource_id=str(asset.id),
-        description=f"Updated composed-slide layout for '{asset.filename}'",
-        details={"widget_count": len(layout.widgets)},
-        request=request,
     )
-    await db.commit()
-    return {
-        "id": str(asset.id),
-        "is_draft": True,
-        "widget_count": len(layout.widgets),
-    }
 
 
 @router.post("/{asset_id}/publish")
@@ -726,3 +916,108 @@ async def publish_composed_endpoint(
         "rebuilt": result.rebuilt,
         "is_draft": False,
     }
+
+
+@router.get("/widget-types")
+async def list_composed_widget_types() -> dict[str, Any]:
+    """Return the catalog of available composed-slide widget types.
+
+    Read-only registry introspection. Each entry has the widget's config
+    JSON-schema, default config, required fields, and whether it
+    references an asset. Powers the AI assistant's widget discovery so
+    it never invents a widget type or config field.
+    """
+    return {"widget_types": _build_widget_types()}
+
+
+@router.get("/{asset_id}/layout")
+async def get_composed_layout(
+    asset_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Return the current draft layout in the friendly widget shape.
+
+    Read-only. Widget ``id``s are included so an AI edit can preserve
+    widget identity by sending them back unchanged. The locked canvas
+    and grid are reported for context but are not editable.
+    """
+    asset, composed = await _load_composed_for_write(asset_id, request, db)
+    raw = composed.layout_json or {}
+    bg = (raw.get("background") or {}).get("color", "#000000")
+
+    widgets_out: list[dict[str, Any]] = []
+    for w in raw.get("widgets", []):
+        cell = w.get("cell") or {}
+        widgets_out.append(
+            {
+                "id": w.get("id"),
+                "type": w.get("type"),
+                "row": cell.get("row"),
+                "col": cell.get("col"),
+                "rowspan": cell.get("rowspan", 1),
+                "colspan": cell.get("colspan", 1),
+                "config": w.get("config", {}),
+                "config_version": w.get("config_version", 1),
+            }
+        )
+
+    return {
+        "id": str(asset.id),
+        "is_draft": composed.is_draft,
+        "background_color": bg,
+        "canvas": {"width": CANVAS_WIDTH, "height": CANVAS_HEIGHT},
+        "grid": {"rows": GRID_ROWS, "cols": GRID_COLS},
+        "widgets": widgets_out,
+    }
+
+
+@router.put("/{asset_id}/layout-friendly")
+async def put_composed_layout_friendly(
+    asset_id: uuid.UUID,
+    request: Request,
+    body: dict[str, Any] = Body(...),
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Replace a draft's layout from the friendly widget shape.
+
+    Body: ``{widgets: [...], background_color?: "#rrggbb"}`` where each
+    widget is ``{type, row, col, rowspan?, colspan?, config?, id?}``.
+    The server assigns/preserves widget UUIDs and pins the locked
+    canvas/grid, then runs the exact same shape + semantic + asset-ACL
+    validation as the canonical PATCH endpoint. Sets ``is_draft=True``.
+
+    This is the AI-assistant write path: the LLM never has to spell out
+    the locked canvas/grid or manage widget UUIDs, which is the source
+    of the "extra inputs not permitted" failures it would otherwise hit.
+    """
+    asset, composed = await _load_composed_for_write(asset_id, request, db)
+
+    # Trigger widget registration before validate_layout uses the registry.
+    import cms.composed.widgets  # noqa: F401, WPS433
+
+    layout_dict = _friendly_to_layout_dict(
+        body.get("widgets", []),
+        body.get("background_color"),
+        composed.layout_json,
+    )
+    try:
+        layout = Layout.model_validate(layout_dict)
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "invalid_layout_shape", "message": str(e)},
+        ) from e
+
+    return await _validate_persist_layout(
+        asset,
+        composed,
+        layout,
+        user,
+        request,
+        db,
+        action="asset.update_composed_layout",
+    )

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -57,11 +57,12 @@ from cms.services.assistant.llm_client import (
     LLMClient,
 )
 from cms.services.assistant.mcp_client import (
-    ALLOWED_TOOLS,
     AssistantMcpClient,
     McpUnavailableError,
-    READ_ONLY_TOOLS,
+    MODE_GENERAL,
     WRITE_TOOLS,
+    executable_tools_for_mode,
+    tools_for_mode,
 )
 from cms.services.assistant.prompts import build_system_prompt
 
@@ -120,8 +121,13 @@ async def _execute_tool_call(
     *,
     mcp: AssistantMcpClient,
     tool_call: dict[str, Any],
+    executable_tools: frozenset[str],
 ) -> str:
     """Run a single OpenAI ``tool_call`` against MCP, returning a string.
+
+    ``executable_tools`` is the set of tools the current thread mode may
+    run inline without an approval click (see
+    :func:`cms.services.assistant.mcp_client.executable_tools_for_mode`).
 
     Never raises — failures are encoded as JSON ``{"error": ...}`` so
     the LLM can see the failure and reason about it on the next turn.
@@ -131,9 +137,9 @@ async def _execute_tool_call(
     args, err = _parse_tool_arguments(fn.get("arguments"))
     if err is not None:
         return json.dumps({"error": "bad_arguments", "message": err})
-    if name not in READ_ONLY_TOOLS:
-        # Non-streaming agent path only invokes reads.  Write tools
-        # need the approval flow, which lives in the streaming agent.
+    if name not in executable_tools:
+        # Either a fleet write tool (needs the approval flow, which lives
+        # in the streaming agent) or a tool not exposed in this mode.
         # Tell the model so it doesn't keep retrying.
         return json.dumps(
             {
@@ -233,7 +239,9 @@ async def run_user_turn(
 
     final_assistant_row: ChatMessage | None = None
     try:
-        tools = await mcp.list_openai_tools()
+        mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
+        executable_tools = executable_tools_for_mode(mode)
+        tools = await mcp.list_openai_tools(mode=mode)
         max_iters = max(1, int(settings.assistant_max_tool_iterations))
 
         for iteration in range(max_iters):
@@ -277,7 +285,9 @@ async def run_user_turn(
             # Execute each tool call and persist its result.
             for tool_call in result.tool_calls:
                 tool_content = await _execute_tool_call(
-                    mcp=mcp, tool_call=tool_call
+                    mcp=mcp,
+                    tool_call=tool_call,
+                    executable_tools=executable_tools,
                 )
                 tool_row = ChatMessage(
                     thread_id=thread.id,
@@ -450,7 +460,10 @@ async def run_user_turn_streaming(
 
     final_row: ChatMessage | None = None
     try:
-        tools = await mcp.list_openai_tools()
+        mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
+        mode_tools = tools_for_mode(mode)
+        executable_tools = executable_tools_for_mode(mode)
+        tools = await mcp.list_openai_tools(mode=mode)
         max_iters = max(1, int(settings.assistant_max_tool_iterations))
 
         for iteration in range(max_iters):
@@ -540,12 +553,12 @@ async def run_user_turn_streaming(
                 # approve / reject endpoint OVERWRITES this row's
                 # content with the real result once the user decides.
                 #
-                # Anything outside the union of READ_ONLY_TOOLS and
-                # WRITE_TOOLS is treated as a hallucinated tool name
-                # and returned as a synthetic error so the LLM can
-                # recover (rather than queuing an approval the user
-                # would just have to reject).
-                if tc_name and tc_name not in ALLOWED_TOOLS:
+                # Anything outside the current mode's tool profile is
+                # treated as a hallucinated or out-of-mode tool name and
+                # returned as a synthetic error so the LLM can recover
+                # (rather than queuing an approval the user would just
+                # have to reject).
+                if tc_name and tc_name not in mode_tools:
                     err = json.dumps(
                         {
                             "error": "tool_not_allowed",
@@ -644,7 +657,9 @@ async def run_user_turn_streaming(
                     continue
 
                 tool_content = await _execute_tool_call(
-                    mcp=mcp, tool_call=tool_call
+                    mcp=mcp,
+                    tool_call=tool_call,
+                    executable_tools=executable_tools,
                 )
                 tool_row = ChatMessage(
                     thread_id=thread.id,

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -147,6 +147,80 @@ WRITE_TOOLS: frozenset[str] = frozenset(
 ALLOWED_TOOLS: frozenset[str] = READ_ONLY_TOOLS | WRITE_TOOLS
 
 
+# ── Composed-slide editor mode ────────────────────────────────────────
+#
+# The composed-slide editor embeds an assistant whose job is to build
+# the *draft* layout of the one slide the user is editing.  It runs in a
+# dedicated thread ``mode`` ("composed_editor") that exposes a small,
+# purpose-built tool profile and NEVER the general device/schedule/
+# profile fleet-management tools.
+#
+# These tools are deliberately kept OUT of ``READ_ONLY_TOOLS`` /
+# ``WRITE_TOOLS`` / ``ALLOWED_TOOLS`` so the general chat tab can neither
+# advertise nor execute them.  They are only reachable when the thread's
+# mode selects the editor profile below.
+MODE_GENERAL = "general"
+MODE_COMPOSED_EDITOR = "composed_editor"
+VALID_MODES: frozenset[str] = frozenset({MODE_GENERAL, MODE_COMPOSED_EDITOR})
+
+# Composed reads — safe to run inline like any other read.
+COMPOSED_READ_TOOLS: frozenset[str] = frozenset(
+    {
+        "list_composed_widget_types",
+        "get_composed_layout",
+    }
+)
+
+# Composed draft writes — these mutate ONLY the unpublished draft layout
+# of a composed slide.  Publishing a slide to devices is a separate,
+# human-only UI button (never an MCP tool), so a draft write is fully
+# reversible and carries no fleet impact.  They therefore run inline
+# WITHOUT an approval click, exactly like reads.
+COMPOSED_DRAFT_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "set_composed_widgets",
+    }
+)
+
+# Tools the agent may execute immediately, with no approval click.
+# Reads are inherently safe; composed draft writes are reversible and
+# device-invisible (see above).
+NO_APPROVAL_TOOLS: frozenset[str] = (
+    READ_ONLY_TOOLS | COMPOSED_READ_TOOLS | COMPOSED_DRAFT_WRITE_TOOLS
+)
+
+# The editor-mode tool profile: just enough to discover/select assets
+# and read+write the current slide's draft layout.  No device, schedule,
+# profile, log, or audit tools.
+COMPOSED_EDITOR_TOOLS: frozenset[str] = (
+    frozenset({"list_assets", "get_asset"})
+    | COMPOSED_READ_TOOLS
+    | COMPOSED_DRAFT_WRITE_TOOLS
+)
+
+
+def tools_for_mode(mode: str | None) -> frozenset[str]:
+    """Return the set of tools advertised/callable for a thread ``mode``.
+
+    Unknown or ``None`` modes fall back to the general profile so a
+    malformed mode value can never *widen* access.
+    """
+    if mode == MODE_COMPOSED_EDITOR:
+        return COMPOSED_EDITOR_TOOLS
+    return ALLOWED_TOOLS
+
+
+def executable_tools_for_mode(mode: str | None) -> frozenset[str]:
+    """No-approval tools the agent may run directly in ``mode``.
+
+    Intersection of the mode's profile with the global no-approval
+    floor — so editor mode runs its composed tools inline, and general
+    mode keeps running only its reads inline (writes still go through
+    the approval flow).
+    """
+    return NO_APPROVAL_TOOLS & tools_for_mode(mode)
+
+
 def _read_service_key(settings: Settings) -> str:
     """Read the MCP service key.
 
@@ -249,8 +323,15 @@ class AssistantMcpClient:
         except Exception:  # pragma: no cover — defensive
             logger.exception("assistant.mcp.close_failed")
 
-    async def list_openai_tools(self) -> list[dict[str, Any]]:
-        """Return MCP tools filtered to the read-only whitelist, in OpenAI format.
+    async def list_openai_tools(
+        self, mode: str = MODE_GENERAL
+    ) -> list[dict[str, Any]]:
+        """Return MCP tools filtered to the ``mode`` profile, in OpenAI format.
+
+        ``mode`` selects which tool profile is advertised to the LLM:
+        ``"general"`` (default) exposes the full read + approval-gated
+        write fleet tools; ``"composed_editor"`` exposes only the small
+        composed-slide editor profile.
 
         OpenAI's tool schema is:
         ``{"type":"function", "function":{"name":..., "description":..., "parameters":{...}}}``
@@ -258,10 +339,11 @@ class AssistantMcpClient:
         """
         if self._session is None:  # pragma: no cover
             raise RuntimeError("AssistantMcpClient not entered")
+        exposed = tools_for_mode(mode)
         listing = await self._session.list_tools()
         out: list[dict[str, Any]] = []
         for tool in listing.tools:
-            if tool.name not in ALLOWED_TOOLS:
+            if tool.name not in exposed:
                 continue
             description = tool.description or ""
             if tool.name in WRITE_TOOLS:
@@ -316,10 +398,10 @@ class AssistantMcpClient:
         """
         if self._session is None:  # pragma: no cover
             raise RuntimeError("AssistantMcpClient not entered")
-        if not bypass_whitelist and name not in READ_ONLY_TOOLS:
+        if not bypass_whitelist and name not in NO_APPROVAL_TOOLS:
             raise PermissionError(
-                f"Tool '{name}' is not in the read-only whitelist "
-                "(writes require approval)."
+                f"Tool '{name}' is not in the no-approval whitelist "
+                "(fleet writes require approval)."
             )
         if bypass_whitelist and name not in ALLOWED_TOOLS:
             # Defence in depth: the approval router calls us with

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -328,6 +328,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - composed
+      summary: Get Composed Layout
+      description: |-
+        Return the current draft layout in the friendly widget shape.
+
+        Read-only. Widget ``id``s are included so an AI edit can preserve
+        widget identity by sending them back unchanged. The locked canvas
+        and grid are reported for context but are not editable.
+      operationId: get_composed_layout_composed__asset_id__layout_get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Composed Layout Composed  Asset Id  Layout Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /composed/{asset_id}/publish:
     post:
       tags:
@@ -358,6 +392,77 @@ paths:
                 type: object
                 additionalProperties: true
                 title: Response Publish Composed Endpoint Composed  Asset Id  Publish Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /composed/widget-types:
+    get:
+      tags:
+      - composed
+      summary: List Composed Widget Types
+      description: |-
+        Return the catalog of available composed-slide widget types.
+
+        Read-only registry introspection. Each entry has the widget's config
+        JSON-schema, default config, required fields, and whether it
+        references an asset. Powers the AI assistant's widget discovery so
+        it never invents a widget type or config field.
+      operationId: list_composed_widget_types_composed_widget_types_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response List Composed Widget Types Composed Widget Types Get
+  /composed/{asset_id}/layout-friendly:
+    put:
+      tags:
+      - composed
+      summary: Put Composed Layout Friendly
+      description: |-
+        Replace a draft's layout from the friendly widget shape.
+
+        Body: ``{widgets: [...], background_color?: "#rrggbb"}`` where each
+        widget is ``{type, row, col, rowspan?, colspan?, config?, id?}``.
+        The server assigns/preserves widget UUIDs and pins the locked
+        canvas/grid, then runs the exact same shape + semantic + asset-ACL
+        validation as the canonical PATCH endpoint. Sets ``is_draft=True``.
+
+        This is the AI-assistant write path: the LLM never has to spell out
+        the locked canvas/grid or manage widget UUIDs, which is the source
+        of the "extra inputs not permitted" failures it would otherwise hit.
+      operationId: put_composed_layout_friendly_composed__asset_id__layout_friendly_put
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Body
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Put Composed Layout Friendly Composed  Asset Id  Layout Friendly Put
         '422':
           description: Validation Error
           content:

--- a/mcp/cms_client.py
+++ b/mcp/cms_client.py
@@ -134,6 +134,19 @@ class CMSClient:
     async def create_webpage_asset(self, data: dict) -> dict:
         return await self._post("/api/assets/webpage", json=data)
 
+    # ── Composed slides (AI editor) ──
+
+    async def list_composed_widget_types(self) -> dict:
+        return await self._get("/composed/widget-types")
+
+    async def get_composed_layout(self, asset_id: str) -> dict:
+        return await self._get(f"/composed/{asset_id}/layout")
+
+    async def set_composed_widgets(self, asset_id: str, payload: dict) -> dict:
+        return await self._put(
+            f"/composed/{asset_id}/layout-friendly", json=payload
+        )
+
     # ── Schedules ──
 
     async def list_schedules(self) -> list:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -100,6 +100,9 @@ TOOL_PERMISSIONS: dict[str, str | None] = {
     "get_server_time": None,  # any authenticated user
     "get_dashboard": None,    # any authenticated user
     "list_audit_events": "audit:read",
+    "list_composed_widget_types": "assets:read",
+    "get_composed_layout": "assets:read",
+    "set_composed_widgets": "assets:write",
 }
 
 
@@ -386,6 +389,82 @@ async def create_webpage_asset(
     if group_id:
         data["group_id"] = group_id
     result = await _call_api("create_webpage_asset", data)
+    return _json_result(result)
+
+
+# ── Composed slides (AI editor) ──
+
+
+@mcp.tool()
+async def list_composed_widget_types() -> str:
+    """List the widget types available for building a composed slide.
+
+    Returns each widget's slug (``type``), display name, config
+    JSON-schema, default config, required fields, and a
+    ``references_asset`` flag. Call this before placing widgets so you
+    use real widget types and valid config keys. Widgets whose
+    ``references_asset`` is true (image, media) need a real ``asset_id``
+    from ``list_assets``.
+    """
+    if err := _check_permission("list_composed_widget_types"):
+        return err
+    result = await _call_api("list_composed_widget_types")
+    return _json_result(result)
+
+
+@mcp.tool()
+async def get_composed_layout(asset_id: str) -> str:
+    """Get the current draft layout of a composed slide.
+
+    Returns the slide's background color, the locked canvas/grid, and
+    the placed widgets in friendly form
+    (``{id, type, row, col, rowspan, colspan, config}``). When editing
+    an existing slide, pass each widget's ``id`` back to
+    ``set_composed_widgets`` to preserve its identity.
+
+    Args:
+        asset_id: UUID of the composed-slide asset being edited.
+    """
+    if err := _check_permission("get_composed_layout"):
+        return err
+    result = await _call_api("get_composed_layout", asset_id)
+    return _json_result(result)
+
+
+@mcp.tool()
+async def set_composed_widgets(
+    asset_id: str,
+    widgets: list[dict],
+    background_color: str | None = None,
+) -> str:
+    """Replace the widgets on a composed-slide draft.
+
+    This writes the draft directly (the canvas is on a fixed 8-row x
+    12-column grid, 1-indexed and inclusive). The human reviews and
+    clicks Publish themselves — this tool never publishes. ``widgets``
+    is the FULL replacement list, so include every widget you want kept.
+
+    Each widget is ``{type, row, col, rowspan?, colspan?, config?,
+    id?}``:
+      - ``type``: a slug from ``list_composed_widget_types``.
+      - ``row``/``col``: top-left cell (row 1-8, col 1-12).
+      - ``rowspan``/``colspan``: default 1; must stay within the grid.
+      - ``config``: the widget's config (see its config_schema).
+      - ``id``: omit for a new widget; pass the existing id (from
+        ``get_composed_layout``) to keep a widget's identity on edit.
+
+    On invalid input the call returns structured per-widget errors —
+    fix and retry. Args:
+        asset_id: UUID of the composed-slide asset being edited.
+        widgets: full replacement list of friendly widget objects.
+        background_color: optional slide background hex (e.g. "#101010").
+    """
+    if err := _check_permission("set_composed_widgets"):
+        return err
+    payload: dict = {"widgets": widgets}
+    if background_color is not None:
+        payload["background_color"] = background_color
+    result = await _call_api("set_composed_widgets", asset_id, payload)
     return _json_result(result)
 
 

--- a/tests/test_assistant_composed_mode.py
+++ b/tests/test_assistant_composed_mode.py
@@ -1,0 +1,180 @@
+"""Tests for assistant tool-scoping by thread ``mode`` (PR 1).
+
+The composed-slide editor embeds an assistant that runs in a dedicated
+thread ``mode`` ("composed_editor").  That mode exposes a small,
+purpose-built tool profile (asset discovery + composed read/write) and
+NEVER the general device/schedule/profile fleet-management tools.  The
+general chat tab ("general" mode) keeps its existing behaviour and is
+never able to see or run the composed tools.
+
+These tests pin the scoping contract at three levels:
+
+* pure-function: ``tools_for_mode`` / ``executable_tools_for_mode``.
+* ``list_openai_tools(mode=...)``: the LLM-facing catalog is filtered by
+  mode, using a real ``AssistantMcpClient`` over a fake MCP session.
+* invariants: composed draft writes run inline (no approval) while fleet
+  writes never leak into editor mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cms.services.assistant.mcp_client import (
+    ALLOWED_TOOLS,
+    COMPOSED_DRAFT_WRITE_TOOLS,
+    COMPOSED_EDITOR_TOOLS,
+    COMPOSED_READ_TOOLS,
+    MODE_COMPOSED_EDITOR,
+    MODE_GENERAL,
+    NO_APPROVAL_TOOLS,
+    READ_ONLY_TOOLS,
+    WRITE_TOOLS,
+    AssistantMcpClient,
+    executable_tools_for_mode,
+    tools_for_mode,
+)
+
+
+# Reuse the fake MCP session doubles from the smoke suite.
+from tests.test_chat_smoke import _FakeMcpTool, _make_real_client
+
+
+# ── pure-function scoping ───────────────────────────────────────────
+
+
+class TestModeProfiles:
+    def test_composed_tools_excluded_from_general_whitelists(self):
+        """The composed tools must live OUTSIDE the general whitelists
+        so the general chat tab can neither advertise nor execute them.
+        """
+        composed = COMPOSED_READ_TOOLS | COMPOSED_DRAFT_WRITE_TOOLS
+        assert not (composed & READ_ONLY_TOOLS)
+        assert not (composed & WRITE_TOOLS)
+        assert not (composed & ALLOWED_TOOLS)
+
+    def test_general_mode_is_allowed_tools(self):
+        assert tools_for_mode(MODE_GENERAL) == ALLOWED_TOOLS
+
+    def test_unknown_or_none_mode_falls_back_to_general(self):
+        # A malformed mode must never WIDEN access.
+        assert tools_for_mode(None) == ALLOWED_TOOLS
+        assert tools_for_mode("nonsense") == ALLOWED_TOOLS
+
+    def test_editor_mode_is_scoped_profile(self):
+        prof = tools_for_mode(MODE_COMPOSED_EDITOR)
+        assert prof == COMPOSED_EDITOR_TOOLS
+        # Exactly: asset discovery + composed read/write.
+        assert {"list_assets", "get_asset"} <= prof
+        assert COMPOSED_READ_TOOLS <= prof
+        assert COMPOSED_DRAFT_WRITE_TOOLS <= prof
+
+    def test_editor_mode_excludes_fleet_tools(self):
+        prof = tools_for_mode(MODE_COMPOSED_EDITOR)
+        for fleet in (
+            "list_devices",
+            "create_schedule",
+            "update_asset",
+            "delete_group",
+            "list_audit_logs",
+        ):
+            assert fleet not in prof, f"{fleet!r} leaked into editor mode"
+
+    def test_composed_draft_write_runs_inline(self):
+        """``set_composed_widgets`` is a draft-only write: it must be in
+        the no-approval floor AND executable in editor mode (inline, no
+        approval click)."""
+        assert COMPOSED_DRAFT_WRITE_TOOLS <= NO_APPROVAL_TOOLS
+        execable = executable_tools_for_mode(MODE_COMPOSED_EDITOR)
+        assert "set_composed_widgets" in execable
+        # ...and it is NOT in the fleet WRITE_TOOLS, so the streaming
+        # approval gate never fires for it.
+        assert "set_composed_widgets" not in WRITE_TOOLS
+
+    def test_general_mode_executes_only_reads_inline(self):
+        execable = executable_tools_for_mode(MODE_GENERAL)
+        # Reads run inline; no fleet write is inline-executable.
+        assert READ_ONLY_TOOLS <= execable
+        assert not (execable & WRITE_TOOLS)
+        # Composed tools are not reachable at all in general mode.
+        assert not (execable & COMPOSED_DRAFT_WRITE_TOOLS)
+
+    def test_executable_is_subset_of_advertised(self):
+        for mode in (MODE_GENERAL, MODE_COMPOSED_EDITOR):
+            assert executable_tools_for_mode(mode) <= tools_for_mode(mode)
+
+
+# ── list_openai_tools(mode=...) over a real client ──────────────────
+
+
+@pytest.mark.asyncio
+class TestListOpenAiToolsByMode:
+    def _mixed_tools(self):
+        # A mix of fleet read/write tools and the composed tools, plus
+        # the asset tools the editor profile keeps.
+        return [
+            _FakeMcpTool("list_devices"),
+            _FakeMcpTool("create_schedule"),
+            _FakeMcpTool("list_assets"),
+            _FakeMcpTool("get_asset"),
+            _FakeMcpTool("list_composed_widget_types"),
+            _FakeMcpTool("get_composed_layout"),
+            _FakeMcpTool("set_composed_widgets"),
+        ]
+
+    async def test_general_mode_excludes_composed_tools(self):
+        client = _make_real_client(self._mixed_tools())
+        names = {
+            t["function"]["name"]
+            for t in await client.list_openai_tools(mode=MODE_GENERAL)
+        }
+        assert "list_devices" in names
+        assert "create_schedule" in names
+        for composed in (
+            "list_composed_widget_types",
+            "get_composed_layout",
+            "set_composed_widgets",
+        ):
+            assert composed not in names, f"{composed!r} leaked into general mode"
+
+    async def test_default_mode_matches_general(self):
+        client = _make_real_client(self._mixed_tools())
+        default = {
+            t["function"]["name"] for t in await client.list_openai_tools()
+        }
+        general = {
+            t["function"]["name"]
+            for t in await client.list_openai_tools(mode=MODE_GENERAL)
+        }
+        assert default == general
+
+    async def test_editor_mode_exposes_only_editor_profile(self):
+        client = _make_real_client(self._mixed_tools())
+        names = {
+            t["function"]["name"]
+            for t in await client.list_openai_tools(mode=MODE_COMPOSED_EDITOR)
+        }
+        assert names == {
+            "list_assets",
+            "get_asset",
+            "list_composed_widget_types",
+            "get_composed_layout",
+            "set_composed_widgets",
+        }
+        # No fleet tools.
+        assert "list_devices" not in names
+        assert "create_schedule" not in names
+
+    async def test_composed_write_has_no_approval_note_in_editor(self):
+        """``set_composed_widgets`` is a draft-only write — its
+        description must NOT carry the approval note that fleet writes
+        get, or the LLM will tell the user to click Approve when there's
+        nothing to approve."""
+        client = _make_real_client([
+            _FakeMcpTool("set_composed_widgets", description="Set widgets."),
+        ])
+        by_name = {
+            t["function"]["name"]: t["function"]["description"]
+            for t in await client.list_openai_tools(mode=MODE_COMPOSED_EDITOR)
+        }
+        assert "approv" not in by_name["set_composed_widgets"].lower()

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -154,10 +154,13 @@ class FakeMcpClient:
     async def __aexit__(self, *a) -> None:
         self.closed = True
 
-    async def list_openai_tools(self) -> list[dict]:
+    async def list_openai_tools(self, mode: str = "general") -> list[dict]:
+        self.last_mode = mode
         return list(self._tools)
 
-    async def call_tool(self, name: str, arguments: dict) -> str:
+    async def call_tool(
+        self, name: str, arguments: dict, *, bypass_whitelist: bool = False
+    ) -> str:
         self.calls.append((name, dict(arguments)))
         if name in self._results:
             return self._results[name]

--- a/tests/test_composed_ai_routes.py
+++ b/tests/test_composed_ai_routes.py
@@ -1,0 +1,470 @@
+"""Tests for the AI-assistant composed-slide HTTP routes (PR 1).
+
+Covers the three endpoints that back the editor-embedded AI assistant:
+
+* ``GET  /composed/widget-types``          — widget catalog introspection.
+* ``GET  /composed/{id}/layout``           — friendly read-back of a draft.
+* ``PUT  /composed/{id}/layout-friendly``  — friendly write path the LLM
+  uses (server assigns/preserves UUIDs, pins the locked canvas/grid,
+  then runs the exact same shape + semantic + asset-ACL validation as
+  the canonical PATCH endpoint).
+
+The friendly endpoints exist so the LLM never has to spell out the
+locked canvas/grid or manage widget UUIDs — the source of the "extra
+inputs not permitted" failures it would otherwise hit.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from cms.composed.schema import (
+    CANVAS_HEIGHT,
+    CANVAS_WIDTH,
+    GRID_COLS,
+    GRID_ROWS,
+    Cell,
+    Layout,
+    WidgetInstance,
+    empty_layout,
+)
+from cms.models.asset import Asset, AssetType
+from cms.models.composed_slide import ComposedSlide
+
+
+def _text_widget(text: str = "hi") -> WidgetInstance:
+    return WidgetInstance(
+        id=uuid.uuid4(),
+        type="text",
+        cell=Cell(row=1, col=1, rowspan=1, colspan=4),
+        config={"text": text, "font_size_px": 64},
+        config_version=1,
+    )
+
+
+async def _make_composed(
+    db_session, *, layout: Layout | None = None, is_draft: bool = True,
+) -> tuple[Asset, ComposedSlide]:
+    asset = Asset(
+        filename=f"composed-{uuid.uuid4()}",
+        display_name="Test composed",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(asset)
+    await db_session.flush()
+
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=(layout or empty_layout()).model_dump(mode="json"),
+        is_draft=is_draft,
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    return asset, cs
+
+
+# ─────────────────────── GET /composed/widget-types ─────────────────
+
+
+@pytest.mark.asyncio
+class TestWidgetTypes:
+    async def test_returns_catalog_with_text_widget(self, client):
+        resp = await client.get("/composed/widget-types")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        types = body["widget_types"]
+        assert isinstance(types, list) and types
+
+        by_type = {w["type"]: w for w in types}
+        assert "text" in by_type
+        text = by_type["text"]
+        # Each descriptor carries everything the LLM needs to place a
+        # widget without inventing a type or config field.
+        for key in (
+            "type",
+            "display_name",
+            "config_version",
+            "references_asset",
+            "required_fields",
+            "default_config",
+            "config_schema",
+        ):
+            assert key in text, f"missing {key!r} in widget descriptor"
+        assert text["references_asset"] is False
+        assert isinstance(text["config_schema"], dict)
+
+    async def test_media_widget_flagged_as_referencing_asset(self, client):
+        resp = await client.get("/composed/widget-types")
+        by_type = {w["type"]: w for w in resp.json()["widget_types"]}
+        # The media widget takes an asset_id, so the AI knows it must
+        # supply a real asset reference.
+        assert by_type["media"]["references_asset"] is True
+
+    async def test_unauth_is_401(self, unauthed_client):
+        resp = await unauthed_client.get("/composed/widget-types")
+        assert resp.status_code in (401, 403)
+
+
+# ─────────────────────── GET /composed/{id}/layout ──────────────────
+
+
+@pytest.mark.asyncio
+class TestGetLayout:
+    async def test_round_trips_widget_ids(self, client, db_session):
+        w = _text_widget("hello")
+        layout = empty_layout()
+        layout.widgets = [w]
+        asset, _ = await _make_composed(db_session, layout=layout)
+
+        resp = await client.get(f"/composed/{asset.id}/layout")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["id"] == str(asset.id)
+        assert body["is_draft"] is True
+        assert body["canvas"] == {"width": CANVAS_WIDTH, "height": CANVAS_HEIGHT}
+        assert body["grid"] == {"rows": GRID_ROWS, "cols": GRID_COLS}
+        assert len(body["widgets"]) == 1
+        out = body["widgets"][0]
+        assert out["id"] == str(w.id)
+        assert out["type"] == "text"
+        assert out["row"] == 1 and out["col"] == 1
+        assert out["colspan"] == 4
+        assert out["config"]["text"] == "hello"
+
+    async def test_missing_asset_is_404(self, client):
+        resp = await client.get(f"/composed/{uuid.uuid4()}/layout")
+        assert resp.status_code == 404
+
+    async def test_unauth_is_401(self, unauthed_client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await unauthed_client.get(f"/composed/{asset.id}/layout")
+        assert resp.status_code in (401, 403)
+
+
+# ─────────────────── PUT /composed/{id}/layout-friendly ─────────────
+
+
+@pytest.mark.asyncio
+class TestPutLayoutFriendly:
+    async def test_happy_path_assigns_uuid_and_sets_draft(
+        self, client, db_session
+    ):
+        asset, _ = await _make_composed(db_session, is_draft=False)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={
+                "widgets": [
+                    {"type": "text", "row": 2, "col": 3, "colspan": 5,
+                     "config": {"text": "AI made this"}},
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == str(asset.id)
+        assert body["is_draft"] is True
+        assert body["widget_count"] == 1
+
+        # Read it back: a UUID was assigned and the cell persisted.
+        read = await client.get(f"/composed/{asset.id}/layout")
+        w = read.json()["widgets"][0]
+        uuid.UUID(w["id"])
+        assert w["type"] == "text"
+        assert w["row"] == 2 and w["col"] == 3 and w["colspan"] == 5
+        assert w["config"]["text"] == "AI made this"
+
+    async def test_preserves_supplied_id(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        wid = str(uuid.uuid4())
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={
+                "widgets": [
+                    {"id": wid, "type": "text", "row": 1, "col": 1,
+                     "config": {"text": "keep my id"}},
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        read = await client.get(f"/composed/{asset.id}/layout")
+        assert read.json()["widgets"][0]["id"] == wid
+
+    async def test_canvas_and_grid_are_pinned(self, client, db_session):
+        """The friendly shape omits canvas/grid; the server pins the
+        locked defaults so the LLM never has to (and can't) change them."""
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "text", "row": 1, "col": 1, "config": {"text": "x"}},
+            ]},
+        )
+        assert resp.status_code == 200, resp.text
+        read = await client.get(f"/composed/{asset.id}/layout")
+        assert read.json()["canvas"] == {
+            "width": CANVAS_WIDTH, "height": CANVAS_HEIGHT,
+        }
+        assert read.json()["grid"] == {"rows": GRID_ROWS, "cols": GRID_COLS}
+
+    async def test_background_color_set_and_falls_back(
+        self, client, db_session
+    ):
+        asset, _ = await _make_composed(db_session)
+        # Explicit color is honoured.
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={
+                "widgets": [
+                    {"type": "text", "row": 1, "col": 1,
+                     "config": {"text": "x"}},
+                ],
+                "background_color": "#123456",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert (await client.get(
+            f"/composed/{asset.id}/layout"
+        )).json()["background_color"] == "#123456"
+
+        # Omitting it on a later write keeps the existing color.
+        resp2 = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "text", "row": 1, "col": 1, "config": {"text": "y"}},
+            ]},
+        )
+        assert resp2.status_code == 200, resp2.text
+        assert (await client.get(
+            f"/composed/{asset.id}/layout"
+        )).json()["background_color"] == "#123456"
+
+    async def test_text_content_is_html_escaped(self, client, db_session):
+        """User/AI text must never round-trip into the rendered bundle
+        as raw HTML — the publish/preview path escapes it.  Here we pin
+        that the friendly write stores the raw text (escaping happens at
+        render time) and that the canonical validator accepted it."""
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "text", "row": 1, "col": 1,
+                 "config": {"text": "<script>alert(1)</script>"}},
+            ]},
+        )
+        assert resp.status_code == 200, resp.text
+        # Stored verbatim; render-time html.escape is covered by the
+        # widget/golden-master suite.
+        stored = (await client.get(
+            f"/composed/{asset.id}/layout"
+        )).json()["widgets"][0]["config"]["text"]
+        assert stored == "<script>alert(1)</script>"
+
+    # ── failure paths ───────────────────────────────────────────────
+
+    async def test_unknown_widget_type_is_422(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "bogus", "row": 1, "col": 1, "config": {}},
+            ]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_layout"
+
+    async def test_bad_widget_config_is_422(self, client, db_session):
+        """Text widget requires non-empty ``text`` — empty config is a
+        semantic 422 (caught by the per-widget ConfigSchema), not a 500.
+        """
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "text", "row": 1, "col": 1, "config": {}},
+            ]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_layout"
+
+    async def test_out_of_bounds_cell_is_422(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "text", "row": 1, "col": GRID_COLS + 1,
+                 "config": {"text": "x"}},
+            ]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_layout_shape"
+
+    async def test_malformed_widget_id_is_422(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"id": "not-a-uuid", "type": "text", "row": 1, "col": 1,
+                 "config": {"text": "x"}},
+            ]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_widget_id"
+
+    async def test_widgets_not_a_list_is_422(self, client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": {"type": "text"}},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_widgets"
+
+    async def test_referenced_asset_missing_is_400(self, client, db_session):
+        """A media widget pointing at a non-existent asset is rejected
+        by the referenced-asset ACL check (same 400 path as the
+        canonical PATCH endpoint)."""
+        missing = uuid.uuid4()
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "media", "row": 1, "col": 1,
+                 "config": {"asset_id": str(missing)}},
+            ]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "not found" in resp.json()["detail"].lower()
+
+    async def test_missing_asset_is_404(self, client):
+        resp = await client.put(
+            f"/composed/{uuid.uuid4()}/layout-friendly",
+            json={"widgets": []},
+        )
+        assert resp.status_code == 404
+
+    async def test_unauth_is_401(self, unauthed_client, db_session):
+        asset, _ = await _make_composed(db_session)
+        resp = await unauthed_client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": []},
+        )
+        assert resp.status_code in (401, 403)
+
+
+# ───────────── referenced-asset caller-visibility (cross-user leak) ──────────
+
+
+async def _make_composed_owned_by(
+    db_session, owner_id, *, layout: Layout | None = None,
+) -> tuple[Asset, ComposedSlide]:
+    """A personal composed slide (no groups, not global) owned by a user."""
+    asset = Asset(
+        filename=f"composed-{uuid.uuid4()}",
+        display_name="Operator composed",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+        uploaded_by_user_id=owner_id,
+        is_global=False,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=(layout or empty_layout()).model_dump(mode="json"),
+        is_draft=True,
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    return asset, cs
+
+
+async def _make_image_asset(
+    db_session, *, owner_id=None, is_global: bool = False,
+) -> Asset:
+    asset = Asset(
+        filename=f"img-{uuid.uuid4()}.png",
+        display_name="Some image",
+        asset_type=AssetType.IMAGE,
+        size_bytes=10,
+        checksum=uuid.uuid4().hex,
+        uploaded_by_user_id=owner_id,
+        is_global=is_global,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    return asset
+
+
+@pytest.mark.asyncio
+class TestReferencedAssetVisibility:
+    """A non-admin must not be able to reference an asset they can't see.
+
+    Regression guard for a cross-user private-asset leak: the friendly
+    PUT (and the canonical PATCH it shares the validate/ACL helper with)
+    used to check only that a referenced asset *existed*, not that the
+    caller could *see* it. A user could therefore inline another user's
+    private (unshared, non-global) asset into a composed-slide bundle by
+    guessing its UUID. The existence query is now scoped to the caller's
+    visible set, so an invisible asset is reported as "not found".
+    """
+
+    async def test_private_asset_of_other_user_is_not_found(
+        self, operator_client, db_session,
+    ):
+        owner_id = operator_client.user_id
+        composed, _ = await _make_composed_owned_by(db_session, owner_id)
+        # Private image with no owner attribution, unshared + not global,
+        # so the operator cannot see it — but it exists.
+        hidden = await _make_image_asset(
+            db_session, owner_id=None, is_global=False,
+        )
+        resp = await operator_client.put(
+            f"/composed/{composed.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "media", "row": 1, "col": 1,
+                 "config": {"asset_id": str(hidden.id)}},
+            ]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "not found" in resp.json()["detail"].lower()
+
+    async def test_global_asset_is_referenceable(
+        self, operator_client, db_session,
+    ):
+        """Positive control: the visibility gate must not over-block a
+        global asset the operator legitimately can see."""
+        owner_id = operator_client.user_id
+        composed, _ = await _make_composed_owned_by(db_session, owner_id)
+        shared = await _make_image_asset(
+            db_session, owner_id=None, is_global=True,
+        )
+        resp = await operator_client.put(
+            f"/composed/{composed.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "media", "row": 1, "col": 1,
+                 "config": {"asset_id": str(shared.id)}},
+            ]},
+        )
+        assert resp.status_code == 200, resp.text
+
+    async def test_malformed_media_asset_id_is_422_not_500(
+        self, client, db_session,
+    ):
+        """A garbage (non-UUID) asset_id is a clean 422, never a 500."""
+        asset, _ = await _make_composed(db_session)
+        resp = await client.put(
+            f"/composed/{asset.id}/layout-friendly",
+            json={"widgets": [
+                {"type": "media", "row": 1, "col": 1,
+                 "config": {"asset_id": "not-a-uuid"}},
+            ]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_layout"


### PR DESCRIPTION
## What

PR 1 of 2 for **AI assistant mode on composed slides** (plan Phase 3).
This PR is the backend + MCP + tool-scoping surface; the embedded
editor chat panel is PR 2.

### CMS endpoints (`cms/routers/composed.py`)
- `GET  /composed/widget-types` — widget catalog the assistant uses to
  know what it can place
- `GET  /composed/{asset_id}/layout` — current layout in an
  AI-friendly shape
- `PUT  /composed/{asset_id}/layout-friendly` — persist a **draft**
  layout produced by the assistant

### MCP tools (`mcp/server.py`, `mcp/cms_client.py`)
- `list_composed_widget_types`
- `get_composed_layout`
- `set_composed_widgets`

### Mode-based assistant tool scoping
`ChatThread` gains a `mode` column (alembic `0039`, server_default
`"general"`). The composed-editor tools live **outside** the
`ALLOWED` / `READ_ONLY` / `WRITE` tool sets and are only reachable when
a thread is in `composed_editor` mode:
- They execute **inline with no approval gate** — they only mutate a
  *draft* layout, never a published asset.
- Unknown/`None` mode falls back to `general` and never widens access.
- Composed tools can never be bypass-executed (bypass path checks
  `ALLOWED_TOOLS`).

## Security fix: cross-user referenced-asset visibility

While reviewing the ACL helper I found a real leak.
`_check_referenced_asset_acl` previously only verified that a
referenced media asset **existed**, not that the caller could **see**
it. A scoped non-admin (e.g. Operator) could inline another user's
private (unshared, non-global) asset into a composed bundle by guessing
its UUID.

Fix: the referenced-asset existence query is now scoped to the caller's
visible set (reusing `assets._visible_asset_ids`). Invisible/missing
assets fall into the existing **400 "not found"** path, which also
avoids disclosing the asset's existence. Admins are unaffected
(`_visible_asset_ids` returns `None` = see-all).

Regression coverage:
`tests/test_composed_ai_routes.py::TestReferencedAssetVisibility`
- Operator + another user's private asset → 400 "not found"
- Operator + global asset → 200 (positive control)
- malformed asset_id → 422 `invalid_layout` (not 500)

## Tests
- `tests/test_assistant_composed_mode.py` — 12 mode-scoping tests
- `tests/test_composed_ai_routes.py` — endpoint + visibility tests
- `docs/openapi.yaml` regenerated (3 new composed paths)

All targeted suites green locally (`-p no:timeout`); full suite runs in
CI.

## Deferred to PR 2
- Embedded editor chat panel
- Server-side editor-thread creation
- editor-thread → asset binding
