### PR TITLE
fix(composed): round inset content when corner radius + inset are set

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -370,9 +370,11 @@ def build_bundle(
         frame_style = _frame_style(inst)
         if frame_style:
             frame_style = " " + frame_style
+        inner_open, inner_close = _frame_inner_wrap(inst)
         widget_html_blocks.append(
             f'<div class="cw-cell" data-widget-instance="{html.escape(wid)}" '
-            f'style="{_grid_area_style(inst)} z-index: {z_index};{frame_style}">{render.html}</div>'
+            f'style="{_grid_area_style(inst)} z-index: {z_index};{frame_style}">'
+            f"{inner_open}{render.html}{inner_close}</div>"
         )
 
     doc = _DOC_TEMPLATE.format(
@@ -425,6 +427,39 @@ def _frame_style(inst: WidgetInstance) -> str:
     # a framed cell never overflows its cell.  Scoped to framed cells only
     # (not the shared .cw-cell rule) to avoid churning every slide's hash.
     return "box-sizing: border-box; " + " ".join(parts)
+
+
+def _frame_inner_wrap(inst: WidgetInstance) -> tuple[str, str]:
+    """Optional inner content wrapper that actually rounds inset content.
+
+    The outer ``.cw-cell`` has ``overflow:hidden`` and carries the frame's
+    ``border-radius``, but CSS rounds the overflow clip at the cell's
+    *padding box* (the outer edge).  When the frame also has an ``inset``
+    (padding), the real content is pushed inward by that padding, so its
+    square corners sit *inside* the rounded clip region and never get
+    rounded — e.g. an inset image keeps square corners inside a rounded
+    matte frame.
+
+    To fix this we wrap the content in a concentric inner box that carries
+    its own (reduced) ``border-radius`` + ``overflow:hidden``, so the
+    content itself is clipped to the rounded shape.  The inner radius is
+    the outer radius minus the distance from the outer edge to the inner
+    content box (border + inset), clamped at zero.
+
+    Only emitted when both ``corner_radius`` and ``inset`` are non-zero —
+    every other case (no frame, no rounding, or rounding with no inset)
+    is correctly handled by the outer clip alone, so those cells stay
+    byte-identical and their bundle hashes don't change.
+    """
+    frame = inst.frame
+    if frame is None or not frame.corner_radius or not frame.inset:
+        return "", ""
+    inner_radius = max(0, frame.corner_radius - frame.inset - frame.border_width)
+    style = (
+        f"width: 100%; height: 100%; "
+        f"border-radius: {inner_radius}px; overflow: hidden;"
+    )
+    return f'<div class="cw-cell-inner" style="{style}">', "</div>"
 
 
 # ── Templates / boilerplate ──────────────────────────────────────────

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1789,7 +1789,12 @@ function applyFramePreview(el, content, frame) {
     if (f.border_width > 0) el.style.border = cqwLen(f.border_width) + " solid " + f.border_color;
     if (f.corner_radius > 0) {
         el.style.borderRadius = cqwLen(f.corner_radius);
-        content.style.borderRadius = cqwLen(f.corner_radius);
+        // Round the inner content concentrically. The published bundle
+        // clips the inset content with a reduced radius (outer radius
+        // minus border + inset), so mirror that here — otherwise an inset
+        // image looks rounded in the editor but ships with square corners.
+        const innerR = Math.max(0, f.corner_radius - f.inset - f.border_width);
+        content.style.borderRadius = cqwLen(innerR);
         content.style.overflow = "hidden";
     }
     if (f.opacity < 1) content.style.opacity = String(f.opacity);

--- a/tests/test_composed_appearance.py
+++ b/tests/test_composed_appearance.py
@@ -174,3 +174,63 @@ class TestFrameBackwardCompat:
         framed = build_bundle(_text_layout(WidgetFrame(corner_radius=10)))
         assert plain.html_bytes != framed.html_bytes
         assert plain.sha256_hex != framed.sha256_hex
+
+
+# ── Inset + corner-radius inner wrapper (rounded inset content) ──────
+
+
+class TestFrameInnerWrap:
+    """corner_radius + inset must round the *inset content*, not just clip
+    at the outer padding box (which leaves inset images square-cornered).
+    """
+
+    def _inner_div(self, html: str) -> str | None:
+        idx = html.find('class="cw-cell-inner"')
+        if idx == -1:
+            return None
+        start = html.index('style="', idx) + len('style="')
+        end = html.index('"', start)
+        return html[start:end]
+
+    def test_radius_with_inset_emits_inner_wrapper(self):
+        frame = WidgetFrame(corner_radius=40, inset=10)
+        html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
+        inner = self._inner_div(html)
+        assert inner is not None
+        # Reduced concentric radius: 40 - 10 inset - 0 border = 30.
+        assert "border-radius: 30px;" in inner
+        assert "overflow: hidden;" in inner
+
+    def test_inner_radius_also_reduced_by_border(self):
+        frame = WidgetFrame(corner_radius=40, inset=10, border_width=5)
+        html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
+        inner = self._inner_div(html)
+        assert inner is not None
+        # 40 - 10 inset - 5 border = 25.
+        assert "border-radius: 25px;" in inner
+
+    def test_inner_radius_clamped_at_zero(self):
+        # Inset larger than the radius can't make a negative radius.
+        frame = WidgetFrame(corner_radius=10, inset=40)
+        html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
+        inner = self._inner_div(html)
+        assert inner is not None
+        assert "border-radius: 0px;" in inner
+
+    def test_radius_without_inset_has_no_inner_wrapper(self):
+        # No inset → outer clip rounds the content correctly; no wrapper,
+        # so these bundles stay byte-identical to the pre-fix output.
+        html = build_bundle(
+            _text_layout(WidgetFrame(corner_radius=24))
+        ).html_bytes.decode("utf-8")
+        assert "cw-cell-inner" not in html
+
+    def test_inset_without_radius_has_no_inner_wrapper(self):
+        html = build_bundle(
+            _text_layout(WidgetFrame(inset=20))
+        ).html_bytes.decode("utf-8")
+        assert "cw-cell-inner" not in html
+
+    def test_no_frame_has_no_inner_wrapper(self):
+        html = build_bundle(_text_layout(None)).html_bytes.decode("utf-8")
+        assert "cw-cell-inner" not in html


### PR DESCRIPTION
## Problem

A widget **Appearance** frame configured with both a **corner radius**
and an **inset** kept square corners on the inset content. Most visibly:
an image with rounded corners + padding rendered with a rounded matte
but a square-cornered image inside it.

## Root cause

The outer `.cw-cell` carries `overflow:hidden` + the frame
`border-radius`, but CSS rounds the overflow clip at the cell's **padding
box** (outer edge). When the frame also has an inset, the real content is
pushed inward by that padding, so its square corners sit *inside* the
rounded clip region and are never clipped round.

## Fix

Wrap the content in a concentric `.cw-cell-inner` box with its own
**reduced** `border-radius` (`corner_radius - inset - border_width`,
clamped at 0) + `overflow:hidden`, so the inset content itself is clipped
to the rounded shape.

- Emitted **only** when both `corner_radius` and `inset` are non-zero.
  Every other case (no frame, rounding-only, inset-only) is correctly
  handled by the outer clip alone, so those bundles stay **byte-identical**
  — no hash churn / device re-cache.
- Editor preview (`applyFramePreview`) now rounds the inner content node
  with the same reduced radius for visual parity.

## Tests

`tests/test_composed_appearance.py` — new `TestFrameInnerWrap`:
- radius + inset emits `cw-cell-inner` with the reduced radius
- inner radius also reduced by border width
- inner radius clamped at 0 when inset > radius
- radius-only / inset-only / no-frame emit **no** wrapper (hash stability)

70 passed (`test_composed_appearance.py` + `test_composed_bundle.py` +
`test_template_inline_js_syntax.py`).

Dev only.
