### PR TITLE
Composed editor: auto-name AI drafts + slideshow-style group picker

### DIFF
--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -115,25 +115,51 @@
     // On a brand-new slide there's no asset yet, so the chat can't bind to
     // one. Mint the draft via the editor bridge (which POSTs /composed/ and
     // PATCHes the seeded layout, no redirect), then proceed as in edit mode.
+
+    // A friendly, sortable default name for slides the user starts via the
+    // assistant without typing one. Built from local Date parts (not
+    // toLocaleString) so it's locale-stable and lexically sortable.
+    function defaultSlideName() {
+        const d = new Date();
+        const p = (n) => String(n).padStart(2, "0");
+        return "Untitled slide " + d.getFullYear() + "-" + p(d.getMonth() + 1)
+            + "-" + p(d.getDate()) + " " + p(d.getHours()) + ":" + p(d.getMinutes());
+    }
+
     async function mintDraft() {
         if (!bridge || typeof bridge.save !== "function") return false;
+        // The create endpoint requires a name. If the user jumped straight to
+        // the assistant without typing one, auto-fill a sensible default so the
+        // first prompt actually mints a draft. Display names need not be unique
+        // (the server uniquifies the filename); the user can rename later from
+        // the Assets page.
+        const nameEl = document.getElementById("composed-name");
+        if (nameEl && !(nameEl.value || "").trim()) {
+            nameEl.value = defaultSlideName();
+        }
         let ok = false;
         try { ok = await bridge.save(); } catch (_) { ok = false; }
         const id = assetId();
         if (!ok || !id) return false;
         // Keep the URL + manual-save behavior consistent with a normal first
-        // save, and lock the create-only config inputs (name/global/groups)
+        // save, and lock the create-only config inputs (name + group picker)
         // now that the asset exists — they're read once at mint time and
         // would otherwise silently no-op on later manual saves.
         try {
             history.replaceState(null, "", "/assets/" + encodeURIComponent(id) + "/composed");
         } catch (_) { /* non-fatal */ }
-        ["composed-name", "composed-global"].forEach((cid) => {
-            const el = document.getElementById(cid);
-            if (el) el.disabled = true;
-        });
-        document.querySelectorAll("input[name='composed_group_ids']").forEach((el) => {
-            el.disabled = true;
+        const nameEl2 = document.getElementById("composed-name");
+        if (nameEl2) nameEl2.disabled = true;
+        const addGroupBtn = document.querySelector("#composed-groups-badges .btn-add-group");
+        if (addGroupBtn) addGroupBtn.disabled = true;
+        const groupPopup = document.getElementById("composed-group-popup");
+        if (groupPopup) {
+            try { if (groupPopup.hidePopover) groupPopup.hidePopover(); } catch (_) { /* not open */ }
+            groupPopup.querySelectorAll(".group-popup-item").forEach((el) => { el.disabled = true; });
+        }
+        document.querySelectorAll("#composed-groups-badges .group-badge").forEach((el) => {
+            el.style.pointerEvents = "none";
+            el.style.opacity = "0.7";
         });
         return true;
     }
@@ -166,8 +192,8 @@
                 if (!minted) {
                     addMsg(
                         "error",
-                        "Couldn't save the draft — check the message at the top of "
-                        + "the page (a slide name is required), then send again."
+                        "Couldn't create the slide — see the message at the top of "
+                        + "the page, then send again."
                     );
                     return;
                 }

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -14,29 +14,32 @@
             <input type="text" id="composed-name" class="form-control" maxlength="255" required
                    placeholder="e.g. Lobby welcome"
                    style="width:100%; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
+            {% if assistant_enabled %}
+            <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
+                Optional when using the AI assistant — leave blank and it'll be auto-named (rename later from the Assets page).
+            </small>
+            {% endif %}
         </div>
-
-        {% if is_admin %}
-        <div class="form-group" style="margin-bottom:0;">
-            <label style="display:block; font-weight:600;">Visibility</label>
-            <label style="display:inline-flex; align-items:center; gap:0.4rem; padding-top:0.4rem;">
-                <input type="checkbox" id="composed-global" checked>
-                Visible to everyone (global)
-            </label>
-        </div>
-        {% endif %}
 
         {% if user_groups | length > 0 %}
         <div class="form-group" style="margin-bottom:0;">
-            <label style="display:block; font-weight:600;">{% if is_admin %}Or share with specific groups{% else %}Share with groups{% endif %}</label>
-            <div id="composed-groups-list"
-                 style="display:flex; flex-direction:column; gap:0.2rem; max-height:120px; overflow:auto; padding:0.35rem; border:1px solid var(--border); border-radius:6px; background:var(--bg);">
-                {% for g in user_groups %}
-                <label style="display:flex; align-items:center; gap:0.35rem; font-weight:normal; margin:0;">
-                    <input type="checkbox" name="composed_group_ids" value="{{ g.id }}"> {{ g.name }}
-                </label>
-                {% endfor %}
+            <label style="display:block; font-weight:600;">Assign to groups</label>
+            <div id="composed-groups-badges" style="display:flex; gap:0.35rem; flex-wrap:wrap; min-height:1.6rem; align-items:center;">
+                <span class="group-picker-wrap" style="position:relative; display:inline-flex;">
+                    <button class="btn-add-group" type="button" onclick="event.stopPropagation(); openGroupPopup('composed-group-popup')" title="Add group">+</button>
+                    <div id="composed-group-popup" popover class="group-popup">
+                        {% for g in user_groups %}
+                        <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
+                                onclick="event.stopPropagation(); pickComposedGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
+                        {% endfor %}
+                    </div>
+                </span>
             </div>
+            {% if is_admin %}
+            <p class="text-muted" style="margin-top:0.25rem; font-size:0.8rem;">
+                Leave empty to make Global.
+            </p>
+            {% endif %}
         </div>
         {% endif %}
     </div>
@@ -1509,13 +1512,10 @@ async function ensureAssetExists() {
         if (nameEl) nameEl.focus();
         return false;
     }
-    const globalEl = document.getElementById("composed-global");
-    const isGlobal = globalEl ? globalEl.checked : false;
-    const groupIds = Array.from(
-        document.querySelectorAll("input[name='composed_group_ids']:checked")
-    ).map(el => el.value);
+    const groupIds = (window.composedSelectedGroupIds || []).slice();
     const body = {name: name};
-    if (!isGlobal && groupIds.length > 0) body.group_ids = groupIds;
+    // Empty groups → Global (matches the slideshow builder).
+    if (groupIds.length > 0) body.group_ids = groupIds;
     try {
         const resp = await fetch("/composed/", {
             method: "POST",
@@ -1724,19 +1724,62 @@ async function cwLeaveSave() {
     if (href) window.location.href = href;
 }
 
-// New-slide metadata edits (name / groups / global) also count as
-// unsaved changes.
+// New-slide metadata edits (name) also count as unsaved changes.
+// Group-picker edits flag dirty from inside pickComposedGroup / badge
+// removal below.
 (function wireMetadataDirty() {
-    const ids = ["composed-name", "composed-global"];
-    ids.forEach((id) => {
-        const el = document.getElementById(id);
-        if (el) el.addEventListener("input", markDirty);
-        if (el) el.addEventListener("change", markDirty);
-    });
-    document.querySelectorAll("input[name='composed_group_ids']").forEach((el) => {
+    const el = document.getElementById("composed-name");
+    if (el) {
+        el.addEventListener("input", markDirty);
         el.addEventListener("change", markDirty);
-    });
+    }
 })();
+
+// ── Group picker (create mode) — mirrors the slideshow builder ──────
+window.composedSelectedGroupIds = window.composedSelectedGroupIds || [];
+
+function openGroupPopup(id) {
+    const el = document.getElementById(id);
+    if (el && el.showPopover) el.showPopover();
+}
+
+function pickComposedGroup(id, name) {
+    // After the draft is minted the groups are already committed (read once
+    // at create time), so ignore late edits to avoid silent no-ops.
+    if (ASSET_ID) return;
+    if (!window.composedSelectedGroupIds.includes(id)) {
+        window.composedSelectedGroupIds.push(id);
+        markDirty();
+    }
+    renderComposedGroupBadges();
+    const popup = document.getElementById("composed-group-popup");
+    if (popup && popup.hidePopover) popup.hidePopover();
+}
+
+function renderComposedGroupBadges() {
+    const wrap = document.getElementById("composed-groups-badges");
+    if (!wrap) return;
+    [...wrap.querySelectorAll(".group-badge")].forEach((n) => n.remove());
+    const popupWrap = wrap.querySelector(".group-picker-wrap");
+    window.composedSelectedGroupIds.forEach((gid) => {
+        const btn = document.querySelector(
+            `#composed-group-popup .group-popup-item[data-group-id="${gid}"]`
+        );
+        if (!btn) return;
+        const span = document.createElement("span");
+        span.className = "group-badge";
+        span.style.cssText =
+            "background:#444;color:#fff;padding:0.15rem 0.5rem;border-radius:0.5rem;font-size:0.8rem;cursor:pointer;";
+        span.textContent = btn.dataset.groupName + " ✕";
+        span.onclick = () => {
+            window.composedSelectedGroupIds =
+                window.composedSelectedGroupIds.filter((x) => x !== gid);
+            markDirty();
+            renderComposedGroupBadges();
+        };
+        wrap.insertBefore(span, popupWrap);
+    });
+}
 
 ensureLayoutShape();
 renderCanvas();

--- a/tests/test_composed_editor_assistant.py
+++ b/tests/test_composed_editor_assistant.py
@@ -329,6 +329,9 @@ class TestCreateModeDrawer:
         # unbound and mints on first send.
         assert 'data-asset-id=""' in text
         assert 'data-asset-id="None"' not in text
+        # The name field advertises that it's optional with the assistant
+        # (mintDraft auto-names an unnamed slide).
+        assert "leave blank and it'll be auto-named" in text.lower()
 
     async def test_new_page_hides_drawer_for_disabled_user(
         self, operator_client, app


### PR DESCRIPTION
## What

Two create-mode cleanups for the composed slide editor.

### 1. AI assistant auto-names an unnamed slide
On a brand-new composed slide the assistant mints the draft on the first message, but `POST /composed/` requires a name — so an unnamed slide silently failed to mint and the prompt did nothing. `mintDraft()` now defaults an empty `#composed-name` to a friendly, sortable `Untitled slide YYYY-MM-DD HH:MM` before saving. Display names need not be unique (the server uniquifies the filename only), and the user can rename later from the Assets page. A hint under the name field (shown only when the assistant is enabled) says it's optional, and the mint-failure message is now generic.

### 2. Group/visibility UI matches the slideshow builder
Per user request, the composed create page now uses the **exact** slideshow pattern: an **Assign to groups** label + `+` badge/popover picker, with the admin-only **Leave empty to make Global.** note. Removed the old "Visible to everyone (global)" checkbox and the multi-checkbox group list. Semantics are unchanged on the server (empty groups → global). Group edits are locked after the AI mint, consistent with the name field.

## Tests
- `tests/test_composed_editor_assistant.py` — 18 passed (added an assertion that the create page advertises the optional/auto-named name field).
- `tests/test_composed_ai_routes.py` + assistant suite — 40 passed.
- `node --check` on the chat JS; Jinja parse of the template.

No server/endpoint or OpenAPI changes.