### PR TITLE
feat(assets): snapshot thumbnails for webpage assets

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -599,18 +599,18 @@ async def lifespan(app: FastAPI):
         from cms.services.transcoder import fix_image_variant_extensions
         await fix_image_variant_extensions(db)
 
-    # Backfill snapshot thumbnails for any composed slides that don't have
-    # one yet (idempotent — slides with a live/in-flight thumbnail are
-    # skipped). Repairs slides created before snapshots shipped, plus any
-    # save that failed to enqueue best-effort.
+    # Backfill snapshot thumbnails for any composed slides or webpage assets
+    # that don't have one yet (idempotent — assets with a live/in-flight
+    # thumbnail are skipped). Repairs assets created before snapshots shipped,
+    # plus any save that failed to enqueue best-effort.
     async for db in get_db():
-        from cms.services.transcoder import enqueue_missing_composed_thumbnails
+        from cms.services.transcoder import enqueue_missing_thumbnails
 
         try:
-            await enqueue_missing_composed_thumbnails(db)
+            await enqueue_missing_thumbnails(db)
         except Exception:  # noqa: BLE001
             logger.warning(
-                "composed thumbnail backfill failed at startup", exc_info=True,
+                "thumbnail backfill failed at startup", exc_info=True,
             )
 
     # Device transport selection (issue #344 Stage 2b.2).

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1242,6 +1242,15 @@ async def create_webpage_asset(
     )
     await db.commit()
     await db.refresh(asset)
+
+    # Best-effort: kick off a thumbnail snapshot of the live page. Never let
+    # a thumbnail failure block asset creation.
+    try:
+        from cms.services.transcoder import enqueue_thumbnail
+        await enqueue_thumbnail(asset, db)
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to enqueue webpage thumbnail for %s", asset.id, exc_info=True)
+
     return asset
 
 
@@ -1988,6 +1997,18 @@ async def update_asset(
         )
     await db.commit()
     await db.refresh(asset)
+
+    # If a webpage asset's URL changed, re-snapshot its thumbnail. Best-effort.
+    if "url" in changes and asset.asset_type == AssetType.WEBPAGE:
+        try:
+            from cms.services.transcoder import enqueue_thumbnail
+            await enqueue_thumbnail(asset, db)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to re-enqueue webpage thumbnail for %s", asset.id,
+                exc_info=True,
+            )
+
     return asset
 
 

--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -42,6 +42,19 @@ logger = logging.getLogger("agora.cms.transcoder")
 # issue #302-ish (image-supersede-over-eager).
 IMAGE_RELEVANT_FIELDS: frozenset[str] = frozenset({"max_width", "max_height"})
 
+# Asset types that have no source media file and whose ONLY meaningful
+# variant is a rendered thumbnail snapshot:
+#   - COMPOSED slides are snapshotted from their generated bundle HTML.
+#   - WEBPAGE assets are snapshotted by navigating headless Chromium to
+#     their live URL.
+# Both must be restricted to thumbnail-purpose profiles — a device-purpose
+# profile would try to ffmpeg a non-existent source file and emit a useless
+# ``.mp4``.
+THUMBNAIL_ONLY_ASSET_TYPES: tuple[AssetType, ...] = (
+    AssetType.COMPOSED,
+    AssetType.WEBPAGE,
+)
+
 # ── Monitor loop intervals ──────────────────────────────────────
 _MONITOR_INTERVAL = int(os.environ.get("AGORA_MONITOR_INTERVAL", "30"))
 _STALE_PROCESSING_TIMEOUT = int(os.environ.get("AGORA_STALE_TIMEOUT", "1800"))  # 30 min
@@ -81,14 +94,15 @@ def _variant_ext_for(asset: Asset, profile: DeviceProfile) -> str:
 def _profile_emits_for_asset(profile: DeviceProfile, asset: Asset) -> bool:
     """Whether ``profile`` should produce a variant for ``asset``.
 
-    Composed slides have no source media file — the only meaningful
-    variant for them is a thumbnail snapshot the worker renders from the
-    slide HTML. A device-purpose profile would try to ffmpeg a
-    non-existent source and emit a useless ``.mp4``, so composed assets
-    are restricted to thumbnail-purpose profiles. All other asset types
-    are emitted by every profile as before.
+    Composed slides and webpage assets have no source media file — the
+    only meaningful variant for them is a thumbnail snapshot the worker
+    renders (from the slide HTML, or by navigating to the webpage URL). A
+    device-purpose profile would try to ffmpeg a non-existent source and
+    emit a useless ``.mp4``, so these asset types are restricted to
+    thumbnail-purpose profiles. All other asset types are emitted by every
+    profile as before.
     """
-    if asset.asset_type == AssetType.COMPOSED:
+    if asset.asset_type in THUMBNAIL_ONLY_ASSET_TYPES:
         return getattr(profile, "purpose", "device") == "thumbnail"
     return True
 
