### PR TITLE
feat(composed): unify create/edit editor UX (editable name + groups in both modes)

### DIFF
--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -141,26 +141,13 @@
         try { ok = await bridge.save(); } catch (_) { ok = false; }
         const id = assetId();
         if (!ok || !id) return false;
-        // Keep the URL + manual-save behavior consistent with a normal first
-        // save, and lock the create-only config inputs (name + group picker)
-        // now that the asset exists — they're read once at mint time and
-        // would otherwise silently no-op on later manual saves.
+        // Keep the URL consistent with a normal first save. The name + group
+        // picker stay editable after mint (unified create/edit UX); the editor
+        // diffs them against the persisted baseline on later manual saves, so
+        // post-mint renames and group changes are honored instead of no-oping.
         try {
             history.replaceState(null, "", "/assets/" + encodeURIComponent(id) + "/composed");
         } catch (_) { /* non-fatal */ }
-        const nameEl2 = document.getElementById("composed-name");
-        if (nameEl2) nameEl2.disabled = true;
-        const addGroupBtn = document.querySelector("#composed-groups-badges .btn-add-group");
-        if (addGroupBtn) addGroupBtn.disabled = true;
-        const groupPopup = document.getElementById("composed-group-popup");
-        if (groupPopup) {
-            try { if (groupPopup.hidePopover) groupPopup.hidePopover(); } catch (_) { /* not open */ }
-            groupPopup.querySelectorAll(".group-popup-item").forEach((el) => { el.disabled = true; });
-        }
-        document.querySelectorAll("#composed-groups-badges .group-badge").forEach((el) => {
-            el.style.pointerEvents = "none";
-            el.style.opacity = "0.7";
-        });
         return true;
     }
 

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -7,16 +7,24 @@
 </div>
 
 <div class="card">
