### PR TITLE
Add shared assistant usage strip to composed-editor drawer

### DIFF
--- a/cms/static/assistant.js
+++ b/cms/static/assistant.js
@@ -614,63 +614,15 @@
     }
 
     // ── Per-user usage strip ─────────────────────────────────────────
-    // Refreshed on init and after every turn completes.  Failures are
-    // swallowed: the strip is informational, not critical, and we'd
-    // rather hide it than block the assistant on a transient 5xx.
-    const $usage = document.getElementById("assistant-usage");
-    const $usageText = document.getElementById("assistant-usage-text");
-    const $usageFill = document.getElementById("assistant-usage-fill");
-
-    function formatTokens(n) {
-        // Compact form for the strip — keeps "1,240 / 50,000" readable.
-        return Number(n || 0).toLocaleString();
-    }
-    function formatUsd(n) {
-        const v = Number(n || 0);
-        // Sub-cent: 4 decimals so $0.0015 isn't reported as $0.00.
-        if (v < 0.01) return `$${v.toFixed(4)}`;
-        if (v < 1) return `$${v.toFixed(3)}`;
-        return `$${v.toFixed(2)}`;
-    }
-    async function refreshUsage() {
-        if (!$usage) return;
-        try {
-            const r = await fetch("/api/chat/usage");
-            if (!r.ok) {
-                $usage.style.display = "none";
-                return;
-            }
-            const u = await r.json();
-            const used = u.used_tokens || 0;
-            const cap = u.cap_tokens || 0;
-            const usd = formatUsd(u.used_usd_estimate);
-            if (u.unlimited) {
-                $usage.dataset.unlimited = "true";
-                $usageText.textContent =
-                    `Today: ${formatTokens(used)} tok • ~${usd} (no cap)`;
-                $usageFill.style.width = "0%";
-            } else if (cap === 0) {
-                // Admin-paused user.  Keep the strip but make it obvious.
-                $usage.dataset.unlimited = "false";
-                $usageText.textContent =
-                    `Today: ${formatTokens(used)} tok • ~${usd} (cap 0 — disabled)`;
-                $usageFill.style.width = "100%";
-                $usageFill.classList.remove("warn");
-                $usageFill.classList.add("danger");
-            } else {
-                $usage.dataset.unlimited = "false";
-                const pct = Math.min(100, (used / cap) * 100);
-                $usageText.textContent =
-                    `Today: ${formatTokens(used)} / ${formatTokens(cap)} tok • ~${usd}`;
-                $usageFill.style.width = pct.toFixed(1) + "%";
-                $usageFill.classList.remove("warn", "danger");
-                if (pct >= 90) $usageFill.classList.add("danger");
-                else if (pct >= 70) $usageFill.classList.add("warn");
-            }
-            $usage.style.display = "";
-        } catch (e) {
-            $usage.style.display = "none";
-        }
+    // Refreshed on init and after every turn completes.  Backed by the
+    // shared window.AssistantUsage component (cms/static/assistant_usage.js)
+    // so the main page and the composed-slide editor drawer stay in sync.
+    const usageStrip =
+        (window.AssistantUsage && document.getElementById("assistant-usage"))
+            ? window.AssistantUsage.create(document.getElementById("assistant-usage"))
+            : null;
+    function refreshUsage() {
+        if (usageStrip) usageStrip.refresh();
     }
 
     // ── Init ─────────────────────────────────────────────────────────

--- a/cms/static/assistant_usage.js
+++ b/cms/static/assistant_usage.js
@@ -1,0 +1,99 @@
+// Shared per-user assistant usage strip.
+//
+// One source of truth for the "Today: used / cap tok • ~$X" strip that
+// appears below the composer on the main Assistant page AND inside the
+// composed-slide editor's AI drawer (and any future popup assistant).
+//
+// Data source: GET /api/chat/usage -> { used_tokens, cap_tokens,
+// used_usd_estimate, unlimited }. Failures are swallowed: the strip is
+// informational, not critical, and we'd rather hide it than block the
+// assistant on a transient 5xx.
+//
+// Usage:
+//   const usage = window.AssistantUsage.create(hostEl);
+//   usage.refresh();   // call on init + after every completed turn
+//
+// `hostEl` is any empty element; the component fills it with its own
+// scoped children, so multiple instances on a page never collide on ids.
+(function () {
+    "use strict";
+
+    function formatTokens(n) {
+        // Compact form for the strip — keeps "1,240 / 50,000" readable.
+        return Number(n || 0).toLocaleString();
+    }
+
+    function formatUsd(n) {
+        const v = Number(n || 0);
+        // Sub-cent: 4 decimals so $0.0015 isn't reported as $0.00.
+        if (v < 0.01) return `$${v.toFixed(4)}`;
+        if (v < 1) return `$${v.toFixed(3)}`;
+        return `$${v.toFixed(2)}`;
+    }
+
+    // Build the strip's DOM inside `host` and return a controller with a
+    // refresh() method. The host gets the `.assistant-usage` class so the
+    // shared CSS (cms/static/style.css) applies wherever it's mounted.
+    function create(host) {
+        if (!host) return { el: null, refresh: async function () {} };
+
+        host.classList.add("assistant-usage");
+        host.style.display = "none";
+        host.innerHTML =
+            '<span class="assistant-usage-text">Today: …</span>' +
+            '<div class="assistant-usage-bar" aria-hidden="true">' +
+            '<div class="assistant-usage-fill"></div>' +
+            "</div>" +
+            '<span class="assistant-usage-hint" ' +
+            'title="USD figure is an estimate based on the configured ' +
+            "Azure OpenAI model's list price. Actual billing may differ " +
+            'slightly.">est.</span>';
+
+        const text = host.querySelector(".assistant-usage-text");
+        const fill = host.querySelector(".assistant-usage-fill");
+
+        async function refresh() {
+            try {
+                const r = await fetch("/api/chat/usage");
+                if (!r.ok) {
+                    host.style.display = "none";
+                    return;
+                }
+                const u = await r.json();
+                const used = u.used_tokens || 0;
+                const cap = u.cap_tokens || 0;
+                const usd = formatUsd(u.used_usd_estimate);
+                if (u.unlimited) {
+                    host.dataset.unlimited = "true";
+                    text.textContent =
+                        `Today: ${formatTokens(used)} tok • ~${usd} (no cap)`;
+                    fill.style.width = "0%";
+                } else if (cap === 0) {
+                    // Admin-paused user.  Keep the strip but make it obvious.
+                    host.dataset.unlimited = "false";
+                    text.textContent =
+                        `Today: ${formatTokens(used)} tok • ~${usd} (cap 0 — disabled)`;
+                    fill.style.width = "100%";
+                    fill.classList.remove("warn");
+                    fill.classList.add("danger");
+                } else {
+                    host.dataset.unlimited = "false";
+                    const pct = Math.min(100, (used / cap) * 100);
+                    text.textContent =
+                        `Today: ${formatTokens(used)} / ${formatTokens(cap)} tok • ~${usd}`;
+                    fill.style.width = pct.toFixed(1) + "%";
+                    fill.classList.remove("warn", "danger");
+                    if (pct >= 90) fill.classList.add("danger");
+                    else if (pct >= 70) fill.classList.add("warn");
+                }
+                host.style.display = "";
+            } catch (e) {
+                host.style.display = "none";
+            }
+        }
+
+        return { el: host, refresh: refresh };
+    }
+
+    window.AssistantUsage = { create: create, formatTokens: formatTokens, formatUsd: formatUsd };
+})();

--- a/cms/static/composed_editor_chat.js
+++ b/cms/static/composed_editor_chat.js
@@ -30,6 +30,17 @@
     const input = document.getElementById("cw-ai-input");
     const sendBtn = document.getElementById("cw-ai-send");
 
+    // Shared per-user usage strip (cms/static/assistant_usage.js). Mirrors
+    // the main Assistant page: refreshed when the drawer opens and after
+    // every completed turn. Hidden if the component or host is missing.
+    const usageStrip =
+        (window.AssistantUsage && document.getElementById("cw-ai-usage"))
+            ? window.AssistantUsage.create(document.getElementById("cw-ai-usage"))
+            : null;
+    function refreshUsage() {
+        if (usageStrip) usageStrip.refresh();
+    }
+
     const state = {
         threadId: null,
         threadPromise: null, // de-dupe concurrent get-or-create
@@ -53,6 +64,7 @@
         launcher.style.display = open ? "none" : "";
         if (open) {
             ensureThread();
+            refreshUsage();
             input.focus();
         }
     }
@@ -259,6 +271,7 @@
             sendBtn.disabled = false;
             input.disabled = false;
             input.focus();
+            refreshUsage();
         }
     }
 

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1697,3 +1697,49 @@ textarea:not(:-webkit-autofill) {
     border: 5px solid transparent;
     border-top-color: var(--accent);
 }
