### PR TITLE
fix(composed): border/background hug the inset content (floating frame)

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -394,6 +394,29 @@ def build_bundle(
     )
 
 
+def _frame_has_decoration(frame: WidgetFrame) -> bool:
+    """True when the frame draws something (background, border, or rounded
+    corners) as opposed to only spacing/opacity."""
+    return bool(
+        frame.corner_radius or frame.border_width or frame.background is not None
+    )
+
+
+def _frame_uses_inner(frame: WidgetFrame | None) -> bool:
+    """Whether the frame's decoration is rendered on a concentric inner box
+    (the "floating frame" model) rather than on the outer cell.
+
+    When a frame has an ``inset``, the decoration — background, border, and
+    rounded corners — hugs the inset content instead of sitting at the
+    cell edge.  The outer ``.cw-cell`` then keeps only the inset padding
+    (a transparent gap) plus opacity, and the inner ``.cw-cell-inner``
+    wrapper carries the visible frame.  With no inset there is nothing to
+    hug, so the decoration stays on the outer cell exactly as before and
+    those bundles remain byte-identical.
+    """
+    return frame is not None and bool(frame.inset) and _frame_has_decoration(frame)
+
+
 def _frame_style(inst: WidgetInstance) -> str:
     """Emit inline CSS declarations for a widget's optional appearance frame.
 
@@ -403,6 +426,11 @@ def _frame_style(inst: WidgetInstance) -> str:
     pre-appearance bundle, so existing slide bundle hashes are unchanged
     and devices don't needlessly re-cache.
 
+    When the frame has an inset *and* a decoration, the decoration moves to
+    the inner wrapper (see ``_frame_uses_inner`` / ``_frame_inner_wrap``)
+    so the border/background/corners hug the inset content; the outer cell
+    then carries only the inset padding and opacity.
+
     Lengths are in 1920x1080 design-space pixels, matching the units the
     widget renderers use for font sizes (the v1 canvas is a fixed
     1920x1080 surface, so design px == device px).
@@ -410,15 +438,21 @@ def _frame_style(inst: WidgetInstance) -> str:
     frame = inst.frame
     if frame is None:
         return ""
+    use_inner = _frame_uses_inner(frame)
     parts: list[str] = []
     if frame.inset:
         parts.append(f"padding: {frame.inset}px;")
-    if frame.background is not None:
-        parts.append(f"background: {frame.background};")
-    if frame.border_width:
-        parts.append(f"border: {frame.border_width}px solid {frame.border_color};")
-    if frame.corner_radius:
-        parts.append(f"border-radius: {frame.corner_radius}px;")
+    if not use_inner:
+        # No inset (or nothing to draw): the decoration sits on the outer
+        # cell edge, byte-identical to legacy bundles.
+        if frame.background is not None:
+            parts.append(f"background: {frame.background};")
+        if frame.border_width:
+            parts.append(
+                f"border: {frame.border_width}px solid {frame.border_color};"
+            )
+        if frame.corner_radius:
+            parts.append(f"border-radius: {frame.corner_radius}px;")
     if frame.opacity < 1.0:
         parts.append(f"opacity: {frame.opacity:g};")
     if not parts:
@@ -430,36 +464,38 @@ def _frame_style(inst: WidgetInstance) -> str:
 
 
 def _frame_inner_wrap(inst: WidgetInstance) -> tuple[str, str]:
-    """Optional inner content wrapper that actually rounds inset content.
+    """Optional inner content wrapper carrying the inset frame decoration.
 
-    The outer ``.cw-cell`` has ``overflow:hidden`` and carries the frame's
-    ``border-radius``, but CSS rounds the overflow clip at the cell's
-    *padding box* (the outer edge).  When the frame also has an ``inset``
-    (padding), the real content is pushed inward by that padding, so its
-    square corners sit *inside* the rounded clip region and never get
-    rounded — e.g. an inset image keeps square corners inside a rounded
-    matte frame.
+    When a frame has an ``inset``, the inset is a transparent gap between
+    the cell edge and the decorated box.  The decoration (background,
+    border, rounded corners) and the overflow clip live on this concentric
+    inner box, so the frame hugs the inset content: an inset image shows
+    its border tight around the image and its corners rounded against the
+    image, not floating at the original cell edge.
 
-    To fix this we wrap the content in a concentric inner box that carries
-    its own (reduced) ``border-radius`` + ``overflow:hidden``, so the
-    content itself is clipped to the rounded shape.  The inner radius is
-    the outer radius minus the distance from the outer edge to the inner
-    content box (border + inset), clamped at zero.
+    The inner box uses ``box-sizing: border-box`` so its border draws just
+    inside its footprint, and ``overflow: hidden`` + ``border-radius``
+    clip the content to the rounded inner edge of the border automatically
+    (the browser insets the clip radius by the border width).
 
-    Only emitted when both ``corner_radius`` and ``inset`` are non-zero —
-    every other case (no frame, no rounding, or rounding with no inset)
-    is correctly handled by the outer clip alone, so those cells stay
+    Only emitted when the frame has both an inset and a decoration — every
+    other case (no frame, spacing only, or decoration with no inset) is
+    handled by ``_frame_style`` on the outer cell, so those cells stay
     byte-identical and their bundle hashes don't change.
     """
     frame = inst.frame
