### PR TITLE
feat(composed): embedded AI assistant chat in slide editor (PR 2)

### DIFF
--- a/alembic/versions/0040_chat_thread_composed_asset.py
+++ b/alembic/versions/0040_chat_thread_composed_asset.py
@@ -1,0 +1,64 @@
+"""Alembic migration 0040 — bind composed-editor chat threads to an asset.
+
+Adds nullable ``composed_asset_id`` to ``chat_threads``.  A
+``composed_editor``-mode thread (see migration 0039) is created
+server-side by the composed-slide editor and bound to the single
+composed-slide asset it edits.  The agent forces this asset id onto
+the composed asset-scoped tools (``get_composed_layout`` /
+``set_composed_widgets``) so the editor assistant can only ever touch
+*this* slide's draft.
+
+``ondelete=CASCADE``: editor chats are asset-scoped ephemera, so
+deleting the underlying composed slide deletes its editor chat too.
+General-mode threads leave the column NULL.
+
+Revision ID: 0040
+Revises: 0039
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0040"
+down_revision = "0039"
+branch_labels = None
+depends_on = None
+
+
+def _uuid_type(bind):
+    """UUID column type matching the dialect (Postgres in prod, SQLite in tests)."""
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.UUID(as_uuid=True)
+    return sa.String(length=36)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    op.add_column(
+        "chat_threads",
+        sa.Column("composed_asset_id", _uuid_type(bind), nullable=True),
+    )
+    op.create_index(
+        "ix_chat_threads_composed_asset_id",
+        "chat_threads",
+        ["composed_asset_id"],
+    )
+    # SQLite (test harness) can't ALTER TABLE ADD CONSTRAINT; the FK is a
+    # Postgres-only concern.  Skipping it under SQLite is safe — the ORM
+    # still declares the relationship and tests don't rely on DB-level
+    # cascade.
+    if bind.dialect.name == "postgresql":
+        op.create_foreign_key(
+            "fk_chat_threads_composed_asset_id_assets",
+            "chat_threads",
+            "assets",
+            ["composed_asset_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0040 is not supported")

--- a/cms/models/chat_thread.py
+++ b/cms/models/chat_thread.py
@@ -45,6 +45,18 @@ class ChatThread(Base):
         default="general",
         server_default="general",
     )
+    # Binds a ``composed_editor``-mode thread to the one composed-slide
+    # asset it is editing.  NULL for general-mode threads.  The agent
+    # forces this asset id onto the composed asset-scoped tools so the
+    # editor assistant can only ever read/write *this* slide's draft,
+    # never another asset's.  ``ondelete=CASCADE``: editor chats are
+    # asset-scoped ephemera, so deleting the slide deletes its chat.
+    composed_asset_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("assets.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -31,6 +31,7 @@ from cms.database import get_db
 from cms.models.chat_message import ChatMessage
 from cms.models.chat_thread import ChatThread
 from cms.models.user import User
+from cms.permissions import ASSETS_WRITE, has_permission
 from cms.schemas.chat import (
     AssistantFeatureStatus,
     AssistantUsageOut,
@@ -50,7 +51,10 @@ from cms.services.assistant.llm_client import (
     AssistantUnavailableError,
     is_available as assistant_llm_available,
 )
-from cms.services.assistant.mcp_client import McpUnavailableError
+from cms.services.assistant.mcp_client import (
+    McpUnavailableError,
+    MODE_COMPOSED_EDITOR,
+)
 from cms.services.assistant.pricing import estimate_usd, model_for_deployment
 from cms.services.assistant_flag import assistant_enabled_for
 from cms.services.audit_service import audit_log
@@ -99,6 +103,46 @@ async def _get_owned_thread(
     if not thread or thread.user_id != user.id:
         raise HTTPException(status_code=404, detail="Thread not found")
     return thread
+
+
+async def _verify_composed_editor_thread(
+    thread: ChatThread,
+    user: User,
+    request: Request,
+    db: AsyncSession,
+) -> None:
+    """Re-validate a ``composed_editor`` thread at turn start.
+
+    No-op for general threads. For an editor-bound thread this defends
+    against state drift between the moment the editor opened the thread
+    and the moment a message is sent:
+
+    * orphaned thread (no bound asset) → 409 — never run the agent with a
+      composed-editor prompt but no slide to scope it to;
+    * the caller lost ``ASSETS_WRITE`` since the thread was created → 403;
+    * the bound slide was deleted, or is no longer visible to the caller
+      → 404 / 403, surfaced by ``_load_composed_for_write``.
+
+    Without this, a stale editor thread could let the assistant attempt
+    draft writes against a slide the user can no longer edit or see.
+    """
+    if thread.mode != MODE_COMPOSED_EDITOR:
+        return
+    if thread.composed_asset_id is None:
+        raise HTTPException(
+            status_code=409, detail="Editor thread is not bound to a slide"
+        )
+    if user.role is None or not has_permission(
+        user.role.permissions, ASSETS_WRITE
+    ):
+        raise HTTPException(
+            status_code=403, detail=f"Missing permission: {ASSETS_WRITE}"
+        )
+    # Existence + visibility (raises 404 / 403). Lazy import avoids a
+    # router import cycle (composed imports nothing from chat).
+    from cms.routers.composed import _load_composed_for_write  # noqa: WPS433
+
+    await _load_composed_for_write(thread.composed_asset_id, request, db)
 
 
 async def _emit_assistant_audit(
@@ -219,12 +263,21 @@ async def list_threads(
     user: User = Depends(_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List the caller's threads, newest-updated first."""
+    """List the caller's general threads, newest-updated first.
+
+    Composed-editor threads (``mode == "composed_editor"``) are excluded:
+    they're asset-scoped ephemera owned by the slide editor's embedded
+    chat panel, not standalone conversations, so they must never appear
+    in the general assistant sidebar.
+    """
     await _require_feature(user, db)
     rows = (
         await db.execute(
             select(ChatThread)
-            .where(ChatThread.user_id == user.id)
+            .where(
+                ChatThread.user_id == user.id,
+                ChatThread.mode != MODE_COMPOSED_EDITOR,
+            )
             .order_by(ChatThread.updated_at.desc())
         )
     ).scalars().all()