+/* ── Shared assistant usage strip ─────────────────────────────────────
+   Used by the main Assistant page composer and the composed-slide
+   editor AI drawer (and any future popup assistant). DOM is built by
+   cms/static/assistant_usage.js. Token + USD figures refresh after
+   every completed turn; the bar fill tracks ``used / cap`` so users
+   can see at a glance how close they are to their daily ceiling. */
+.assistant-usage {
+    border-top: 1px solid var(--border);
+    padding: 0.4rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.assistant-usage-text {
+    white-space: nowrap;
+}
+.assistant-usage-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--surface-2, rgba(0,0,0,0.06));
+    border-radius: 3px;
+    overflow: hidden;
+    min-width: 60px;
+}
+.assistant-usage-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--accent, #4e8cff);
+    transition: width 0.3s ease, background-color 0.3s ease;
+}
+.assistant-usage-fill.warn {
+    background: var(--warning, #e6a817);
+}
+.assistant-usage-fill.danger {
+    background: var(--danger, #c93434);
+}
+.assistant-usage[data-unlimited="true"] .assistant-usage-bar {
+    display: none;
+}
+.assistant-usage .assistant-usage-hint {
+    cursor: help;
+    border-bottom: 1px dotted var(--text-muted);
+}

--- a/cms/templates/assistant.html
+++ b/cms/templates/assistant.html
@@ -378,51 +378,9 @@
     cursor: not-allowed;
 }
 
-/* ── Per-user usage strip (PR: usage display) ─────────────────────
-   Sits below the composer, in the right-hand column only.  Token +
-   USD figures are refreshed after every turn completes; the bar fill
-   tracks ``used / cap`` so users can see at a glance how close they
-   are to their daily ceiling. */
-.assistant-usage {
-    border-top: 1px solid var(--border);
-    padding: 0.4rem 0.75rem;
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-    font-size: 0.78rem;
-    color: var(--text-muted);
-    flex-shrink: 0;
-}
-.assistant-usage-text {
-    white-space: nowrap;
-}
-.assistant-usage-bar {
-    flex: 1;
-    height: 6px;
-    background: var(--surface-2, rgba(0,0,0,0.06));
-    border-radius: 3px;
-    overflow: hidden;
-    min-width: 60px;
-}
-.assistant-usage-fill {
-    height: 100%;
-    width: 0%;
-    background: var(--accent, #4e8cff);
-    transition: width 0.3s ease, background-color 0.3s ease;
-}
-.assistant-usage-fill.warn {
-    background: var(--warning, #e6a817);
-}
-.assistant-usage-fill.danger {
-    background: var(--danger, #c93434);
-}
-.assistant-usage[data-unlimited="true"] .assistant-usage-bar {
-    display: none;
-}
-.assistant-usage .assistant-usage-hint {
-    cursor: help;
-    border-bottom: 1px dotted var(--text-muted);
-}
+/* The per-user usage strip styles now live in cms/static/style.css
+   (.assistant-usage*) so they're shared with the composed-slide editor
+   AI drawer and any future popup assistant. */
 
 .assistant-streaming-indicator {
     align-self: flex-start;
@@ -480,14 +438,7 @@
                     disabled></textarea>
                 <button type="submit" id="assistant-send" disabled>Send</button>
             </form>
-            <div class="assistant-usage" id="assistant-usage" style="display:none;">
-                <span class="assistant-usage-text" id="assistant-usage-text">Today: …</span>
-                <div class="assistant-usage-bar" aria-hidden="true">
-                    <div class="assistant-usage-fill" id="assistant-usage-fill"></div>
-                </div>
-                <span class="assistant-usage-hint" id="assistant-usage-hint"
-                      title="USD figure is an estimate based on the configured Azure OpenAI model's list price. Actual billing may differ slightly.">est.</span>
-            </div>
+            <div class="assistant-usage" id="assistant-usage" style="display:none;"></div>
         </section>
     </div>
 </div>
@@ -499,6 +450,7 @@
 
 <script src="/static/vendor/marked.min.js"></script>
 <script src="/static/vendor/purify.min.js"></script>
+<script src="/static/assistant_usage.js?v={{ static_version }}"></script>
 <script src="/static/assistant.js?v={{ static_version }}"></script>
 <script>
     // Fit the assistant app to the viewport.  We don't know in advance

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -146,6 +146,7 @@
                     when you're happy with it.
                 </div>
             </div>
+            <div id="cw-ai-usage" style="display:none;"></div>
             <form id="cw-ai-form" onsubmit="return cwAiSubmit(event)">
                 <textarea id="cw-ai-input" rows="2"
                           placeholder="Describe a change…"
@@ -1987,6 +1988,7 @@ window.composedEditorBridge = {
      deferred drawer IIFE runs. -->
 <script src="/static/vendor/marked.min.js"></script>
 <script src="/static/vendor/purify.min.js"></script>
+<script src="/static/assistant_usage.js" defer></script>
 <script src="/static/composed_editor_chat.js" defer></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## What

Adds the daily token/cost **usage strip** (from the main Assistant page) to the AI assistant drawer inside the **composed-slide editor**, built as a **shared, reusable component** so the popup assistant can be reused elsewhere.

## Why

User: "on the assistant page we have total usage and cost estimate, can we add this to the assistant thing on the composed slide?" — and: "lets make this a shared component of sorts as i want to reuse this popup assistant in other places soon."

## Changes

- **New `cms/static/assistant_usage.js`** — `window.AssistantUsage.create(hostEl)` → `{el, refresh}`. Container-scoped (no global ids), so multiple instances coexist. Render logic mirrors the old main-page strip exactly (unlimited / cap-0 / pct with warn≥70, danger≥90). Failures swallowed → host hidden.
- **`cms/static/style.css`** — moved the `.assistant-usage*` CSS out of `assistant.html`'s inline block into the global stylesheet (loaded via `base.html`, so it's available in both places). Uses existing theme vars.
- **`assistant.html` + `assistant.js`** — refactored onto the shared component. Markup simplified to a single empty host; `refreshUsage()` now delegates to the component. Existing call sites (init + post-turn) preserved.
- **`composed_editor.html`** — added `#cw-ai-usage` host inside the drawer (between log and form) + `assistant_usage.js` include (unversioned, matching the sibling `composed_editor_chat.js` include).
- **`composed_editor_chat.js`** — creates the component and refreshes it on **drawer open** and in the `sendMessage()` `finally` (after **each completed turn**).

No backend change — reuses `GET /api/chat/usage`.

## Validation

- `node --check` on all three JS files ✅
- `tests/test_template_inline_js_syntax.py` → 17 passed ✅

## Scope

Dev only.
