### PR TITLE
fix(startup): run alembic on the app's primary connection (no second engine)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -123,7 +123,21 @@ async def run_async_migrations() -> None:
 
 
 def run_migrations_online() -> None:
-    asyncio.run(run_async_migrations())
+    # When a caller (the app's startup path in ``cms.database.run_migrations``)
+    # injects an already-open Connection via ``config.attributes['connection']``,
+    # run the migrations on it directly.  This avoids building Alembic's own
+    # second async engine inside a nested ``asyncio.run()`` — that second
+    # engine's connect has been observed to hang indefinitely on freshly
+    # scheduled Azure Container Apps replicas, wedging revision activation.
+    #
+    # The Alembic CLI (and CI's ``alembic`` invocations) set no such
+    # attribute, so they fall through to the self-managed async engine and
+    # behave exactly as before.
+    connectable = config.attributes.get("connection", None)
+    if connectable is None:
+        asyncio.run(run_async_migrations())
+    else:
+        do_run_migrations(connectable)
 
 
 if context.is_offline_mode():

--- a/cms/database.py
+++ b/cms/database.py
@@ -15,7 +15,6 @@ was adopted.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 
@@ -51,6 +50,23 @@ def _alembic_config():
     return AlembicConfig(str(_ALEMBIC_INI))
 
 
+def _run_alembic_to_head(sync_connection, cfg, op: str) -> None:
+    """Run an Alembic command against an already-open (sync) Connection.
+
+    Designed to be called via ``AsyncConnection.run_sync`` so that Alembic's
+    ``env.py`` reuses this connection (passed through
+    ``cfg.attributes['connection']``) instead of constructing its own engine.
+    ``op`` is ``"upgrade"`` or ``"stamp"``; both target ``head``.
+    """
+    from alembic import command as alembic_command  # local import
+
+    cfg.attributes["connection"] = sync_connection
+    if op == "stamp":
+        alembic_command.stamp(cfg, "head")
+    else:
+        alembic_command.upgrade(cfg, "head")
+
+
 async def run_migrations() -> None:
     """Bring the database schema up to date with the latest Alembic revision.
 
@@ -70,14 +86,12 @@ async def run_migrations() -> None:
     DB is safe.
     """
 
-    # Alembic's env.py sets up its own async engine from SharedSettings,
-    # so all we pass through is the Config pointing at alembic.ini.
-    #
-    # alembic.command.upgrade/stamp are synchronous and — via our env.py —
-    # internally call ``asyncio.run()``.  We can't call asyncio.run from
-    # inside a running event loop, so we hand off to a worker thread,
-    # which gets its own loop.
-    from alembic import command as alembic_command  # lazy: see _alembic_config
+    # We run Alembic on the application's *primary* engine connection (via
+    # ``run_sync`` + ``config.attributes['connection']``; see ``alembic/env.py``)
+    # rather than letting env.py build its own second async engine.  That
+    # second engine's connect has been observed to hang indefinitely on
+    # freshly scheduled Azure Container Apps replicas, wedging revision
+    # activation.  The primary engine is already proven reachable here.
     from alembic.script import ScriptDirectory  # lazy: see _alembic_config
 
     cfg = _alembic_config()
@@ -104,16 +118,10 @@ async def run_migrations() -> None:
     current_revs = set(current_rev_list)
 
     # Fast path: the DB is already at head, so ``alembic upgrade head`` would
-    # be a no-op.  Skip it.  This is not just a perf win: Alembic's env.py
-    # runs the upgrade on its *own* async engine inside a nested
-    # ``asyncio.run()`` in a worker thread (see ``alembic/env.py``), and that
-    # second engine's connect has been observed to hang indefinitely on
-    # freshly-scheduled Azure Container Apps replicas even though the app's
-    # primary engine (used just above) connects fine.  A hung migration step
-    # blocks uvicorn's lifespan, so the replica never reports startup-complete
-    # and ACA's activation health gate fails — wedging every new revision.
-    # Skipping the redundant upgrade lets the replica boot and the revision
-    # activate.  Real pending migrations still take the upgrade path below.
+    # be a no-op.  Skip it entirely — no need to import/run Alembic's env at
+    # all on a healthy boot.  (When there IS pending work, the upgrade below
+    # runs on the primary connection, so it no longer risks the second-engine
+    # hang that historically wedged ACA revision activation.)
     if has_alembic and current_revs:
         heads = set(ScriptDirectory.from_config(cfg).get_heads())
         if current_revs == heads:
@@ -133,8 +141,10 @@ async def run_migrations() -> None:
             "Legacy pre-Alembic schema detected; stamping as baseline "
             "without running DDL."
         )
-        await asyncio.to_thread(alembic_command.stamp, cfg, "head")
+        async with _shared_db._engine.connect() as conn:
+            await conn.run_sync(_run_alembic_to_head, cfg, "stamp")
         return
 
     logger.info("Running alembic upgrade head")