-    {% if not edit_mode %}
+    {# Unified toolbar — identical Name + Groups controls in create and edit
+       mode so the two flows have near-identical UX. In create mode the Name
+       and Groups POST to /composed/ on first save; in edit mode Name PATCHes
+       the asset and group changes share/unshare the asset on Save. #}
     <div class="composed-toolbar">
         <div class="form-group" style="margin-bottom:0;">
             <label for="composed-name" style="display:block; font-weight:600;">Name</label>
             <input type="text" id="composed-name" class="form-control" maxlength="255" required
+                   value="{{ asset_name }}"
                    placeholder="e.g. Lobby welcome"
-                   style="width:100%; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
-            {% if assistant_enabled %}
+                   style="width:100%; max-width:420px; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
+            {% if edit_mode %}
             <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
-                Optional when using the AI assistant — leave blank and it'll be auto-named (rename later from the Assets page).
+                Renames the slide when you Save.
+            </small>
+            {% elif assistant_enabled %}
+            <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
+                Optional when using the AI assistant — leave blank and it'll be auto-named (rename later anytime).
             </small>
             {% endif %}
         </div>
@@ -35,7 +43,7 @@
                     </div>
                 </span>
             </div>
-            {% if is_admin %}
+            {% if is_admin and not edit_mode %}
             <p class="text-muted" style="margin-top:0.25rem; font-size:0.8rem;">
                 Leave empty to make Global.
             </p>
@@ -43,19 +51,6 @@
         </div>
         {% endif %}
     </div>
-    {% else %}
-    <div class="composed-toolbar">
-        <div class="form-group" style="margin-bottom:0;">
-            <label for="composed-name" style="display:block; font-weight:600;">Name</label>
-            <input type="text" id="composed-name" class="form-control" maxlength="255" required
-                   value="{{ asset_name }}"
-                   style="width:100%; max-width:420px; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
-            <small class="text-muted" style="display:block; margin-top:0.25rem; font-size:0.78rem;">
-                Renames the slide when you Save. Group assignments are managed from the Assets page.
-            </small>
-        </div>
-    </div>
-    {% endif %}
 
     <div style="display:flex; align-items:baseline; gap:1rem; flex-wrap:wrap;">
         <span id="status-pill"
@@ -597,6 +592,10 @@ let LAYOUT = {{ layout_json|tojson }};
 // Original display name (edit mode only) so saveLayout can detect a rename
 // and PATCH /api/assets/{id} {display_name}. Empty in create mode.
 let COMPOSED_ORIG_NAME = {% if edit_mode %}{{ asset_name|tojson }}{% else %}""{% endif %};
+// Persisted group-id set (edit mode pre-populates from the asset's current
+// group assignments; empty in create mode). saveLayout diffs the picker's
+// live selection against this to share/unshare on Save.
+let COMPOSED_ORIG_GROUPS = {{ asset_groups | tojson }};
 let selectedPaletteType = null;
 let selectedWidgetId = null;
 
@@ -1581,6 +1580,12 @@ async function ensureAssetExists() {
         }
         const data = await resp.json();
         ASSET_ID = data.id;
+        // The POST persisted name + groups, so reset the diff baselines to
+        // what's now on the server. Keeps later edit-mode saves (preview /
+        // publish / assistant mint) from redundantly re-PATCHing or
+        // re-sharing the same values.
+        COMPOSED_ORIG_NAME = name;
+        COMPOSED_ORIG_GROUPS = groupIds;
         return true;
     } catch (e) {
         flash("Network error creating slide: " + e, false);
@@ -1621,7 +1626,10 @@ async function saveLayout(opts) {
             window.location.href = "/assets/" + ASSET_ID + "/composed";
             return true;
         }
-        if (!isCreate) await maybeRenameSlide();
+        if (!isCreate) {
+            await maybeRenameSlide();
+            await maybeUpdateGroups();
+        }
         return true;
     } catch (e) {
         flash("Network error: " + e, false);
@@ -1652,6 +1660,44 @@ async function maybeRenameSlide() {
         if (titleName) titleName.textContent = name;
     } catch (e) {
         flash("Saved, but rename failed: " + e, false);
+    }
+}
+
+async function maybeUpdateGroups() {
+    // Edit/post-mint only: diff the live group selection against the
+    // persisted baseline and share/unshare the asset accordingly. Reuses the
+    // same endpoints as the Assets-page group picker.
+    if (!ASSET_ID) return;
+    const desired = (window.composedSelectedGroupIds || []).slice();
+    const orig = COMPOSED_ORIG_GROUPS.slice();
+    const toAdd = desired.filter((g) => !orig.includes(g));
+    const toRemove = orig.filter((g) => !desired.includes(g));
+    if (!toAdd.length && !toRemove.length) return;
+    let failed = false;
+    for (const gid of toAdd) {
+        try {
+            const r = await fetch(
+                "/api/assets/" + ASSET_ID + "/share?group_id=" + encodeURIComponent(gid),
+                {method: "POST"}
+            );
+            // 200 (shared) and already-shared both count as success.
+            if (!r.ok) failed = true;
+        } catch (_) { failed = true; }
+    }
+    for (const gid of toRemove) {
+        try {
+            const r = await fetch(
+                "/api/assets/" + ASSET_ID + "/share?group_id=" + encodeURIComponent(gid),
+                {method: "DELETE"}
+            );
+            // 404 means it wasn't shared anymore — treat as already-removed.
+            if (!r.ok && r.status !== 404) failed = true;
+        } catch (_) { failed = true; }
+    }
+    if (failed) {
+        flash("Saved, but some group changes failed.", false);
+    } else {
+        COMPOSED_ORIG_GROUPS = desired;
     }
 }
 
@@ -1809,8 +1855,10 @@ async function cwLeaveSave() {
     }
 })();
 