@@ -317,6 +370,7 @@ async def post_message(
     """
     await _require_feature(user, db)
     thread = await _get_owned_thread(thread_id, user, db)
+    await _verify_composed_editor_thread(thread, user, request, db)
 
     try:
         await check_budget(db, user)
@@ -473,6 +527,7 @@ async def post_message_stream(
     """
     await _require_feature(user, db)
     thread = await _get_owned_thread(thread_id, user, db)
+    await _verify_composed_editor_thread(thread, user, request, db)
 
     # Budget pre-check.  Runs BEFORE EventSourceResponse so a user
     # over their cap gets a clean 429 instead of a half-open SSE

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -54,9 +54,12 @@ from cms.composed.validate import validate_layout
 from cms.database import get_db
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.models.chat_thread import ChatThread
 from cms.models.group_asset import GroupAsset
 from cms.models.user import User
 from cms.permissions import ASSETS_WRITE
+from cms.services.assistant.mcp_client import MODE_COMPOSED_EDITOR
+from cms.services.assistant_flag import assistant_enabled_for
 from cms.services.audit_service import audit_log
 
 logger = logging.getLogger(__name__)
@@ -1021,3 +1024,61 @@ async def put_composed_layout_friendly(
         db,
         action="asset.update_composed_layout",
     )
+
+
+@router.post("/{asset_id}/assistant/thread")
+async def composed_assistant_thread(
+    asset_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Get-or-create the editor-scoped AI chat thread for this slide.
+
+    Powers the embedded chat panel in the composed-slide editor. The
+    thread is bound to ``asset_id`` and runs in ``composed_editor`` mode,
+    which scopes the assistant to the composed read/draft-write tools and
+    forces every composed tool call onto *this* slide.
+
+    Reuses the caller's newest existing ``composed_editor`` thread for the
+    slide if one exists (so reopening the editor resumes the same
+    conversation); otherwise creates one. Returns ``{thread_id, created}``.
+
+    Gated identically to the editor itself: requires ``ASSETS_WRITE``,
+    that the slide exists and is visible to the caller, and that the
+    Assistant feature is enabled for the caller (404 otherwise, to keep
+    the hidden feature invisible).
+    """
+    asset, _composed = await _load_composed_for_write(asset_id, request, db)
+
+    if not await assistant_enabled_for(db, user):
+        raise HTTPException(status_code=404, detail="Not found")
+
+    existing = (
+        await db.execute(
+            select(ChatThread)
+            .where(
+                ChatThread.user_id == user.id,
+                ChatThread.composed_asset_id == asset_id,
+                ChatThread.mode == MODE_COMPOSED_EDITOR,
+            )
+            .order_by(ChatThread.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return {"thread_id": str(existing.id), "created": False}
+
+    asset_name = (
+        asset.display_name or asset.original_filename or asset.filename or "slide"
+    )
+    thread = ChatThread(
+        user_id=user.id,
+        mode=MODE_COMPOSED_EDITOR,
+        composed_asset_id=asset_id,
+        title=f"Editing {asset_name}"[:200],
+    )
+    db.add(thread)
+    await db.commit()
+    await db.refresh(thread)
+    return {"thread_id": str(thread.id), "created": True}

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -58,7 +58,9 @@ from cms.services.assistant.llm_client import (
 )
 from cms.services.assistant.mcp_client import (
     AssistantMcpClient,
+    COMPOSED_ASSET_SCOPED_TOOLS,
     McpUnavailableError,
+    MODE_COMPOSED_EDITOR,
     MODE_GENERAL,
     WRITE_TOOLS,
     executable_tools_for_mode,
@@ -122,12 +124,21 @@ async def _execute_tool_call(
     mcp: AssistantMcpClient,
     tool_call: dict[str, Any],
     executable_tools: frozenset[str],
+    bound_asset_id: uuid.UUID | str | None = None,
 ) -> str:
     """Run a single OpenAI ``tool_call`` against MCP, returning a string.
 
     ``executable_tools`` is the set of tools the current thread mode may
     run inline without an approval click (see
     :func:`cms.services.assistant.mcp_client.executable_tools_for_mode`).
+
+    ``bound_asset_id`` is set for ``composed_editor``-mode threads: it is
+    the composed slide the thread is bound to.  For the composed
+    asset-scoped tools (``get_composed_layout`` / ``set_composed_widgets``)
+    the agent OVERRIDES any model-supplied ``asset_id`` with this bound id,
+    so the editor assistant can only ever read/write the slide the user
+    actually has open — never another asset, even if the model is coaxed
+    into emitting a different id.
 
     Never raises — failures are encoded as JSON ``{"error": ...}`` so
     the LLM can see the failure and reason about it on the next turn.
@@ -137,6 +148,10 @@ async def _execute_tool_call(
     args, err = _parse_tool_arguments(fn.get("arguments"))
     if err is not None:
         return json.dumps({"error": "bad_arguments", "message": err})
+    if bound_asset_id is not None and name in COMPOSED_ASSET_SCOPED_TOOLS:
+        # Force the thread's bound slide id; ignore whatever the model sent.
+        args = dict(args or {})
+        args["asset_id"] = str(bound_asset_id)
     if name not in executable_tools:
         # Either a fleet write tool (needs the approval flow, which lives
         # in the streaming agent) or a tool not exposed in this mode.
@@ -218,9 +233,25 @@ async def run_user_turn(
         )
     ).scalars().all()
 
-    # 3. Build the OpenAI-format payload.
+    # 3. Build the OpenAI-format payload.  Compute the thread mode +
+    #    bound composed asset up front so the system prompt can render
+    #    the right variant (general fleet helper vs. composed-slide
+    #    editor scoped to one slide).
+    mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
+    bound_asset_id = (
+        getattr(thread, "composed_asset_id", None)
+        if mode == MODE_COMPOSED_EDITOR
+        else None
+    )
     openai_messages: list[dict[str, Any]] = [
-        {"role": "system", "content": build_system_prompt(user)},
+        {
+            "role": "system",
+            "content": build_system_prompt(
+                user,
+                mode=mode,
+                composed_asset_id=str(bound_asset_id) if bound_asset_id else None,
+            ),
+        },
     ]
     openai_messages.extend(_history_to_openai_messages(list(rows)))
 
@@ -239,7 +270,6 @@ async def run_user_turn(
 
     final_assistant_row: ChatMessage | None = None
     try:
-        mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
         executable_tools = executable_tools_for_mode(mode)
         tools = await mcp.list_openai_tools(mode=mode)
         max_iters = max(1, int(settings.assistant_max_tool_iterations))
@@ -288,6 +318,7 @@ async def run_user_turn(
                     mcp=mcp,
                     tool_call=tool_call,
                     executable_tools=executable_tools,
+                    bound_asset_id=bound_asset_id,
                 )
                 tool_row = ChatMessage(
                     thread_id=thread.id,
@@ -444,8 +475,21 @@ async def run_user_turn_streaming(
         )
     ).scalars().all()
 
+    mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
+    bound_asset_id = (
+        getattr(thread, "composed_asset_id", None)
+        if mode == MODE_COMPOSED_EDITOR
+        else None
+    )
     openai_messages: list[dict[str, Any]] = [
-        {"role": "system", "content": build_system_prompt(user)},
+        {
+            "role": "system",
+            "content": build_system_prompt(
+                user,
+                mode=mode,
+                composed_asset_id=str(bound_asset_id) if bound_asset_id else None,
+            ),
+        },
     ]
     openai_messages.extend(_history_to_openai_messages(list(rows)))
 
@@ -460,7 +504,6 @@ async def run_user_turn_streaming(
 
     final_row: ChatMessage | None = None
     try:
-        mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
         mode_tools = tools_for_mode(mode)
         executable_tools = executable_tools_for_mode(mode)
         tools = await mcp.list_openai_tools(mode=mode)
@@ -660,6 +703,7 @@ async def run_user_turn_streaming(
                     mcp=mcp,
                     tool_call=tool_call,
                     executable_tools=executable_tools,
+                    bound_asset_id=bound_asset_id,
                 )
                 tool_row = ChatMessage(
                     thread_id=thread.id,

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -182,6 +182,20 @@ COMPOSED_DRAFT_WRITE_TOOLS: frozenset[str] = frozenset(
     }
 )
 
+# Composed tools that operate on one specific composed-slide asset
+# (their MCP signature takes an ``asset_id``).  In ``composed_editor``
+# mode the agent FORCES the thread's bound asset id onto these so the
+# editor assistant can never read or write a slide other than the one
+# the user has open.  ``list_assets`` / ``get_asset`` are deliberately
+# excluded — they legitimately read *other* assets (e.g. an image to
+# embed) and are not slide-mutating.
+COMPOSED_ASSET_SCOPED_TOOLS: frozenset[str] = frozenset(
+    {
+        "get_composed_layout",
+        "set_composed_widgets",
+    }
+)
+
 # Tools the agent may execute immediately, with no approval click.
 # Reads are inherently safe; composed draft writes are reversible and
 # device-invisible (see above).

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -60,13 +60,78 @@ Guidelines:
 """
 
 
-def build_system_prompt(user: User, *, now: datetime | None = None) -> str:
+COMPOSED_EDITOR_PROMPT_TEMPLATE = """\
+You are the Agora CMS Composed-Slide Assistant.  You are embedded in
+the slide editor and your ONLY job is to build the layout of the one
+composed slide the operator ({username}) currently has open.  The
+current UTC time is {utc_now}.
+
+The slide you are editing has asset id ``{composed_asset_id}``.  Every
+composed tool you call already operates on THIS slide — you never need
+to ask the user which slide, and you must not try to edit any other
+slide.
+
+How to work:
+* Start by calling ``get_composed_layout`` to see the current widgets,
+  their grid positions, and configs.  Build on what's already there
+  unless the user asks to start over.
+* Call ``list_composed_widget_types`` to discover the available widget
+  types and the exact config fields each one accepts.  Do this before
+  inventing config keys — never guess a field name.
+* Apply changes by calling ``set_composed_widgets`` with the full list
+  of widgets you want the slide to have (it replaces the draft layout).
+  Preserve the ``id`` of any existing widget you are keeping so its
+  identity is stable; omit ``id`` for brand-new widgets.
+* To place a widget on an image or video, first find the asset with
+  ``list_assets`` / ``get_asset`` and reference it by its real id —
+  never invent an asset id.
+
+Canvas + grid facts (these are fixed; you cannot change them):
+* The canvas is 1920×1080 (16:9).
+* The grid is 8 rows × 12 columns.  Widget cells use 1-based
+  ``row``/``col`` with ``rowspan``/``colspan`` ≥ 1, and must stay
+  inside the grid.  Widgets cannot overlap.
+* Widget array order is the stacking order (later = on top).
+
+Important:
+* Your ``set_composed_widgets`` calls save a **draft only**.  Nothing
+  you do appears on any device until the operator clicks **Publish**
+  in the editor — tell them that when you've made changes.
+* Be concise.  After a change, briefly say what you placed and where.
+* If a tool call fails or returns nothing, say so plainly instead of
+  pretending it worked.
+* You do NOT have access to device, schedule, group, profile, or any
+  other fleet-management tools.  If the user asks for something
+  outside building this slide, explain that you can only edit the
+  current slide's layout.
+"""
+
+
+def build_system_prompt(
+    user: User,
+    *,
+    now: datetime | None = None,
+    mode: str = "general",
+    composed_asset_id: str | None = None,
+) -> str:
     """Render the system prompt for ``user``.
 
     ``now`` is injected for deterministic testing; defaults to current
     UTC time.
+
+    ``mode`` selects the prompt variant.  ``"composed_editor"`` (with a
+    bound ``composed_asset_id``) renders the slide-editor prompt that
+    scopes the assistant to building one slide via the composed tools;
+    every other value falls back to the general fleet-assistant prompt
+    so an unknown mode can never widen the assistant's apparent remit.
     """
     when = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M UTC")
+    if mode == "composed_editor" and composed_asset_id:
+        return COMPOSED_EDITOR_PROMPT_TEMPLATE.format(
+            username=user.username,
+            utc_now=when,
+            composed_asset_id=composed_asset_id,
+        )
     return SYSTEM_PROMPT_TEMPLATE.format(
         username=user.username,
         email=user.email or "no email",

--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -1,0 +1,248 @@
+// Composed-editor AI chat drawer.
+//
+// Lives inside the composed-slide editor (gated on the Assistant
+// feature flag). The user describes a slide; the assistant edits the
+// *draft* layout via the composed_editor MCP tools and the canvas
+// refreshes when a write lands.
+//
+// It talks to the editor only through window.composedEditorBridge
+// (getAssetId / isDirty / save / refreshFromServer) and to the server
+// through two endpoints:
+//   POST /composed/{assetId}/assistant/thread   → get-or-create the
+//        editor-scoped thread bound to this composed asset.
+//   POST /api/chat/threads/{threadId}/stream     → run one turn (SSE).
+//
+// The SSE parser mirrors cms/static/assistant.js. No approval cards:
+// composed_editor tools run inline (draft-only), so a stray
+// approval_request is tolerated, not rendered as an interactive card.
+(function () {
+    "use strict";
+
+    const root = document.getElementById("cw-ai");
+    if (!root) return; // drawer not rendered (flag off / create mode)
+
+    const bridge = window.composedEditorBridge;
+    const launcher = document.getElementById("cw-ai-launcher");
+    const panel = document.getElementById("cw-ai-panel");
+    const closeBtn = document.getElementById("cw-ai-close");
+    const log = document.getElementById("cw-ai-log");
+    const form = document.getElementById("cw-ai-form");
+    const input = document.getElementById("cw-ai-input");
+    const sendBtn = document.getElementById("cw-ai-send");
+
+    const state = {
+        threadId: null,
+        threadPromise: null, // de-dupe concurrent get-or-create
+        open: false,
+        sending: false,
+    };
+
+    function assetId() {
+        if (bridge && typeof bridge.getAssetId === "function") {
+            const id = bridge.getAssetId();
+            if (id) return id;
+        }
+        return root.dataset.assetId || null;
+    }
+
+    // ── Drawer open/close ────────────────────────────────────────────
+    function setOpen(open) {
+        state.open = open;
+        panel.hidden = !open;
+        launcher.setAttribute("aria-expanded", open ? "true" : "false");
+        launcher.style.display = open ? "none" : "";
+        if (open) {
+            ensureThread();
+            input.focus();
+        }
+    }
+    window.cwAiToggle = function () { setOpen(!state.open); };
+    launcher.addEventListener("click", () => setOpen(true));
+    closeBtn.addEventListener("click", () => setOpen(false));
+
+    // ── Thread get-or-create ─────────────────────────────────────────
+    function ensureThread() {
+        if (state.threadId) return Promise.resolve(state.threadId);
+        if (state.threadPromise) return state.threadPromise;
+        const id = assetId();
+        if (!id) return Promise.resolve(null);
+        state.threadPromise = fetch(
+            "/composed/" + encodeURIComponent(id) + "/assistant/thread",
+            { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
+        )
+            .then(async (resp) => {
+                if (!resp.ok) throw new Error("thread → " + resp.status);
+                const j = await resp.json();
+                state.threadId = j.thread_id;
+                return state.threadId;
+            })
+            .catch((e) => {
+                addMsg("error", "Couldn't start the assistant: " + e.message);
+                state.threadPromise = null; // allow retry on next send
+                return null;
+            });
+        return state.threadPromise;
+    }
+
+    // ── Log rendering ────────────────────────────────────────────────
+    function addMsg(kind, text) {
+        const div = document.createElement("div");
+        div.className = "cw-ai-msg " + kind;
+        div.textContent = text;
+        log.appendChild(div);
+        log.scrollTop = log.scrollHeight;
+        return div;
+    }
+
+    // ── Submit / stream ──────────────────────────────────────────────
+    window.cwAiSubmit = function (e) {
+        if (e) e.preventDefault();
+        if (state.sending) return false;
+        const content = (input.value || "").trim();
+        if (!content) return false;
+        sendMessage(content);
+        return false;
+    };
+
+    async function sendMessage(content) {
+        const threadId = await ensureThread();
+        if (!threadId) return;
+
+        state.sending = true;
+        sendBtn.disabled = true;
+        input.disabled = true;
+        input.value = "";
+        addMsg("user", content);
+
+        // The assistant reads server-side draft state, so flush any
+        // unsaved manual edits first — otherwise the post-turn refresh
+        // (which clears the dirty flag) would silently drop them.
+        if (bridge && bridge.isDirty && bridge.isDirty()) {
+            try { await bridge.save(); } catch (_) { /* flashed by editor */ }
+        }
+
+        let assistantBubble = null;
+        let assistantText = "";
+        let sawSuccessfulWrite = false;
+
+        const ensureBubble = () => {
+            if (!assistantBubble) assistantBubble = addMsg("assistant", "");
+            return assistantBubble;
+        };
+
+        try {
+            const resp = await fetch(
+                "/api/chat/threads/" + encodeURIComponent(threadId) + "/stream",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ content: content }),
+                }
+            );
+            if (!resp.ok) {
+                const errText = await resp.text();
+                throw new Error(resp.status + ": " + errText);
+            }
+            await consumeSseStream(resp.body, (evt) => {
+                switch (evt.event) {
+                    case "token":
+                        assistantText += (evt.data && evt.data.text) || "";
+                        ensureBubble().textContent = assistantText;
+                        log.scrollTop = log.scrollHeight;
+                        break;
+                    case "tool_call":
+                        addMsg("tool", "→ " + ((evt.data && evt.data.name) || "tool") + "…");
+                        break;
+                    case "tool_result": {
+                        const name = (evt.data && evt.data.name) || "tool";
+                        addMsg("tool", "✓ " + name);
+                        if (name === "set_composed_widgets" && !toolResultIsError(evt.data)) {
+                            sawSuccessfulWrite = true;
+                        }
+                        break;
+                    }
+                    case "approval_request":
+                        // composed_editor tools never need approval; if one
+                        // arrives, note it rather than blocking the drawer.
+                        addMsg("tool", "(skipped an approval-gated action)");
+                        break;
+                    case "done":
+                        break;
+                    case "error":
+                        addMsg("error", "Error: " + ((evt.data && evt.data.message) || "unknown"));
+                        break;
+                }
+            });
+        } catch (e) {
+            addMsg("error", "Request failed: " + e.message);
+        } finally {
+            if (sawSuccessfulWrite && bridge && bridge.refreshFromServer) {
+                try { await bridge.refreshFromServer(); } catch (_) { /* non-fatal */ }
+            }
+            state.sending = false;
+            sendBtn.disabled = false;
+            input.disabled = false;
+            input.focus();
+        }
+    }
+
+    // A tool result's content is a JSON string; success == no "error" key.
+    function toolResultIsError(data) {
+        const raw = data && data.content;
+        if (typeof raw !== "string") return false;
+        try {
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === "object" && "error" in parsed;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    // ── SSE byte-stream parser (mirrors assistant.js) ────────────────
+    async function consumeSseStream(stream, onEvent) {
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let idx;
+            while ((idx = findFrameBoundary(buffer)) !== -1) {
+                const raw = buffer.slice(0, idx);
+                buffer = buffer.slice(idx).replace(/^(\r?\n){2}/, "");
+                const evt = parseFrame(raw);
+                if (evt) onEvent(evt);
+            }
+        }
+    }
+
+    function findFrameBoundary(buf) {
+        const a = buf.indexOf("\n\n");
+        const b = buf.indexOf("\r\n\r\n");
+        if (a === -1) return b;
+        if (b === -1) return a;
+        return Math.min(a, b);
+    }
+
+    function parseFrame(raw) {
+        let event = "message";
+        let data = "";
+        raw.split(/\r?\n/).forEach((line) => {
+            if (line.startsWith(":")) return; // comment / heartbeat
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) data += line.slice(5).trim();
+        });
+        if (!data) return null;
+        try { return { event: event, data: JSON.parse(data) }; }
+        catch (e) { return { event: event, data: { _raw: data } }; }
+    }
+
+    // Submit on Enter (Shift+Enter = newline).
+    input.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            window.cwAiSubmit(e);
+        }
+    });
+})();

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -116,6 +116,39 @@
             <p class="text-muted" style="font-size:0.85rem;">Click a placed widget to edit it.</p>
         </aside>
     </div>
+{% if edit_mode and assistant_enabled %}
+    <!-- AI assistant chat drawer. Floating launcher + slide-up panel.
+         Gated on the Assistant feature flag (edit mode only). The
+         drawer talks to the editor via window.composedEditorBridge and
+         drives the bound composed_editor chat thread; see
+         /static/composed_editor_chat.js. -->
+    <div id="cw-ai" data-asset-id="{{ asset_id }}">
+        <button type="button" id="cw-ai-launcher" onclick="cwAiToggle()"
+                aria-expanded="false" aria-controls="cw-ai-panel"
+                title="Build this slide with AI">✨ AI Assistant</button>
+        <section id="cw-ai-panel" role="dialog" aria-label="AI slide assistant" hidden>
+            <header id="cw-ai-head">
+                <strong>✨ AI Assistant</strong>
+                <button type="button" id="cw-ai-close" onclick="cwAiToggle()"
+                        aria-label="Close assistant">×</button>
+            </header>
+            <div id="cw-ai-log" aria-live="polite">
+                <div class="cw-ai-hint">
+                    Describe the slide you want and I'll build it — e.g.
+                    “Add a big welcome heading at the top and a clock in
+                    the corner.” I edit a draft; click <strong>Publish</strong>
+                    when you're happy with it.
+                </div>
+            </div>
+            <form id="cw-ai-form" onsubmit="return cwAiSubmit(event)">
+                <textarea id="cw-ai-input" rows="2"
+                          placeholder="Describe a change…"
+                          aria-label="Message the AI assistant"></textarea>
+                <button type="submit" id="cw-ai-send" class="btn btn-primary">Send</button>
+            </form>
+        </section>
+    </div>
+{% endif %}
 </div>
 
 <style>
@@ -461,6 +494,56 @@
     .cw-modal-actions .danger { background: #b91c1c; color: #fff; border-color: #b91c1c; }
     .cw-modal-actions .primary { background: #2563eb; color: #fff; border-color: #2563eb; }
     .cw-modal-actions .ghost { background: transparent; color: var(--text, #e6e6e6); }
+
+    /* ── AI assistant drawer ── */
+    #cw-ai-launcher {
+        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 60;
+        padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer;
+        border: 1px solid var(--accent, #2563eb);
+        background: var(--primary, #2563eb); color: #fff; font-size: 0.9rem;
+        box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+    }
+    #cw-ai-panel {
+        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 61;
+        width: min(380px, calc(100vw - 2rem));
+        height: min(540px, calc(100vh - 6rem));
+        display: flex; flex-direction: column;
+        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        border-radius: 12px; overflow: hidden;
+        background: var(--surface, #1a1a2e); color: var(--text, #e6e6e6);
+        box-shadow: 0 10px 34px rgba(0,0,0,0.45);
+    }
+    #cw-ai-panel[hidden] { display: none; }
+    #cw-ai-head {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 0.6rem 0.85rem;
+        border-bottom: 1px solid var(--border, rgba(255,255,255,0.18));
+        background: var(--surface-alt, #16213e);
+    }
+    #cw-ai-close {
+        background: transparent; border: none; color: var(--text, #e6e6e6);
+        font-size: 1.4rem; line-height: 1; cursor: pointer; padding: 0 0.25rem;
+    }
+    #cw-ai-log {
+        flex: 1; overflow-y: auto; padding: 0.75rem;
+        display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.88rem;
+    }
+    .cw-ai-hint { color: var(--text-muted, #b3b3c0); font-size: 0.82rem; }
+    .cw-ai-msg { padding: 0.5rem 0.7rem; border-radius: 10px; max-width: 90%; white-space: pre-wrap; word-wrap: break-word; }
+    .cw-ai-msg.user { align-self: flex-end; background: var(--primary, #2563eb); color: #fff; }
+    .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, rgba(255,255,255,0.18)); }
+    .cw-ai-msg.tool { align-self: flex-start; font-size: 0.78rem; color: var(--text-muted, #b3b3c0); font-style: italic; padding: 0.2rem 0.5rem; }
+    .cw-ai-msg.error { align-self: flex-start; background: #fee2e2; color: #991b1b; }
+    #cw-ai-form {
+        display: flex; gap: 0.5rem; padding: 0.6rem;
+        border-top: 1px solid var(--border, rgba(255,255,255,0.18));
+    }
+    #cw-ai-input {
+        flex: 1; resize: none; padding: 0.5rem; border-radius: 8px;
+        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        background: var(--bg, #0f0f1a); color: var(--text, #e6e6e6); font: inherit;
+    }
+    #cw-ai-send:disabled { opacity: 0.55; cursor: progress; }
 </style>
 
 <div id="cw-leave-modal" class="cw-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="cw-leave-title">
@@ -1647,5 +1730,57 @@ ensureLayoutShape();
 renderCanvas();
 renderSettings();
 startClockTimer();
+
+// ── AI assistant bridge ─────────────────────────────────────────────
+// Re-loads LAYOUT from the server's friendly GET after the AI writes
+// the draft via the set_composed_widgets MCP tool, then re-renders.
+// Reshapes the flat server widget rows ({row,col,rowspan,colspan}) into
+// the editor's canonical {cell:{...}} shape.
+async function refreshLayoutFromServer() {
+    if (!ASSET_ID) return false;
+    let data;
+    try {
+        const resp = await fetch("/composed/" + ASSET_ID + "/layout", {
+            headers: {"Accept": "application/json"},
+        });
+        if (!resp.ok) return false;
+        data = await resp.json();
+    } catch (_) {
+        return false;
+    }
+    ensureLayoutShape();
+    if (data.canvas) LAYOUT.canvas = {width: data.canvas.width, height: data.canvas.height};
+    if (data.grid) LAYOUT.grid = {rows: data.grid.rows, cols: data.grid.cols};
+    LAYOUT.background = {color: (data.background_color || "#000000")};
+    LAYOUT.widgets = (data.widgets || []).map(w => ({
+        id: w.id,
+        type: w.type,
+        cell: {
+            row: w.row, col: w.col,
+            rowspan: w.rowspan || 1, colspan: w.colspan || 1,
+        },
+        config: w.config || {},
+        config_version: w.config_version,
+    }));
+    selectedWidgetId = null;
+    ensureLayoutShape();
+    renderCanvas();
+    renderSettings();
+    clearDirty();
+    markDraft();
+    return true;
+}
+
+// Stable surface the chat drawer (composed_editor_chat.js) talks to,
+// so it never reaches into editor internals directly.
+window.composedEditorBridge = {
+    getAssetId() { return ASSET_ID; },
+    isDirty() { return !!_dirty; },
+    async save() { return await saveLayout({skipRedirect: true}); },
+    async refreshFromServer() { return await refreshLayoutFromServer(); },
+};
 </script>
+{% if edit_mode and assistant_enabled %}
+<script src="/static/composed_editor_chat.js" defer></script>
+{% endif %}
 {% endblock %}

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1884,6 +1884,7 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         "asset_groups": [],
         "asset_is_global": False,
         "media_assets": media_assets,
+        "assistant_enabled": False,
     }
 
     if asset_id is not None:
@@ -1913,6 +1914,9 @@ async def _composed_builder_context(request, db, *, asset_id=None):
             select(GroupAsset.group_id).where(GroupAsset.asset_id == aid)
         )).scalars().all()
 
+        from cms.services.assistant_flag import assistant_enabled_for
+        assistant_on = bool(user) and await assistant_enabled_for(db, user)
+
         ctx.update({
             "edit_mode": True,
             "asset": asset,
@@ -1924,6 +1928,7 @@ async def _composed_builder_context(request, db, *, asset_id=None):
             "schema_version": composed.schema_version,
             "asset_groups": [str(g) for g in asset_group_rows],
             "asset_is_global": bool(asset.is_global),
+            "assistant_enabled": assistant_on,
         })
     return ctx
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -469,6 +469,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /composed/{asset_id}/assistant/thread:
+    post:
+      tags:
+      - composed
+      summary: Composed Assistant Thread
+      description: |-
+        Get-or-create the editor-scoped AI chat thread for this slide.
+
+        Powers the embedded chat panel in the composed-slide editor. The
+        thread is bound to ``asset_id`` and runs in ``composed_editor`` mode,
+        which scopes the assistant to the composed read/draft-write tools and
+        forces every composed tool call onto *this* slide.
+
+        Reuses the caller's newest existing ``composed_editor`` thread for the
+        slide if one exists (so reopening the editor resumes the same
+        conversation); otherwise creates one. Returns ``{thread_id, created}``.
+
+        Gated identically to the editor itself: requires ``ASSETS_WRITE``,
+        that the slide exists and is visible to the caller, and that the
+        Assistant feature is enabled for the caller (404 otherwise, to keep
+        the hidden feature invisible).
+      operationId: composed_assistant_thread_composed__asset_id__assistant_thread_post
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Composed Assistant Thread Composed  Asset Id  Assistant Thread Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/check-updates:
     post:
       summary: Check For Updates
@@ -1979,7 +2024,13 @@ paths:
   /api/chat/threads:
     get:
       summary: List Threads
-      description: List the caller's threads, newest-updated first.
+      description: |-
+        List the caller's general threads, newest-updated first.
+
+        Composed-editor threads (``mode == "composed_editor"``) are excluded:
+        they're asset-scoped ephemera owned by the slide editor's embedded
+        chat panel, not standalone conversations, so they must never appear
+        in the general assistant sidebar.
       operationId: list_threads_api_chat_threads_get
       responses:
         '200':

--- a/tests/test_composed_editor_assistant.py
+++ b/tests/test_composed_editor_assistant.py
@@ -1,0 +1,306 @@
+"""Tests for the composed-editor embedded AI assistant (PR 2).
+
+Covers the server-side pieces that back the chat panel embedded in the
+composed-slide editor:
+
+* ``POST /composed/{id}/assistant/thread`` — get-or-create the
+  editor-scoped, asset-bound chat thread.
+* ``list_threads`` excludes ``composed_editor`` threads from the
+  general assistant sidebar.
+* ``build_system_prompt`` renders the slide-editor variant only in
+  ``composed_editor`` mode with a bound asset id (never widens).
+* ``_execute_tool_call`` forces the bound slide id onto the composed
+  asset-scoped tools and leaves everything else untouched.
+* ``_verify_composed_editor_thread`` re-validates an editor thread at
+  turn start (orphaned → 409, permission lost → 403, general → no-op).
+"""
+
+from __future__ import annotations
+
+import json
+import types
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from cms.composed.schema import empty_layout
+from cms.models.asset import Asset, AssetType
+from cms.models.chat_thread import ChatThread
+from cms.models.composed_slide import ComposedSlide
+from cms.services.assistant.mcp_client import MODE_COMPOSED_EDITOR, MODE_GENERAL
+
+
+# ── fixtures / helpers ──────────────────────────────────────────────
+
+
+async def _make_composed(
+    db_session, *, owner_id=None, is_global: bool = False,
+) -> Asset:
+    asset = Asset(
+        filename=f"composed-{uuid.uuid4()}",
+        display_name="Test composed",
+        asset_type=AssetType.COMPOSED,
+        size_bytes=0,
+        checksum="",
+        uploaded_by_user_id=owner_id,
+        is_global=is_global,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    cs = ComposedSlide(
+        asset_id=asset.id,
+        layout_json=empty_layout().model_dump(mode="json"),
+        is_draft=True,
+    )
+    db_session.add(cs)
+    await db_session.commit()
+    return asset
+
+
+async def _disable_all(app) -> None:
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [])
+        break
+
+
+# ── POST /composed/{id}/assistant/thread ────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAssistantThreadEndpoint:
+    async def test_creates_then_reuses_same_thread(self, client, db_session):
+        asset = await _make_composed(db_session)
+
+        first = await client.post(f"/composed/{asset.id}/assistant/thread")
+        assert first.status_code == 200, first.text
+        b1 = first.json()
+        assert b1["created"] is True
+        uuid.UUID(b1["thread_id"])
+
+        second = await client.post(f"/composed/{asset.id}/assistant/thread")
+        assert second.status_code == 200, second.text
+        b2 = second.json()
+        assert b2["created"] is False
+        assert b2["thread_id"] == b1["thread_id"]
+
+    async def test_thread_is_bound_and_in_editor_mode(self, client, db_session):
+        asset = await _make_composed(db_session)
+        resp = await client.post(f"/composed/{asset.id}/assistant/thread")
+        assert resp.status_code == 200, resp.text
+        tid = uuid.UUID(resp.json()["thread_id"])
+
+        row = (
+            await db_session.execute(
+                select(ChatThread).where(ChatThread.id == tid)
+            )
+        ).scalar_one()
+        assert row.mode == MODE_COMPOSED_EDITOR
+        assert row.composed_asset_id == asset.id
+
+    async def test_missing_asset_is_404(self, client):
+        resp = await client.post(
+            f"/composed/{uuid.uuid4()}/assistant/thread"
+        )
+        assert resp.status_code == 404
+
+    async def test_feature_off_is_404(self, operator_client, app, db_session):
+        # Operator owns the slide (so it's visible), but the Assistant
+        # feature is off → the endpoint must 404 to keep it invisible.
+        await _disable_all(app)
+        asset = await _make_composed(
+            db_session, owner_id=operator_client.user_id
+        )
+        resp = await operator_client.post(
+            f"/composed/{asset.id}/assistant/thread"
+        )
+        assert resp.status_code == 404
+
+    async def test_unauth_is_401(self, unauthed_client, db_session):
+        asset = await _make_composed(db_session)
+        resp = await unauthed_client.post(
+            f"/composed/{asset.id}/assistant/thread"
+        )
+        assert resp.status_code in (401, 403)
+
+
+# ── list_threads excludes editor threads ────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestListThreadsExcludesEditor:
+    async def test_editor_thread_hidden_from_sidebar(self, client, db_session):
+        # A normal general thread shows up…
+        general = await client.post("/api/chat/threads", json={"title": "Promo"})
+        assert general.status_code == 201
+        general_id = general.json()["id"]
+
+        # …an editor-bound thread does not.
+        asset = await _make_composed(db_session)
+        editor = await client.post(f"/composed/{asset.id}/assistant/thread")
+        editor_id = editor.json()["thread_id"]
+
+        listing = (await client.get("/api/chat/threads")).json()
+        ids = {t["id"] for t in listing}
+        assert general_id in ids
+        assert editor_id not in ids
+
+
+# ── build_system_prompt mode awareness ──────────────────────────────
+
+
+class TestBuildSystemPrompt:
+    def _user(self):
+        return types.SimpleNamespace(username="alice", email="alice@test.com")
+
+    def test_composed_mode_renders_editor_prompt_with_bound_id(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="composed_editor", composed_asset_id=aid
+        )
+        assert aid in prompt
+        assert "Composed-Slide Assistant" in prompt
+        assert "set_composed_widgets" in prompt
+        # Editor prompt must NOT advertise fleet tooling.
+        assert "create_schedule" not in prompt
+
+    def test_composed_mode_without_id_falls_back_to_general(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        prompt = build_system_prompt(
+            self._user(), mode="composed_editor", composed_asset_id=None
+        )
+        assert "Composed-Slide Assistant" not in prompt
+
+    def test_unknown_mode_does_not_widen(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        prompt = build_system_prompt(
+            self._user(), mode="nonsense", composed_asset_id=str(uuid.uuid4())
+        )
+        assert "Composed-Slide Assistant" not in prompt
+
+    def test_default_mode_is_general(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        prompt = build_system_prompt(self._user())
+        assert "Composed-Slide Assistant" not in prompt
+
+
+# ── _execute_tool_call bound-asset override ──────────────────────────
+
+
+class _RecordingMcp:
+    """Minimal AssistantMcpClient double that records call_tool args."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call_tool(self, name, args):
+        self.calls.append((name, dict(args or {})))
+        return "{}"
+
+
+def _tool_call(name: str, **args) -> dict:
+    return {"function": {"name": name, "arguments": json.dumps(args)}}
+
+
+@pytest.mark.asyncio
+class TestExecuteToolCallBinding:
+    async def test_composed_scoped_tool_forces_bound_id(self):
+        from cms.services.assistant.agent import _execute_tool_call
+
+        bound = str(uuid.uuid4())
+        mcp = _RecordingMcp()
+        await _execute_tool_call(
+            mcp=mcp,
+            tool_call=_tool_call(
+                "set_composed_widgets", asset_id=str(uuid.uuid4()), widgets=[]
+            ),
+            executable_tools=frozenset({"set_composed_widgets"}),
+            bound_asset_id=bound,
+        )
+        assert mcp.calls and mcp.calls[0][1]["asset_id"] == bound
+
+    async def test_non_scoped_tool_left_untouched(self):
+        from cms.services.assistant.agent import _execute_tool_call
+
+        bound = str(uuid.uuid4())
+        mcp = _RecordingMcp()
+        await _execute_tool_call(
+            mcp=mcp,
+            tool_call=_tool_call("list_assets", asset_type="image"),
+            executable_tools=frozenset({"list_assets"}),
+            bound_asset_id=bound,
+        )
+        assert mcp.calls and "asset_id" not in mcp.calls[0][1]
+
+    async def test_no_binding_keeps_model_asset_id(self):
+        from cms.services.assistant.agent import _execute_tool_call
+
+        model_id = str(uuid.uuid4())
+        mcp = _RecordingMcp()
+        await _execute_tool_call(
+            mcp=mcp,
+            tool_call=_tool_call(
+                "set_composed_widgets", asset_id=model_id, widgets=[]
+            ),
+            executable_tools=frozenset({"set_composed_widgets"}),
+            bound_asset_id=None,
+        )
+        assert mcp.calls and mcp.calls[0][1]["asset_id"] == model_id
+
+
+# ── _verify_composed_editor_thread ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestVerifyComposedEditorThread:
+    async def test_general_thread_is_noop(self):
+        from cms.routers.chat import _verify_composed_editor_thread
+
+        thread = ChatThread(
+            user_id=uuid.uuid4(), mode=MODE_GENERAL, title="x"
+        )
+        # request/db unused on the general no-op path.
+        await _verify_composed_editor_thread(thread, None, None, None)
+
+    async def test_orphaned_editor_thread_is_409(self):
+        from fastapi import HTTPException
+
+        from cms.routers.chat import _verify_composed_editor_thread
+
+        thread = ChatThread(
+            user_id=uuid.uuid4(),
+            mode=MODE_COMPOSED_EDITOR,
+            composed_asset_id=None,
+            title="x",
+        )
+        with pytest.raises(HTTPException) as ei:
+            await _verify_composed_editor_thread(thread, None, None, None)
+        assert ei.value.status_code == 409
+
+    async def test_permission_lost_is_403(self):
+        from fastapi import HTTPException
+
+        from cms.routers.chat import _verify_composed_editor_thread
+
+        thread = ChatThread(
+            user_id=uuid.uuid4(),
+            mode=MODE_COMPOSED_EDITOR,
+            composed_asset_id=uuid.uuid4(),
+            title="x",
+        )
+        # Role without ASSETS_WRITE → 403 before any DB/visibility work.
+        viewer = types.SimpleNamespace(
+            role=types.SimpleNamespace(permissions=["assets:read"])
+        )
+        with pytest.raises(HTTPException) as ei:
+            await _verify_composed_editor_thread(thread, viewer, None, None)
+        assert ei.value.status_code == 403


### PR DESCRIPTION
## PR 2 of 2 — composed-slide AI assistant mode

Builds on PR #721 (shipped). Adds the **embedded chat drawer inside the composed-slide editor** so a user can describe a slide and watch the assistant build it via the composed MCP tools, with the canvas refreshing on each AI write.

### Backend
- ChatThread.composed_asset_id FK + alembic `0040`.
- `POST /composed/{id}/assistant/thread` — get-or-create the editor-scoped, asset-bound thread (requires `ASSETS_WRITE`, slide visible, assistant enabled; reuses the caller's newest thread for the slide).
- Mode-aware `build_system_prompt` — `composed_editor` variant scoped to the bound slide; unknown/None mode falls back to general (never widens).
- `_execute_tool_call` forces the bound slide id onto the composed asset-scoped tools (`get_composed_layout` / `set_composed_widgets`); other tools untouched.
- `_verify_composed_editor_thread` re-validates editor threads at turn start (orphaned → 409, `ASSETS_WRITE` lost → 403, slide gone/invisible → 404/403). `list_threads` hides `composed_editor` threads from the general sidebar.

### Frontend
- `composed_editor.html`: feature-gated chat drawer (markup + CSS), `refreshLayoutFromServer()` + `window.composedEditorBridge`, external `composed_editor_chat.js` tag.
- `composed_editor_chat.js`: drawer SSE controller — get-or-create thread on open, auto-save-if-dirty before send, stream over `/api/chat/threads/{id}/stream`, refresh the canvas when `set_composed_widgets` succeeds.

### Tests
`tests/test_composed_editor_assistant.py` — thread get-or-create/reuse, binding + mode, feature gating (404), missing asset (404), unauth; prompt mode-awareness; tool-call bound-id override; editor-thread re-validation (409/403/no-op). 16 new tests; related suites (composed_ai_routes, assistant_composed_mode, chat_threads) green.
