### PR TITLE
Add standalone Shape widget (rectangle / ellipse / line divider)

### DIFF
--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -24,6 +24,7 @@ from cms.composed.widgets.clock import ClockWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.qr import QrWidget
+from cms.composed.widgets.shape import ShapeWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
 from cms.composed.widgets.weather import WeatherWidget
@@ -42,6 +43,7 @@ for _widget_cls in (
     TickerWidget,
     WeatherWidget,
     QrWidget,
+    ShapeWidget,
 ):
     if not _reg.has(_widget_cls.slug):
         _reg.register(_widget_cls())
@@ -52,6 +54,7 @@ __all__ = [
     "ImageWidget",
     "MediaWidget",
     "QrWidget",
+    "ShapeWidget",
     "TextWidget",
     "TickerWidget",
     "WeatherWidget",

--- a/cms/composed/widgets/shape.py
+++ b/cms/composed/widgets/shape.py
@@ -1,0 +1,168 @@
+"""Shape widget — pure-CSS rectangle, ellipse, or line/divider.
+
+The simplest *decorative* widget: it draws a single geometric primitive
+filling its cell.  No JS, no asset dependencies, no external references —
+everything is emitted as instance-scoped CSS, so a given config always
+produces byte-identical output (bundle hash stability).
+
+Three shapes:
+
+* ``rectangle`` — a filled box.  ``corner_radius`` rounds its corners;
+  ``border_width`` / ``border_color`` draw an outline.  Combine a high
+  ``corner_radius`` with no fill (transparent) + a border to get a pill
+  outline, or use it as a solid colour-block / matte panel behind other
+  widgets.
+* ``ellipse`` — same as rectangle but ``border-radius: 50%`` (a circle in
+  a square cell, an oval otherwise).  ``corner_radius`` is ignored.
+* ``line`` — a divider rule.  ``orientation`` picks horizontal/vertical;
+  ``thickness`` sets its weight in design px; the line is centred in the
+  cell and uses ``fill`` as its colour.  ``corner_radius`` rounds the
+  line's end-caps.
+
+Opacity / inset / a wrapper background are intentionally **not** config
+fields here — the shared per-widget "Appearance" frame (the ``.cw-cell``
+wrapper) already provides them for every widget.  Keeping them out avoids
+two competing opacity knobs.
+
+Instance scoping: the wrapper ``<div>`` class is suffixed with the widget
+instance UUID so two shape widgets in the same bundle never collide.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+_HEX6 = r"^#[0-9a-fA-F]{6}$"
+
+
+class ShapeWidgetConfig(BaseModel):
+    """User-editable config for :class:`ShapeWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    shape: Literal["rectangle", "ellipse", "line"] = "rectangle"
+    # ``fill`` doubles as the line colour for ``shape == "line"``.
+    fill: str = Field(default="#3b82f6", pattern=_HEX6)
+    # Outline for rectangle/ellipse. Ignored for line.
+    border_width: int = Field(default=0, ge=0, le=100)
+    border_color: str = Field(default="#000000", pattern=_HEX6)
+    # Rounds rectangle corners (and line end-caps). Ignored for ellipse.
+    corner_radius: int = Field(default=0, ge=0, le=500)
+    # Line-only geometry.
+    thickness: int = Field(default=8, ge=1, le=500)
+    orientation: Literal["horizontal", "vertical"] = "horizontal"
+
+
+class ShapeWidget(Widget):
+    """Pure-CSS geometric primitive (rectangle / ellipse / line)."""
+
+    slug: ClassVar[str] = "shape"
+    display_name: ClassVar[str] = "Shape"
+    icon: ClassVar[str] = "⬛"
+    ConfigSchema: ClassVar[type[BaseModel]] = ShapeWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "shape": "rectangle",
+            "fill": "#3b82f6",
+            "border_width": 0,
+            "border_color": "#000000",
+            "corner_radius": 0,
+            "thickness": 8,
+            "orientation": "horizontal",
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/shape.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # Shape has no asset deps; ctx/cell are ignored.
+        del ctx, cell
+        assert isinstance(config, ShapeWidgetConfig), (
+            "ShapeWidget.render_html expects a ShapeWidgetConfig instance"
+        )
+
+        css_class = f"cw-shape-{instance_id}"
+
+        if config.shape == "line":
+            css_out, html_out = self._render_line(config, css_class)
+        else:
+            css_out, html_out = self._render_box(config, css_class)
+
+        return WidgetRender(html=html_out, css=css_out)
+
+    def _render_box(
+        self, config: ShapeWidgetConfig, css_class: str
+    ) -> tuple[str, str]:
+        """Rectangle or ellipse — a single filled, optionally bordered box."""
+        decls = [
+            "width: 100%;",
+            "height: 100%;",
+            "box-sizing: border-box;",
+            f"background: {config.fill};",
+        ]
+        if config.shape == "ellipse":
+            decls.append("border-radius: 50%;")
+        elif config.corner_radius > 0:
+            decls.append(f"border-radius: {config.corner_radius}px;")
+        if config.border_width > 0:
+            decls.append(
+                f"border: {config.border_width}px solid {config.border_color};"
+            )
+        body = "\n".join(f"  {d}" for d in decls)
+        css_out = f".{css_class} {{\n{body}\n}}"
+        html_out = f'<div class="{css_class}"></div>'
+        return css_out, html_out
+
+    def _render_line(
+        self, config: ShapeWidgetConfig, css_class: str
+    ) -> tuple[str, str]:
+        """Centered divider rule, horizontal or vertical."""
+        if config.orientation == "vertical":
+            size_decls = (
+                f"width: {config.thickness}px;\n"
+                f"  height: 100%;"
+            )
+        else:
+            size_decls = (
+                f"width: 100%;\n"
+                f"  height: {config.thickness}px;"
+            )
+        radius = (
+            f"\n  border-radius: {config.corner_radius}px;"
+            if config.corner_radius > 0
+            else ""
+        )
+        # Wrapper centers the rule both ways so it sits in the middle of
+        # the cell regardless of the cell's aspect ratio.
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"}}\n"
+            f".{css_class}-rule {{\n"
+            f"  {size_decls}\n"
+            f"  background: {config.fill};{radius}\n"
+            f"}}"
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div class="{css_class}-rule"></div>'
+            f"</div>"
+        )
+        return css_out, html_out

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -102,6 +102,7 @@
             <button type="button" class="palette-btn" data-type="ticker" onclick="selectPaletteType('ticker')">📰 Ticker</button>
             <button type="button" class="palette-btn" data-type="weather" onclick="selectPaletteType('weather')">⛅ Weather</button>
             <button type="button" class="palette-btn" data-type="qr" onclick="selectPaletteType('qr')">▦ QR Code</button>
+            <button type="button" class="palette-btn" data-type="shape" onclick="selectPaletteType('shape')">⬛ Shape</button>
             <div id="palette-status" style="margin-top:0.5rem; font-size:0.85rem; color:var(--text-muted);">
                 None selected.
             </div>
@@ -673,6 +674,8 @@ const DEFAULTS = {
              font_size_px:64, refresh_seconds:900},
     qr: {url:"https://example.com", error_correction:"M", foreground:"#000000",
          background:"#ffffff", quiet_zone:true},
+    shape: {shape:"rectangle", fill:"#3b82f6", border_width:0, border_color:"#000000",
+            corner_radius:0, thickness:8, orientation:"horizontal"},
 };
 
 function flash(msg, ok) {
@@ -850,6 +853,8 @@ function renderWidgetContent(w) {
             root.appendChild(renderMediaPreview(cfg));
         } else if (w.type === "qr") {
             root.appendChild(buildQrPreview(cfg));
+        } else if (w.type === "shape") {
+            root.appendChild(buildShapePreview(cfg));
         } else {
             root.textContent = w.type;
         }
@@ -879,6 +884,44 @@ function buildQrPreview(cfg) {
     label.textContent = cfg.url || "";
     wrap.appendChild(box);
     wrap.appendChild(label);
+    return wrap;
+}
+
+function buildShapePreview(cfg) {
+    const wrap = document.createElement("div");
+    wrap.style.cssText =
+        "width:100%;height:100%;display:flex;align-items:center;" +
+        "justify-content:center;box-sizing:border-box;";
+    const fill = cfg.fill || "#3b82f6";
+    if (cfg.shape === "line") {
+        const rule = document.createElement("div");
+        const thick = cqwLen(Number(cfg.thickness) || 8);
+        const radius = Number(cfg.corner_radius) > 0 ? cqwLen(cfg.corner_radius) : "0";
+        if (cfg.orientation === "vertical") {
+            rule.style.cssText =
+                "width:" + thick + ";height:100%;background:" + fill +
+                ";border-radius:" + radius + ";";
+        } else {
+            rule.style.cssText =
+                "width:100%;height:" + thick + ";background:" + fill +
+                ";border-radius:" + radius + ";";
+        }
+        wrap.appendChild(rule);
+        return wrap;
+    }
+    const box = document.createElement("div");
+    let css = "width:100%;height:100%;box-sizing:border-box;background:" + fill + ";";
+    if (cfg.shape === "ellipse") {
+        css += "border-radius:50%;";
+    } else if (Number(cfg.corner_radius) > 0) {
+        css += "border-radius:" + cqwLen(cfg.corner_radius) + ";";
+    }
+    if (Number(cfg.border_width) > 0) {
+        css += "border:" + cqwLen(cfg.border_width) + " solid " +
+               (cfg.border_color || "#000000") + ";";
+    }
+    box.style.cssText = css;
+    wrap.appendChild(box);
     return wrap;
 }
 
@@ -1274,7 +1317,7 @@ function moveSelectedZ(op) {
     renderSettings();
 }
 
-const LAYER_ICONS = {text:"🅰", media:"🎬", clock:"🕒", analog_clock:"🕧", ticker:"📰", weather:"⛅"};
+const LAYER_ICONS = {text:"🅰", media:"🎬", clock:"🕒", analog_clock:"🕧", ticker:"📰", weather:"⛅", qr:"▦", shape:"⬛"};
 
 // Build the always-visible layer list (front → back). This is the
 // authoritative way to select a widget that is fully covered by
@@ -1584,6 +1627,70 @@ function renderSettings() {
             </label>
             <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
                 The QR code is generated when the slide is published. The editor shows a placeholder.
+            </p>`;
+    } else if (w.type === "shape") {
+        const sh = w.config.shape || "rectangle";
+        const isLine = sh === "line";
+        const isEllipse = sh === "ellipse";
+        const boxControls = `
+            <div class="row">
+                <div>
+                    <label>Fill</label>
+                    <input type="color" value="${w.config.fill||"#3b82f6"}"
+                           oninput="updateSelected(x=>x.config.fill=this.value)">
+                </div>
+                <div>
+                    <label>Corner radius</label>
+                    <input type="number" min="0" max="500" ${isEllipse?"disabled":""}
+                           value="${clampInt(w.config.corner_radius,0,500)}"
+                           oninput="updateSelected(x=>x.config.corner_radius=clampInt(this.value,0,500))">
+                </div>
+            </div>
+            <div class="row">
+                <div>
+                    <label>Border width</label>
+                    <input type="number" min="0" max="100" value="${clampInt(w.config.border_width,0,100)}"
+                           oninput="updateSelected(x=>x.config.border_width=clampInt(this.value,0,100))">
+                </div>
+                <div>
+                    <label>Border color</label>
+                    <input type="color" value="${w.config.border_color||"#000000"}"
+                           oninput="updateSelected(x=>x.config.border_color=this.value)">
+                </div>
+            </div>`;
+        const lineControls = `
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.fill||"#3b82f6"}"
+                           oninput="updateSelected(x=>x.config.fill=this.value)">
+                </div>
+                <div>
+                    <label>Thickness (px)</label>
+                    <input type="number" min="1" max="500" value="${clampInt(w.config.thickness,1,500)}"
+                           oninput="updateSelected(x=>x.config.thickness=clampInt(this.value,1,500))">
+                </div>
+            </div>
+            <label style="margin-top:0.5rem;">Orientation</label>
+            <select oninput="updateSelected(x=>x.config.orientation=this.value)">
+                <option value="horizontal" ${w.config.orientation==="horizontal"?"selected":""}>Horizontal</option>
+                <option value="vertical" ${w.config.orientation==="vertical"?"selected":""}>Vertical</option>
+            </select>
+            <label style="margin-top:0.5rem;">End-cap radius</label>
+            <input type="number" min="0" max="500" value="${clampInt(w.config.corner_radius,0,500)}"
+                   oninput="updateSelected(x=>x.config.corner_radius=clampInt(this.value,0,500))">`;
+        configHtml = `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Shape widget</h4>
+            <label>Shape</label>
+            <select oninput="updateSelected(x=>x.config.shape=this.value)">
+                <option value="rectangle" ${sh==="rectangle"?"selected":""}>Rectangle</option>
+                <option value="ellipse" ${sh==="ellipse"?"selected":""}>Ellipse</option>
+                <option value="line" ${sh==="line"?"selected":""}>Line / Divider</option>
+            </select>
+            ${isLine ? lineControls : boxControls}
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                Tip: use a rectangle behind other widgets as a color block, or the
+                Appearance panel below to add opacity, inset, or a matte frame.
             </p>`;
     }
 

