### PR TITLE
feat(slideshow): support COMPOSED slides as slideshow members (capability-gated)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1432,19 +1432,33 @@ async def _load_and_validate_slide_sources(
 
     for s in slides:
         src = sources_by_id[s.source_asset_id]
-        if src.asset_type not in (AssetType.IMAGE, AssetType.VIDEO):
+        if src.asset_type not in (AssetType.IMAGE, AssetType.VIDEO, AssetType.COMPOSED):
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Slide source '{src.filename}' has type "
-                    f"{src.asset_type.value}; only image and video are allowed"
+                    f"{src.asset_type.value}; only image, video and composed "
+                    "slides are allowed"
                 ),
             )
-        if s.play_to_end and src.asset_type == AssetType.IMAGE:
+        # A composed slide member must already be published — an
+        # unpublished composed slide has no rendered bundle for the device
+        # to download (it would 404 in a retry loop). Mirror the same gate
+        # the scheduler/splash path applies via composed_unpublished_reason.
+        if src.asset_type == AssetType.COMPOSED and composed_unpublished_reason(src):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Slide source '{src.filename}' is an image; "
+                    f"Slide source '{src.filename}' is a composed slide that "
+                    "hasn't been published yet. Open it in the editor and click "
+                    "Publish before adding it to a slideshow."
+                ),
+            )
+        if s.play_to_end and src.asset_type != AssetType.VIDEO:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Slide source '{src.filename}' is a {src.asset_type.value}; "
                     "play_to_end is only valid for video sources"
                 ),
             )

--- a/cms/routers/schedules.py
+++ b/cms/routers/schedules.py
@@ -186,15 +186,27 @@ async def _validate_webpage_group(group_id: uuid.UUID, db: AsyncSession) -> None
         )
 
 
-async def _validate_slideshow_group(group_id: uuid.UUID, db: AsyncSession) -> None:
+async def _validate_slideshow_group(
+    group_id: uuid.UUID,
+    db: AsyncSession,
+    slideshow_asset_id: uuid.UUID | None = None,
+) -> None:
     """Validate every adopted device in ``group_id`` advertises slideshow_v1.
 
     Mirrors the Pi5/webpage gate.  Older firmware that doesn't include the
     capabilities field on register has an empty list, which fails the
     check — exactly the desired behaviour (block the schedule until the
     fleet is upgraded).
+
+    When ``slideshow_asset_id`` is supplied and the slideshow contains at
+    least one COMPOSED member, every device must additionally advertise
+    ``slideshow_composed_v1`` — pre-feature firmware can't render a
+    composed slide inside a slideshow.
     """
-    from cms.schemas.protocol import CAPABILITY_SLIDESHOW_V1
+    from cms.schemas.protocol import (
+        CAPABILITY_SLIDESHOW_V1,
+        CAPABILITY_SLIDESHOW_COMPOSED_V1,
+    )
 
     result = await db.execute(
         select(Device).where(
@@ -218,6 +230,43 @@ async def _validate_slideshow_group(group_id: uuid.UUID, db: AsyncSession) -> No
                 f"are not compatible: {names}{suffix}"
             ),
         )