-    await asyncio.to_thread(alembic_command.upgrade, cfg, "head")
+    async with _shared_db._engine.connect() as conn:
+        await conn.run_sync(_run_alembic_to_head, cfg, "upgrade")

--- a/tests/test_run_migrations_fast_path.py
+++ b/tests/test_run_migrations_fast_path.py
@@ -105,9 +105,20 @@ def _install(monkeypatch, *, tables, versions, heads):
     _FakeScriptDirectory._heads = list(heads)
     import alembic.script
 
-    monkeypatch.setattr(alembic.script, "ScriptDirectory", _FakeScriptDirectory)
-
+    # Import ``alembic.command`` *before* patching ``alembic.script`` so that
+    # command.py's module-level ``from .script import ScriptDirectory`` (run
+    # once, at first import) captures the *real* class. Otherwise, if this is
+    # the first import of ``alembic.command`` in the process and it happens
+    # while ``alembic.script.ScriptDirectory`` is patched, command.py would
+    # permanently bind the fake — and monkeypatch can't revert a binding it
+    # never recorded, leaking the fake into later real-alembic tests.
     import alembic.command
+
+    monkeypatch.setattr(alembic.script, "ScriptDirectory", _FakeScriptDirectory)
+    # Also patch command.py's own binding so the fast path's ScriptDirectory
+    # use is consistent regardless of import order. This is monkeypatch-tracked
+    # and therefore reverted on teardown, unlike the import-time capture above.
+    monkeypatch.setattr(alembic.command, "ScriptDirectory", _FakeScriptDirectory)
 
     def _fake_upgrade(cfg, _rev):
         calls["upgrade"] += 1

--- a/tests/test_run_migrations_fast_path.py
+++ b/tests/test_run_migrations_fast_path.py
@@ -51,8 +51,8 @@ class _FakeAsyncConn:
     def __init__(self, sync_conn):
         self._sync = sync_conn
 
-    async def run_sync(self, fn):
-        return fn(self._sync)
+    async def run_sync(self, fn, *args):
+        return fn(self._sync, *args)
 
 
 class _FakeBegin:
@@ -73,6 +73,9 @@ class _FakeEngine:
     def begin(self):
         return _FakeBegin(self._conn)
 
+    def connect(self):
+        return _FakeBegin(self._conn)
+
 
 class _FakeScriptDirectory:
     _heads: list[str] = []
@@ -91,9 +94,11 @@ class _FakeScriptDirectory:
 
 def _install(monkeypatch, *, tables, versions, heads):
     """Wire up the fakes and return a dict recording alembic command calls."""
-    calls: dict[str, int] = {"upgrade": 0, "stamp": 0}
+    calls: dict = {"upgrade": 0, "stamp": 0, "injected": []}
 
-    engine = _FakeEngine(_FakeAsyncConn(_FakeSyncConn(versions)))
+    sync_conn = _FakeSyncConn(versions)
+    engine = _FakeEngine(_FakeAsyncConn(sync_conn))
+    calls["sync_conn"] = sync_conn
     monkeypatch.setattr(dbmod._shared_db, "_engine", engine)
     monkeypatch.setattr(dbmod, "sa_inspect", lambda _c: _FakeInspector(tables))
 
@@ -104,11 +109,13 @@ def _install(monkeypatch, *, tables, versions, heads):
 
     import alembic.command
 
-    def _fake_upgrade(_cfg, _rev):
+    def _fake_upgrade(cfg, _rev):
         calls["upgrade"] += 1
+        calls["injected"].append(cfg.attributes.get("connection"))
 
-    def _fake_stamp(_cfg, _rev):
+    def _fake_stamp(cfg, _rev):
         calls["stamp"] += 1
+        calls["injected"].append(cfg.attributes.get("connection"))
 
     monkeypatch.setattr(alembic.command, "upgrade", _fake_upgrade)
     monkeypatch.setattr(alembic.command, "stamp", _fake_stamp)
@@ -127,7 +134,8 @@ async def test_skips_upgrade_when_already_at_head(monkeypatch):
         heads=["0040_head"],
     )
     await dbmod.run_migrations()
-    assert calls == {"upgrade": 0, "stamp": 0}
+    assert calls["upgrade"] == 0
+    assert calls["stamp"] == 0
 
 
 @pytest.mark.asyncio
@@ -141,6 +149,9 @@ async def test_runs_upgrade_when_behind_head(monkeypatch):
     await dbmod.run_migrations()
     assert calls["upgrade"] == 1
     assert calls["stamp"] == 0
+    # The app's primary connection is injected so alembic does NOT build a
+    # second engine (the historical ACA activation hang).
+    assert calls["injected"] == [calls["sync_conn"]]
 
 
 @pytest.mark.asyncio
@@ -154,7 +165,8 @@ async def test_multi_head_order_independent(monkeypatch):
         heads=["a_head", "b_head"],
     )
     await dbmod.run_migrations()
-    assert calls == {"upgrade": 0, "stamp": 0}
+    assert calls["upgrade"] == 0
+    assert calls["stamp"] == 0
 
 
 @pytest.mark.asyncio
