### PR TITLE
fix(transcoder): tolerate multiple existing variants in enqueue_for_new_profile

### DIFF
--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -338,13 +338,17 @@ async def enqueue_for_new_profile(
     new_variant_ids: list[uuid.UUID] = []
     for asset in assets:
         existing = await db.execute(
-            select(AssetVariant).where(
+            select(AssetVariant.id).where(
                 AssetVariant.source_asset_id == asset.id,
                 AssetVariant.profile_id == profile_id,
                 AssetVariant.deleted_at.is_(None),
-            )
+            ).limit(1)
         )
-        if existing.scalar_one_or_none():
+        # The latest-READY-wins thumbnail flow can leave more than one
+        # non-deleted variant per (asset, profile); we only care whether
+        # *any* already exists, so never use scalar_one_or_none here
+        # (it raises MultipleResultsFound and crashed startup seeding).
+        if existing.first() is not None:
             continue
 
         variant_id = uuid.uuid4()

--- a/tests/test_composed_thumbnail_snapshot.py
+++ b/tests/test_composed_thumbnail_snapshot.py
@@ -158,6 +158,38 @@ class TestEnqueueForNewProfile:
         assert len(rows) == 1
         assert rows[0].filename.endswith(".jpg")
 
+    async def test_skips_asset_with_multiple_existing_variants(self, db_session):
+        """Regression: the latest-READY-wins thumbnail flow legitimately
+        leaves >1 non-deleted variant per (asset, profile). The
+        "already has a variant?" guard must treat that as existence, not
+        uniqueness — ``scalar_one_or_none`` raised ``MultipleResultsFound``
+        and crashed ``_seed_profiles`` at startup (dev deploy blocker)."""
+        asset, _ = await _make_composed(db_session)
+        prof = _thumb_profile("thumb-dupes")
+        db_session.add(prof)
+        await db_session.flush()
+        for _ in range(2):
+            db_session.add(AssetVariant(
+                id=uuid.uuid4(),
+                source_asset_id=asset.id,
+                profile_id=prof.id,
+                filename=f"{uuid.uuid4()}.jpg",
+                status=VariantStatus.PENDING,
+            ))
+        await db_session.commit()
+
+        # Must not raise MultipleResultsFound; existing variants => skip.
+        new_ids = await enqueue_for_new_profile(prof.id, db_session)
+        assert new_ids == []
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset.id,
+                AssetVariant.profile_id == prof.id,
+            )
+        )).scalars().all()
+        assert len(rows) == 2, "must not add a third variant"
+
 
 @pytest.mark.asyncio
 class TestEnqueueComposedThumbnail:


### PR DESCRIPTION
## Problem

Fresh CMS replicas crash-loop during FastAPI startup on Goodwill **dev** ACA, so new revisions never activate. #729 fixed an alembic no-op-upgrade hang and unmasked the real blocker:

`\
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
  at cms/services/transcoder.py:347 (enqueue_for_new_profile)
  via cms/main.py:129 (_seed_profiles) <- cms/main.py:595 (lifespan)
`\

## Root cause

`enqueue_for_new_profile` guarded "does a variant already exist for this (asset, profile)?" with `existing.scalar_one_or_none()`. The composed-thumbnail **latest-READY-wins** flow (#726) deliberately leaves the prior non-deleted variant in place until the reaper supersedes it, so a thumbnail-purpose profile legitimately accumulates 2+ non-deleted variants per composed asset. `scalar_one_or_none()` **raises** on >1 row -> seeding crashes at startup -> revision never goes Healthy -> rollback.

## Fix

The check only needs *existence*. Switched to `select(AssetVariant.id)...limit(1)` + `.first()`.

## Tests

- New regression `test_skips_asset_with_multiple_existing_variants` (2 existing variants -> no raise, no third variant added). Fails pre-fix with `MultipleResultsFound`.
- Local: `test_composed_thumbnail_snapshot` (15), `test_thumbnail_profile` + `test_profile_enable_disable` (33) all green.

Supersedes the alembic theory behind #730 (alembic was a real but secondary fix).
