### PR TITLE
feat(composed): per-widget Appearance styling (corner radius, border, opacity, inset, background)

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -367,9 +367,12 @@ def build_bundle(
         # explicit z-index (rather than relying on DOM paint order)
         # makes overlap deterministic and stops a child widget's own
         # z-index from interleaving with sibling cells.
+        frame_style = _frame_style(inst)
+        if frame_style:
+            frame_style = " " + frame_style
         widget_html_blocks.append(
             f'<div class="cw-cell" data-widget-instance="{html.escape(wid)}" '
-            f'style="{_grid_area_style(inst)} z-index: {z_index};">{render.html}</div>'
+            f'style="{_grid_area_style(inst)} z-index: {z_index};{frame_style}">{render.html}</div>'
         )
 
     doc = _DOC_TEMPLATE.format(
@@ -387,6 +390,41 @@ def build_bundle(
         sha256_hex=sha,
         source_asset_ids=source_asset_ids,
     )
+
+
+def _frame_style(inst: WidgetInstance) -> str:
+    """Emit inline CSS declarations for a widget's optional appearance frame.
+
+    Only non-default declarations are emitted, and an empty string is
+    returned when the widget has no frame (or an all-default frame).  A
+    cell that emits no frame style is therefore byte-identical to a
+    pre-appearance bundle, so existing slide bundle hashes are unchanged
+    and devices don't needlessly re-cache.
+
+    Lengths are in 1920x1080 design-space pixels, matching the units the
+    widget renderers use for font sizes (the v1 canvas is a fixed
+    1920x1080 surface, so design px == device px).
+    """
+    frame = inst.frame
+    if frame is None:
+        return ""
+    parts: list[str] = []
+    if frame.inset:
+        parts.append(f"padding: {frame.inset}px;")
+    if frame.background is not None:
+        parts.append(f"background: {frame.background};")
+    if frame.border_width:
+        parts.append(f"border: {frame.border_width}px solid {frame.border_color};")
+    if frame.corner_radius:
+        parts.append(f"border-radius: {frame.corner_radius}px;")
+    if frame.opacity < 1.0:
+        parts.append(f"opacity: {frame.opacity:g};")
+    if not parts:
+        return ""
+    # box-sizing keeps padding + border inside the grid-track footprint so
+    # a framed cell never overflows its cell.  Scoped to framed cells only
+    # (not the shared .cw-cell rule) to avoid churning every slide's hash.
+    return "box-sizing: border-box; " + " ".join(parts)
 
 
 # ── Templates / boilerplate ──────────────────────────────────────────

--- a/cms/composed/schema.py
+++ b/cms/composed/schema.py
@@ -56,6 +56,31 @@ class Cell(BaseModel):
     colspan: int = Field(default=1, ge=1, le=GRID_COLS)
 
 
+class WidgetFrame(BaseModel):
+    """Optional per-widget appearance styling applied to the cell wrapper.
+
+    Purely cosmetic — applied to the ``.cw-cell`` div that wraps every
+    widget's rendered HTML in the bundle.  Lets any widget (image,
+    video, text, …) get rounded corners, a border, reduced opacity, an
+    inset/padding gutter, and an optional background-fill matte without
+    each widget needing to know about styling.
+
+    All fields default to a no-op, so ``frame=None`` and a frame whose
+    fields are all default produce byte-identical bundle output (see
+    :func:`cms.composed.bundle._frame_style`).  Lengths are in 1920x1080
+    design-space pixels (the same space widget font sizes use).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    corner_radius: int = Field(default=0, ge=0, le=500)
+    border_width: int = Field(default=0, ge=0, le=50)
+    border_color: str = Field(default="#000000", pattern=r"^#[0-9a-fA-F]{6}$")
+    opacity: float = Field(default=1.0, ge=0.0, le=1.0)
+    inset: int = Field(default=0, ge=0, le=500)
+    background: str | None = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
+
+
 class WidgetInstance(BaseModel):
     """One placed widget in a composed-slide layout.
 
@@ -84,6 +109,7 @@ class WidgetInstance(BaseModel):
     cell: Cell
     config: dict = Field(default_factory=dict)
     config_version: int = Field(default=1, ge=1)
+    frame: WidgetFrame | None = None
 
     @field_validator("type")
     @classmethod

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -361,6 +361,7 @@ def _friendly_to_layout_dict(
                 },
                 "config": w.get("config", {}),
                 "config_version": config_version,
+                "frame": w.get("frame"),
             }
         )
 
@@ -778,6 +779,7 @@ async def get_composed_layout(
                 "colspan": cell.get("colspan", 1),
                 "config": w.get("config", {}),
                 "config_version": w.get("config_version", 1),
+                "frame": w.get("frame"),
             }
         )
 

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -645,6 +645,18 @@ function cqwFont(px) {
     const n = Number(px);
     return ((isFinite(n) ? n : 48) / 19.2).toFixed(3) + "cqw";
 }