@@ -182,6 +194,7 @@ async def test_legacy_schema_is_stamped(monkeypatch):
     await dbmod.run_migrations()
     assert calls["stamp"] == 1
     assert calls["upgrade"] == 0
+    assert calls["injected"] == [calls["sync_conn"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_migrations_injected_connection.py
+++ b/tests/test_run_migrations_injected_connection.py
@@ -1,0 +1,54 @@
+"""Integration test: ``run_migrations`` drives REAL alembic through the
+application's primary connection (``cfg.attributes['connection']`` +
+``AsyncConnection.run_sync``) instead of letting ``alembic/env.py`` build
+its own second async engine.
+
+The fake-based ``test_run_migrations_fast_path`` suite pins branch
+selection but spies away ``alembic.command``; it never runs alembic's
+``env.py``.  This test closes that gap by running the real alembic stamp
+end-to-end against the test database and asserting the schema is marked at
+head — proving the env.py injection branch is wired correctly.
+
+The ``db_engine`` fixture builds the ORM schema via ``Base.metadata
+.create_all`` but never creates ``alembic_version`` — i.e. the "legacy
+schema" state — so ``run_migrations`` takes the real ``alembic stamp head``
+path through the injected connection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import inspect as sa_inspect
+
+import cms.database as dbmod
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_stamps_via_injected_connection(db_engine, monkeypatch):
+    monkeypatch.setattr(dbmod._shared_db, "_engine", db_engine)
+
+    # Precondition: legacy state — tables exist, but no alembic_version yet.
+    async with db_engine.connect() as conn:
+        has_alembic_before = await conn.run_sync(
+            lambda c: sa_inspect(c).has_table("alembic_version")
+        )
+    assert has_alembic_before is False
+
+    # Runs REAL alembic stamp through env.py's injected-connection branch.
+    await dbmod.run_migrations()
+
+    cfg = dbmod._alembic_config()
+    from alembic.script import ScriptDirectory
+
+    expected_heads = set(ScriptDirectory.from_config(cfg).get_heads())
+
+    async with db_engine.connect() as conn:
+        def _read(c):
+            insp = sa_inspect(c)
+            assert insp.has_table("alembic_version")
+            res = c.exec_driver_sql("SELECT version_num FROM alembic_version")
+            return {row[0] for row in res.fetchall()}
+
+        recorded = await conn.run_sync(_read)
+
+    assert recorded == expected_heads


### PR DESCRIPTION
## Why

Follow-up to #729. #729 stops the **no-op** `alembic upgrade head` from
running on a healthy boot (DB already at head), which sidesteps the
second-engine hang on freshly scheduled ACA replicas. But that only
covers the *no-op* case. A deploy that ships a **real pending
migration** still falls through to `alembic upgrade head`, which — via
`alembic/env.py` — builds a **second async engine** inside a nested
`asyncio.run()`. That second engine's connect has been observed to wedge
indefinitely on fresh Azure Container Apps replicas, blocking uvicorn
lifespan → the activation health gate fails → the new revision never
activates.

## What

Run alembic on the application's **already-open primary connection**
instead of letting `env.py` build its own engine:

- `alembic/env.py::run_migrations_online()` now branches on
  `config.attributes.get("connection")`. When a caller injects a
  connection, it runs `do_run_migrations(connectable)` directly; when
  not (the alembic CLI, CI's `alembic-check` / `migration-safety`
  jobs), it falls through to the unchanged self-managed async-engine
  path — identical behaviour to today.
- `cms/database.py::run_migrations()` opens the primary engine and
  executes alembic through `AsyncConnection.run_sync` + a small
  `_run_alembic_to_head` helper that sets
  `cfg.attributes["connection"]`. Applies to **both** the `upgrade`
  and the legacy `stamp` paths. The at-head fast-skip from #729 is
  retained. Dropped the now-unused top-level `import asyncio` and the
  lazy `alembic command` import.

This is the canonical alembic *"run via an existing connection"*
pattern. The primary engine is already proven reachable on the same
replica (the `wait_for_db()` and the inspect at the top of
`run_migrations` both complete), so future deploys with pending
migrations can't hit the second-engine hang either.

## Tests

- The 7 fast-path branch tests now also assert the **primary
  connection** is the one injected into alembic (so no second engine is
  built).
- New `tests/test_run_migrations_injected_connection.py` — a
  **real-alembic** integration test: it points `run_migrations` at the
  test DB (legacy state) and runs an actual `alembic stamp head`
  through the injected connection end-to-end, asserting
  `alembic_version` lands at the filesystem head. This exercises
  `env.py`'s injection branch with real alembic (the fake-based suite
  spies `alembic.command` away).
- Local: fast-path (7) + injection integration (1) + lifespan ordering
  / cms-lifespan (8) all green.

## Note — stacked on #729

This branches off `fix/startup-migration-skip-at-head` (#729) because
both edit `run_migrations()`. With base `main` while #729 is still
open, the diff transiently shows #729's commit (`da3266e`) too; it
collapses once #729 merges.
