### PR TITLE
Fix composed worker transcode (fastapi import) + empty asset grid

### DIFF
--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -20,6 +20,13 @@ Raising ``HTTPException`` from here is intentional: the preview route
 relies on FastAPI translating these into the same 404/403/422 responses
 it produced before the extraction. The worker wraps the call in
 try/except and marks the variant failed on any error.
+
+``fastapi`` is a CMS-only dependency and is **not** installed in the
+worker image. So that the worker can import this module to render
+thumbnails, ``HTTPException`` is imported lazily with a lightweight,
+API-compatible fallback (same ``status_code`` / ``detail`` attributes)
+when fastapi is absent. In the CMS the real ``fastapi.HTTPException`` is
+used, so the preview route's response translation is unchanged.
 """
 
 from __future__ import annotations
@@ -31,7 +38,24 @@ import uuid
 from dataclasses import dataclass
 from typing import Awaitable, Callable
 
-from fastapi import HTTPException
+try:  # fastapi is a CMS-only dep; the worker image does not install it.
+    from fastapi import HTTPException
+except ModuleNotFoundError:  # pragma: no cover - exercised only in the worker image
+
+    class HTTPException(Exception):  # type: ignore[no-redef]
+        """Minimal stand-in for ``fastapi.HTTPException``.
+
+        Mirrors the ``status_code`` / ``detail`` attributes so the raise
+        sites below behave identically. The worker catches any exception
+        from this module and marks the variant failed, so the concrete
+        type does not matter there.
+        """
+
+        def __init__(self, status_code: int = 500, detail: object = None) -> None:
+            self.status_code = status_code
+            self.detail = detail
+            super().__init__(detail)
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -438,6 +438,16 @@
 
 {% block scripts %}
 <script>
+// Page-global user context. Declared at the script's top level (NOT inside
+// an IIFE) so every IIFE in this script — including the grid-render helpers
+// further down — can see these via lexical scope. (Regression history: these
+// once lived inside the first IIFE; the grid kebab in a later IIFE then threw
+// "__currentUserId is not defined".)
+const __userGroups = [{% for g in user_groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}];
+const __isAdmin = {{ 'true' if is_admin else 'false' }};
+const __hasAssetsWrite = {{ 'true' if "assets:write" in user_perms else 'false' }};
+const __currentUserId = {{ (current_user_id | string) | tojson if current_user_id else 'null' }};
+
 (function() {
     // Tab switching for add-asset panel
     window.switchAddTab = function(tab) {
@@ -449,11 +459,7 @@
         tabs.forEach(t => { if (t.textContent.trim() === labels[tab]) t.classList.add('active'); });
     };
 
-    // User context for scope rebuilds
-    const __userGroups = [{% for g in user_groups %}{"id":"{{ g.id }}","name":"{{ g.name }}"}{% if not loop.last %},{% endif %}{% endfor %}];
-    const __isAdmin = {{ 'true' if is_admin else 'false' }};
-    const __hasAssetsWrite = {{ 'true' if "assets:write" in user_perms else 'false' }};
-    const __currentUserId = {{ (current_user_id | string) | tojson if current_user_id else 'null' }};
+    // (user context hoisted to script top level — see top of this <script>)
 
     function _escHtml(s) {
         const d = document.createElement('div');


### PR DESCRIPTION
## Two production regressions (Goodwill dev) after #726 / #727

### 1. Composed thumbnail transcodes fail: `No module named 'fastapi'`
The worker renders composed-slide thumbnails by importing
`build_composed_html` from `cms/composed/render.py`, which did a
top-level `from fastapi import HTTPException`. **`fastapi` is a
CMS-only dependency and is not installed in the worker image**, so the
entire composed render path failed to import and every composed
thumbnail job errored.

`render.py` is the **only** `fastapi` import in the worker's
transitive import chain (verified across `cms/composed/**` and
`cms/models/**`). Fix imports `HTTPException` lazily with an
API-compatible fallback (same `status_code` / `detail`) when fastapi
is absent:
- **CMS**: real `fastapi.HTTPException` — preview route's 404/403/422
  translation is unchanged.
- **Worker**: lightweight `Exception` subclass; the worker already
  wraps the call in try/except and marks the variant failed on any
  error, so the concrete type doesn't matter there.

### 2. Asset grid renders empty: `__currentUserId is not defined`
The page-context globals (`__userGroups`, `__isAdmin`,
`__hasAssetsWrite`, `__currentUserId`) were declared as `const`
**inside the first IIFE** in `assets.html`. #727's grid kebab was the
first grid-side code (in a **later, sibling IIFE**) to reference them.
`const` bindings aren't visible across sibling IIFEs → `ReferenceError`
→ the no-try/catch grid render loop aborted → blank grid.

Fix hoists the four declarations to the script's **top level** so
every IIFE in the script sees them via lexical scope. The list-view
kebab was unaffected because it's server-rendered Jinja.

## Validation
- `cms/composed/render.py` imports successfully with `fastapi` blocked
  (simulated worker); `HTTPException` falls back to an `Exception`
  subclass. Under the CMS the real `fastapi.HTTPException` is used.
- Jinja template parse OK; `node --check` of the rendered script OK.
- `pytest -k "composed_render or composed_preview or render or transcod"`
  → **200 passed, 46 skipped**.