+// Appearance frame lengths (corner radius / border / inset) are also in
+// 1920x1080 design-space px; convert to cqw so the editor preview scales
+// the same way the published bundle does on the device.
+function cqwLen(px) {
+    const n = Number(px);
+    return ((isFinite(n) ? n : 0) / 19.2).toFixed(3) + "cqw";
+}
+// Default appearance frame (matches cms/composed/schema.py WidgetFrame).
+const FRAME_DEFAULTS = {
+    corner_radius: 0, border_width: 0, border_color: "#000000",
+    opacity: 1.0, inset: 0, background: null,
+};
 const MEDIA_ASSETS = {{ media_assets|tojson }};
 const NULL_UUID = "00000000-0000-0000-0000-000000000000";
 
@@ -755,6 +767,7 @@ function renderCanvas() {
         content.style.pointerEvents = "none";
         el.classList.add("has-preview");
         el.appendChild(content);
+        applyFramePreview(el, content, w.frame);
         el.onclick = (e) => { e.stopPropagation(); selectWidget(w.id); };
         el.addEventListener("pointerdown", (e) => beginDrag(e, w.id, "move"));
         for (const dir of ["n","s","e","w","ne","nw","se","sw"]) {
@@ -1574,6 +1587,49 @@ function renderSettings() {
             </p>`;
     }
 
+    const fr = w.frame || FRAME_DEFAULTS;
+    const frBgOn = fr.background != null;
+    const frBgColor = frBgOn ? fr.background : "#000000";
+    const appearanceHtml = `
+        <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Appearance</h4>
+        <p style="font-size:0.75rem; color:var(--text-muted); margin:0.25rem 0 0.5rem;">
+            Frame styling applied to this widget. Rounded corners clip images and video.
+        </p>
+        <div class="row">
+            <div>
+                <label>Corner radius</label>
+                <input type="number" min="0" max="500" value="${clampInt(fr.corner_radius,0,500)}"
+                       oninput="updateSelected(x=>frameSet(x,'corner_radius',clampInt(this.value,0,500)))">
+            </div>
+            <div>
+                <label>Inset (padding)</label>
+                <input type="number" min="0" max="500" value="${clampInt(fr.inset,0,500)}"
+                       oninput="updateSelected(x=>frameSet(x,'inset',clampInt(this.value,0,500)))">
+            </div>
+        </div>
+        <div class="row">
+            <div>
+                <label>Border width</label>
+                <input type="number" min="0" max="50" value="${clampInt(fr.border_width,0,50)}"
+                       oninput="updateSelected(x=>frameSet(x,'border_width',clampInt(this.value,0,50)))">
+            </div>
+            <div>
+                <label>Border color</label>
+                <input type="color" value="${escapeHtml(fr.border_color || '#000000')}"
+                       oninput="updateSelected(x=>frameSet(x,'border_color',this.value))">
+            </div>
+        </div>
+        <label style="margin-top:0.5rem;">Opacity: <span id="frame-op-val">${Math.round((fr.opacity ?? 1)*100)}</span>%</label>
+        <input type="range" min="0" max="100" value="${Math.round((fr.opacity ?? 1)*100)}" style="width:100%;"
+               oninput="document.getElementById('frame-op-val').textContent=this.value; updateSelected(x=>frameSet(x,'opacity',clampInt(this.value,0,100)/100))">
+        <label style="display:block; margin-top:0.5rem;">
+            <input type="checkbox" id="frame-bg-toggle" ${frBgOn ? "checked" : ""}
+                   oninput="updateSelected(x=>frameSet(x,'background', this.checked ? (document.getElementById('frame-bg-color').value || '#000000') : null))">
+            Background fill
+        </label>
+        <input type="color" id="frame-bg-color" value="${escapeHtml(frBgColor)}"
+               oninput="updateSelected(x=>{ if (document.getElementById('frame-bg-toggle').checked) frameSet(x,'background',this.value); })">`;
+
     panel.innerHTML = `
         ${renderLayersHtml()}
         <h4 class="cw-sec">Arrange</h4>
@@ -1586,6 +1642,7 @@ function renderSettings() {
         <div style="font-size:0.75rem; color:var(--text-muted,#57606a); word-break:break-all; margin-top:0.5rem;">${w.id}</div>
         ${cellHtml}
         ${configHtml}
+        ${appearanceHtml}
         <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>`;
 }
 
@@ -1599,6 +1656,36 @@ function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, c => ({
         "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"
     }[c]));
+}
+
+// ── Appearance frame helpers ────────────────────────────────────────
+function ensureFrame(w) {
+    if (!w.frame) w.frame = Object.assign({}, FRAME_DEFAULTS);
+    return w.frame;
+}
+function frameSet(w, k, v) { ensureFrame(w)[k] = v; }
+
+// Mirror the published bundle's .cw-cell frame onto the editor preview.
+// el (.placed-widget) gets padding/border/background/radius; the inner
+// content node gets the radius + overflow clip + opacity. We deliberately
+// keep overflow OFF el and opacity OFF el so the resize handles stay
+// visible and fully opaque.
+function applyFramePreview(el, content, frame) {
+    if (!frame) return;
+    const f = Object.assign({}, FRAME_DEFAULTS, frame);
+    const active = f.inset > 0 || f.background != null || f.border_width > 0 ||
+                   f.corner_radius > 0 || f.opacity < 1;
+    if (!active) return;
+    el.style.boxSizing = "border-box";
+    if (f.inset > 0) el.style.padding = cqwLen(f.inset);
+    if (f.background != null) el.style.background = f.background;
+    if (f.border_width > 0) el.style.border = cqwLen(f.border_width) + " solid " + f.border_color;
+    if (f.corner_radius > 0) {
+        el.style.borderRadius = cqwLen(f.corner_radius);
+        content.style.borderRadius = cqwLen(f.corner_radius);
+        content.style.overflow = "hidden";
+    }
+    if (f.opacity < 1) content.style.opacity = String(f.opacity);
 }
 
 function deleteSelected() {
@@ -2025,6 +2112,7 @@ async function refreshLayoutFromServer() {
         },
         config: w.config || {},
         config_version: w.config_version,
+        frame: w.frame || null,
     }));
     selectedWidgetId = null;
     ensureLayoutShape();

--- a/tests/test_composed_appearance.py
+++ b/tests/test_composed_appearance.py
@@ -1,0 +1,176 @@
+"""Tests for the per-widget Appearance ("frame") styling system.
+
+Option B: every widget can carry an optional ``WidgetFrame`` that the
+bundle builder turns into inline CSS on the shared ``.cw-cell`` wrapper
+(corner radius, border, opacity, inset/padding, optional background
+fill).  Covered here:
+
+- ``WidgetFrame`` Pydantic range/shape validation.
+- ``WidgetInstance.frame`` is optional and backward compatible.
+- The bundle emits only non-default declarations.
+- A ``frame=None`` (or all-default) widget produces a bundle that is
+  byte-identical to a pre-appearance bundle (so existing slide hashes
+  never churn and devices don't needlessly re-cache).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+# Import to trigger widget auto-registration into the global registry.
+import cms.composed.widgets  # noqa: F401
+from cms.composed.bundle import build_bundle
+from cms.composed.schema import (
+    Cell,
+    Layout,
+    WidgetFrame,
+    WidgetInstance,
+)
+
+_WID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _text_layout(frame: WidgetFrame | None = None) -> Layout:
+    return Layout(
+        widgets=[
+            WidgetInstance(
+                id=_WID,
+                type="text",
+                cell=Cell(row=1, col=1, rowspan=2, colspan=3),
+                config={"text": "Hello", "color": "#ff0000"},
+                frame=frame,
+            ),
+        ],
+    )
+
+
+# ── Schema validation ────────────────────────────────────────────────
+
+
+class TestWidgetFrameSchema:
+    def test_defaults_are_all_neutral(self):
+        f = WidgetFrame()
+        assert f.corner_radius == 0
+        assert f.border_width == 0
+        assert f.border_color == "#000000"
+        assert f.opacity == 1.0
+        assert f.inset == 0
+        assert f.background is None
+
+    def test_frame_is_optional_on_widget_instance(self):
+        inst = WidgetInstance(
+            id=_WID,
+            type="text",
+            cell=Cell(row=1, col=1),
+            config={"text": "x"},
+        )
+        assert inst.frame is None
+
+    @pytest.mark.parametrize("value", [-1, 501])
+    def test_corner_radius_out_of_range_rejected(self, value):
+        with pytest.raises(ValidationError):
+            WidgetFrame(corner_radius=value)
+
+    @pytest.mark.parametrize("value", [-1, 51])
+    def test_border_width_out_of_range_rejected(self, value):
+        with pytest.raises(ValidationError):
+            WidgetFrame(border_width=value)
+
+    @pytest.mark.parametrize("value", [-1, 501])
+    def test_inset_out_of_range_rejected(self, value):
+        with pytest.raises(ValidationError):
+            WidgetFrame(inset=value)
+
+    @pytest.mark.parametrize("value", [-0.01, 1.01])
+    def test_opacity_out_of_range_rejected(self, value):
+        with pytest.raises(ValidationError):
+            WidgetFrame(opacity=value)
+
+    @pytest.mark.parametrize("color", ["red", "#fff", "#1234567", "fff000"])
+    def test_border_color_must_be_six_hex(self, color):
+        with pytest.raises(ValidationError):
+            WidgetFrame(border_color=color)
+
+    @pytest.mark.parametrize("color", ["red", "#abc", "rgb(0,0,0)"])
+    def test_background_must_be_six_hex_when_set(self, color):
+        with pytest.raises(ValidationError):
+            WidgetFrame(background=color)
+
+    def test_background_none_allowed(self):
+        assert WidgetFrame(background=None).background is None
+
+    def test_extra_keys_forbidden(self):
+        with pytest.raises(ValidationError):
+            WidgetFrame(bogus=1)
+
+
+# ── Bundle CSS emission ──────────────────────────────────────────────
+
+
+class TestFrameBundleEmission:
+    def _cell_style(self, html: str) -> str:
+        marker = 'data-widget-instance="11111111-1111-1111-1111-111111111111"'
+        idx = html.index(marker)
+        start = html.index('style="', idx) + len('style="')
+        end = html.index('"', start)
+        return html[start:end]
+
+    def test_full_frame_emits_all_decls(self):
+        frame = WidgetFrame(
+            corner_radius=24,
+            border_width=4,
+            border_color="#112233",
+            opacity=0.5,
+            inset=12,
+            background="#445566",
+        )
+        html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
+        style = self._cell_style(html)
+
+        assert "box-sizing: border-box;" in style
+        assert "padding: 12px;" in style
+        assert "background: #445566;" in style
+        assert "border: 4px solid #112233;" in style
+        assert "border-radius: 24px;" in style
+        assert "opacity: 0.5;" in style
+
+    def test_partial_frame_emits_only_set_decls(self):
+        frame = WidgetFrame(corner_radius=16)
+        html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
+        style = self._cell_style(html)
+
+        assert "border-radius: 16px;" in style
+        assert "box-sizing: border-box;" in style
+        # Untouched fields must NOT emit declarations.
+        assert "padding:" not in style
+        assert "border:" not in style
+        assert "opacity:" not in style
+        assert "background:" not in style
+
+    def test_default_frame_emits_no_decls(self):
+        # A frame object whose every field is default must behave exactly
+        # like frame=None — no box-sizing, no decls.
+        html = build_bundle(_text_layout(WidgetFrame())).html_bytes.decode("utf-8")
+        style = self._cell_style(html)
+        assert "box-sizing" not in style
+        assert "border-radius" not in style
+
+
+# ── Backward compatibility / hash stability ──────────────────────────
+
+
+class TestFrameBackwardCompat:
+    def test_frame_none_is_byte_identical_to_default_frame(self):
+        none_bundle = build_bundle(_text_layout(None))
+        default_bundle = build_bundle(_text_layout(WidgetFrame()))
+        assert none_bundle.html_bytes == default_bundle.html_bytes
+        assert none_bundle.sha256_hex == default_bundle.sha256_hex
+
+    def test_framed_bundle_differs_from_unframed(self):
+        plain = build_bundle(_text_layout(None))
+        framed = build_bundle(_text_layout(WidgetFrame(corner_radius=10)))
+        assert plain.html_bytes != framed.html_bytes
+        assert plain.sha256_hex != framed.sha256_hex


### PR DESCRIPTION
## Per-widget Appearance styling (Option B)

Adds an optional **Appearance** frame to every composed-slide widget, applied via the shared .cw-cell wrapper. This enables rounded-corner images/videos, bordered/matte-framed widgets, opacity, and inner padding — without a standalone shape widget.

### What's included
- **Corner radius** (0–500 px), **border** (width 0–50 + hex color), **opacity** (0–1), **inset/padding** (0–500 px), optional **background fill** (hex).
- Schema: new `WidgetFrame` model + optional `frame` on `WidgetInstance` (`extra="forbid"`, fully backward compatible).
- Bundle: emits **only** non-default declarations; a `None`/all-default frame is **byte-identical** to a pre-appearance bundle, so existing slide hashes don't churn and devices don't needlessly re-cache.
- Editor: Appearance settings panel with live canvas preview (design-px → cqw conversion; preview keeps resize handles visible/opaque).
- Routers: `frame` carried through the friendly GET/PUT serializers so AI edits round-trip frames.

### Tests
- New `tests/test_composed_appearance.py`: `WidgetFrame` range/shape validation, bundle CSS emission, hash-stability & backward-compat.
- Local: appearance + bundle + schema + publish + routes + ai + editor-assistant suites green; inline-JS syntax test green.

### Notes
- A standalone **shape/divider/panel widget** (Option A) is the queued follow-up.
- Dev only.