-    if frame is None or not frame.corner_radius or not frame.inset:
+    if not _frame_uses_inner(frame):
         return "", ""
-    inner_radius = max(0, frame.corner_radius - frame.inset - frame.border_width)
-    style = (
-        f"width: 100%; height: 100%; "
-        f"border-radius: {inner_radius}px; overflow: hidden;"
-    )
-    return f'<div class="cw-cell-inner" style="{style}">', "</div>"
+    assert frame is not None  # narrowed by _frame_uses_inner
+    parts: list[str] = ["width: 100%;", "height: 100%;", "box-sizing: border-box;"]
+    if frame.background is not None:
+        parts.append(f"background: {frame.background};")
+    if frame.border_width:
+        parts.append(f"border: {frame.border_width}px solid {frame.border_color};")
+    if frame.corner_radius:
+        parts.append(f"border-radius: {frame.corner_radius}px;")
+    parts.append("overflow: hidden;")
+    return f'<div class="cw-cell-inner" style="{" ".join(parts)}">', "</div>"
 
 
 # ── Templates / boilerplate ──────────────────────────────────────────

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1772,11 +1772,14 @@ function ensureFrame(w) {
 }
 function frameSet(w, k, v) { ensureFrame(w)[k] = v; }
 
-// Mirror the published bundle's .cw-cell frame onto the editor preview.
-// el (.placed-widget) gets padding/border/background/radius; the inner
-// content node gets the radius + overflow clip + opacity. We deliberately
-// keep overflow OFF el and opacity OFF el so the resize handles stay
-// visible and fully opaque.
+// Mirror the published bundle's frame onto the editor preview. When the
+// frame has an inset it uses the "floating frame" model: the decoration
+// (background/border/rounded corners + overflow clip) hugs the inset
+// content and lives on the inner content node, while el keeps only the
+// inset padding. With no inset, the decoration sits on el (the cell edge),
+// matching the published bundle's outer-cell styling. We deliberately keep
+// overflow OFF el and opacity OFF el so the resize handles stay visible and
+// fully opaque.
 function applyFramePreview(el, content, frame) {
     if (!frame) return;
     const f = Object.assign({}, FRAME_DEFAULTS, frame);
@@ -1785,17 +1788,28 @@ function applyFramePreview(el, content, frame) {
     if (!active) return;
     el.style.boxSizing = "border-box";
     if (f.inset > 0) el.style.padding = cqwLen(f.inset);
-    if (f.background != null) el.style.background = f.background;
-    if (f.border_width > 0) el.style.border = cqwLen(f.border_width) + " solid " + f.border_color;
-    if (f.corner_radius > 0) {
-        el.style.borderRadius = cqwLen(f.corner_radius);
-        // Round the inner content concentrically. The published bundle
-        // clips the inset content with a reduced radius (outer radius
-        // minus border + inset), so mirror that here — otherwise an inset
-        // image looks rounded in the editor but ships with square corners.
-        const innerR = Math.max(0, f.corner_radius - f.inset - f.border_width);
-        content.style.borderRadius = cqwLen(innerR);
+    const hasDecoration = f.background != null || f.border_width > 0 ||
+                          f.corner_radius > 0;
+    if (f.inset > 0 && hasDecoration) {
+        // Floating-frame model: the decoration hugs the inset content.
+        content.style.boxSizing = "border-box";
+        content.style.width = "100%";
+        content.style.height = "100%";
+        if (f.background != null) content.style.background = f.background;
+        if (f.border_width > 0) content.style.border = cqwLen(f.border_width) + " solid " + f.border_color;
+        if (f.corner_radius > 0) content.style.borderRadius = cqwLen(f.corner_radius);
         content.style.overflow = "hidden";
+    } else {
+        // Decoration sits at the cell edge (no inset, or nothing to hug).
+        if (f.background != null) el.style.background = f.background;
+        if (f.border_width > 0) el.style.border = cqwLen(f.border_width) + " solid " + f.border_color;
+        if (f.corner_radius > 0) {
+            el.style.borderRadius = cqwLen(f.corner_radius);
+            // Clip the content node too (overflow stays off el so the
+            // resize handles aren't clipped).
+            content.style.borderRadius = cqwLen(f.corner_radius);
+            content.style.overflow = "hidden";
+        }
     }
     if (f.opacity < 1) content.style.opacity = String(f.opacity);
 }

--- a/tests/test_composed_appearance.py
+++ b/tests/test_composed_appearance.py
@@ -118,7 +118,18 @@ class TestFrameBundleEmission:
         end = html.index('"', start)
         return html[start:end]
 
+    def _inner_style(self, html: str) -> str | None:
+        idx = html.find('class="cw-cell-inner"')
+        if idx == -1:
+            return None
+        start = html.index('style="', idx) + len('style="')
+        end = html.index('"', start)
+        return html[start:end]
+
     def test_full_frame_emits_all_decls(self):
+        # With an inset, the decoration hugs the inset content: the outer
+        # cell carries only the inset padding + opacity (+ box-sizing) and
+        # the inner wrapper carries background/border/rounded corners.
         frame = WidgetFrame(
             corner_radius=24,
             border_width=4,
@@ -132,10 +143,18 @@ class TestFrameBundleEmission:
 
         assert "box-sizing: border-box;" in style
         assert "padding: 12px;" in style
-        assert "background: #445566;" in style
-        assert "border: 4px solid #112233;" in style
-        assert "border-radius: 24px;" in style
         assert "opacity: 0.5;" in style
+        # Decoration moved to the inner wrapper, not the outer cell.
+        assert "background:" not in style
+        assert "border:" not in style
+        assert "border-radius:" not in style
+
+        inner = self._inner_style(html)
+        assert inner is not None
+        assert "background: #445566;" in inner
+        assert "border: 4px solid #112233;" in inner
+        assert "border-radius: 24px;" in inner
+        assert "overflow: hidden;" in inner
 
     def test_partial_frame_emits_only_set_decls(self):
         frame = WidgetFrame(corner_radius=16)
@@ -180,8 +199,9 @@ class TestFrameBackwardCompat:
 
 
 class TestFrameInnerWrap:
-    """corner_radius + inset must round the *inset content*, not just clip
-    at the outer padding box (which leaves inset images square-cornered).
+    """With an inset, a frame's decoration (background, border, rounded
+    corners) hugs the inset content via a concentric inner wrapper — the
+    "floating frame" model — instead of sitting at the outer cell edge.
     """
 
     def _inner_div(self, html: str) -> str | None:
@@ -192,44 +212,77 @@ class TestFrameInnerWrap:
         end = html.index('"', start)
         return html[start:end]
 
-    def test_radius_with_inset_emits_inner_wrapper(self):
+    def _cell_style(self, html: str) -> str:
+        marker = 'data-widget-instance="11111111-1111-1111-1111-111111111111"'
+        idx = html.index(marker)
+        start = html.index('style="', idx) + len('style="')
+        end = html.index('"', start)
+        return html[start:end]
+
+    def test_radius_with_inset_inner_uses_full_radius(self):
+        # The inner box IS the frame, sitting inset from the cell edge, so
+        # it carries the full corner_radius (no concentric reduction). The
+        # outer cell keeps only the inset padding.
         frame = WidgetFrame(corner_radius=40, inset=10)
         html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
         inner = self._inner_div(html)
         assert inner is not None
-        # Reduced concentric radius: 40 - 10 inset - 0 border = 30.
-        assert "border-radius: 30px;" in inner
+        assert "border-radius: 40px;" in inner
         assert "overflow: hidden;" in inner
+        assert "box-sizing: border-box;" in inner
+        # Radius no longer lives on the outer cell.
+        outer = self._cell_style(html)
+        assert "border-radius:" not in outer
+        assert "padding: 10px;" in outer
 
-    def test_inner_radius_also_reduced_by_border(self):
-        frame = WidgetFrame(corner_radius=40, inset=10, border_width=5)
+    def test_border_with_inset_moves_to_inner(self):
+        # The border hugs the inset content: it's on the inner box, and the
+        # outer cell carries no border.
+        frame = WidgetFrame(border_width=6, border_color="#abcdef", inset=8)
         html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
         inner = self._inner_div(html)
         assert inner is not None
-        # 40 - 10 inset - 5 border = 25.
-        assert "border-radius: 25px;" in inner
+        assert "border: 6px solid #abcdef;" in inner
+        outer = self._cell_style(html)
+        assert "border:" not in outer
+        assert "padding: 8px;" in outer
 
-    def test_inner_radius_clamped_at_zero(self):
-        # Inset larger than the radius can't make a negative radius.
-        frame = WidgetFrame(corner_radius=10, inset=40)
+    def test_background_with_inset_moves_to_inner(self):
+        frame = WidgetFrame(background="#123456", inset=8)
         html = build_bundle(_text_layout(frame)).html_bytes.decode("utf-8")
         inner = self._inner_div(html)
         assert inner is not None
-        assert "border-radius: 0px;" in inner
+        assert "background: #123456;" in inner
+        outer = self._cell_style(html)
+        assert "background:" not in outer
 
     def test_radius_without_inset_has_no_inner_wrapper(self):
-        # No inset → outer clip rounds the content correctly; no wrapper,
-        # so these bundles stay byte-identical to the pre-fix output.
+        # No inset → the decoration sits on the outer cell exactly as
+        # before, so these bundles stay byte-identical to legacy output.
         html = build_bundle(
             _text_layout(WidgetFrame(corner_radius=24))
         ).html_bytes.decode("utf-8")
         assert "cw-cell-inner" not in html
+        assert "border-radius: 24px;" in self._cell_style(html)
 
-    def test_inset_without_radius_has_no_inner_wrapper(self):
+    def test_inset_without_decoration_has_no_inner_wrapper(self):
+        # Inset only (no background/border/radius) → nothing to hug, so no
+        # wrapper; the outer cell just carries the padding.
         html = build_bundle(
             _text_layout(WidgetFrame(inset=20))
         ).html_bytes.decode("utf-8")
         assert "cw-cell-inner" not in html
+        assert "padding: 20px;" in self._cell_style(html)
+
+    def test_inset_with_only_opacity_has_no_inner_wrapper(self):
+        # Opacity is not decoration; it stays on the outer cell.
+        html = build_bundle(
+            _text_layout(WidgetFrame(inset=20, opacity=0.4))
+        ).html_bytes.decode("utf-8")
+        assert "cw-cell-inner" not in html
+        outer = self._cell_style(html)
+        assert "padding: 20px;" in outer
+        assert "opacity: 0.4;" in outer
 
     def test_no_frame_has_no_inner_wrapper(self):
         html = build_bundle(_text_layout(None)).html_bytes.decode("utf-8")


### PR DESCRIPTION
## What

When a composed-slide widget frame has both an **inset** and **decoration**
(background / border / rounded corners), the decoration now **hugs the inset
content** — the "floating frame" model — instead of sitting at the outer cell
edge with the content floating inside it.

## Why

Reported on Goodwill dev: a bordered image with an inset showed the border at
the original (non-inset) cell boundary, detached from the image it was framing.
The user chose "border hugs the inset image (inset pulls the border inward
too)."

## How

- `cms/composed/bundle.py`
  - New helpers `_frame_has_decoration` / `_frame_uses_inner`.
  - When `inset > 0` AND there's decoration, the outer `.cw-cell` carries only
    `box-sizing` + inset `padding` + `opacity`; a concentric
    `.cw-cell-inner` wrapper carries `background` / `border` / **full**
    `border-radius` + `overflow:hidden`. The inner box *is* the frame, so it
    gets the full radius (no concentric reduction) and border-box +
    overflow:hidden clips content.
  - Otherwise (no inset, or nothing to hug) decoration stays on the outer cell,
    **byte-identical** to legacy output.
- `cms/templates/composed_editor.html` — `applyFramePreview` mirrors the same
  model so the editor preview matches the published bundle.

## Hash stability

The inner wrapper is emitted only when `inset > 0` AND decoration is present.
Inset-only, decoration-only, and no-frame cells stay byte-identical, so
unaffected slides don't needlessly invalidate device caches. Affected cells
(radius+inset, border+inset, bg+inset) do change hashes — expected and
acceptable for this dev-only feature.

## Tests

`TestFrameInnerWrap` rewritten + `test_full_frame_emits_all_decls` updated for
the hug model. Targeted suites green locally:

```
tests/test_composed_appearance.py tests/test_composed_bundle.py tests/test_template_inline_js_syntax.py
71 passed
```