--- a/tests/test_composed_shape_widget.py
+++ b/tests/test_composed_shape_widget.py
@@ -1,0 +1,204 @@
+"""Tests for cms.composed.widgets.shape.ShapeWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.shape import ShapeWidget, ShapeWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestShapeWidgetConfig:
+    def test_defaults(self):
+        c = ShapeWidgetConfig()
+        assert c.shape == "rectangle"
+        assert c.fill == "#3b82f6"
+        assert c.border_width == 0
+        assert c.border_color == "#000000"
+        assert c.corner_radius == 0
+        assert c.thickness == 8
+        assert c.orientation == "horizontal"
+
+    def test_shape_allowlist(self):
+        for ok in ("rectangle", "ellipse", "line"):
+            ShapeWidgetConfig(shape=ok)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(shape="triangle")  # type: ignore[arg-type]
+
+    def test_orientation_allowlist(self):
+        for ok in ("horizontal", "vertical"):
+            ShapeWidgetConfig(shape="line", orientation=ok)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(orientation="diagonal")  # type: ignore[arg-type]
+
+    def test_fill_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(fill="blue")
+
+    def test_border_color_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(border_color="black")
+
+    def test_border_width_bounds(self):
+        ShapeWidgetConfig(border_width=0)
+        ShapeWidgetConfig(border_width=100)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(border_width=-1)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(border_width=101)
+
+    def test_corner_radius_bounds(self):
+        ShapeWidgetConfig(corner_radius=0)
+        ShapeWidgetConfig(corner_radius=500)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(corner_radius=501)
+
+    def test_thickness_bounds(self):
+        ShapeWidgetConfig(thickness=1)
+        ShapeWidgetConfig(thickness=500)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(thickness=0)
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(thickness=501)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            ShapeWidgetConfig(rotation=45)  # type: ignore[call-arg]
+
+
+class TestShapeWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("shape")
+        assert isinstance(w, ShapeWidget)
+        assert w.slug == "shape"
+
+    def test_default_config_validates(self):
+        w = ShapeWidget()
+        ShapeWidgetConfig(**w.default_config())
+
+    def test_not_assistant_hidden(self):
+        # The assistant should be able to place shapes.
+        assert get_registry().get("shape").assistant_hidden is False
+
+
+class TestShapeWidgetRender:
+    def test_no_declared_assets(self):
+        w = ShapeWidget()
+        assert w.declared_asset_ids(ShapeWidgetConfig()) == []
+
+    def test_rectangle_fill(self):
+        w = ShapeWidget()
+        r = w.render_html(ShapeWidgetConfig(fill="#112233"), _cell(), "abc")
+        assert "background: #112233" in r.css
+        assert "border-radius" not in r.css  # no rounding by default
+
+    def test_rectangle_corner_radius(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(shape="rectangle", corner_radius=24),
+            _cell(),
+            "abc",
+        )
+        assert "border-radius: 24px;" in r.css
+
+    def test_rectangle_border(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(border_width=5, border_color="#abcdef"),
+            _cell(),
+            "abc",
+        )
+        assert "border: 5px solid #abcdef;" in r.css
+
+    def test_ellipse_is_round(self):
+        w = ShapeWidget()
+        r = w.render_html(ShapeWidgetConfig(shape="ellipse"), _cell(), "abc")
+        assert "border-radius: 50%;" in r.css
+
+    def test_ellipse_ignores_corner_radius(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(shape="ellipse", corner_radius=40),
+            _cell(),
+            "abc",
+        )
+        assert "border-radius: 50%;" in r.css
+        assert "40px" not in r.css
+
+    def test_line_horizontal(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(shape="line", thickness=12, fill="#ff0000"),
+            _cell(),
+            "abc",
+        )
+        assert "height: 12px;" in r.css
+        assert "width: 100%;" in r.css
+        assert "background: #ff0000;" in r.css
+        assert "-rule" in r.html
+
+    def test_line_vertical(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(
+                shape="line", orientation="vertical", thickness=6
+            ),
+            _cell(),
+            "abc",
+        )
+        assert "width: 6px;" in r.css
+        assert "height: 100%;" in r.css
+
+    def test_line_endcap_radius(self):
+        w = ShapeWidget()
+        r = w.render_html(
+            ShapeWidgetConfig(shape="line", corner_radius=4),
+            _cell(),
+            "abc",
+        )
+        assert "border-radius: 4px;" in r.css
+
+    def test_no_init_js_or_assets(self):
+        w = ShapeWidget()
+        r = w.render_html(ShapeWidgetConfig(), _cell(), "abc")
+        assert r.init_js is None
+        assert r.js == ""
+        assert r.static_assets == []
+        assert r.referenced_asset_ids == []
+
+    def test_no_external_references(self):
+        w = ShapeWidget()
+        r = w.render_html(ShapeWidgetConfig(), _cell(), "abc")
+        assert "src=" not in r.html
+        assert "href=" not in r.html
+        assert "<script" not in r.html
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = ShapeWidget()
+        cfg = ShapeWidgetConfig()
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+        assert "cw-shape-inst-A" in r1.html
+        assert "cw-shape-inst-A" in r1.css
+        assert "cw-shape-inst-B" in r2.html
+        assert "cw-shape-inst-B" not in r1.html
+        assert "cw-shape-inst-A" not in r2.html
+
+    def test_render_is_deterministic(self):
+        w = ShapeWidget()
+        cfg = ShapeWidgetConfig(shape="ellipse", fill="#0a0b0c")
+        r1 = w.render_html(cfg, _cell(), "abc")
+        r2 = w.render_html(cfg, _cell(), "abc")
+        assert r1.html == r2.html
+        assert r1.css == r2.css
+
+    def test_validate_semantic_ok(self):
+        w = ShapeWidget()
+        assert w.validate_semantic(ShapeWidgetConfig()) == []


### PR DESCRIPTION
## Summary

Adds a standalone **Shape** widget to the composed-slide editor — the "Option A" follow-up to the per-widget Appearance frame (#745). Draws a single pure-CSS geometric primitive that fills its cell.

| Shape | What it does | Config |
|-------|--------------|--------|
| **Rectangle** | Filled box; color-block / matte panel behind other widgets | `fill`, `corner_radius`, `border_width`/`border_color` |
| **Ellipse** | Filled oval/circle (`border-radius:50%`) | `fill`, `border_width`/`border_color` |
| **Line / Divider** | Centered rule, horizontal or vertical | `fill` (color), `thickness`, `orientation`, end-cap `corner_radius` |

## Design notes

- **No JS, no asset deps, no external references.** Deterministic, instance-scoped CSS (`cw-shape-<uuid>`), so bundle hashes stay stable.
- **Opacity / inset / matte background are intentionally NOT shape config** — the shared per-widget **Appearance** frame (the `.cw-cell` wrapper, shipped in #745) already provides them for every widget. Avoids two competing opacity knobs. Combine a rectangle + Appearance corner_radius/inset for framed color-blocks.
- Auto-registered into the widget registry → the AI assistant can place it (confirmed `shape` appears in `_build_widget_types()`).

## Editor wiring

Palette button (`⬛ Shape`), `DEFAULTS` entry, live canvas preview (`buildShapePreview`), shape-dependent settings panel (line controls vs box controls), and layer icon.

## Tests

`tests/test_composed_shape_widget.py` — 33 tests covering config validation (allowlists, hex, bounds, extra-forbid), per-shape render output, instance scoping, determinism. Local run:
- shape + JS-syntax + appearance: **67 passed**
- bundle + registry + widget_types: **28 passed, 1 skipped**

## Deploy

Goodwill **dev only**, as usual.
