### PR TITLE
fix(composed): hide legacy image widget from AI assistant

### DIFF
--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -113,6 +113,11 @@ class Widget:
     icon: ClassVar[str]
     ConfigSchema: ClassVar[type[BaseModel]]
     config_version: ClassVar[int] = 1
+    # Legacy/internal widgets that should not be offered to the AI
+    # assistant as a placeable type. The publish/render path still
+    # supports them (for slides that already use them), but the
+    # assistant must not mint new instances. Defaults to visible.
+    assistant_hidden: ClassVar[bool] = False
 
     # ── Mandatory overrides ──────────────────────────────────────
     def render_html(

--- a/cms/composed/widgets/image.py
+++ b/cms/composed/widgets/image.py
@@ -64,6 +64,11 @@ class ImageWidget(Widget):
     icon: ClassVar[str] = "🖼"
     ConfigSchema: ClassVar[type[BaseModel]] = ImageWidgetConfig
     config_version: ClassVar[int] = 1
+    # Legacy image-only widget. Superseded by MediaWidget (slug
+    # "media"), which the editor UI renders richly (preview + swap)
+    # and which handles both images and videos. Hidden from the AI
+    # assistant so it always mints "media" tiles instead.
+    assistant_hidden: ClassVar[bool] = True
 
     def default_config(self) -> dict:
         # The editor will replace ``asset_id`` immediately upon drop;

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -262,6 +262,10 @@ def _build_widget_types() -> list[dict[str, Any]]:
     registry = get_registry()
     out: list[dict[str, Any]] = []
     for widget in registry.all():
+        if getattr(widget, "assistant_hidden", False):
+            # Legacy/internal widgets (e.g. the image-only widget) are
+            # never offered to the assistant — it must use "media".
+            continue
         schema = widget.ConfigSchema.model_json_schema()
         props = schema.get("properties", {})
         out.append(

--- a/tests/test_composed_ai_routes.py
+++ b/tests/test_composed_ai_routes.py
@@ -104,6 +104,16 @@ class TestWidgetTypes:
         # supply a real asset reference.
         assert by_type["media"]["references_asset"] is True
 
+    async def test_legacy_image_widget_is_hidden_from_assistant(self, client):
+        # The legacy image-only widget (slug "image") is superseded by
+        # the "media" tile, which the editor renders richly (preview +
+        # swap). The assistant must never mint "image" widgets — they
+        # show as a degraded black box with no rich settings panel.
+        resp = await client.get("/composed/widget-types")
+        types = {w["type"] for w in resp.json()["widget_types"]}
+        assert "image" not in types
+        assert "media" in types
+
     async def test_unauth_is_401(self, unauthed_client):
         resp = await unauthed_client.get("/composed/widget-types")
         assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Problem

Using the in-editor AI assistant to add an image produced a degraded element: a black box labeled `image` on the canvas, no preview/swap UI in the side panel (only position + delete), and a layer label of `image` rather than the asset name. Preview rendered the actual image fine, which made it confusing.

## Root cause

The registry has two asset widgets:
- legacy `ImageWidget` (slug `image`, image-only)
- modern `MediaWidget` (slug `media`, image **or** video) — the unified tile the editor renders richly (preview, swap, layer label, full settings panel).

`list_composed_widget_types` exposed **both**, and the LLM naturally picked `image`. But the editor frontend only handles `type === "media"`, so an `image` widget fell through to the degraded default render.

The two widgets have schema-identical configs (`asset_id`, `object_fit`, `alt`), and the human editor palette never offered `image` — it's purely legacy/assistant-facing.

## Fix

Backend-only. Add an `assistant_hidden` ClassVar to the `Widget` base, set it `True` on `ImageWidget`, and skip hidden widgets in `_build_widget_types`. The assistant now only ever mints `media` tiles.

The publish/render path is untouched — any slide that already uses an `image` widget still renders correctly.

## Tests

- New `test_legacy_image_widget_is_hidden_from_assistant` asserts `image` is absent and `media` present in `GET /composed/widget-types`.
- Targeted suites green locally: `test_composed_ai_routes.py`, `test_assistant_composed_mode.py`, `test_composed_editor_assistant.py` (53 passed).

Dev only.
