### PR TITLE
feat(composed): add QR code widget

### DIFF
--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -23,6 +23,7 @@ from cms.composed.widgets.analog_clock import AnalogClockWidget
 from cms.composed.widgets.clock import ClockWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
+from cms.composed.widgets.qr import QrWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
 from cms.composed.widgets.weather import WeatherWidget
@@ -40,6 +41,7 @@ for _widget_cls in (
     AnalogClockWidget,
     TickerWidget,
     WeatherWidget,
+    QrWidget,
 ):
     if not _reg.has(_widget_cls.slug):
         _reg.register(_widget_cls())
@@ -49,6 +51,7 @@ __all__ = [
     "ClockWidget",
     "ImageWidget",
     "MediaWidget",
+    "QrWidget",
     "TextWidget",
     "TickerWidget",
     "WeatherWidget",

--- a/cms/composed/widgets/qr.py
+++ b/cms/composed/widgets/qr.py
@@ -1,0 +1,142 @@
+"""QR code widget — renders a scannable QR code for a target URL.
+
+The QR matrix is generated **server-side at bundle-build time** with
+:mod:`segno` (pure-Python, zero runtime deps) and embedded as an inline
+``<svg>``.  This keeps the widget deterministic (a given config + URL
+always produces byte-identical SVG), fully offline (no runtime fetch,
+no external ``src=``/``href=``), and resolution-independent (the SVG
+``viewBox`` scales crisply to any cell size).
+
+No JS, no asset dependencies — the simplest widget shape in the set.
+
+Instance scoping: the wrapper ``<div>`` class is suffixed with the
+widget instance UUID so two QR widgets in the same bundle don't
+collide.  The inner ``segno``/``qrline`` classes segno emits on the
+SVG are never styled by us, so they can't cross-contaminate.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+from urllib.parse import urlparse
+
+import segno
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+# URLs longer than this are rejected — well within QR byte capacity even
+# at the highest error-correction level (version 40 / H holds ~1273
+# bytes) and a sane upper bound for a sign someone is meant to scan.
+_MAX_URL_LEN = 1000
+
+# Only real, scannable web targets.  No javascript:/data:/tel: etc. —
+# matches the layout-level URL allowlist (https/http only).
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+class QrWidgetConfig(BaseModel):
+    """User-editable config for :class:`QrWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(min_length=1, max_length=_MAX_URL_LEN)
+    error_correction: Literal["L", "M", "Q", "H"] = "M"
+    foreground: str = Field(default="#000000", pattern=r"^#[0-9a-fA-F]{6}$")
+    background: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    quiet_zone: bool = True
+
+    @field_validator("url")
+    @classmethod
+    def _url_scheme_allowed(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("url must not be blank")
+        scheme = urlparse(v).scheme.lower()
+        if scheme not in _ALLOWED_SCHEMES:
+            allowed = ", ".join(_ALLOWED_SCHEMES)
+            raise ValueError(f"url scheme must be one of: {allowed}")
+        return v
+
+
+class QrWidget(Widget):
+    """Server-rendered QR code pointing at a URL."""
+
+    slug: ClassVar[str] = "qr"
+    display_name: ClassVar[str] = "QR Code"
+    icon: ClassVar[str] = "▦"
+    ConfigSchema: ClassVar[type[BaseModel]] = QrWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "url": "https://example.com",
+            "error_correction": "M",
+            "foreground": "#000000",
+            "background": "#ffffff",
+            "quiet_zone": True,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/qr.html"
+
+    def validate_semantic(self, config: BaseModel) -> list[str]:
+        assert isinstance(config, QrWidgetConfig)
+        errors: list[str] = []
+        scheme = urlparse(config.url).scheme.lower()
+        if scheme not in _ALLOWED_SCHEMES:
+            errors.append(
+                f"QR url scheme '{scheme}' is not allowed "
+                f"(must be one of: {', '.join(_ALLOWED_SCHEMES)})"
+            )
+        return errors
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # QR has no asset deps; ctx is ignored.
+        del ctx, cell
+        assert isinstance(config, QrWidgetConfig), (
+            "QrWidget.render_html expects a QrWidgetConfig instance"
+        )
+
+        css_class = f"cw-qr-{instance_id}"
+
+        qr = segno.make(config.url, error=config.error_correction.lower())
+        # ``omitsize=True`` drops the fixed width/height and emits a
+        # ``viewBox`` instead, so the matrix scales to fill its box while
+        # the default ``preserveAspectRatio`` keeps it square (no
+        # distortion in non-square cells — it letterboxes).
+        svg = qr.svg_inline(
+            omitsize=True,
+            border=4 if config.quiet_zone else 0,
+            dark=config.foreground,
+            light=config.background,
+        )
+
+        html_out = f'<div class="{css_class}">{svg}</div>'
+
+        # Wrapper background matches the QR light colour so the letterbox
+        # gutter in a non-square cell blends seamlessly with the code.
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  background: {config.background};\n"
+            f"}}\n"
+            f".{css_class} svg {{\n"
+            f"  display: block;\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"}}"
+        )
+
+        return WidgetRender(html=html_out, css=css_out)

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -101,6 +101,7 @@
             <button type="button" class="palette-btn" data-type="analog_clock" onclick="selectPaletteType('analog_clock')">🕧 Analog Clock</button>
             <button type="button" class="palette-btn" data-type="ticker" onclick="selectPaletteType('ticker')">📰 Ticker</button>
             <button type="button" class="palette-btn" data-type="weather" onclick="selectPaletteType('weather')">⛅ Weather</button>
+            <button type="button" class="palette-btn" data-type="qr" onclick="selectPaletteType('qr')">▦ QR Code</button>
             <div id="palette-status" style="margin-top:0.5rem; font-size:0.85rem; color:var(--text-muted);">
                 None selected.
             </div>
@@ -658,6 +659,8 @@ const DEFAULTS = {
     weather: {latitude:47.6062, longitude:-122.3321, location_label:"Seattle", units:"imperial",
              show_condition:true, show_location:true, color:"#ffffff", font_family:"sans",
              font_size_px:64, refresh_seconds:900},
+    qr: {url:"https://example.com", error_correction:"M", foreground:"#000000",
+         background:"#ffffff", quiet_zone:true},
 };
 
 function flash(msg, ok) {
@@ -832,6 +835,8 @@ function renderWidgetContent(w) {
             root.appendChild(strip);
         } else if (w.type === "media") {
             root.appendChild(renderMediaPreview(cfg));
+        } else if (w.type === "qr") {
+            root.appendChild(buildQrPreview(cfg));
         } else {
             root.textContent = w.type;
         }
@@ -839,6 +844,29 @@ function renderWidgetContent(w) {
         root.textContent = w.type;
     }
     return root;
+}
+
+function buildQrPreview(cfg) {
+    const wrap = document.createElement("div");
+    wrap.style.cssText =
+        "width:100%;height:100%;display:flex;flex-direction:column;" +
+        "align-items:center;justify-content:center;gap:0.4rem;box-sizing:border-box;" +
+        "padding:0.5rem;background:" + (cfg.background || "#ffffff") + ";";
+    const box = document.createElement("div");
+    box.style.cssText =
+        "width:60%;aspect-ratio:1/1;max-width:140px;border:2px solid " +
+        (cfg.foreground || "#000000") +
+        ";display:flex;align-items:center;justify-content:center;" +
+        "font-size:0.8rem;font-weight:600;color:" + (cfg.foreground || "#000000") + ";";
+    box.textContent = "QR";
+    const label = document.createElement("div");
+    label.style.cssText =
+        "font-size:0.7rem;color:" + (cfg.foreground || "#000000") +
+        ";max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+    label.textContent = cfg.url || "";
+    wrap.appendChild(box);
+    wrap.appendChild(label);
+    return wrap;
 }
 
 function renderMediaPreview(cfg) {
@@ -1155,6 +1183,7 @@ function summarize(w) {
     if (w.type === "analog_clock") return "analog";
     if (w.type === "ticker") return (w.config.text || "").slice(0, 24);
     if (w.type === "weather") return (w.config.location_label || "weather").slice(0, 24);
+    if (w.type === "qr") return (w.config.url || "").slice(0, 24);
     if (w.type === "media") {
         const aid = w.config.asset_id;
         if (!aid || aid === NULL_UUID) return "(no asset)";
@@ -1509,6 +1538,39 @@ function renderSettings() {
                    oninput="updateSelected(x=>x.config.refresh_seconds=clampInt(this.value,600,86400))">
             <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
                 Live temperature is fetched on the device. The preview shows placeholder values.
+            </p>`;
+    } else if (w.type === "qr") {
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">QR Code widget</h4>
+            <label>URL</label>
+            <input type="text" maxlength="1000" value="${escapeHtml(w.config.url||"")}"
+                   placeholder="https://example.com"
+                   oninput="updateSelected(x=>x.config.url=this.value)">
+            <label style="margin-top:0.5rem;">Error correction</label>
+            <select oninput="updateSelected(x=>x.config.error_correction=this.value)">
+                <option value="L" ${w.config.error_correction==="L"?"selected":""}>L — Low (7%)</option>
+                <option value="M" ${w.config.error_correction==="M"?"selected":""}>M — Medium (15%)</option>
+                <option value="Q" ${w.config.error_correction==="Q"?"selected":""}>Q — Quartile (25%)</option>
+                <option value="H" ${w.config.error_correction==="H"?"selected":""}>H — High (30%)</option>
+            </select>
+            <div class="row">
+                <div>
+                    <label>Foreground</label>
+                    <input type="color" value="${w.config.foreground||"#000000"}"
+                           oninput="updateSelected(x=>x.config.foreground=this.value)">
+                </div>
+                <div>
+                    <label>Background</label>
+                    <input type="color" value="${w.config.background||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.background=this.value)">
+                </div>
+            </div>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.quiet_zone?"checked":""}
+                    oninput="updateSelected(x=>x.config.quiet_zone=this.checked)"> Quiet zone (border)
+            </label>
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                The QR code is generated when the slide is published. The editor shows a placeholder.
             </p>`;
     }
 

--- a/requirements-shared.txt
+++ b/requirements-shared.txt
@@ -13,3 +13,9 @@ httpx>=0.27,<1.0
 # Azure Blob Storage (only needed when AGORA_CMS_STORAGE_BACKEND=azure)
 azure-storage-blob>=12.20,<13.0
 aiohttp>=3.9,<4.0
+
+# segno — pure-Python QR code generation for the composed-slide QR
+# widget.  Both the CMS (publish/preview) and the worker (Playwright
+# thumbnail render) execute the widget's render_html, so segno must be
+# present in both images.
+segno>=1.6,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,12 @@ azure-storage-blob>=12.20,<13.0
 azure-storage-queue>=12.9,<13.0
 aiohttp>=3.9,<4.0
 
+# segno — pure-Python QR code generation for the composed-slide QR
+# widget.  Duplicated from requirements-shared.txt (CMS image installs
+# requirements.txt only, not the shared file) so publish/preview can
+# render the QR SVG.
+segno>=1.6,<2.0
+
 # Azure Key Vault (service key exchange in Azure deployments)
 azure-identity>=1.16,<2.0
 azure-keyvault-secrets>=4.8,<5.0

--- a/tests/test_composed_qr_widget.py
+++ b/tests/test_composed_qr_widget.py
@@ -1,0 +1,174 @@
+"""Tests for cms.composed.widgets.qr.QrWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.qr import QrWidget, QrWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestQrWidgetConfig:
+    def test_defaults(self):
+        c = QrWidgetConfig(url="https://example.com")
+        assert c.url == "https://example.com"
+        assert c.error_correction == "M"
+        assert c.foreground == "#000000"
+        assert c.background == "#ffffff"
+        assert c.quiet_zone is True
+
+    def test_error_correction_allowlist(self):
+        for ok in ("L", "M", "Q", "H"):
+            QrWidgetConfig(url="https://example.com", error_correction=ok)
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(
+                url="https://example.com",
+                error_correction="Z",  # type: ignore[arg-type]
+            )
+
+    def test_url_required_and_non_blank(self):
+        with pytest.raises(ValidationError):
+            QrWidgetConfig()  # type: ignore[call-arg]
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(url="   ")
+
+    def test_url_scheme_allowlist(self):
+        QrWidgetConfig(url="http://example.com")
+        QrWidgetConfig(url="https://example.com/path?a=1")
+        for bad in (
+            "javascript:alert(1)",
+            "data:text/html,<h1>x</h1>",
+            "ftp://example.com",
+            "example.com",
+        ):
+            with pytest.raises(ValidationError):
+                QrWidgetConfig(url=bad)
+
+    def test_url_stripped(self):
+        c = QrWidgetConfig(url="  https://example.com  ")
+        assert c.url == "https://example.com"
+
+    def test_url_length_capped(self):
+        long_url = "https://example.com/" + ("a" * 2000)
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(url=long_url)
+
+    def test_foreground_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(url="https://example.com", foreground="black")
+
+    def test_background_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(url="https://example.com", background="white")
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            QrWidgetConfig(
+                url="https://example.com",
+                center_label="hi",  # type: ignore[call-arg]
+            )
+
+
+class TestQrWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("qr")
+        assert isinstance(w, QrWidget)
+        assert w.slug == "qr"
+
+    def test_default_config_validates(self):
+        w = QrWidget()
+        # default_config must round-trip through the config schema.
+        QrWidgetConfig(**w.default_config())
+
+
+class TestQrWidgetRender:
+    def test_no_declared_assets(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+        assert w.declared_asset_ids(cfg) == []
+
+    def test_render_emits_inline_svg(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "<svg" in r.html
+        assert "viewBox" in r.html
+
+    def test_no_init_js_or_assets(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is None
+        assert r.js == ""
+        assert r.static_assets == []
+        assert r.referenced_asset_ids == []
+
+    def test_no_external_references(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+        r = w.render_html(cfg, _cell(), "abc")
+        # Fully self-contained: no external resource loads.
+        assert "src=" not in r.html
+        assert "href=" not in r.html
+        assert "<script" not in r.html
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+
+        assert "cw-qr-inst-A" in r1.html
+        assert "cw-qr-inst-A" in r1.css
+        assert "cw-qr-inst-B" in r2.html
+        # No cross-contamination
+        assert "cw-qr-inst-B" not in r1.html
+        assert "cw-qr-inst-A" not in r2.html
+
+    def test_render_is_deterministic(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com", error_correction="Q")
+        r1 = w.render_html(cfg, _cell(), "abc")
+        r2 = w.render_html(cfg, _cell(), "abc")
+        assert r1.html == r2.html
+        assert r1.css == r2.css
+
+    def test_colors_propagate(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(
+            url="https://example.com",
+            foreground="#123456",
+            background="#445566",
+        )
+        r = w.render_html(cfg, _cell(), "abc")
+        # foreground colours the dark modules in the SVG; background
+        # colours the wrapper gutter via CSS.  (segno collapses 6-hex to
+        # 3-hex when each channel's digits repeat, so we pick a value
+        # that survives verbatim.)
+        assert "#123456" in r.html
+        assert "background: #445566" in r.css
+
+    def test_quiet_zone_changes_matrix_border(self):
+        w = QrWidget()
+        url = "https://example.com"
+        r_on = w.render_html(
+            QrWidgetConfig(url=url, quiet_zone=True), _cell(), "a"
+        )
+        r_off = w.render_html(
+            QrWidgetConfig(url=url, quiet_zone=False), _cell(), "b"
+        )
+        # The quiet zone adds a 4-module border, enlarging the viewBox.
+        assert r_on.html != r_off.html
+
+    def test_validate_semantic_ok(self):
+        w = QrWidget()
+        cfg = QrWidgetConfig(url="https://example.com")
+        assert w.validate_semantic(cfg) == []


### PR DESCRIPTION
## QR code widget for composed slides

First item off the widget backlog (#743).

### What
A new **QR Code** widget you can drop on a composed slide. The QR is
generated **server-side at build time** with [`segno`](https://pypi.org/project/segno/):
deterministic, offline-safe, responsive inline SVG — no runtime fetch,
no external `<script>`/`<img>`, no asset dependencies.

### Config
- **URL** — http/https only, scheme-validated (rejects `javascript:`,
  `data:`, `ftp:`, bare domains)
- **Error correction** — L / M / Q / H (default M)
- **Foreground / background** — hex colors
- **Quiet zone** — toggle the white border

### Backend
- `cms/composed/widgets/qr.py` — `QrWidget` + `QrWidgetConfig`
- registered in `cms/composed/widgets/__init__.py`
- `segno>=1.6,<2.0` added to **both** `requirements.txt` (CMS image)
  and `requirements-shared.txt` (worker — the Playwright thumbnail
  render runs every widget's `render_html`, which calls segno)

### Editor
Palette button, DEFAULTS entry, canvas preview placeholder, layer
summary, and settings panel wired into `composed_editor.html`. The
editor shows a labeled placeholder box; the real QR renders at publish
time (and in the worker thumbnail snapshot). The assistant gets the
widget for free via registry introspection.

### Tests
- `tests/test_composed_qr_widget.py` — 20 tests (config validation,
  registry, render shape, no external refs, instance scoping,
  determinism, color/quiet-zone propagation, `validate_semantic`).
  All green locally.
- `tests/test_template_inline_js_syntax.py` — 17/17 (editor JS edits
  parse clean).

### Deferred
Center label / logo overlay (needs image compositing) — future
iteration.

🛑 **Dev only — do not deploy to prod.**
