### PR TITLE
feat(composed): inline rename in composed editor

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{% if edit_mode %}Edit{% else %}New{% endif %} Composed Slide — Agora CMS{% endblock %}
 {% block content %}
-<h1>{% if edit_mode %}{% if is_draft %}Edit Composed Slide{% else %}Composed Slide{% endif %} — {{ asset_name }}{% else %}New Composed Slide{% endif %}</h1>
+<h1>{% if edit_mode %}{% if is_draft %}Edit Composed Slide{% else %}Composed Slide{% endif %} — <span id="composed-title-name">{{ asset_name }}</span>{% else %}New Composed Slide{% endif %}</h1>
 <div class="sub-tabs">
     <a href="{% if edit_mode %}/assets{% else %}/assets/new{% endif %}" class="sub-tab">← Back to Assets</a>
 </div>
@@ -44,9 +44,17 @@
         {% endif %}
     </div>
     {% else %}
-    <p class="text-muted" style="font-size:0.85rem; margin:0 0 0.75rem;">
-        Group assignments and rename are managed via the Assets page actions.
-    </p>
+    <div class="composed-toolbar">
+        <div class="form-group" style="margin-bottom:0;">
+            <label for="composed-name" style="display:block; font-weight:600;">Name</label>
+            <input type="text" id="composed-name" class="form-control" maxlength="255" required
+                   value="{{ asset_name }}"
+                   style="width:100%; max-width:420px; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
+            <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
+                Renames the slide when you Save. Group assignments are managed from the Assets page.
+            </small>
+        </div>
+    </div>
     {% endif %}
 
     <div style="display:flex; align-items:baseline; gap:1rem; flex-wrap:wrap;">
@@ -586,6 +594,9 @@ const EDIT_MODE = {% if edit_mode %}true{% else %}false{% endif %};
 let BUNDLE_EVER_BUILT = {% if bundle_built_at %}true{% else %}false{% endif %};
 const SCHEMA_VERSION = {{ schema_version|tojson }};
 let LAYOUT = {{ layout_json|tojson }};
+// Original display name (edit mode only) so saveLayout can detect a rename
+// and PATCH /api/assets/{id} {display_name}. Empty in create mode.
+let COMPOSED_ORIG_NAME = {% if edit_mode %}{{ asset_name|tojson }}{% else %}""{% endif %};
 let selectedPaletteType = null;
 let selectedWidgetId = null;
 
@@ -1610,10 +1621,37 @@ async function saveLayout(opts) {
             window.location.href = "/assets/" + ASSET_ID + "/composed";
             return true;
         }
+        if (!isCreate) await maybeRenameSlide();
         return true;
     } catch (e) {
         flash("Network error: " + e, false);
         return false;
+    }
+}
+
+async function maybeRenameSlide() {
+    // Edit mode only: if the name field changed, PATCH the asset's
+    // display_name. Reuses the same endpoint as the Assets-page rename.
+    if (!ASSET_ID) return;
+    const el = document.getElementById("composed-name");
+    if (!el) return;
+    const name = el.value.trim();
+    if (!name || name === COMPOSED_ORIG_NAME) return;
+    try {
+        const resp = await fetch("/api/assets/" + ASSET_ID, {
+            method: "PATCH",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({display_name: name}),
+        });
+        if (!resp.ok) {
+            flash("Saved, but rename failed.", false);
+            return;
+        }
+        COMPOSED_ORIG_NAME = name;
+        const titleName = document.getElementById("composed-title-name");
+        if (titleName) titleName.textContent = name;
+    } catch (e) {
+        flash("Saved, but rename failed: " + e, false);
     }
 }
 

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -197,6 +197,23 @@ class TestComposedUI:
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
 
+    async def test_editor_edit_mode_exposes_rename_field(
+        self, client, db_session
+    ):
+        # The editor must let users rename the slide inline (not only
+        # from the Assets-page table). Edit mode should render an
+        # editable name input pre-filled with the current name plus a
+        # title span the JS updates after a successful rename.
+        asset, _ = await _make_composed(db_session)
+        resp = await client.get(f"/assets/{asset.id}/composed")
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'id="composed-name"' in body
+        assert 'value="Test composed"' in body
+        assert 'id="composed-title-name"' in body
+        # The old deferred-rename note must be gone.
+        assert "rename are managed via the Assets page" not in body
+
     async def test_editor_redirects_for_missing_asset(self, client):
         resp = await client.get(
             f"/assets/{uuid.uuid4()}/composed", follow_redirects=False


### PR DESCRIPTION
Adds an inline rename affordance to the composed-slide editor's edit mode. Users could already rename a composed slide from the Assets-page table view but not from inside the editor itself.

## What changed
- Edit mode now renders an editable **Name** input (`#composed-name`) pre-filled with the current name, replacing the old static "managed from the Assets page" note.
- On **Save**, after the layout PATCH succeeds, the editor issues a rename PATCH to `/api/assets/{id}` (`{display_name}`) when the name changed, then updates the page title (`#composed-title-name`) in place. Rename failure is non-fatal (flash warning).
- Title `<h1>` wraps the name in a span so JS can update it after rename.

Frontend-only — backend `update_asset` already accepts `display_name` for any asset type.

## Tests
- New `test_editor_edit_mode_exposes_rename_field` asserts the edit-mode editor renders `#composed-name` pre-filled with the current display_name + the title span.
- `tests/test_composed_routes_phase2.py` + `tests/test_template_inline_js_syntax.py` green (35 passed).
