### PR TITLE
fix(composed-editor,asset-grid): stale save badge + live grid thumbnail refresh

### DIFF
--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -866,20 +866,33 @@ const __currentUserId = {{ (current_user_id | string) | tojson if current_user_i
                 const card = document.querySelector('[data-grid-card="' + a.id + '"]');
                 if (card) {
                     const thumbDiv = card.querySelector('.asset-grid-thumb');
-                    if (thumbDiv && !thumbDiv.querySelector('img')) {
-                        // Placeholder icon present -- replace with <img> while
-                        // preserving every overlay element (checkbox, Global
-                        // badge, and the composed UNPUBLISHED tag, which is a
-                        // plain span -- not a .badge -- and was being dropped).
-                        const overlays = Array.from(thumbDiv.children);
-                        const img = document.createElement('img');
-                        img.loading = 'lazy';
-                        img.src = a.thumbnail_url;
-                        img.alt = '';
-                        img.style.cssText = 'width:100%; height:100%; object-fit:cover;';
-                        thumbDiv.textContent = '';
-                        thumbDiv.appendChild(img);
-                        overlays.forEach(el => thumbDiv.appendChild(el));
+                    if (thumbDiv) {
+                        const existingImg = thumbDiv.querySelector('img');
+                        if (!existingImg) {
+                            // Placeholder icon present -- replace with <img> while
+                            // preserving every overlay element (checkbox, Global
+                            // badge, and the composed UNPUBLISHED tag, which is a
+                            // plain span -- not a .badge -- and was being dropped).
+                            const overlays = Array.from(thumbDiv.children);
+                            const img = document.createElement('img');
+                            img.loading = 'lazy';
+                            img.src = a.thumbnail_url;
+                            img.alt = '';
+                            img.style.cssText = 'width:100%; height:100%; object-fit:cover;';
+                            thumbDiv.textContent = '';
+                            thumbDiv.appendChild(img);
+                            overlays.forEach(el => thumbDiv.appendChild(el));
+                        } else if (existingImg.getAttribute('src') !== a.thumbnail_url) {
+                            // Thumbnail re-rendered: an edited composed slide or a
+                            // re-captured webpage mints a NEW thumbnail variant
+                            // (new variant id -> new URL), so the card already has
+                            // an <img> showing the stale thumbnail. Swap the src so
+                            // the grid updates live without a manual refresh.
+                            // Compare the raw attribute (relative) rather than
+                            // existingImg.src (resolved absolute) so we don't reset
+                            // it every poll.
+                            existingImg.setAttribute('src', a.thumbnail_url);
+                        }
                     }
                 }
             }

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -58,7 +58,7 @@
                      background:{% if is_draft %}#f39c12;color:#1a1a2e{% else %}#2ecc71;color:#1a1a2e{% endif %};">
             {% if edit_mode %}{% if is_draft %}Draft{% else %}Published{% endif %}{% else %}New{% endif %}
         </span>
-        <span style="font-size:0.8rem; color:var(--text-muted);">
+        <span id="bundle-info" style="font-size:0.8rem; color:var(--text-muted);">
             {% if edit_mode %}{% if bundle_built_at %}Bundle built {{ bundle_built_at.strftime("%Y-%m-%d %H:%M UTC") }}{% else %}Never published{% endif %}{% else %}Not saved yet{% endif %}
         </span>
         <div style="margin-left:auto; display:flex; gap:0.5rem;">
@@ -1773,6 +1773,15 @@ function markDraft() {
     pill.style.background = "#fef3c7";
     pill.style.color = "#92400e";
     setPublishBanner(BUNDLE_EVER_BUILT ? "stale" : "never");
+    // New-mode page: once the draft is minted (e.g. by the AI assistant or
+    // a manual save that skips the redirect) the static "Not saved yet"
+    // placeholder is stale — the slide IS persisted, just not published.
+    if (!EDIT_MODE && ASSET_ID) {
+        const info = document.getElementById("bundle-info");
+        if (info && info.textContent.trim() === "Not saved yet") {
+            info.textContent = BUNDLE_EVER_BUILT ? "Unpublished changes" : "Never published";
+        }
+    }
 }
 
 function markPublished() {


### PR DESCRIPTION
## Two asset-library / composed-editor UX nits (Goodwill **dev** only)

### Nit 1 — stale "Not saved yet" badge after AI-assistant edit
When the AI assistant mints a composed-slide draft in *new* mode, it saves the slide server-side via the `skipRedirect` path (only `history.replaceState` to the edit URL — no reload). The muted status span was a static `"Not saved yet"` placeholder that was never updated, so the editor claimed the slide was unsaved even though Save was greyed out, no leave-warning fired, and it appeared in the library.

**Fix:** gave the span `id="bundle-info"` and extended `markDraft()` to replace the placeholder with `"Unpublished changes"`/`"Never published"` once `ASSET_ID` exists. Guarded on the exact placeholder text so edit-mode's server-rendered text is never clobbered.

### Nit 2 — grid thumbnails don't auto-refresh after a transcode
In grid view, when a transcode finished regenerating a thumbnail for an **edited** composed slide or a **re-captured** webpage, the card stayed stale until a manual refresh. The status poller's swap only handled placeholder-icon → `<img>` (fresh upload); a card already showing an old thumbnail was skipped. Since #726 mints a **new** thumbnail variant (new variant id → new URL) on every save, the URL genuinely changes on edit.

**Fix:** the poller now also updates an existing `<img>`'s `src` when `a.thumbnail_url` differs (comparing the raw relative attribute, not the resolved absolute `.src`, to avoid resetting it every poll). All overlays preserved.

## Testing
- `tests/test_template_inline_js_syntax.py` — 17 passed (covers inline JS in both templates).
- List/table view has no inline thumbnail `<img>`, so grid is the only affected view.
- `/api/assets/status` always returns visible assets with `thumbnail_url` populated → no race.

**Dev only — do NOT deploy to prod.**