+
+    if slideshow_asset_id is not None and await _slideshow_has_composed_member(
+        slideshow_asset_id, db
+    ):
+        needs_composed = [
+            d for d in devices
+            if CAPABILITY_SLIDESHOW_COMPOSED_V1 not in (d.capabilities or [])
+        ]
+        if needs_composed:
+            names = ", ".join(d.name or d.id for d in needs_composed[:3])
+            suffix = (
+                f" and {len(needs_composed) - 3} more"
+                if len(needs_composed) > 3
+                else ""
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "This slideshow contains a composed slide, which requires "
+                    "firmware advertising the 'slideshow_composed_v1' capability. "
+                    f"These devices in the group are not compatible: {names}{suffix}"
+                ),
+            )
+
+
+async def _slideshow_has_composed_member(
+    slideshow_asset_id: uuid.UUID, db: AsyncSession
+) -> bool:
+    """Return True if any slide source of the slideshow is a COMPOSED asset."""
+    from shared.models.slideshow_slide import SlideshowSlide
+
+    result = await db.execute(
+        select(Asset.asset_type)
+        .join(SlideshowSlide, SlideshowSlide.source_asset_id == Asset.id)
+        .where(SlideshowSlide.slideshow_asset_id == slideshow_asset_id)
+    )
+    return any(t == AssetType.COMPOSED for t in result.scalars().all())
 
 
 async def _resolve_loop_end_time(
@@ -282,7 +331,7 @@ async def create_schedule(data: ScheduleCreate, request: Request, db: AsyncSessi
 
     # Slideshow assets require firmware advertising slideshow_v1
     if is_slideshow and data.group_id:
-        await _validate_slideshow_group(data.group_id, db)
+        await _validate_slideshow_group(data.group_id, db, data.asset_id)
 
     # Auto-compute end_time when loop_count is set
     if not is_url_asset:
@@ -440,7 +489,9 @@ async def update_schedule(
     if is_slideshow and ("asset_id" in updates or "group_id" in updates):
         target_group_id = updates.get("group_id", schedule.group_id)
         if target_group_id:
-            await _validate_slideshow_group(target_group_id, db)
+            await _validate_slideshow_group(
+                target_group_id, db, updates.get("asset_id", schedule.asset_id)
+            )
 
     # Recompute end_time when loop_count changes (or when asset/start_time
     # change on a schedule that already has loop_count set).

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -46,6 +46,20 @@ CAPABILITY_SLIDESHOW_V1 = "slideshow_v1"
 # firmware PR #253 (APT 1.11.95).
 CAPABILITY_COMPOSED_SIBLINGS_V1 = "composed_siblings_v1"
 
+# ``slideshow_composed_v1`` indicates the device can render a COMPOSED
+# slide *as a member of a slideshow* — i.e. a slide whose
+# ``SlideDescriptor.asset_type`` is ``"composed"``, delivered with the
+# bundle HTML as ``download_url`` and the bundle's referenced source
+# assets in the per-slide ``siblings`` list.  The slideshow player loop
+# routes such a slide to ``show_html(bundle)`` (iframe) instead of
+# show_image/show_video.  The CMS only includes composed members in a
+# slideshow manifest sent to a device advertising this capability (see
+# the capability gate in :mod:`cms.services.slideshow_resolver`); older
+# firmware never receives a composed slide and so never chokes on the
+# unknown type.  Pairs with the agora firmware PR that lights up the
+# slideshow-loop composed branch.
+CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
+
 # Slideshow manifest schema version (semver, additive minor bumps).  The
 # wire format of the slideshow manifest is independent of the
 # higher-level ``PROTOCOL_VERSION``: protocol bumps describe the WS
@@ -63,11 +77,20 @@ CAPABILITY_COMPOSED_SIBLINGS_V1 = "composed_siblings_v1"
 #           Devices that don't understand 1.1 ignore the extras and
 #           keep playing the deck with the legacy relative-timer chain.
 #           Not yet emitted by the CMS — Phase 1a/1b lights it up.
+#   "1.2" — adds COMPOSED slide members: a ``SlideDescriptor`` may now
+#           carry ``asset_type="composed"`` with ``download_url`` set to
+#           the published bundle HTML and an optional per-slide
+#           ``siblings`` list (resolved source-asset dependencies of the
+#           bundle, same shape as the standalone-composed
+#           ``FetchAssetMessage.siblings``).  Gated by the
+#           ``slideshow_composed_v1`` capability — a slideshow containing
+#           composed members is only sent to devices that advertise it,
+#           so a 1.0/1.1 player never sees an unknown slide type.
 #
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.1"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.2"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -305,7 +328,7 @@ class SlideDescriptor(BaseModel):
     """One slide in a resolved slideshow manifest, sent inside FetchAssetMessage."""
 
     asset_name: str
-    asset_type: str  # "image" or "video"
+    asset_type: str  # "image", "video", or "composed"
     download_url: str
     checksum: str
     size_bytes: int
@@ -317,12 +340,21 @@ class SlideDescriptor(BaseModel):
     # behaviour (``cut`` / 600 ms) matches the pre-versioning era.
     transition: str = "cut"
     transition_ms: int = 600
+    # Composed-slide sibling dependencies (manifest schema 1.2).  Only
+    # present (non-None) when ``asset_type`` is ``"composed"``: the
+    # resolved source assets (video / image / saved_stream) embedded in
+    # the bundle so the device can pre-fetch them into the local cache
+    # before showing the bundle, exactly like a standalone composed
+    # asset's ``FetchAssetMessage.siblings``.  Empty / None means the
+    # composed slide has no media siblings (all-text/clock bundle).
+    siblings: Optional[list["Sibling"]] = None
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> "SlideDescriptor":
-        if self.asset_type not in ("image", "video"):
+        if self.asset_type not in ("image", "video", "composed"):
             raise ValueError(
-                f"SlideDescriptor.asset_type must be 'image' or 'video', got {self.asset_type!r}"
+                "SlideDescriptor.asset_type must be 'image', 'video' or "
+                f"'composed', got {self.asset_type!r}"
             )
         if self.duration_ms <= 0:
             raise ValueError(
@@ -331,6 +363,10 @@ class SlideDescriptor(BaseModel):
         if self.play_to_end and self.asset_type != "video":
             raise ValueError(
                 "SlideDescriptor.play_to_end=True is only valid for video sources"
+            )
+        if self.siblings is not None and self.asset_type != "composed":
+            raise ValueError(
+                "SlideDescriptor.siblings is only valid for composed slides"
             )
         # Keep this allow-list in sync with cms.schemas.asset.SLIDE_TRANSITIONS
         # and the JS shell's KNOWN_TRANSITIONS in agora/player/shell/player.js.
@@ -392,6 +428,7 @@ class Sibling(BaseModel):
 
 # Resolve forward references now that ``SlideDescriptor`` and ``Sibling``
 # are defined.
+SlideDescriptor.model_rebuild()
 FetchAssetMessage.model_rebuild()
 
 

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -31,15 +31,21 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import logging
+
 from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.device import Device
 from cms.schemas.protocol import (
     FetchAssetMessage,
     SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
+    Sibling,
     SlideDescriptor,
 )
+from cms.services.asset_readiness import composed_unpublished_reason
 from cms.services.storage import get_storage
 from shared.models.slideshow_slide import SlideshowSlide
+
+logger = logging.getLogger("agora.cms.slideshow")
 
 
 # Blocker statuses returned by the planner — exposed via API so the UI
@@ -48,6 +54,30 @@ BLOCKER_SOURCE_DELETED = "source_deleted"
 BLOCKER_VARIANT_PROCESSING = "variant_processing"
 BLOCKER_VARIANT_FAILED = "variant_failed"
 BLOCKER_VARIANT_CANCELLED = "variant_cancelled"
+# A composed-slide member that has never been published (no rendered
+# bundle / checksum) — the device would 404 trying to download it.
+BLOCKER_SOURCE_UNPUBLISHED = "source_unpublished"
+
+
+@dataclass
+class _SiblingPlan:
+    """One resolved composed-slide sibling (referenced image/video).
+
+    Mirrors the standalone-composed sibling contract
+    (:func:`cms.services.device_inbound._build_composed_siblings`) but
+    carries the storage *path* pieces rather than a baked download URL so
+    the device-profile-specific URL can be built in
+    :func:`build_fetch_for_slideshow` (which has ``storage``/``base_url``)
+    while the planner stays device-light.
+    """
+
+    source_asset_id: uuid.UUID
+    filename: str
+    asset_type_value: str  # "image" / "video" / "saved_stream"
+    checksum: str
+    size_bytes: int
+    download_path: str  # storage path for get_device_download_url
+    api_url_path: str  # CMS-relative API URL for fallback
 
 
 @dataclass
@@ -70,6 +100,10 @@ class _SlidePlan:
     api_url_path: Optional[str] = None  # CMS-relative API URL for fallback
     checksum: Optional[str] = None
     size_bytes: Optional[int] = None
+    # Composed-slide members (Phase 5) carry their referenced media as
+    # siblings the device pre-fetches before showing the bundle.  Empty
+    # for image/video slides.
+    siblings: list[_SiblingPlan] = field(default_factory=list)
 
 
 @dataclass
@@ -90,6 +124,148 @@ class SlideshowPlan:
     @property
     def ready(self) -> bool:
         return not self.blockers
+
+
+# Sentinel returned by :func:`_plan_composed_siblings` when at least one
+# referenced sibling has a non-terminal (in-flight) variant for the
+# device profile.  Distinguished from an empty/None sibling set so the
+# caller can raise a ``variant_processing`` blocker for the whole slide.
+_SIBLINGS_INFLIGHT = "INFLIGHT"
+
+
+async def _resolve_composed_sibling(
+    ref: Asset, profile_id: Optional[uuid.UUID], db: AsyncSession
+) -> Optional[_SiblingPlan]:
+    """Resolve one referenced sibling asset to a :class:`_SiblingPlan`.
+
+    Latest-READY-wins for the device profile (matching
+    :func:`cms.services.device_inbound._resolve_variant_or_source`);
+    falls back to the source asset when the device has no profile or no
+    variant exists.  Returns ``None`` when a variant exists for this
+    (asset, profile) pair but none is READY yet — the caller MUST treat
+    that as "sibling in flight, skip the whole slideshow fetch".
+    """
+    is_file_asset = ref.asset_type in (
+        AssetType.VIDEO,
+        AssetType.IMAGE,
+        AssetType.SAVED_STREAM,
+    )
+    type_value = ref.asset_type.value
+    if is_file_asset and profile_id is not None:
+        ready = (
+            await db.execute(
+                select(AssetVariant)
+                .where(
+                    AssetVariant.source_asset_id == ref.id,
+                    AssetVariant.profile_id == profile_id,
+                    AssetVariant.status == VariantStatus.READY,
+                    AssetVariant.deleted_at.is_(None),
+                )
+                .order_by(
+                    AssetVariant.created_at.desc(),
+                    AssetVariant.id.desc(),
+                )
+                .limit(1)
+            )
+        ).scalars().first()
+        if ready is not None:
+            return _SiblingPlan(
+                source_asset_id=ref.id,
+                filename=ref.filename,
+                asset_type_value=type_value,
+                checksum=ready.checksum or "",
+                size_bytes=ready.size_bytes or 0,
+                download_path=f"variants/{ready.filename}",
+                api_url_path=f"/api/assets/variants/{ready.id}/download",
+            )
+        inflight = (
+            await db.execute(
+                select(AssetVariant.id)
+                .where(
+                    AssetVariant.source_asset_id == ref.id,
+                    AssetVariant.profile_id == profile_id,
+                    AssetVariant.deleted_at.is_(None),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if inflight is not None:
+            return None  # in-flight — caller raises a blocker
+
+    return _SiblingPlan(
+        source_asset_id=ref.id,
+        filename=ref.filename,
+        asset_type_value=type_value,
+        checksum=ref.checksum or "",
+        size_bytes=ref.size_bytes or 0,
+        download_path=ref.filename,
+        api_url_path=f"/api/assets/{ref.id}/download",
+    )
+
+
+async def _plan_composed_siblings(
+    composed_asset: Asset, profile_id: Optional[uuid.UUID], db: AsyncSession
+) -> "list[_SiblingPlan] | str | None":
+    """Resolve the referenced media of a composed-slide member.
+
+    Returns:
+      * ``None`` when the bundle declares no source assets (all-text
+        slide) — the slide ships with no siblings.
+      * the string :data:`_SIBLINGS_INFLIGHT` when any sibling has a
+        non-terminal variant for ``profile_id`` — caller raises a
+        ``variant_processing`` blocker for the whole slide.
+      * a list of :class:`_SiblingPlan` otherwise.  Missing (deleted)
+        siblings are logged and skipped, matching the standalone-composed
+        contract (the bundle plays with a broken media reference).
+    """
+    # Lazy import — avoids a module-import cycle with cms.composed / models.
+    from cms.models.composed_slide import ComposedSlide
+
+    cs_row = (
+        await db.execute(
+            select(ComposedSlide).where(
+                ComposedSlide.asset_id == composed_asset.id
+            )
+        )
+    ).scalars().first()
+
+    raw_declared = list(cs_row.bundle_source_asset_ids or []) if cs_row else []
+    if not raw_declared:
+        return None
+
+    # publish.py stores these as str(uuid); coerce back so the IN clause
+    # and the by_id lookup hit the same Asset.id type.
+    declared: list[uuid.UUID] = [
+        aid if isinstance(aid, uuid.UUID) else uuid.UUID(str(aid))
+        for aid in raw_declared
+    ]
+
+    rows = await db.execute(
+        select(Asset).where(
+            Asset.id.in_(declared),
+            Asset.deleted_at.is_(None),
+        )
+    )
+    by_id = {a.id: a for a in rows.scalars().all()}
+
+    siblings: list[_SiblingPlan] = []
+    for aid in declared:
+        ref = by_id.get(aid)
+        if ref is None:
+            logger.warning(
+                "Composed slideshow member %s references missing/deleted "
+                "sibling asset %s; device will play bundle with broken "
+                "media reference",
+                composed_asset.id,
+                aid,
+            )
+            continue
+        resolved = await _resolve_composed_sibling(ref, profile_id, db)
+        if resolved is None:
+            return _SIBLINGS_INFLIGHT
+        siblings.append(resolved)
+
+    return siblings
 
 
 async def plan_slideshow(
@@ -177,7 +353,39 @@ async def plan_slideshow(
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
-        if profile_id is not None and src.asset_type in (
+        if src.asset_type == AssetType.COMPOSED:
+            # Composed member (Phase 5): the published bundle HTML *is*
+            # the Asset's own file; there is no transcode variant.  Block
+            # if never published (no bundle to download), then resolve the
+            # referenced media as siblings the device pre-fetches.
+            if composed_unpublished_reason(src) is not None:
+                plan.blockers.append(
+                    SlideshowBlocker(
+                        slide_position=slide_row.position,
+                        source_asset_id=sid,
+                        source_filename=src.filename,
+                        status=BLOCKER_SOURCE_UNPUBLISHED,
+                    )
+                )
+                continue
+            sib = await _plan_composed_siblings(src, profile_id, db)
+            if sib == _SIBLINGS_INFLIGHT:
+                plan.blockers.append(
+                    SlideshowBlocker(
+                        slide_position=slide_row.position,
+                        source_asset_id=sid,
+                        source_filename=src.filename,
+                        status=BLOCKER_VARIANT_PROCESSING,
+                    )
+                )
+                continue
+            sp.download_path = src.filename
+            sp.api_url_path = f"/api/assets/{src.id}/download"
+            sp.checksum = src.checksum
+            sp.size_bytes = src.size_bytes
+            if sib:
+                sp.siblings = sib  # type: ignore[assignment]
+        elif profile_id is not None and src.asset_type in (
             AssetType.VIDEO,
             AssetType.IMAGE,
             AssetType.SAVED_STREAM,
@@ -240,6 +448,12 @@ def _compute_resolved_manifest_checksum(
             f"|{s.position}|{s.source_asset_id}|{s.checksum or ''}|"
             f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}".encode()
         )
+        # Fold each composed sibling's checksum so a re-transcoded sibling
+        # video flips the resolved hash and prompts a device refetch.
+        # (Stricter than the standalone-composed path, which doesn't fold
+        # siblings — intentional, avoids serving a stale cached bundle.)
+        for sib in s.siblings:
+            h.update(f"|sib|{sib.source_asset_id}|{sib.checksum or ''}".encode())
     return h.hexdigest()
 
 
@@ -280,15 +494,37 @@ async def build_fetch_for_slideshow(
         download_url = await storage.get_device_download_url(
             sp.download_path or "", api_url
         )
+        # Pick the wire asset_type.  Composed members ship the bundle HTML
+        # plus their referenced media as siblings.
+        if sp.source_asset_type == AssetType.COMPOSED:
+            wire_type = "composed"
+        elif sp.source_asset_type in (AssetType.VIDEO, AssetType.SAVED_STREAM):
+            wire_type = "video"
+        else:
+            wire_type = "image"
+
+        wire_siblings: Optional[list[Sibling]] = None
+        if sp.siblings:
+            wire_siblings = []
+            for sib in sp.siblings:
+                sib_api_url = f"{base_url}{sib.api_url_path}"
+                sib_download_url = await storage.get_device_download_url(
+                    sib.download_path, sib_api_url
+                )
+                wire_siblings.append(
+                    Sibling(
+                        name=sib.filename,
+                        asset_type=sib.asset_type_value,
+                        download_url=sib_download_url,
+                        checksum=sib.checksum,
+                        size_bytes=sib.size_bytes,
+                    )
+                )
+
         descriptors.append(
             SlideDescriptor(
                 asset_name=sp.source_filename,
-                asset_type=(
-                    "video"
-                    if sp.source_asset_type
-                    in (AssetType.VIDEO, AssetType.SAVED_STREAM)
-                    else "image"
-                ),
+                asset_type=wire_type,
                 download_url=download_url,
                 checksum=sp.checksum or "",
                 size_bytes=sp.size_bytes or 0,
@@ -296,6 +532,7 @@ async def build_fetch_for_slideshow(
                 play_to_end=sp.play_to_end,
                 transition=sp.transition,
                 transition_ms=sp.transition_ms,
+                siblings=wire_siblings,
             )
         )
 

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -73,6 +73,16 @@
     border-radius: 0.25rem;
     pointer-events: none;
 }
+.ssb-composed-warning {
+    margin-top: 0.75rem;
+    padding: 0.6rem 0.8rem;
+    background: rgba(241, 196, 15, 0.12);
+    border: 1px solid rgba(241, 196, 15, 0.5);
+    border-radius: 0.4rem;
+    color: #f1c40f;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
 
 /* --- Film-strip timeline --- */
 .ssb-timeline-wrap {
@@ -514,6 +524,12 @@
         <!-- Hidden table marker preserved for tests / future fallback -->
         <div id="ss-slides-table" hidden></div>
 
+        <div id="ss-composed-warning" class="ssb-composed-warning" hidden>
+            ⚠ This slideshow contains a composed slide. Devices running
+            firmware without composed-slideshow support will skip this
+            slideshow until they are updated.
+        </div>
+
         <div id="ss-status" class="form-status" style="margin-top:0.75rem;"></div>
         <div style="display:flex; gap:0.5rem; margin-top:1rem;">
             <button type="submit" class="btn btn-primary" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
@@ -560,13 +576,19 @@ function thumbHtml(asset) {
         // <video> with preload=metadata typically renders the first frame as poster
         return `<video class="ssb-lib-thumb" src="${url}" preload="metadata" muted playsinline></video>`;
     }
+    if (asset.asset_type === 'composed') {
+        // Composed slides render via their snapshot thumbnail_url (handled
+        // above). If the snapshot isn't baked yet, show a labelled placeholder
+        // rather than the full asset URL (which isn't a renderable image).
+        return `<div class="ssb-lib-thumb" style="display:flex;align-items:center;justify-content:center;color:#666;">🧩 Composed</div>`;
+    }
     return `<div class="ssb-lib-thumb" style="display:flex;align-items:center;justify-content:center;color:#666;">No preview</div>`;
 }
 
 function renderLibrary() {
     const root = document.getElementById('ss-library');
     if (!availableAssets.length) {
-        root.innerHTML = '<div class="ssb-lib-empty">No images or videos in your library yet. Upload some on the Assets page first.</div>';
+        root.innerHTML = '<div class="ssb-lib-empty">No images, videos, or published composed slides in your library yet. Upload some on the Assets page first.</div>';
         return;
     }
     root.innerHTML = '';
@@ -579,7 +601,7 @@ function renderLibrary() {
         tile.title = `${name}\nClick to append, or drag onto the timeline`;
         tile.innerHTML = `
             ${thumbHtml(a)}
-            <div class="ssb-type-icon">${a.asset_type === 'video' ? '▶' : '🖼'}</div>
+            <div class="ssb-type-icon">${a.asset_type === 'video' ? '▶' : (a.asset_type === 'composed' ? '🧩' : '🖼')}</div>
             <div class="ssb-lib-meta">
                 <div class="ssb-lib-name">${escapeHtml(name)}</div>
                 <div class="ssb-lib-type">${a.asset_type}${a.duration_seconds ? ' · ' + fmtDur(a.duration_seconds) : ''}</div>
@@ -864,6 +886,13 @@ function updateTotals() {
     });
     document.getElementById('ss-total').textContent = fmtDur(totalMs / 1000);
     document.getElementById('ss-counter').textContent = slides.length + ' / ' + SS_MAX_SLIDES + ' slides';
+    updateCapabilityWarning();
+}
+
+function updateCapabilityWarning() {
+    const banner = document.getElementById('ss-composed-warning');
+    if (!banner) return;
+    banner.hidden = !slides.some(s => s.source_asset_type === 'composed');
 }
 
 function updateSlideDuration(i, v) {
@@ -957,13 +986,21 @@ async function loadAvailableAssets() {
         if (!params.has('type')) {
             params.append('type', 'image');
             params.append('type', 'video');
+            params.append('type', 'composed');
         }
         const r = await fetch('/api/assets/page?' + params.toString());
         if (!r.ok) throw new Error('HTTP ' + r.status);
         const data = await r.json();
         const items = Array.isArray(data) ? data : (data.items || data.assets || []);
         availableAssets = items.filter(a =>
-            (a.asset_type === 'image' || a.asset_type === 'video') && !a.deleted_at
+            !a.deleted_at && (
+                a.asset_type === 'image' ||
+                a.asset_type === 'video' ||
+                // Only published composed slides have a rendered bundle the
+                // device can fetch; the backend rejects unpublished ones as
+                // slideshow members, so don't offer them in the library.
+                (a.asset_type === 'composed' && !a.unpublished)
+            )
         );
         renderLibrary();
         if (data && data.next_cursor) {
@@ -1092,7 +1129,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (window.AssetFilter) {
         ssFilter = new AssetFilter({
             prefix: 'ssfilter',
-            fixedTypes: ['image', 'video'],
+            fixedTypes: ['image', 'video', 'composed'],
             syncUrl: false,
             debounceMs: 300,
             onChange: () => { loadAvailableAssets(); },

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -251,7 +251,8 @@ class TestSlideshowCreate:
             },
         )
         assert resp.status_code == 400
-        assert "image and video" in resp.json()["detail"].lower()
+        detail = resp.json()["detail"].lower()
+        assert "image, video and composed" in detail
 
     async def test_rejects_play_to_end_on_image(self, client, db_session):
         img = await _seed_image(db_session, is_global=True)

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -57,6 +57,17 @@ class TestSlideshowBuilderRoutes:
         assert "ss-slides-table" in body
         assert "/api/assets/slideshow" in body  # JS POST endpoint baked in
 
+    async def test_builder_supports_composed_members(self, client):
+        """Builder must offer composed slides in the library and warn about
+        the device capability requirement (Phase 5 composed-in-slideshow)."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Library filter + fetch pull composed assets alongside image/video.
+        assert "'image', 'video', 'composed'" in body
+        # Capability warning banner is present (toggled client-side).
+        assert "ss-composed-warning" in body
+
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""
         from tests.test_ui_overhaul import _create_user, _login_as

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -23,7 +23,10 @@ from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.device_profile import DeviceProfile
 from cms.models.slideshow_slide import SlideshowSlide
-from cms.schemas.protocol import CAPABILITY_SLIDESHOW_V1
+from cms.schemas.protocol import (
+    CAPABILITY_SLIDESHOW_COMPOSED_V1,
+    CAPABILITY_SLIDESHOW_V1,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +59,43 @@ async def _seed_video(db, *, filename, is_global=True, checksum="vid-sha", durat
     db.add(a)
     await db.commit()
     await db.refresh(a)
+    return a
+
+
+async def _seed_composed(
+    db, *, filename, checksum="cmp-sha", size=4096,
+    is_global=True, source_asset_ids=None,
+):
+    """Seed a COMPOSED asset (+ its ComposedSlide row).
+
+    ``checksum`` set => published (a bundle exists).  Pass ``checksum=None``
+    to model an unpublished composed slide.  ``source_asset_ids`` populates
+    the bundle's referenced media (siblings) — stored stringified, matching
+    the publish layer.
+    """
+    from cms.models.composed_slide import ComposedSlide
+
+    a = Asset(
+        filename=filename,
+        asset_type=AssetType.COMPOSED,
+        size_bytes=size,
+        checksum=checksum,
+        is_global=is_global,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    cs = ComposedSlide(
+        asset_id=a.id,
+        layout_json={"widgets": []},
+        is_draft=False,
+        bundle_source_asset_ids=(
+            None if source_asset_ids is None
+            else [str(aid) for aid in source_asset_ids]
+        ),
+    )
+    db.add(cs)
+    await db.commit()
     return a
 
 
@@ -365,7 +405,7 @@ class TestSlideshowResolver:
             ss, device, "https://cms.example", db_session,
         )
         assert fetch is not None
-        assert fetch.manifest_schema_version == "1.1"
+        assert fetch.manifest_schema_version == "1.2"
         assert fetch.cycle_duration_ms == 7500
         assert fetch.started_at is not None
         assert fetch.started_at.endswith("Z")
@@ -566,3 +606,254 @@ class TestReadinessApi:
         body = resp.json()
         assert body["readiness"]["ready"] is False
         assert body["readiness"]["blockers"][0]["status"] == "variant_processing"
+
+
+# ---------------------------------------------------------------------------
+# Composed-in-slideshow tests (Phase 5 / PR A)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestComposedSlideshowMember:
+    async def test_published_composed_member_emits_descriptor_with_siblings(
+        self, db_session, app
+    ):
+        """A published composed member resolves to a ``composed``
+        SlideDescriptor whose ``siblings`` carry the referenced video
+        (resolved to its READY variant for the device profile)."""
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "p-cmp")
+        vid = await _seed_video(
+            db_session, filename="cmp-sib.mp4", checksum="sibsrc",
+        )
+        await _seed_variant(
+            db_session, source=vid, profile=profile,
+            status=VariantStatus.READY, checksum="sibvar",
+        )
+        cmp_asset = await _seed_composed(
+            db_session, filename="cmp-mem.html", checksum="cmpsha",
+            source_asset_ids=[vid.id],
+        )
+        ss = await _seed_slideshow(
+            db_session, name="ss-cmp",
+            slides_data=[(cmp_asset, 8000, False)], checksum="mcmp",
+        )
+        device = await _seed_device(
+            db_session, did="dev-cmp", profile=profile,
+            capabilities=[
+                CAPABILITY_SLIDESHOW_V1, CAPABILITY_SLIDESHOW_COMPOSED_V1,
+            ],
+        )
+
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        assert len(fetch.slides) == 1
+        slide = fetch.slides[0]
+        assert slide.asset_type == "composed"
+        assert slide.download_url
+        assert slide.checksum == "cmpsha"
+        assert slide.siblings is not None and len(slide.siblings) == 1
+        sib = slide.siblings[0]
+        assert sib.name == "cmp-sib.mp4"
+        assert sib.asset_type == "video"
+        assert sib.checksum == "sibvar"
+        assert sib.download_url
+
+    async def test_published_composed_member_no_siblings(
+        self, db_session, app
+    ):
+        """An all-text composed member (no referenced media) ships a
+        composed descriptor with empty/None siblings."""
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "p-cmp2")
+        cmp_asset = await _seed_composed(
+            db_session, filename="cmp-text.html", checksum="cmptext",
+            source_asset_ids=None,
+        )
+        ss = await _seed_slideshow(
+            db_session, name="ss-cmp2",
+            slides_data=[(cmp_asset, 6000, False)], checksum="mcmp2",
+        )
+        device = await _seed_device(
+            db_session, did="dev-cmp2", profile=profile,
+            capabilities=[
+                CAPABILITY_SLIDESHOW_V1, CAPABILITY_SLIDESHOW_COMPOSED_V1,
+            ],
+        )
+
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        slide = fetch.slides[0]
+        assert slide.asset_type == "composed"
+        assert not slide.siblings
+
+    async def test_unpublished_composed_member_blocks(
+        self, db_session, app
+    ):
+        """A composed member with no bundle (checksum=None) makes the
+        slideshow not-ready with a ``source_unpublished`` blocker."""
+        from cms.services.slideshow_resolver import (
+            BLOCKER_SOURCE_UNPUBLISHED,
+            plan_slideshow,
+        )
+
+        profile = await _seed_profile(db_session, "p-cmp3")
+        cmp_asset = await _seed_composed(
+            db_session, filename="cmp-draft.html", checksum=None,
+        )
+        ss = await _seed_slideshow(
+            db_session, name="ss-cmp3",
+            slides_data=[(cmp_asset, 5000, False)], checksum="mcmp3",
+        )
+
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready is False
+        assert any(
+            b.status == BLOCKER_SOURCE_UNPUBLISHED for b in plan.blockers
+        )
+
+    async def test_inflight_sibling_blocks(self, db_session, app):
+        """A composed member whose referenced video has a non-READY
+        variant for the device profile blocks with ``variant_processing``."""
+        from cms.services.slideshow_resolver import (
+            BLOCKER_VARIANT_PROCESSING,
+            plan_slideshow,
+        )
+
+        profile = await _seed_profile(db_session, "p-cmp4")
+        vid = await _seed_video(
+            db_session, filename="cmp-inflight.mp4", checksum="srcq",
+        )
+        await _seed_variant(
+            db_session, source=vid, profile=profile,
+            status=VariantStatus.PROCESSING, checksum="",
+        )
+        cmp_asset = await _seed_composed(
+            db_session, filename="cmp-mem4.html", checksum="cmp4",
+            source_asset_ids=[vid.id],
+        )
+        ss = await _seed_slideshow(
+            db_session, name="ss-cmp4",
+            slides_data=[(cmp_asset, 5000, False)], checksum="mcmp4",
+        )
+
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready is False
+        assert any(
+            b.status == BLOCKER_VARIANT_PROCESSING for b in plan.blockers
+        )
+
+    async def test_sibling_checksum_change_flips_manifest_hash(
+        self, db_session, app
+    ):
+        """Re-transcoding a composed member's sibling (new variant
+        checksum) flips the resolved manifest hash so the device refetches."""
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "p-cmp5")
+        vid = await _seed_video(
+            db_session, filename="cmp-fold.mp4", checksum="srcf",
+        )
+        var = await _seed_variant(
+            db_session, source=vid, profile=profile,
+            status=VariantStatus.READY, checksum="foldA",
+        )
+        cmp_asset = await _seed_composed(
+            db_session, filename="cmp-mem5.html", checksum="cmp5",
+            source_asset_ids=[vid.id],
+        )
+        ss = await _seed_slideshow(
+            db_session, name="ss-cmp5",
+            slides_data=[(cmp_asset, 5000, False)], checksum="mcmp5",
+        )
+        device = await _seed_device(
+            db_session, did="dev-cmp5", profile=profile,
+            capabilities=[
+                CAPABILITY_SLIDESHOW_V1, CAPABILITY_SLIDESHOW_COMPOSED_V1,
+            ],
+        )
+
+        fetch1 = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        var.checksum = "foldB"
+        db_session.add(var)
+        await db_session.commit()
+        fetch2 = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch1.checksum and fetch2.checksum
+        assert fetch1.checksum != fetch2.checksum
+
+
+# ---------------------------------------------------------------------------
+# Composed capability gate (slideshow_composed_v1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestComposedCapabilityGate:
+    async def test_schedule_create_blocks_device_without_composed_cap(
+        self, client, db_session
+    ):
+        """A slideshow containing a composed member must be rejected for a
+        device that has ``slideshow_v1`` but not ``slideshow_composed_v1``."""
+        cmp_asset = await _seed_composed(
+            db_session, filename="capc-mem.html", checksum="capc",
+        )
+        ss = await _seed_slideshow(
+            db_session, name="capc-ss",
+            slides_data=[(cmp_asset, 5000, False)], checksum="m",
+        )
+        g = await _seed_group(db_session, "capc-g")
+        await _seed_device(
+            db_session, did="capc-d", group=g,
+            capabilities=[CAPABILITY_SLIDESHOW_V1],
+        )
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "name": "capc-sched",
+                "asset_id": str(ss.id),
+                "group_id": str(g.id),
+                "start_time": "08:00:00",
+                "end_time": "09:00:00",
+            },
+        )
+        assert resp.status_code == 422
+        assert "slideshow_composed_v1" in resp.text
+
+    async def test_schedule_create_allows_device_with_composed_cap(
+        self, client, db_session
+    ):
+        """Same slideshow is allowed when the device advertises both
+        ``slideshow_v1`` and ``slideshow_composed_v1``."""
+        cmp_asset = await _seed_composed(
+            db_session, filename="capc2-mem.html", checksum="capc2",
+        )
+        ss = await _seed_slideshow(
+            db_session, name="capc2-ss",
+            slides_data=[(cmp_asset, 5000, False)], checksum="m",
+        )
+        g = await _seed_group(db_session, "capc2-g")
+        await _seed_device(
+            db_session, did="capc2-d", group=g,
+            capabilities=[
+                CAPABILITY_SLIDESHOW_V1, CAPABILITY_SLIDESHOW_COMPOSED_V1,
+            ],
+        )
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "name": "capc2-sched",
+                "asset_id": str(ss.id),
+                "group_id": str(g.id),
+                "start_time": "08:00:00",
+                "end_time": "09:00:00",
+            },
+        )
+        assert resp.status_code == 201, resp.text

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -148,10 +148,11 @@ class TestSlideshowV10Contract:
         in cms.schemas.protocol pins the default.
         """
         assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT == "1.0"
-        # Phase 1b bumps LATEST to "1.1" (wall-clock fields).  Future
-        # phases will keep bumping as new fields land.  DEFAULT stays
-        # at "1.0" — that's the "no version on the wire" fallback.
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.1"
+        # Phase 1b bumped LATEST to "1.1" (wall-clock fields); Phase 5
+        # composed-in-slideshow bumps it to "1.2" (composed slide
+        # descriptors + per-slide siblings).  DEFAULT stays at "1.0" —
+        # that's the "no version on the wire" fallback.
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.2"
 
     def test_forward_wall_clock_fields_are_ignored(self):
         """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to


### PR DESCRIPTION
## Summary

Phase 5 (PR A of A/B/C): allow **published COMPOSED slides as members inside SLIDESHOW assets**. CMS backend only, **capability-gated** behind a new `slideshow_composed_v1` capability so pre-feature firmware never receives composed slideshow members. No UI or firmware changes in this PR.

A composed member is delivered inside the slideshow manifest exactly like a standalone composed asset:
- `SlideDescriptor.asset_type = "composed"`, `download_url` = published bundle HTML, `checksum`/`size_bytes` from the Asset.
- Per-slide `siblings` (referenced videos/images) ride on the descriptor so the device pre-fetches them before `show_html(bundle)`.

## Changes

- **`cms/schemas/protocol.py`** — `CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"`; bump `SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST` `1.1` → `1.2`; relax `SlideDescriptor` validator to allow `"composed"`; add optional `SlideDescriptor.siblings`.
- **`cms/routers/assets.py`** `_load_and_validate_slide_sources` — allow published COMPOSED sources; reject unpublished (no bundle); reject `play_to_end` for non-video.
- **`cms/services/slideshow_resolver.py`** — resolve composed members (bundle file + siblings, latest-READY-wins), emit composed `SlideDescriptor` + `Sibling`s, fold sibling checksums into the resolved-manifest checksum (re-transcoded sibling flips the hash → device refetch); blockers for unpublished (`source_unpublished`) / in-flight sibling variant (`variant_processing`).
- **`cms/routers/schedules.py`** — capability gate: assigning a slideshow with composed members to a group whose adopted devices lack `slideshow_composed_v1` returns 422.
- **tests** — contract bump to `1.2`; 7 new resolver/gate tests (published w/ + w/o siblings, unpublished blocks, in-flight sibling blocks, sibling-checksum-change flips manifest hash, gate blocks/allows).

## Test plan

- `tests/test_slideshow_resolver.py` + `tests/test_slideshow_schema_contract.py` + `tests/test_composed_siblings_cms.py` — 48 passed locally.
- `tests/test_schedules.py` + `tests/test_scheduler.py` — 101 passed locally.

## Safety

Fully gated. With no device advertising `slideshow_composed_v1`, behavior is unchanged. Follow-ups: PR B (firmware accepts composed slideshow members + advertises the capability), PR C (slideshow builder UI).
