### PR TITLE
Composed AI assistant: create-mode drawer + Markdown replies

### DIFF
--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -94,6 +94,50 @@
         return div;
     }
 
+    // The model emits Markdown; render assistant replies as sanitized HTML
+    // (bold, lists, code) when marked + DOMPurify are present. User/tool/
+    // error bubbles stay plain text. Mirrors cms/static/assistant.js.
+    const _hasMarkdown =
+        typeof window.marked !== "undefined" && typeof window.DOMPurify !== "undefined";
+    if (_hasMarkdown) {
+        window.marked.setOptions({ gfm: true, breaks: true });
+    }
+    function renderAssistantMarkdown(bubble, text) {
+        if (!_hasMarkdown) {
+            bubble.textContent = text || "";
+            return;
+        }
+        bubble.innerHTML = window.DOMPurify.sanitize(window.marked.parse(text || ""));
+        bubble.classList.add("is-markdown");
+    }
+
+    // ── Create-mode mint ─────────────────────────────────────────────
+    // On a brand-new slide there's no asset yet, so the chat can't bind to
+    // one. Mint the draft via the editor bridge (which POSTs /composed/ and
+    // PATCHes the seeded layout, no redirect), then proceed as in edit mode.
+    async function mintDraft() {
+        if (!bridge || typeof bridge.save !== "function") return false;
+        let ok = false;
+        try { ok = await bridge.save(); } catch (_) { ok = false; }
+        const id = assetId();
+        if (!ok || !id) return false;
+        // Keep the URL + manual-save behavior consistent with a normal first
+        // save, and lock the create-only config inputs (name/global/groups)
+        // now that the asset exists — they're read once at mint time and
+        // would otherwise silently no-op on later manual saves.
+        try {
+            history.replaceState(null, "", "/assets/" + encodeURIComponent(id) + "/composed");
+        } catch (_) { /* non-fatal */ }
+        ["composed-name", "composed-global"].forEach((cid) => {
+            const el = document.getElementById(cid);
+            if (el) el.disabled = true;
+        });
+        document.querySelectorAll("input[name='composed_group_ids']").forEach((el) => {
+            el.disabled = true;
+        });
+        return true;
+    }
+
     // ── Submit / stream ──────────────────────────────────────────────
     window.cwAiSubmit = function (e) {
         if (e) e.preventDefault();
@@ -105,32 +149,51 @@
     };
 
     async function sendMessage(content) {
-        const threadId = await ensureThread();
-        if (!threadId) return;
-
+        if (state.sending) return;
+        // Lock the UI up-front so a rapid double-submit can't mint the draft
+        // twice or kick off two concurrent streams.
         state.sending = true;
         sendBtn.disabled = true;
         input.disabled = true;
         input.value = "";
         addMsg("user", content);
 
-        // The assistant reads server-side draft state, so flush any
-        // unsaved manual edits first — otherwise the post-turn refresh
-        // (which clears the dirty flag) would silently drop them.
-        if (bridge && bridge.isDirty && bridge.isDirty()) {
-            try { await bridge.save(); } catch (_) { /* flashed by editor */ }
-        }
-
-        let assistantBubble = null;
-        let assistantText = "";
         let sawSuccessfulWrite = false;
-
-        const ensureBubble = () => {
-            if (!assistantBubble) assistantBubble = addMsg("assistant", "");
-            return assistantBubble;
-        };
-
         try {
+            // Create mode: mint the draft asset so the chat can bind to it.
+            if (!assetId()) {
+                const minted = await mintDraft();
+                if (!minted) {
+                    addMsg(
+                        "error",
+                        "Couldn't save the draft — check the message at the top of "
+                        + "the page (a slide name is required), then send again."
+                    );
+                    return;
+                }
+            }
+
+            // The assistant reads server-side draft state, so flush any
+            // unsaved manual edits first — otherwise the post-turn refresh
+            // (which clears the dirty flag) would silently drop them.
+            if (bridge && bridge.isDirty && bridge.isDirty()) {
+                const ok = await bridge.save();
+                if (!ok) {
+                    addMsg("error", "Couldn't save your latest changes — fix the error above and try again.");
+                    return;
+                }
+            }
+
+            const threadId = await ensureThread();
+            if (!threadId) return; // ensureThread already surfaced the error
+
+            let assistantBubble = null;
+            let assistantText = "";
+            const ensureBubble = () => {
+                if (!assistantBubble) assistantBubble = addMsg("assistant", "");
+                return assistantBubble;
+            };
+
             const resp = await fetch(
                 "/api/chat/threads/" + encodeURIComponent(threadId) + "/stream",
                 {
@@ -147,7 +210,7 @@
                 switch (evt.event) {
                     case "token":
                         assistantText += (evt.data && evt.data.text) || "";
-                        ensureBubble().textContent = assistantText;
+                        renderAssistantMarkdown(ensureBubble(), assistantText);
                         log.scrollTop = log.scrollHeight;
                         break;
                     case "tool_call":

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -116,13 +116,13 @@
             <p class="text-muted" style="font-size:0.85rem;">Click a placed widget to edit it.</p>
         </aside>
     </div>
-{% if edit_mode and assistant_enabled %}
+{% if assistant_enabled %}
     <!-- AI assistant chat drawer. Floating launcher + slide-up panel.
-         Gated on the Assistant feature flag (edit mode only). The
-         drawer talks to the editor via window.composedEditorBridge and
-         drives the bound composed_editor chat thread; see
-         /static/composed_editor_chat.js. -->
-    <div id="cw-ai" data-asset-id="{{ asset_id }}">
+         Gated on the Assistant feature flag. Available in BOTH create and
+         edit mode: in create mode the drawer mints the draft asset on the
+         first message (via window.composedEditorBridge) so the chat can
+         bind to it. See /static/composed_editor_chat.js. -->
+    <div id="cw-ai" data-asset-id="{{ asset_id or '' }}">
         <button type="button" id="cw-ai-launcher" onclick="cwAiToggle()"
                 aria-expanded="false" aria-controls="cw-ai-panel"
                 title="Build this slide with AI">✨ AI Assistant</button>
@@ -534,6 +534,18 @@
     .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, rgba(255,255,255,0.18)); }
     .cw-ai-msg.tool { align-self: flex-start; font-size: 0.78rem; color: var(--text-muted, #b3b3c0); font-style: italic; padding: 0.2rem 0.5rem; }
     .cw-ai-msg.error { align-self: flex-start; background: #fee2e2; color: #991b1b; }
+    /* Rendered Markdown (assistant replies). Drop pre-wrap so marked's
+       <br> handling doesn't double up blank lines, and tame block margins
+       inside the bubble. */
+    .cw-ai-msg.is-markdown { white-space: normal; }
+    .cw-ai-msg.is-markdown > :first-child { margin-top: 0; }
+    .cw-ai-msg.is-markdown > :last-child { margin-bottom: 0; }
+    .cw-ai-msg.is-markdown p { margin: 0 0 0.5rem; }
+    .cw-ai-msg.is-markdown ul, .cw-ai-msg.is-markdown ol { margin: 0 0 0.5rem 1.15rem; padding: 0; }
+    .cw-ai-msg.is-markdown li { margin: 0.1rem 0; }
+    .cw-ai-msg.is-markdown strong { font-weight: 700; }
+    .cw-ai-msg.is-markdown code { background: rgba(255,255,255,0.12); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
+    .cw-ai-msg.is-markdown a { color: var(--accent, #60a5fa); }
     #cw-ai-form {
         display: flex; gap: 0.5rem; padding: 0.6rem;
         border-top: 1px solid var(--border, rgba(255,255,255,0.18));
@@ -1780,7 +1792,12 @@ window.composedEditorBridge = {
     async refreshFromServer() { return await refreshLayoutFromServer(); },
 };
 </script>
-{% if edit_mode and assistant_enabled %}
+{% if assistant_enabled %}
+<!-- marked + DOMPurify render the assistant's Markdown replies as HTML
+     (bold, lists, code). Non-deferred so they're ready before the
+     deferred drawer IIFE runs. -->
+<script src="/static/vendor/marked.min.js"></script>
+<script src="/static/vendor/purify.min.js"></script>
 <script src="/static/composed_editor_chat.js" defer></script>
 {% endif %}
 {% endblock %}

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1869,6 +1869,13 @@ async def _composed_builder_context(request, db, *, asset_id=None):
     # lock-step with ``cms.composed.schema`` forever.
     from cms.composed.schema import empty_layout
 
+    # The AI assistant drawer is available in BOTH create and edit mode for
+    # an enabled user. In create mode the drawer mints the draft asset on the
+    # first message (client-side via the editor bridge), so the chat can bind
+    # to it — there's no longer a "save first to see the assistant" gap.
+    from cms.services.assistant_flag import assistant_enabled_for
+    assistant_on = bool(user) and await assistant_enabled_for(db, user)
+
     ctx = {
         "active_tab": "assets",
         "is_admin": is_admin,
@@ -1884,7 +1891,7 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         "asset_groups": [],
         "asset_is_global": False,
         "media_assets": media_assets,
-        "assistant_enabled": False,
+        "assistant_enabled": assistant_on,
     }
 
     if asset_id is not None:
@@ -1914,9 +1921,8 @@ async def _composed_builder_context(request, db, *, asset_id=None):
             select(GroupAsset.group_id).where(GroupAsset.asset_id == aid)
         )).scalars().all()
 
-        from cms.services.assistant_flag import assistant_enabled_for
-        assistant_on = bool(user) and await assistant_enabled_for(db, user)
-
+        # ``assistant_enabled`` is already computed in the base ctx above
+        # (same value for create + edit mode), so no recompute here.
         ctx.update({
             "edit_mode": True,
             "asset": asset,
@@ -1928,7 +1934,6 @@ async def _composed_builder_context(request, db, *, asset_id=None):
             "schema_version": composed.schema_version,
             "asset_groups": [str(g) for g in asset_group_rows],
             "asset_is_global": bool(asset.is_global),
-            "assistant_enabled": assistant_on,
         })
     return ctx
 

--- a/tests/test_composed_editor_assistant.py
+++ b/tests/test_composed_editor_assistant.py
@@ -304,3 +304,41 @@ class TestVerifyComposedEditorThread:
         with pytest.raises(HTTPException) as ei:
             await _verify_composed_editor_thread(thread, viewer, None, None)
         assert ei.value.status_code == 403
+
+# ── create-mode drawer gating (PR 3) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestCreateModeDrawer:
+    """The AI assistant drawer must be available on a brand-new composed
+    slide (``/assets/new/composed``), not just after the first save. The
+    drawer mints the draft on the first message client-side, so the
+    server only needs to render it (with an empty asset id) whenever the
+    Assistant feature flag is on for the user."""
+
+    async def test_new_page_shows_drawer_for_enabled_user(self, client):
+        # ``client`` is an admin (settings:write), so the assistant flag is
+        # always on regardless of the allowlist.
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'id="cw-ai"' in text
+        assert '<script src="/static/composed_editor_chat.js"' in text
+        # Create mode has no asset yet — the drawer must render an EMPTY
+        # data-asset-id (not the string "None"), so the client treats it as
+        # unbound and mints on first send.
+        assert 'data-asset-id=""' in text
+        assert 'data-asset-id="None"' not in text
+
+    async def test_new_page_hides_drawer_for_disabled_user(
+        self, operator_client, app
+    ):
+        # A non-admin Operator with the allowlist cleared has the assistant
+        # disabled, so the drawer (and its scripts) must not render. The
+        # Operator still has ASSETS_WRITE, so the page itself loads.
+        await _disable_all(app)
+        resp = await operator_client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'id="cw-ai"' not in text
+        assert '<script src="/static/composed_editor_chat.js"' not in text


### PR DESCRIPTION
Two follow-up fixes to the embedded composed-slide AI chat drawer (PR #722), from user review on dev (v1.38.111).

## 1. Drawer available on a brand-new composed slide
Previously gated `{% if edit_mode and assistant_enabled %}`, so the drawer only appeared after saving once. Now gated on the flag alone — it renders in create mode too. On the first message the drawer mints the draft asset client-side (via `window.composedEditorBridge.save()`, which POSTs `/composed/` then PATCHes the seeded layout, no redirect), then binds the chat to it. Create-only config inputs (name/global/group) are disabled after mint so they can't silently no-op on later saves.

## 2. Assistant replies render Markdown
The model emits Markdown but replies were shown with `textContent`, so `**Publish**` displayed literal asterisks. Now rendered through `marked` + `DOMPurify` (same vendor scripts the sidebar assistant uses), with `.is-markdown` bubble styles.

## Changes
- **cms/ui.py** — compute `assistant_enabled` once in the base editor context (covers create mode); drop the duplicate in the edit branch.
- **cms/templates/composed_editor.html** — broaden both gates to `{% if assistant_enabled %}`; render `data-asset-id="{{ asset_id or '' }}"` (avoid the literal `"None"`); load `marked.min.js` + `purify.min.js` before the deferred chat script; add `.is-markdown` CSS (incl. `white-space: normal`).
- **cms/static/composed_editor_chat.js** — `renderAssistantMarkdown`, `mintDraft`, hardened `sendMessage` (sending-lock set before mint to block double-submit; dirty-save failure aborts with a clear error; render tokens as Markdown).
- **tests/test_composed_editor_assistant.py** — `TestCreateModeDrawer`: drawer shown for an enabled user with an empty `data-asset-id`; hidden for a disabled (non-admin, allowlist-cleared) user.

## Tests
`tests/test_composed_editor_assistant.py` (18) + `tests/test_composed_routes_phase2.py` green locally. `node --check` on the JS, Jinja parse on the template.