-// ── Group picker (create mode) — mirrors the slideshow builder ──────
-window.composedSelectedGroupIds = window.composedSelectedGroupIds || [];
+// ── Group picker — mirrors the slideshow builder; works in both modes ──
+// Seed the live selection from the persisted baseline (edit mode pre-selects
+// the asset's current groups; empty in create mode).
+window.composedSelectedGroupIds = (COMPOSED_ORIG_GROUPS || []).slice();
 
 function openGroupPopup(id) {
     const el = document.getElementById(id);
@@ -1818,9 +1866,6 @@ function openGroupPopup(id) {
 }
 
 function pickComposedGroup(id, name) {
-    // After the draft is minted the groups are already committed (read once
-    // at create time), so ignore late edits to avoid silent no-ops.
-    if (ASSET_ID) return;
     if (!window.composedSelectedGroupIds.includes(id)) {
         window.composedSelectedGroupIds.push(id);
         markDirty();
@@ -1860,6 +1905,7 @@ renderCanvas();
 renderSettings();
 startClockTimer();
 updateActionButtons();
+renderComposedGroupBadges();
 
 // ── Keyboard: Backspace/Delete removes the selected widget ──────────
 // Only fires when a widget is selected AND focus is not in a text-entry

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -214,6 +214,38 @@ class TestComposedUI:
         # The old deferred-rename note must be gone.
         assert "rename are managed via the Assets page" not in body
 
+    async def test_editor_edit_mode_exposes_group_picker(
+        self, client, db_session
+    ):
+        # Edit mode must let users change group assignments inline (parity
+        # with create mode), not just from the Assets page. The editor should
+        # render the group picker and pre-seed the asset's current groups
+        # into both the live selection and the diff baseline so Save can
+        # share/unshare deltas.
+        from cms.models.device import DeviceGroup
+        from cms.models.group_asset import GroupAsset
+
+        asset, _ = await _make_composed(db_session)
+        group = DeviceGroup(name="Lobby Screens", description="")
+        db_session.add(group)
+        await db_session.flush()
+        db_session.add(GroupAsset(asset_id=asset.id, group_id=group.id))
+        await db_session.commit()
+
+        resp = await client.get(f"/assets/{asset.id}/composed")
+        assert resp.status_code == 200
+        body = resp.text
+        # Picker markup present in edit mode.
+        assert 'id="composed-groups-badges"' in body
+        assert "Lobby Screens" in body
+        assert "pickComposedGroup(" in body
+        # Both the live selection and the diff baseline are seeded with the
+        # asset's current group id.
+        gid = str(group.id)
+        assert f'COMPOSED_ORIG_GROUPS = ["{gid}"]' in body
+        # The stale "managed from the Assets page" note must be gone.
+        assert "Group assignments are managed from the Assets page" not in body
+
     async def test_editor_redirects_for_missing_asset(self, client):
         resp = await client.get(
             f"/assets/{uuid.uuid4()}/composed", follow_redirects=False


### PR DESCRIPTION
## What

Unifies the create-mode and edit-mode UX of the composed-slide editor
so they are nearly identical. Both modes now render a single toolbar
with an **editable Name input** and a **Groups picker**, and both
persist name + group changes on Save.

## Why

Two gaps reported on dev:

1. When the AI assistant auto-mints a draft composed slide with a
   default title, the Name input became **disabled/uneditable** in
   create mode.
2. **Edit mode** could not edit **group assignments** — that was only
   possible from the Assets-page table.

## Changes (frontend only — all backend endpoints already exist)

- **`cms/templates/composed_editor.html`**
  - Single `.composed-toolbar` rendered in both modes. `#composed-name`
    always editable (`value="{{ asset_name }}"`). Groups picker
    (`#composed-groups-badges`) renders in both modes when the user has
    visible groups. "Leave empty to make Global." note is create-mode +
    admin only. Removed the stale "managed from the Assets page" note.
  - New `COMPOSED_ORIG_GROUPS` baseline global; seeds the picker
    selection and renders pre-selected badges on load in edit mode.
  - `maybeUpdateGroups()` diffs the live selection vs baseline and
    shares/unshares via `/api/assets/{id}/share` (idempotent:
    already-shared POST and not-shared DELETE 404 both treated as
    success). Wired into `saveLayout()`'s edit branch next to
    `maybeRenameSlide()`.
  - `ensureAssetExists()` resets both name/group baselines after a
    successful create POST, so the assistant-mint path gets correct
    baselines for free.
- **`cms/static/composed_editor_chat.js`**
  - `mintDraft()` no longer disables the name/group inputs after the
    assistant names a draft.
- **`tests/test_composed_routes_phase2.py`**
  - New `test_editor_edit_mode_exposes_group_picker`.

## Tests

- `tests/test_composed_routes_phase2.py` — 19 passed (incl. new group
  picker test + existing rename test).
- `tests/test_composed_editor_assistant.py` — 18 passed (mintDraft
  change).
- `node --check composed_editor_chat.js` OK; Jinja parse OK.

## Deploy

Dev only.
