### PR TITLE
feat(composed): pill badge, kebab Preview, live grid thumbnail

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1568,6 +1568,38 @@ function previewAsset(assetId, filename, assetType) {
     }
 }
 
+function previewComposed(assetId, name) {
+    // Composed slides have no raster image -- show the live HTML render,
+    // sized to its true 1920x1080 canvas and scaled to fit via CSS
+    // container-query units (.composed-preview-frame).
+    const { box, close } = createModal({
+        closeOnBackdrop: true,
+        closeOnEsc: true,
+    });
+    box.classList.add("preview-box");
+    const header = document.createElement("div");
+    header.className = "preview-header";
+    const title = document.createElement("span");
+    title.textContent = name || "Composed slide";
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "btn btn-secondary btn-sm";
+    closeBtn.textContent = "Close";
+    closeBtn.onclick = () => close();
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+    box.appendChild(header);
+
+    const wrap = document.createElement("div");
+    wrap.className = "composed-preview composed-preview-modal";
+    const frame = document.createElement("iframe");
+    frame.className = "composed-preview-frame";
+    frame.src = "/composed/" + encodeURIComponent(assetId) + "/preview";
+    frame.setAttribute("scrolling", "no");
+    frame.setAttribute("tabindex", "-1");
+    wrap.appendChild(frame);
+    box.appendChild(wrap);
+}
+
 function previewVariant(variantId, filename, assetType, profileName) {
     // Lightbox: backdrop dismiss is the expected pattern.
     const { box, close } = createModal({

--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -115,25 +115,51 @@
     // On a brand-new slide there's no asset yet, so the chat can't bind to
     // one. Mint the draft via the editor bridge (which POSTs /composed/ and
     // PATCHes the seeded layout, no redirect), then proceed as in edit mode.
+
+    // A friendly, sortable default name for slides the user starts via the
+    // assistant without typing one. Built from local Date parts (not
+    // toLocaleString) so it's locale-stable and lexically sortable.
+    function defaultSlideName() {
+        const d = new Date();
+        const p = (n) => String(n).padStart(2, "0");
+        return "Untitled slide " + d.getFullYear() + "-" + p(d.getMonth() + 1)
+            + "-" + p(d.getDate()) + " " + p(d.getHours()) + ":" + p(d.getMinutes());
+    }
+
     async function mintDraft() {
         if (!bridge || typeof bridge.save !== "function") return false;
+        // The create endpoint requires a name. If the user jumped straight to
+        // the assistant without typing one, auto-fill a sensible default so the
+        // first prompt actually mints a draft. Display names need not be unique
+        // (the server uniquifies the filename); the user can rename later from
+        // the Assets page.
+        const nameEl = document.getElementById("composed-name");
+        if (nameEl && !(nameEl.value || "").trim()) {
+            nameEl.value = defaultSlideName();
+        }
         let ok = false;
         try { ok = await bridge.save(); } catch (_) { ok = false; }
         const id = assetId();
         if (!ok || !id) return false;
         // Keep the URL + manual-save behavior consistent with a normal first
-        // save, and lock the create-only config inputs (name/global/groups)
+        // save, and lock the create-only config inputs (name + group picker)
         // now that the asset exists — they're read once at mint time and
         // would otherwise silently no-op on later manual saves.
         try {
             history.replaceState(null, "", "/assets/" + encodeURIComponent(id) + "/composed");
         } catch (_) { /* non-fatal */ }
-        ["composed-name", "composed-global"].forEach((cid) => {
-            const el = document.getElementById(cid);
-            if (el) el.disabled = true;
-        });
-        document.querySelectorAll("input[name='composed_group_ids']").forEach((el) => {
-            el.disabled = true;
+        const nameEl2 = document.getElementById("composed-name");
+        if (nameEl2) nameEl2.disabled = true;
+        const addGroupBtn = document.querySelector("#composed-groups-badges .btn-add-group");
+        if (addGroupBtn) addGroupBtn.disabled = true;
+        const groupPopup = document.getElementById("composed-group-popup");
+        if (groupPopup) {
+            try { if (groupPopup.hidePopover) groupPopup.hidePopover(); } catch (_) { /* not open */ }
+            groupPopup.querySelectorAll(".group-popup-item").forEach((el) => { el.disabled = true; });
+        }
+        document.querySelectorAll("#composed-groups-badges .group-badge").forEach((el) => {
+            el.style.pointerEvents = "none";
+            el.style.opacity = "0.7";
         });
         return true;
     }
@@ -166,8 +192,8 @@
                 if (!minted) {
                     addMsg(
                         "error",
-                        "Couldn't save the draft — check the message at the top of "
-                        + "the page (a slide name is required), then send again."
+                        "Couldn't create the slide — see the message at the top of "
+                        + "the page, then send again."
                     );
                     return;
                 }

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -370,6 +370,7 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .badge-stream { background: #e67e22; color: var(--text); }
 .badge-saved_stream { background: #d35400; color: var(--text); }
 .badge-slideshow { background: #16a085; color: var(--text); }
+.badge-composed { background: #6366f1; color: var(--text); }
 .badge-builtin { background: var(--primary); color: var(--text); font-size: 0.65rem; margin-left: 0.3rem; vertical-align: middle; }
 .badge-processing { background: #3498db; color: #fff; margin-left: 0.4rem; }
 /* Progress-fill badge: darker "filled" region on the left grows to the
@@ -763,6 +764,32 @@ select.inline-edit:hover { border-color: var(--accent); }
     display: block;
     margin: 0 auto;
     background: #000;
+}
+
+/* Composed-slide live preview.  A composed slide has no raster image, only
+   a live HTML render (GET /composed/{id}/preview).  Widgets use fixed px
+   font sizes, so we render the iframe at the true 1920x1080 canvas size and
+   scale it down with CSS container-query units -- (container width / canvas
+   width) -- so the layout stays proportional at any thumbnail size. No JS. */
+.composed-preview {
+    position: relative;
+    overflow: hidden;
+    container-type: size;
+}
+.composed-preview-frame {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1920px;
+    height: 1080px;
+    border: 0;
+    transform-origin: top left;
+    transform: scale(calc(100cqw / 1920px));
+    background: #000;
+}
+.composed-preview-modal {
+    width: min(90vw, 1280px);
+    aspect-ratio: 16 / 9;
 }
 
 /* Toast notification */

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -290,6 +290,7 @@
                         <a role="menuitem" href="/assets/{{ a.id }}/slideshow">View slides</a>
                         {% endif %}
                     {% elif a.asset_type.value == 'composed' %}
+                        <button type="button" role="menuitem" onclick="previewComposed('{{ a.id }}', {{ (a.display_name or a.original_filename or a.filename) | tojson | forceescape }})">Preview</button>
                         {% if 'assets:write' in user_perms and is_owner %}
                         <a role="menuitem" href="/assets/{{ a.id }}/composed">Edit composed</a>
                         {% else %}

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -1218,6 +1218,22 @@ function fallbackCopy(text, onSuccess) {
         return Math.round(bytes / 1024) + ' KB';
     }
 
+    // Composed slides have no raster thumbnail -- their grid preview is a
+    // live HTML render (/composed/{id}/preview) framed at true canvas size
+    // and CSS-scaled.  That render inlines base64 media, so defer loading
+    // each iframe until its card nears the viewport; a grid of many
+    // composed slides would otherwise fetch them all at once.
+    const _composedThumbObserver = ('IntersectionObserver' in window)
+        ? new IntersectionObserver(function (entries, obs) {
+            entries.forEach(function (e) {
+                if (!e.isIntersecting) return;
+                const f = e.target;
+                if (f.dataset.src && !f.src) f.src = f.dataset.src;
+                obs.unobserve(f);
+            });
+        }, { rootMargin: '300px' })
+        : null;
+
     function _renderGridCard(a) {
         const card = document.createElement('div');
         card.className = 'asset-grid-card';
@@ -1245,12 +1261,16 @@ function fallbackCopy(text, onSuccess) {
         // (full-res) here -- a 2MB image per card is wasteful and there
         // is no equivalent for video sources.
         let previewSrc = a.thumbnail_url || null;
+        const isComposed = a.asset_type === 'composed';
+        const thumbInner = isComposed
+            ? '<iframe class="composed-preview-frame composed-thumb-lazy" data-src="/composed/' + encodeURIComponent(a.id) + '/preview" loading="lazy" scrolling="no" tabindex="-1" aria-hidden="true" style="pointer-events:none;"></iframe>'
+            : (previewSrc
+                ? '<img loading="lazy" src="' + previewSrc + '" alt="" style="width:100%; height:100%; object-fit:cover;" onerror="this.replaceWith(document.createTextNode(\'' + _typeIcon(a.asset_type) + '\'))">'
+                : _typeIcon(a.asset_type));
 
         card.innerHTML =
-            '<div class="asset-grid-thumb" style="aspect-ratio:16/9; background:#0a0a0a; display:flex; align-items:center; justify-content:center; font-size:2rem; color:#666; position:relative;">' +
-                (previewSrc
-                    ? '<img loading="lazy" src="' + previewSrc + '" alt="" style="width:100%; height:100%; object-fit:cover;" onerror="this.replaceWith(document.createTextNode(\'' + _typeIcon(a.asset_type) + '\'))">'
-                    : _typeIcon(a.asset_type)) +
+            '<div class="asset-grid-thumb' + (isComposed ? ' composed-preview' : '') + '" style="aspect-ratio:16/9; background:#0a0a0a; display:flex; align-items:center; justify-content:center; font-size:2rem; color:#666; position:relative;">' +
+                thumbInner +
                 '<input type="checkbox" class="bulk-select-grid" data-asset-id="' + a.id + '" onclick="event.stopPropagation()" style="position:absolute; top:6px; left:6px; transform:scale(1.2);">' +
                 (a.is_global ? '<span class="badge badge-ready" style="position:absolute; top:6px; right:6px; font-size:0.7rem;">Global</span>' : '') +
                 (a.unpublished ? '<span title="This composed slide has not been published — it will not appear on devices until you open it and click Publish." style="position:absolute; bottom:6px; left:6px; background:#dc2626; color:#fff; font-size:0.65rem; font-weight:700; letter-spacing:0.03em; padding:0.15rem 0.4rem; border-radius:4px;">⚠ UNPUBLISHED</span>' : '') +
@@ -1275,6 +1295,15 @@ function fallbackCopy(text, onSuccess) {
             const tableCb = tbody.querySelector('.bulk-select-row[data-asset-id="' + a.id + '"]');
             if (tableCb) tableCb.checked = cb.checked;
         });
+
+        // Lazy-load the composed-slide preview iframe when it nears view.
+        if (isComposed) {
+            const frame = card.querySelector('.composed-thumb-lazy');
+            if (frame) {
+                if (_composedThumbObserver) _composedThumbObserver.observe(frame);
+                else frame.src = frame.dataset.src;
+            }
+        }
 
         // Card body itself is non-interactive in Phase 1 — only the
         // checkbox is wired. (Earlier prototype flipped to table view

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -14,29 +14,32 @@
             <input type="text" id="composed-name" class="form-control" maxlength="255" required
                    placeholder="e.g. Lobby welcome"
                    style="width:100%; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
+            {% if assistant_enabled %}
+            <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
+                Optional when using the AI assistant — leave blank and it'll be auto-named (rename later from the Assets page).
+            </small>
+            {% endif %}
         </div>
-
-        {% if is_admin %}
-        <div class="form-group" style="margin-bottom:0;">
-            <label style="display:block; font-weight:600;">Visibility</label>
-            <label style="display:inline-flex; align-items:center; gap:0.4rem; padding-top:0.4rem;">
-                <input type="checkbox" id="composed-global" checked>
-                Visible to everyone (global)
-            </label>
-        </div>
-        {% endif %}
 
         {% if user_groups | length > 0 %}
         <div class="form-group" style="margin-bottom:0;">
-            <label style="display:block; font-weight:600;">{% if is_admin %}Or share with specific groups{% else %}Share with groups{% endif %}</label>
-            <div id="composed-groups-list"
-                 style="display:flex; flex-direction:column; gap:0.2rem; max-height:120px; overflow:auto; padding:0.35rem; border:1px solid var(--border); border-radius:6px; background:var(--bg);">
-                {% for g in user_groups %}
-                <label style="display:flex; align-items:center; gap:0.35rem; font-weight:normal; margin:0;">
-                    <input type="checkbox" name="composed_group_ids" value="{{ g.id }}"> {{ g.name }}
-                </label>
-                {% endfor %}
+            <label style="display:block; font-weight:600;">Assign to groups</label>
+            <div id="composed-groups-badges" style="display:flex; gap:0.35rem; flex-wrap:wrap; min-height:1.6rem; align-items:center;">
+                <span class="group-picker-wrap" style="position:relative; display:inline-flex;">
+                    <button class="btn-add-group" type="button" onclick="event.stopPropagation(); openGroupPopup('composed-group-popup')" title="Add group">+</button>
+                    <div id="composed-group-popup" popover class="group-popup">
+                        {% for g in user_groups %}
+                        <button type="button" class="group-popup-item" data-group-id="{{ g.id }}" data-group-name="{{ g.name }}"
+                                onclick="event.stopPropagation(); pickComposedGroup('{{ g.id }}', {{ g.name | tojson | forceescape }})">{{ g.name }}</button>
+                        {% endfor %}
+                    </div>
+                </span>
             </div>
+            {% if is_admin %}
+            <p class="text-muted" style="margin-top:0.25rem; font-size:0.8rem;">
+                Leave empty to make Global.
+            </p>
+            {% endif %}
         </div>
         {% endif %}
     </div>
@@ -1509,13 +1512,10 @@ async function ensureAssetExists() {
         if (nameEl) nameEl.focus();
         return false;
     }
-    const globalEl = document.getElementById("composed-global");
-    const isGlobal = globalEl ? globalEl.checked : false;
-    const groupIds = Array.from(
-        document.querySelectorAll("input[name='composed_group_ids']:checked")
-    ).map(el => el.value);
+    const groupIds = (window.composedSelectedGroupIds || []).slice();
     const body = {name: name};
-    if (!isGlobal && groupIds.length > 0) body.group_ids = groupIds;
+    // Empty groups → Global (matches the slideshow builder).
+    if (groupIds.length > 0) body.group_ids = groupIds;
     try {
         const resp = await fetch("/composed/", {
             method: "POST",
@@ -1724,19 +1724,62 @@ async function cwLeaveSave() {
     if (href) window.location.href = href;
 }
 
-// New-slide metadata edits (name / groups / global) also count as
-// unsaved changes.
+// New-slide metadata edits (name) also count as unsaved changes.
+// Group-picker edits flag dirty from inside pickComposedGroup / badge
+// removal below.
 (function wireMetadataDirty() {
-    const ids = ["composed-name", "composed-global"];
-    ids.forEach((id) => {
-        const el = document.getElementById(id);
-        if (el) el.addEventListener("input", markDirty);
-        if (el) el.addEventListener("change", markDirty);
-    });
-    document.querySelectorAll("input[name='composed_group_ids']").forEach((el) => {
+    const el = document.getElementById("composed-name");
+    if (el) {
+        el.addEventListener("input", markDirty);
         el.addEventListener("change", markDirty);
-    });
+    }
 })();
+
+// ── Group picker (create mode) — mirrors the slideshow builder ──────
+window.composedSelectedGroupIds = window.composedSelectedGroupIds || [];
+
+function openGroupPopup(id) {
+    const el = document.getElementById(id);
+    if (el && el.showPopover) el.showPopover();
+}
+
+function pickComposedGroup(id, name) {
+    // After the draft is minted the groups are already committed (read once
+    // at create time), so ignore late edits to avoid silent no-ops.
+    if (ASSET_ID) return;
+    if (!window.composedSelectedGroupIds.includes(id)) {
+        window.composedSelectedGroupIds.push(id);
+        markDirty();
+    }
+    renderComposedGroupBadges();
+    const popup = document.getElementById("composed-group-popup");
+    if (popup && popup.hidePopover) popup.hidePopover();
+}
+
+function renderComposedGroupBadges() {
+    const wrap = document.getElementById("composed-groups-badges");
+    if (!wrap) return;
+    [...wrap.querySelectorAll(".group-badge")].forEach((n) => n.remove());
+    const popupWrap = wrap.querySelector(".group-picker-wrap");
+    window.composedSelectedGroupIds.forEach((gid) => {
+        const btn = document.querySelector(
+            `#composed-group-popup .group-popup-item[data-group-id="${gid}"]`
+        );
+        if (!btn) return;
+        const span = document.createElement("span");
+        span.className = "group-badge";
+        span.style.cssText =
+            "background:#444;color:#fff;padding:0.15rem 0.5rem;border-radius:0.5rem;font-size:0.8rem;cursor:pointer;";
+        span.textContent = btn.dataset.groupName + " ✕";
+        span.onclick = () => {
+            window.composedSelectedGroupIds =
+                window.composedSelectedGroupIds.filter((x) => x !== gid);
+            markDirty();
+            renderComposedGroupBadges();
+        };
+        wrap.insertBefore(span, popupWrap);
+    });
+}
 
 ensureLayoutShape();
 renderCanvas();

--- a/tests/test_composed_editor_assistant.py
+++ b/tests/test_composed_editor_assistant.py
@@ -329,6 +329,9 @@ class TestCreateModeDrawer:
         # unbound and mints on first send.
         assert 'data-asset-id=""' in text
         assert 'data-asset-id="None"' not in text
+        # The name field advertises that it's optional with the assistant
+        # (mintDraft auto-names an unnamed slide).
+        assert "leave blank and it'll be auto-named" in text.lower()
 
     async def test_new_page_hides_drawer_for_disabled_user(
         self, operator_client, app


### PR DESCRIPTION
Three polish nits for composed-slide assets on the asset library page (from user review):

1. **Badge pill** — added a \.badge-composed\ color (indigo \#6366f1\) so the composed type badge renders as a colored pill like every other asset type, instead of falling back to no background.
2. **Kebab Preview** — added a **Preview** action to the composed asset's kebab menu. It opens the live \/composed/{id}/preview\ render in a modal (\previewComposed\ in app.js), mirroring \previewAsset\.
3. **Grid thumbnail** — composed slides now show a real live HTML preview in the grid card instead of the generic 📄 document icon.

### How the thumbnail works
Composed slides have no raster thumbnail — the only render is the live HTML endpoint. Widgets use fixed \px\ font sizes, so the iframe is framed at the true **1920×1080** canvas size and scaled down with CSS **container-query units** (\	ransform: scale(calc(100cqw / 1920px))\, \.composed-preview-frame\). No JS scaling/ResizeObserver needed — it's proportional at any size.

To avoid a grid of composed slides fetching every base64-inlined render at once, each thumbnail iframe is **lazy-loaded** via a shared module-level \IntersectionObserver\ (300px rootMargin), with a fallback to immediate \src\ if IO is unavailable.

### Notes
- No \sandbox\ on the iframes (would break clock/ticker/weather widget JS). Thumbnails use \pointer-events:none; tabindex=-1; aria-hidden\.
- Preview intentionally shows the current draft-or-live render (what users expect).
- Pure frontend: CSS + JS + 2 Jinja templates. \
ode --check\ and Jinja parse both pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>