@@ -325,7 +339,7 @@ async def enqueue_for_new_profile(
 
     wanted_types = [AssetType.VIDEO, AssetType.IMAGE]
     if getattr(profile, "purpose", "device") == "thumbnail":
-        wanted_types.append(AssetType.COMPOSED)
+        wanted_types.extend(THUMBNAIL_ONLY_ASSET_TYPES)
 
     result = await db.execute(
         select(Asset).where(
@@ -369,21 +383,26 @@ async def enqueue_for_new_profile(
 async def enqueue_composed_thumbnail(
     asset: Asset, db: AsyncSession
 ) -> list[uuid.UUID]:
-    """Queue a fresh snapshot render for a composed slide.
+    """Queue a fresh snapshot render for a thumbnail-only asset.
+
+    Handles both composed slides (snapshotted from the bundle HTML) and
+    webpage assets (snapshotted from the live URL) — any asset type in
+    :data:`THUMBNAIL_ONLY_ASSET_TYPES`. Other asset types are a no-op.
 
     Mirrors the latest-READY-wins flow used for profile changes: any
     existing thumbnail variant rows are left in place (the grid keeps
     showing the previous snapshot) while a new PENDING variant is added
-    per enabled thumbnail-purpose profile. The worker renders the slide
-    HTML to a JPEG; when the new variant reaches READY the reaper sweep
+    per enabled thumbnail-purpose profile. The worker renders the snapshot
+    to a JPEG; when the new variant reaches READY the reaper sweep
     supersedes the older sibling.
 
     Self-contained: creates the variant rows, commits, and enqueues the
     transcode jobs. Designed to be called best-effort from the layout
-    save hook (caller wraps in try/except so a transient failure never
-    blocks a save). Returns the new variant ids.
+    save hook / webpage create+URL-edit hooks (caller wraps in try/except
+    so a transient failure never blocks a save). Returns the new variant
+    ids.
     """
-    if asset.asset_type != AssetType.COMPOSED:
+    if asset.asset_type not in THUMBNAIL_ONLY_ASSET_TYPES:
         return []
 
     profiles = (
@@ -437,19 +456,28 @@ async def enqueue_composed_thumbnail(
         await enqueue_variants(db, new_variant_ids)
         logger.info(
             "enqueue_composed_thumbnail: queued %d snapshot render(s) for "
-            "composed asset %s", len(new_variant_ids), asset.id,
+            "%s asset %s", len(new_variant_ids), asset.asset_type.value,
+            asset.id,
         )
     return new_variant_ids
 
 
-async def enqueue_missing_composed_thumbnails(db: AsyncSession) -> int:
-    """Idempotent startup backfill: ensure every composed slide has a thumbnail.
+# Clearer generic alias — both composed slides and webpage assets enqueue
+# the same thumbnail snapshot render. New callers (webpage create / URL-edit
+# hooks) should prefer this name.
+enqueue_thumbnail = enqueue_composed_thumbnail
 
-    For each non-deleted COMPOSED asset that has no live thumbnail variant
-    (PENDING / PROCESSING / READY) under any enabled thumbnail-purpose
-    profile, enqueue a fresh snapshot render. Slides that already have one
-    — or have one in flight — are skipped, so this is safe to run on every
-    boot. Returns the number of slides for which a render was enqueued.
+
+async def enqueue_missing_composed_thumbnails(db: AsyncSession) -> int:
+    """Idempotent startup backfill: ensure every thumbnail-only asset has one.
+
+    For each non-deleted asset whose type is in
+    :data:`THUMBNAIL_ONLY_ASSET_TYPES` (composed slides + webpage assets)
+    that has no live thumbnail variant (PENDING / PROCESSING / READY)
+    under any enabled thumbnail-purpose profile, enqueue a fresh snapshot
+    render. Assets that already have one — or have one in flight — are
+    skipped, so this is safe to run on every boot. Returns the number of
+    assets for which a render was enqueued.
     """
     profiles = (
         await db.execute(
@@ -464,7 +492,7 @@ async def enqueue_missing_composed_thumbnails(db: AsyncSession) -> int:
     assets = (
         await db.execute(
             select(Asset).where(
-                Asset.asset_type == AssetType.COMPOSED,
+                Asset.asset_type.in_(THUMBNAIL_ONLY_ASSET_TYPES),
                 Asset.deleted_at.is_(None),
             )
         )
@@ -514,9 +542,13 @@ async def enqueue_missing_composed_thumbnails(db: AsyncSession) -> int:
         await enqueue_variants(db, new_variant_ids)
         logger.info(
             "enqueue_missing_composed_thumbnails: enqueued snapshot render(s) "
-            "for %d composed slide(s)", enqueued,
+            "for %d asset(s)", enqueued,
         )
     return enqueued
+
+
+# Clearer generic alias for the backfill (covers composed + webpage).
+enqueue_missing_thumbnails = enqueue_missing_composed_thumbnails
 
 
 async def fix_image_variant_extensions(db: AsyncSession) -> int:

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -73,17 +73,6 @@
     border-radius: 0.25rem;
     pointer-events: none;
 }
-.ssb-composed-warning {
-    margin-top: 0.75rem;
-    padding: 0.6rem 0.8rem;
-    background: rgba(241, 196, 15, 0.12);
-    border: 1px solid rgba(241, 196, 15, 0.5);
-    border-radius: 0.4rem;
-    color: #f1c40f;
-    font-size: 0.85rem;
-    line-height: 1.4;
-}
-
 /* --- Film-strip timeline --- */
 .ssb-timeline-wrap {
     margin-top: 0.5rem;
@@ -524,12 +513,6 @@
         <!-- Hidden table marker preserved for tests / future fallback -->
         <div id="ss-slides-table" hidden></div>
 
-        <div id="ss-composed-warning" class="ssb-composed-warning" hidden>
-            ⚠ This slideshow contains a composed slide. Devices running
-            firmware without composed-slideshow support will skip this
-            slideshow until they are updated.
-        </div>
-
         <div id="ss-status" class="form-status" style="margin-top:0.75rem;"></div>
         <div style="display:flex; gap:0.5rem; margin-top:1rem;">
             <button type="submit" class="btn btn-primary" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
@@ -886,13 +869,6 @@ function updateTotals() {
     });
     document.getElementById('ss-total').textContent = fmtDur(totalMs / 1000);
     document.getElementById('ss-counter').textContent = slides.length + ' / ' + SS_MAX_SLIDES + ' slides';
-    updateCapabilityWarning();
-}
-
-function updateCapabilityWarning() {
-    const banner = document.getElementById('ss-composed-warning');
-    if (!banner) return;
-    banner.hidden = !slides.some(s => s.source_asset_type === 'composed');
 }
 
 function updateSlideDuration(i, v) {

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -58,15 +58,13 @@ class TestSlideshowBuilderRoutes:
         assert "/api/assets/slideshow" in body  # JS POST endpoint baked in
 
     async def test_builder_supports_composed_members(self, client):
-        """Builder must offer composed slides in the library and warn about
-        the device capability requirement (Phase 5 composed-in-slideshow)."""
+        """Builder must offer composed slides in the asset library
+        (Phase 5 composed-in-slideshow)."""
         resp = await client.get("/assets/new/slideshow")
         assert resp.status_code == 200, resp.text
         body = resp.text
         # Library filter + fetch pull composed assets alongside image/video.
         assert "'image', 'video', 'composed'" in body
-        # Capability warning banner is present (toggled client-side).
-        assert "ss-composed-warning" in body
 
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""

--- a/tests/test_webpage_thumbnail_snapshot.py
+++ b/tests/test_webpage_thumbnail_snapshot.py
@@ -1,0 +1,361 @@
+"""Tests for webpage-asset snapshot thumbnails.
+
+Generalizes the composed-slide snapshot pipeline (PR #726) to webpage
+assets: a webpage asset's thumbnail is a static JPEG screenshot of its
+live URL rendered in headless Chromium in the worker, stored as a normal
+``thumbnail``-purpose ``AssetVariant`` and surfaced via the existing
+``thumbnail_url``.
+
+Covers:
+
+* Profile filtering — webpage assets only ever get thumbnail-purpose
+  variants (a device profile must never emit a useless ``.mp4``).
+* ``enqueue_thumbnail`` / ``enqueue_missing_thumbnails`` aliases cover
+  the WEBPAGE type now that the service is generalized.
+* Create + URL-edit hooks queue a fresh snapshot render.
+* Worker render branch — a webpage thumbnail variant is rendered to a
+  JPEG and marked READY (Playwright mocked); a webpage routed to a
+  device profile / with no URL fails loudly instead of ffmpeg-ing a
+  missing file.
+* SSRF guard — ``_host_is_safe`` rejects loopback / private /
+  link-local / unspecified hosts and ``render_url_to_png`` refuses
+  unsafe hosts and non-http(s) schemes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+from cms.models.device_profile import DeviceProfile
+from cms.services.transcoder import (
+    _profile_emits_for_asset,
+    enqueue_for_new_profile,
+    enqueue_missing_thumbnails,
+    enqueue_thumbnail,
+)
+
+
+def _thumb_profile(name: str = "thumb") -> DeviceProfile:
+    return DeviceProfile(
+        name=name,
+        video_codec="h264",
+        video_profile="main",
+        max_width=480,
+        max_height=270,
+        max_fps=1,
+        builtin=True,
+        purpose="thumbnail",
+    )
+
+
+def _device_profile(name: str = "dev") -> DeviceProfile:
+    return DeviceProfile(
+        name=name,
+        video_codec="h264",
+        video_profile="main",
+        max_width=1920,
+        max_height=1080,
+        max_fps=30,
+        builtin=True,
+        purpose="device",
+    )
+
+
+def _webpage_asset(url: str = "https://example.com/") -> Asset:
+    return Asset(
+        id=uuid.uuid4(),
+        filename=f"webpage-{uuid.uuid4()}",
+        asset_type=AssetType.WEBPAGE,
+        size_bytes=0,
+        checksum="",
+        url=url,
+    )
+
+
+async def _make_webpage(db_session, url: str = "https://example.com/") -> Asset:
+    asset = _webpage_asset(url)
+    db_session.add(asset)
+    await db_session.commit()
+    return asset
+
+
+# ───────────────────────── profile applicability ─────────────────────
+
+
+class TestProfileEmitsForAsset:
+    def test_webpage_only_for_thumbnail_profile(self):
+        wp = _webpage_asset()
+        assert _profile_emits_for_asset(_thumb_profile(), wp) is True
+        assert _profile_emits_for_asset(_device_profile(), wp) is False
+
+
+@pytest.mark.asyncio
+class TestEnqueueForNewProfile:
+    async def test_device_profile_skips_webpage(self, db_session):
+        asset = await _make_webpage(db_session)
+        prof = _device_profile("dev-skip-wp")
+        db_session.add(prof)
+        await db_session.commit()
+
+        await enqueue_for_new_profile(prof.id, db_session)
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset.id,
+                AssetVariant.profile_id == prof.id,
+            )
+        )).scalars().all()
+        assert rows == [], "device profile must not transcode a webpage asset"
+
+    async def test_thumbnail_profile_creates_jpg_for_webpage(self, db_session):
+        asset = await _make_webpage(db_session)
+        prof = _thumb_profile("thumb-new-wp")
+        db_session.add(prof)
+        await db_session.commit()
+
+        new_ids = await enqueue_for_new_profile(prof.id, db_session)
+        assert len(new_ids) == 1
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset.id,
+                AssetVariant.profile_id == prof.id,
+            )
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].filename.endswith(".jpg")
+
+
+@pytest.mark.asyncio
+class TestEnqueueThumbnail:
+    async def test_creates_pending_jpg_under_thumbnail_only(self, db_session):
+        asset = await _make_webpage(db_session)
+        thumb = _thumb_profile("t1-wp")
+        dev = _device_profile("d1-wp")
+        db_session.add_all([thumb, dev])
+        await db_session.commit()
+
+        new_ids = await enqueue_thumbnail(asset, db_session)
+        assert len(new_ids) == 1
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(AssetVariant.source_asset_id == asset.id)
+        )).scalars().all()
+        assert len(rows) == 1
+        v = rows[0]
+        assert v.profile_id == thumb.id
+        assert v.filename.endswith(".jpg")
+        assert v.status == VariantStatus.PENDING
+
+    async def test_noop_for_image(self, db_session):
+        img = Asset(
+            id=uuid.uuid4(), filename="i.jpg", asset_type=AssetType.IMAGE,
+            size_bytes=1, checksum="c",
+        )
+        db_session.add_all([img, _thumb_profile("t2-wp")])
+        await db_session.commit()
+        assert await enqueue_thumbnail(img, db_session) == []
+
+    async def test_coalesces_when_pending_exists(self, db_session):
+        asset = await _make_webpage(db_session)
+        db_session.add(_thumb_profile("t3-wp"))
+        await db_session.commit()
+
+        first = await enqueue_thumbnail(asset, db_session)
+        second = await enqueue_thumbnail(asset, db_session)
+        assert len(first) == 1
+        assert second == []
+
+
+@pytest.mark.asyncio
+class TestCreateAndEditHooks:
+    async def test_create_webpage_queues_snapshot(self, client, db_session):
+        db_session.add(_thumb_profile("t-create-wp"))
+        await db_session.commit()
+
+        resp = await client.post(
+            "/api/assets/webpage",
+            json={"url": "https://example.com/", "name": "Example"},
+        )
+        assert resp.status_code == 201, resp.text
+        asset_id = uuid.UUID(resp.json()["id"])
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset_id,
+                AssetVariant.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].status == VariantStatus.PENDING
+        assert rows[0].filename.endswith(".jpg")
+
+    async def test_url_edit_requeues_snapshot(self, client, db_session):
+        db_session.add(_thumb_profile("t-edit-wp"))
+        asset = await _make_webpage(db_session, "https://example.com/")
+        await db_session.commit()
+
+        # First render queued out-of-band; mark it READY so a fresh edit
+        # must enqueue a brand-new PENDING render.
+        thumb = (await db_session.execute(
+            select(DeviceProfile).where(DeviceProfile.name == "t-edit-wp")
+        )).scalar_one()
+        db_session.add(AssetVariant(
+            id=uuid.uuid4(), source_asset_id=asset.id, profile_id=thumb.id,
+            filename=f"{uuid.uuid4()}.jpg", status=VariantStatus.READY,
+        ))
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"url": "https://example.org/new"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        pending = (await db_session.execute(
+            select(AssetVariant).where(
+                AssetVariant.source_asset_id == asset.id,
+                AssetVariant.status == VariantStatus.PENDING,
+                AssetVariant.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+class TestBackfill:
+    async def test_backfills_missing_then_idempotent(self, db_session):
+        asset = await _make_webpage(db_session)
+        db_session.add(_thumb_profile("t-bf-wp"))
+        await db_session.commit()
+
+        first = await enqueue_missing_thumbnails(db_session)
+        assert first >= 1
+
+        second = await enqueue_missing_thumbnails(db_session)
+        assert second == 0
+
+        rows = (await db_session.execute(
+            select(AssetVariant).where(AssetVariant.source_asset_id == asset.id)
+        )).scalars().all()
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+class TestWorkerWebpageBranch:
+    async def _seed_variant(self, db_session, profile, *, url="https://example.com/"):
+        asset = _webpage_asset(url)
+        db_session.add(asset)
+        db_session.add(profile)
+        await db_session.flush()
+        variant = AssetVariant(
+            id=uuid.uuid4(),
+            source_asset_id=asset.id,
+            profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.jpg",
+            status=VariantStatus.PENDING,
+        )
+        db_session.add(variant)
+        await db_session.commit()
+        return asset, variant
+
+    async def test_renders_webpage_thumbnail_ready(
+        self, db_session, tmp_path, monkeypatch
+    ):
+        from worker import transcoder as wt
+        from worker import composed_render as wcr
+
+        thumb = _thumb_profile("t-worker-wp")
+        asset, variant = await self._seed_variant(db_session, thumb)
+
+        async def _fake_png(url):
+            assert url == asset.url
+            return b"\x89PNG-fake"
+
+        async def _fake_convert(src, dst, *, max_width, max_height):
+            dst.write_bytes(b"jpegbytes")
+            return True
+
+        class _Storage:
+            async def on_file_stored(self, key):
+                return None
+
+        monkeypatch.setattr(wcr, "render_url_to_png", _fake_png)
+        monkeypatch.setattr(wt, "convert_image", _fake_convert)
+        monkeypatch.setattr(wt, "get_storage", lambda: _Storage())
+
+        await wt._transcode_one(variant, db_session, tmp_path)
+
+        await db_session.refresh(variant)
+        assert variant.status == VariantStatus.READY
+        assert variant.size_bytes > 0
+        assert variant.checksum
+
+    async def test_webpage_on_device_profile_fails(self, db_session, tmp_path):
+        from worker import transcoder as wt
+
+        dev = _device_profile("d-worker-wp")
+        asset, variant = await self._seed_variant(db_session, dev)
+
+        await wt._transcode_one(variant, db_session, tmp_path)
+        await db_session.refresh(variant)
+        assert variant.status == VariantStatus.FAILED
+
+    async def test_webpage_without_url_fails(self, db_session, tmp_path):
+        from worker import transcoder as wt
+
+        thumb = _thumb_profile("t-worker-nourl")
+        asset, variant = await self._seed_variant(db_session, thumb, url="")
+
+        await wt._transcode_one(variant, db_session, tmp_path)
+        await db_session.refresh(variant)
+        assert variant.status == VariantStatus.FAILED
+
+
+# ───────────────────────── SSRF guard ────────────────────────────────
+
+
+class TestHostIsSafe:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "",
+            "localhost",
+            "foo.local",
+            "127.0.0.1",      # loopback
+            "10.0.0.1",       # private
+            "192.168.1.1",    # private
+            "169.254.169.254",  # link-local / cloud metadata
+            "0.0.0.0",        # unspecified
+            "::1",            # loopback (ipv6)
+        ],
+    )
+    def test_rejects_unsafe(self, host):
+        from worker.composed_render import _host_is_safe
+
+        assert _host_is_safe(host) is False
+
+    @pytest.mark.parametrize("host", ["8.8.8.8", "1.1.1.1"])
+    def test_accepts_public_literal(self, host):
+        from worker.composed_render import _host_is_safe
+
+        assert _host_is_safe(host) is True
+
+
+@pytest.mark.asyncio
+class TestRenderUrlToPngGuards:
+    async def test_rejects_non_http_scheme(self):
+        from worker.composed_render import WebpageRenderError, render_url_to_png
+
+        with pytest.raises(WebpageRenderError):
+            await render_url_to_png("ftp://example.com/x")
+
+    async def test_rejects_loopback_host(self):
+        from worker.composed_render import WebpageRenderError, render_url_to_png
+
+        with pytest.raises(WebpageRenderError):
+            await render_url_to_png("http://127.0.0.1/")

--- a/worker/composed_render.py
+++ b/worker/composed_render.py
@@ -1,24 +1,36 @@
-"""Headless-Chromium snapshot renderer for composed slides (worker side).
+"""Headless-Chromium snapshot renderer for composed slides + webpages (worker).
 
-Renders the self-contained composed-slide HTML — produced by
-:func:`cms.composed.render.build_composed_html` — to a PNG using
-Playwright's bundled Chromium. All network is blocked: only ``data:``
-URIs (the already-inlined images / videos / fonts) ever load, so a slide
-can never make the worker reach out to an arbitrary origin while it is
-being snapshotted. The weather widget's live Open-Meteo fetch is blocked
-too, so it renders its offline fallback in the thumbnail — acceptable for
-a static snapshot.
+Two public renderers, both backed by a single shared lazy-singleton
+Chromium process (a fresh isolated context+page per render so state never
+leaks):
 
-A single Chromium process is reused for the life of the worker (lazy
-singleton); every render gets a fresh, isolated browser context + page so
-state never leaks between slides. ``process_pending`` renders variants
-one at a time, so there is no concurrent access to a shared page.
+* :func:`render_composed_to_png` — renders the self-contained
+  composed-slide HTML produced by
+  :func:`cms.composed.render.build_composed_html` with **all network
+  blocked**: only ``data:`` URIs (already-inlined images / videos /
+  fonts) ever load, so a slide can never make the worker reach out to an
+  arbitrary origin while it is being snapshotted. The weather widget's
+  live Open-Meteo fetch is blocked too, so it renders its offline
+  fallback in the thumbnail — acceptable for a static snapshot.
+
+* :func:`render_url_to_png` — navigates to a live webpage URL and
+  screenshots it, so network **must** be allowed. To keep this from
+  becoming an SSRF sink, the target host is DNS-resolved and rejected if
+  any resolved IP is private / loopback / link-local / reserved /
+  multicast / unspecified (the link-local check covers the
+  169.254.169.254 cloud-metadata endpoint), and every navigation request
+  (including redirects) is re-validated by the route handler.
+
+``process_pending`` renders variants one at a time, so there is no
+concurrent access to a shared page.
 """
 
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
+import socket
 
 logger = logging.getLogger("agora.worker.composed_render")
 
@@ -128,6 +140,144 @@ async def render_composed_to_png(html_bytes: bytes) -> bytes:
         except Exception:  # noqa: BLE001
             logger.warning(
                 "composed snapshot readiness wait failed/timed out; "
+                "screenshotting current state", exc_info=True,
+            )
+
+        await page.wait_for_timeout(_SETTLE_MS)
+
+        return await page.screenshot(
+            type="png",
+            clip={"x": 0, "y": 0, "width": 1920, "height": 1080},
+        )
+    finally:
+        await context.close()
+
+
+class WebpageRenderError(Exception):
+    """Raised when a webpage URL can't be safely or successfully rendered."""
+
+
+def _host_is_safe(host: str) -> bool:
+    """Whether ``host`` is safe to navigate to (synchronous; DNS-resolves).
+
+    Rejects empty hosts, ``localhost`` and ``*.local`` by name, then
+    resolves the host and rejects it if ANY resolved IP is private,
+    loopback, link-local (covers the 169.254.169.254 cloud-metadata
+    endpoint), reserved, multicast, or unspecified. IPv4-mapped IPv6
+    addresses are unwrapped before classification.
+
+    Wrap in ``asyncio.to_thread`` from async code — ``getaddrinfo`` blocks.
+    """
+    if not host:
+        return False
+    lowered = host.strip().lower().rstrip(".")
+    if not lowered or lowered == "localhost" or lowered.endswith(".local"):
+        return False
+    try:
+        infos = socket.getaddrinfo(lowered, None)
+    except OSError:
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        sockaddr = info[4]
+        raw_ip = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(raw_ip)
+        except ValueError:
+            return False
+        mapped = getattr(ip, "ipv4_mapped", None)
+        if mapped is not None:
+            ip = mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return False
+    return True
+
+
+def _host_of(url: str) -> str:
+    from urllib.parse import urlsplit
+
+    return (urlsplit(url).hostname or "").strip()
+
+
+async def render_url_to_png(url: str) -> bytes:
+    """Render a live webpage URL to a 1920×1080 PNG.
+
+    Unlike :func:`render_composed_to_png`, network is ALLOWED so the live
+    page can load. SSRF defense: the target host (and every redirected
+    navigation host) is DNS-resolved and rejected if it maps to a
+    private / loopback / link-local / reserved / multicast / unspecified
+    address. Only ``http``/``https`` schemes are permitted. Raises
+    :class:`WebpageRenderError` for an unsafe / disallowed target; other
+    exceptions propagate so the caller marks the variant failed.
+    """
+    from urllib.parse import urlsplit
+
+    parts = urlsplit(url)
+    scheme = (parts.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise WebpageRenderError(f"unsupported scheme for webpage render: {scheme!r}")
+
+    target_host = (parts.hostname or "").strip()
+    if not await asyncio.to_thread(_host_is_safe, target_host):
+        raise WebpageRenderError(f"refusing to render unsafe webpage host: {target_host!r}")
+
+    # Per-render DNS-safety cache so the route handler doesn't re-resolve
+    # the same host on every sub-request. Navigation requests (including
+    # redirect targets) are re-validated to catch redirect-based SSRF.
+    safe_hosts: dict[str, bool] = {target_host.lower(): True}
+
+    browser = await _get_browser()
+    context = await browser.new_context(
+        viewport=_VIEWPORT,
+        device_scale_factor=1,
+        java_script_enabled=True,
+    )
+    try:
+        page = await context.new_page()
+
+        async def _guard(route):
+            request = route.request
+            if not request.is_navigation_request():
+                # Sub-resources (images/css/fonts/xhr) are allowed through;
+                # they can't redirect the top frame to an internal host.
+                await route.continue_()
+                return
+            host = _host_of(request.url).lower()
+            if not host:
+                await route.abort()
+                return
+            ok = safe_hosts.get(host)
+            if ok is None:
+                ok = await asyncio.to_thread(_host_is_safe, host)
+                safe_hosts[host] = ok
+            if ok:
+                await route.continue_()
+            else:
+                logger.warning(
+                    "webpage render: blocked navigation to unsafe host %s", host,
+                )
+                await route.abort()
+
+        await page.route("**/*", _guard)
+        page.set_default_timeout(_NAV_TIMEOUT_MS)
+
+        await page.goto(url, wait_until="load", timeout=_NAV_TIMEOUT_MS)
+
+        try:
+            await asyncio.wait_for(
+                page.evaluate(_READINESS_JS), timeout=_READY_TIMEOUT_MS / 1000,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "webpage snapshot readiness wait failed/timed out; "
                 "screenshotting current state", exc_info=True,
             )
 

--- a/worker/transcoder.py
+++ b/worker/transcoder.py
@@ -521,41 +521,24 @@ async def _mark_failed(variant: AssetVariant, source: Asset, message: str, db: A
     except SQLAlchemyError:
         logger.warning("Variant %s deleted before failure recorded", variant.id)
 
-async def _render_composed_thumbnail(
+async def _render_thumbnail_from_png(
     variant: AssetVariant,
     source: Asset,
     profile: DeviceProfile,
     output_path: Path,
-    asset_dir: Path,
+    png_bytes: bytes,
     db: AsyncSession,
 ) -> None:
-    """Render a composed slide's HTML to a JPEG thumbnail snapshot.
+    """Shared tail: PNG snapshot bytes → profile JPEG thumbnail → READY.
 
-    Builds the same self-contained HTML the live preview serves (shared
-    ``cms.composed.render.build_composed_html``), rasterises it in headless
-    Chromium with all network blocked, then downscales the PNG to the
-    profile's JPEG thumbnail via :func:`convert_image`. Marks the variant
-    READY on success or FAILED on any error (mirrors the image/video
-    thumbnail tail).
+    Common to composed-slide and webpage thumbnails (the only difference
+    is how the PNG is produced). Downscales the PNG to the profile's JPEG
+    via :func:`convert_image`, hashes + sizes it, and marks the variant
+    READY — or FAILED on any error. Cleans up the temp PNG in ``finally``.
+    Assumes the caller has already set the variant PROCESSING.
     """
-    from types import SimpleNamespace
-
-    variant.status = VariantStatus.PROCESSING
-    variant.progress = 0.0
-    await db.commit()
-
-    # Distinct temp name per variant (no collision with the .jpg output).
     tmp_png = output_path.parent / f"{output_path.stem}.src.png"
     try:
-        from cms.composed.render import build_composed_html
-        from worker.composed_render import render_composed_to_png
-
-        # build_composed_html only reads settings.asset_storage_path, which
-        # in the worker is exactly the asset_dir it transcodes from.
-        settings_shim = SimpleNamespace(asset_storage_path=asset_dir)
-        rendered = await build_composed_html(db, settings_shim, source.id)
-
-        png_bytes = await render_composed_to_png(rendered.html_bytes)
         tmp_png.write_bytes(png_bytes)
 
         ok = await convert_image(
@@ -565,7 +548,7 @@ async def _render_composed_thumbnail(
         )
         if not ok:
             await _mark_failed(
-                variant, source, "Composed thumbnail conversion failed", db,
+                variant, source, "Thumbnail conversion failed", db,
             )
             return
 
@@ -588,25 +571,100 @@ async def _render_composed_thumbnail(
             await db.commit()
         except SQLAlchemyError:
             logger.warning(
-                "Variant %s deleted before composed thumbnail recorded",
-                variant.id,
+                "Variant %s deleted before thumbnail recorded", variant.id,
             )
             return
 
         logger.info(
-            "Composed thumbnail complete: %s (%d bytes)",
+            "Thumbnail complete: %s (%d bytes)",
             variant.filename, variant.size_bytes,
         )
         storage = get_storage()
         await storage.on_file_stored(f"variants/{variant.filename}")
     except Exception as e:  # noqa: BLE001
         await _mark_failed(variant, source, str(e)[:500], db)
-        logger.exception("Composed thumbnail error for %s", variant.filename)
+        logger.exception("Thumbnail error for %s", variant.filename)
     finally:
         try:
             tmp_png.unlink(missing_ok=True)
         except OSError:
-            logger.debug("composed thumbnail temp cleanup failed", exc_info=True)
+            logger.debug("thumbnail temp cleanup failed", exc_info=True)
+
+
+async def _render_composed_thumbnail(
+    variant: AssetVariant,
+    source: Asset,
+    profile: DeviceProfile,
+    output_path: Path,
+    asset_dir: Path,
+    db: AsyncSession,
+) -> None:
+    """Render a composed slide's HTML to a JPEG thumbnail snapshot.
+
+    Builds the same self-contained HTML the live preview serves (shared
+    ``cms.composed.render.build_composed_html``), rasterises it in headless
+    Chromium with all network blocked, then hands the PNG to the shared
+    :func:`_render_thumbnail_from_png` tail.
+    """
+    from types import SimpleNamespace
+
+    variant.status = VariantStatus.PROCESSING
+    variant.progress = 0.0
+    await db.commit()
+
+    try:
+        from cms.composed.render import build_composed_html
+        from worker.composed_render import render_composed_to_png
+
+        # build_composed_html only reads settings.asset_storage_path, which
+        # in the worker is exactly the asset_dir it transcodes from.
+        settings_shim = SimpleNamespace(asset_storage_path=asset_dir)
+        rendered = await build_composed_html(db, settings_shim, source.id)
+        png_bytes = await render_composed_to_png(rendered.html_bytes)
+    except Exception as e:  # noqa: BLE001
+        await _mark_failed(variant, source, str(e)[:500], db)
+        logger.exception("Composed thumbnail render error for %s", variant.filename)
+        return
+
+    await _render_thumbnail_from_png(
+        variant, source, profile, output_path, png_bytes, db,
+    )
+
+
+async def _render_webpage_thumbnail(
+    variant: AssetVariant,
+    source: Asset,
+    profile: DeviceProfile,
+    output_path: Path,
+    db: AsyncSession,
+) -> None:
+    """Render a webpage asset's live URL to a JPEG thumbnail snapshot.
+
+    Navigates headless Chromium to ``source.url`` (network allowed, but
+    SSRF-guarded inside :func:`render_url_to_png`), then hands the PNG to
+    the shared :func:`_render_thumbnail_from_png` tail.
+    """
+    variant.status = VariantStatus.PROCESSING
+    variant.progress = 0.0
+    await db.commit()
+
+    url = (source.url or "").strip()
+    if not url:
+        await _mark_failed(variant, source, "Webpage asset has no URL", db)
+        return
+
+    try:
+        from worker.composed_render import render_url_to_png
+
+        png_bytes = await render_url_to_png(url)
+    except Exception as e:  # noqa: BLE001
+        await _mark_failed(variant, source, str(e)[:500], db)
+        logger.exception("Webpage thumbnail render error for %s", variant.filename)
+        return
+
+    await _render_thumbnail_from_png(
+        variant, source, profile, output_path, png_bytes, db,
+    )
 
 
 async def _transcode_one(variant: AssetVariant, db: AsyncSession, asset_dir: Path) -> None:
@@ -659,6 +717,22 @@ async def _transcode_one(variant: AssetVariant, db: AsyncSession, asset_dir: Pat
             return
         await _render_composed_thumbnail(
             variant, source, profile, output_path, asset_dir, db,
+        )
+        return
+
+    # ── Webpage snapshot branch ────────────────────────────────
+    # Webpage assets have no source media file on disk either — their
+    # thumbnail is a static snapshot of the live URL rendered in a headless
+    # browser. Same shape as the composed branch above.
+    if source.asset_type == AssetType.WEBPAGE:
+        if not is_thumbnail:
+            await _mark_failed(
+                variant, source,
+                "Webpage assets only support thumbnail variants", db,
+            )
+            return
+        await _render_webpage_thumbnail(
+            variant, source, profile, output_path, db,
         )
         return
 


### PR DESCRIPTION
## What

Generate real snapshot thumbnails for **WEBPAGE** assets so the asset
library shows a preview image instead of a generic icon — by
**generalizing the existing composed-slide thumbnail pipeline**
(`COMPOSED` → `{COMPOSED, WEBPAGE}`) rather than duplicating it.

Also folds in a small cleanup: removes the composed-slideshow
device-capability warning banner from the slideshow builder (no longer
needed now the fleet supports composed slides).

## How

- **`cms/services/transcoder.py`** — `THUMBNAIL_ONLY_ASSET_TYPES =
  (COMPOSED, WEBPAGE)`. Profile-emit filtering, new-profile seeding,
  enqueue, and startup backfill all generalized. Added
  `enqueue_thumbnail` / `enqueue_missing_thumbnails` aliases (composed
  names kept for back-compat). Kept the existence-only variant check
  from #731 (no `scalar_one_or_none` → no `MultipleResultsFound`).
- **`worker/composed_render.py`** — new `render_url_to_png(url)` drives
  headless Chromium to a clipped 1920×1080 PNG. Critical difference
  from the composed renderer (which blocks all network): this one
  **must** allow network, so it ships an SSRF guard `_host_is_safe`
  that rejects loopback / private / link-local / reserved / multicast /
  unspecified hosts (incl. IPv4-mapped IPv6 and the
  `169.254.169.254` cloud-metadata address) and re-validates every
  navigation request to catch redirect-based SSRF.
- **`worker/transcoder.py`** — shared `_render_thumbnail_from_png` tail
  + `_render_webpage_thumbnail` + a `WEBPAGE` branch in `_transcode_one`.
- **`cms/routers/assets.py`** — enqueue a thumbnail on webpage create
  and re-enqueue on URL edit (best-effort, never blocks the request).
- **`cms/main.py`** — startup backfill now covers composed slides
  **and** webpage assets.
- No worker-image `fastapi` imports added (PR #728 lesson).

## Tests

`tests/test_webpage_thumbnail_snapshot.py` (25 tests): profile
filtering, new-profile seeding, enqueue coalescing / no-op-for-image,
create + edit hooks (`POST /api/assets/webpage`, `PATCH
/api/assets/{id}`), backfill, the worker `WEBPAGE` render branch
(render → READY; device profile → FAILED; empty URL → FAILED), and the
SSRF guard + `render_url_to_png` scheme/host rejection.

Local: 25 new + 15 composed regression + 75 transcoder/worker/asset
related tests all green.
