### PR TITLE
fix(cms): skip alembic upgrade on startup when DB already at head (unblocks ACA revision activation)

### DIFF
--- a/cms/database.py
+++ b/cms/database.py
@@ -70,14 +70,6 @@ async def run_migrations() -> None:
     DB is safe.
     """
 
-    async with _shared_db._engine.begin() as conn:
-        has_alembic = await conn.run_sync(
-            lambda c: sa_inspect(c).has_table("alembic_version")
-        )
-        has_legacy_assets = await conn.run_sync(
-            lambda c: sa_inspect(c).has_table("assets")
-        )
-
     # Alembic's env.py sets up its own async engine from SharedSettings,
     # so all we pass through is the Config pointing at alembic.ini.
     #
@@ -86,8 +78,55 @@ async def run_migrations() -> None:
     # inside a running event loop, so we hand off to a worker thread,
     # which gets its own loop.
     from alembic import command as alembic_command  # lazy: see _alembic_config
+    from alembic.script import ScriptDirectory  # lazy: see _alembic_config
 
     cfg = _alembic_config()
+
+    # Inspect the DB on the application's *primary* engine — the same one
+    # the app already proved it can reach via ``wait_for_db()``.  While we
+    # hold that connection, also read the current Alembic revision(s) so we
+    # can short-circuit the no-op case below.
+    async with _shared_db._engine.begin() as conn:
+        def _inspect(c):
+            insp = sa_inspect(c)
+            has_alembic = insp.has_table("alembic_version")
+            has_legacy = insp.has_table("assets")
+            revs: list[str] = []
+            if has_alembic:
+                res = c.exec_driver_sql("SELECT version_num FROM alembic_version")
+                revs = [row[0] for row in res.fetchall()]
+            return has_alembic, has_legacy, revs
+
+        has_alembic, has_legacy_assets, current_rev_list = await conn.run_sync(
+            _inspect
+        )
+
+    current_revs = set(current_rev_list)
+
+    # Fast path: the DB is already at head, so ``alembic upgrade head`` would
+    # be a no-op.  Skip it.  This is not just a perf win: Alembic's env.py
+    # runs the upgrade on its *own* async engine inside a nested
+    # ``asyncio.run()`` in a worker thread (see ``alembic/env.py``), and that
+    # second engine's connect has been observed to hang indefinitely on
+    # freshly-scheduled Azure Container Apps replicas even though the app's
+    # primary engine (used just above) connects fine.  A hung migration step
+    # blocks uvicorn's lifespan, so the replica never reports startup-complete
+    # and ACA's activation health gate fails — wedging every new revision.
+    # Skipping the redundant upgrade lets the replica boot and the revision
+    # activate.  Real pending migrations still take the upgrade path below.
+    if has_alembic and current_revs:
+        heads = set(ScriptDirectory.from_config(cfg).get_heads())
+        if current_revs == heads:
+            logger.info(
+                "Database already at head (%s); skipping alembic upgrade.",
+                ", ".join(sorted(current_revs)),
+            )
+            return
+        logger.info(
+            "Database revisions %s differ from alembic heads %s; running upgrade.",
+            sorted(current_revs),
+            sorted(heads),
+        )
 
     if not has_alembic and has_legacy_assets:
         logger.info(

--- a/tests/test_run_migrations_fast_path.py
+++ b/tests/test_run_migrations_fast_path.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``cms.database.run_migrations`` branch selection.
+
+These are DB-independent: the application engine, the SQLAlchemy
+inspector, alembic's ``ScriptDirectory``, and alembic's
+``command.upgrade`` / ``command.stamp`` are all faked/spied so we can
+assert exactly which path ``run_migrations`` takes for each DB state.
+
+The behaviour under test is the "already at head" fast path added to
+avoid spinning up alembic's own (second) async engine on every boot —
+that second engine has been observed to hang on freshly-scheduled
+Azure Container Apps replicas, wedging revision activation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cms.database as dbmod
+
+
+# ── Fakes ──────────────────────────────────────────────────────────────
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeSyncConn:
+    """Stand-in for the sync connection handed to ``run_sync`` callbacks."""
+
+    def __init__(self, versions):
+        self._versions = versions
+
+    def exec_driver_sql(self, _sql):
+        return _FakeResult([(v,) for v in self._versions])
+
+
+class _FakeInspector:
+    def __init__(self, tables):
+        self._tables = tables
+
+    def has_table(self, name):
+        return name in self._tables
+
+
+class _FakeAsyncConn:
+    def __init__(self, sync_conn):
+        self._sync = sync_conn
+
+    async def run_sync(self, fn):
+        return fn(self._sync)
+
+
+class _FakeBegin:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def begin(self):
+        return _FakeBegin(self._conn)
+
+
+class _FakeScriptDirectory:
+    _heads: list[str] = []
+
+    @classmethod
+    def from_config(cls, _cfg):
+        inst = cls()
+        return inst
+
+    def get_heads(self):
+        return list(type(self)._heads)
+
+
+# ── Harness ────────────────────────────────────────────────────────────
+
+
+def _install(monkeypatch, *, tables, versions, heads):
+    """Wire up the fakes and return a dict recording alembic command calls."""
+    calls: dict[str, int] = {"upgrade": 0, "stamp": 0}
+
+    engine = _FakeEngine(_FakeAsyncConn(_FakeSyncConn(versions)))
+    monkeypatch.setattr(dbmod._shared_db, "_engine", engine)
+    monkeypatch.setattr(dbmod, "sa_inspect", lambda _c: _FakeInspector(tables))
+
+    _FakeScriptDirectory._heads = list(heads)
+    import alembic.script
+
+    monkeypatch.setattr(alembic.script, "ScriptDirectory", _FakeScriptDirectory)
+
+    import alembic.command
+
+    def _fake_upgrade(_cfg, _rev):
+        calls["upgrade"] += 1
+
+    def _fake_stamp(_cfg, _rev):
+        calls["stamp"] += 1
+
+    monkeypatch.setattr(alembic.command, "upgrade", _fake_upgrade)
+    monkeypatch.setattr(alembic.command, "stamp", _fake_stamp)
+    return calls
+
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skips_upgrade_when_already_at_head(monkeypatch):
+    calls = _install(
+        monkeypatch,
+        tables={"alembic_version", "assets"},
+        versions=["0040_head"],
+        heads=["0040_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls == {"upgrade": 0, "stamp": 0}
+
+
+@pytest.mark.asyncio
+async def test_runs_upgrade_when_behind_head(monkeypatch):
+    calls = _install(
+        monkeypatch,
+        tables={"alembic_version", "assets"},
+        versions=["0039_old"],
+        heads=["0040_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls["upgrade"] == 1
+    assert calls["stamp"] == 0
+
+
+@pytest.mark.asyncio
+async def test_multi_head_order_independent(monkeypatch):
+    # Two heads recorded in a different order than the filesystem reports;
+    # set comparison must treat them as equal and skip.
+    calls = _install(
+        monkeypatch,
+        tables={"alembic_version"},
+        versions=["b_head", "a_head"],
+        heads=["a_head", "b_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls == {"upgrade": 0, "stamp": 0}
+
+
+@pytest.mark.asyncio
+async def test_partial_multi_head_runs_upgrade(monkeypatch):
+    # DB at one of two heads -> not fully merged -> must upgrade.
+    calls = _install(
+        monkeypatch,
+        tables={"alembic_version"},
+        versions=["a_head"],
+        heads=["a_head", "b_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls["upgrade"] == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_schema_is_stamped(monkeypatch):
+    # No alembic_version but a legacy assets table -> stamp, never upgrade.
+    calls = _install(
+        monkeypatch,
+        tables={"assets"},
+        versions=[],
+        heads=["0040_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls["stamp"] == 1
+    assert calls["upgrade"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_runs_upgrade(monkeypatch):
+    # Neither marker present -> fresh DB -> upgrade builds everything.
+    calls = _install(
+        monkeypatch,
+        tables=set(),
+        versions=[],
+        heads=["0040_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls["upgrade"] == 1
+    assert calls["stamp"] == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_version_table_runs_upgrade(monkeypatch):
+    # alembic_version exists but is empty -> don't skip; let alembic decide.
+    calls = _install(
+        monkeypatch,
+        tables={"alembic_version"},
+        versions=[],
+        heads=["0040_head"],
+    )
+    await dbmod.run_migrations()
+    assert calls["upgrade"] == 1


### PR DESCRIPTION
## Problem
New CMS revisions on Goodwill **dev** Container Apps could not **activate**. A freshly scheduled replica hung during FastAPI startup right after `Running alembic upgrade head` and never completed uvicorn's lifespan, so ACA's activation health gate failed and traffic never moved. This blocked **every** deploy since 1.38.115 (including #727/#728's fixes), even though the merged code is correct.

Key evidence it's per-fresh-replica, not the code/image:
- Restarting an already-activated revision -> fresh replicas come up Healthy.
- Creating ANY new revision (even from the exact `:1.38.115` image currently serving healthy) crash-loops identically.
- `pg_stat_activity` during the hang: no blocked/active alembic query, no ungranted locks -> not DB contention.

## Root cause
`alembic/env.py` runs the upgrade on its **own** async engine (`async_engine_from_config` + `NullPool`) inside a nested `asyncio.run()` in a worker thread. The app's **primary** engine connects fine on these replicas (the `has_table` inspects at the top of `run_migrations` complete and the replica logs `Running alembic upgrade head`), but that **second** NullPool engine's connect/first-query wedges indefinitely on freshly scheduled replicas. The DB is already at head (0040), so the upgrade is a pure no-op.

## Fix
In `run_migrations()`, read the current `alembic_version` revision(s) on the primary engine (proven to work on the hung replicas) and compare to the filesystem heads from `ScriptDirectory`. If already at head, log and **return** without invoking the alembic command — never spinning up the second engine. Real pending migrations still take the unchanged upgrade path; legacy-stamp and fresh-DB paths are unchanged.

This breaks the catch-22: the new revision's fresh replicas skip the hanging no-op upgrade, complete startup, and the revision activates.

## Tests
`tests/test_run_migrations_fast_path.py` (DB-independent, fakes engine/inspector/ScriptDirectory, spies on alembic `upgrade`/`stamp`):
- at-head -> skip
- behind -> upgrade
- multi-head order independence -> skip
- partial multi-head -> upgrade
- legacy (no alembic_version, has assets) -> stamp
- fresh DB -> upgrade
- empty version table -> upgrade

Existing lifespan/startup tests still pass.

## Known follow-up (not in this PR)
A future deploy that **does** include a pending migration would still exercise the second-engine path and could hang on a fresh replica. The durable fix is to run alembic through the app's existing connection via `cfg.attributes['connection']` in `env.py`. Tracked separately.
