### PR TITLE
feat(composed): add countdown/countup timer widget

### DIFF
--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from cms.composed.registry import get_registry
 from cms.composed.widgets.analog_clock import AnalogClockWidget
 from cms.composed.widgets.clock import ClockWidget
+from cms.composed.widgets.countdown import CountdownWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.qr import QrWidget
@@ -40,6 +41,7 @@ for _widget_cls in (
     MediaWidget,
     ClockWidget,
     AnalogClockWidget,
+    CountdownWidget,
     TickerWidget,
     WeatherWidget,
     QrWidget,
@@ -51,6 +53,7 @@ for _widget_cls in (
 __all__ = [
     "AnalogClockWidget",
     "ClockWidget",
+    "CountdownWidget",
     "ImageWidget",
     "MediaWidget",
     "QrWidget",

--- a/cms/composed/widgets/countdown.py
+++ b/cms/composed/widgets/countdown.py
@@ -1,0 +1,278 @@
+"""Countdown / count-up timer widget — pure-JS, no asset dependencies.
+
+Counts **down** to a target wall-clock moment (a sale ending, an event
+starting) or **up** from one (days since a milestone).  Like the clock
+widget it reads the device's local ``Date`` so the displayed value
+follows the OS clock + timezone — intentional for v1 (no per-slide TZ
+metadata yet).
+
+The target moment is a **naive local datetime** (``YYYY-MM-DDTHH:MM``,
+from the editor's ``datetime-local`` input).  It is baked into the init
+script as a ``new Date(y, mo-1, d, h, mi, s)`` constructor so the device
+interprets it in its own local time — deterministic, offline-tolerant,
+and byte-identical across rebuilds.
+
+Unit selection: any combination of days / hours / minutes / seconds may
+be shown.  The highest *enabled* unit absorbs the overflow of any larger
+disabled units (e.g. with only hours+minutes shown, a 2-day remainder
+renders as ``52h 00m``).  At least one unit must be enabled.
+
+Security: the only config value interpolated into emitted JS is
+``completed_text``, and it is injected as a JSON-encoded string literal
+(``json.dumps``) so it can never break out of its literal.  The optional
+``label`` lives in HTML and is escaped there.  Instance scoping: every
+DOM ID + CSS class is suffixed with the widget instance UUID.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import ClassVar, Literal
+
+from markupsafe import escape
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+# Font-family allowlist — kept local so each widget evolves typography
+# independently (mirrors clock.py).
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+
+class CountdownWidgetConfig(BaseModel):
+    """User-editable config for :class:`CountdownWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Naive local datetime, e.g. "2030-01-01T00:00" or with seconds.
+    target: str = Field(default="2030-01-01T00:00:00")
+    direction: Literal["down", "up"] = "down"
+    label: str = Field(default="", max_length=120)
+    completed_text: str = Field(default="", max_length=120)
+    show_days: bool = True
+    show_hours: bool = True
+    show_minutes: bool = True
+    show_seconds: bool = False
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=96, ge=8, le=512)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+    @field_validator("target")
+    @classmethod
+    def _target_is_naive_local_datetime(cls, v: str) -> str:
+        try:
+            parsed = datetime.fromisoformat(v)
+        except ValueError as exc:
+            raise ValueError(
+                "target must be an ISO 8601 datetime (YYYY-MM-DDTHH:MM)"
+            ) from exc
+        if parsed.tzinfo is not None:
+            raise ValueError(
+                "target must be a naive local datetime (no timezone offset)"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _at_least_one_unit(self) -> CountdownWidgetConfig:
+        if not (
+            self.show_days
+            or self.show_hours
+            or self.show_minutes
+            or self.show_seconds
+        ):
+            raise ValueError("at least one time unit must be shown")
+        return self
+
+
+# Per-instance init script.  Placeholders use ``$NAME`` rather than
+# ``{name}`` so we don't have to brace-double the JS body (see clock.py).
+_COUNTDOWN_INIT_JS_TEMPLATE = """
+var timeEl = document.getElementById($TIME_ID_LIT);
+var targetMs = $TARGET_EXPR;
+var dir = '$DIRECTION';
+var completed = $COMPLETED_LIT;
+var defs = [
+  [$SHOW_DAYS, 86400, 'd'],
+  [$SHOW_HOURS, 3600, 'h'],
+  [$SHOW_MINUTES, 60, 'm'],
+  [$SHOW_SECONDS, 1, 's']
+];
+var intervalId = null;
+function pad2(n) { return n < 10 ? '0' + n : '' + n; }
+function render() {
+  var now = Date.now();
+  var diff = dir === 'down' ? (targetMs - now) : (now - targetMs);
+  var done = false;
+  if (diff <= 0) {
+    if (dir === 'down') { done = true; }
+    diff = 0;
+  }
+  if (done && completed.length > 0) {
+    if (timeEl) { timeEl.textContent = completed; }
+    if (intervalId !== null) { clearInterval(intervalId); intervalId = null; }
+    return;
+  }
+  var rem = Math.floor(diff / 1000);
+  var parts = [];
+  var leading = true;
+  for (var i = 0; i < defs.length; i++) {
+    if (!defs[i][0]) { continue; }
+    var unitSec = defs[i][1];
+    var val = Math.floor(rem / unitSec);
+    rem = rem - val * unitSec;
+    parts.push((leading ? ('' + val) : pad2(val)) + defs[i][2]);
+    leading = false;
+  }
+  if (timeEl) { timeEl.textContent = parts.join(' '); }
+}
+render();
+intervalId = setInterval(render, 1000);
+""".strip()
+
+
+def _target_expr(target: str) -> str:
+    """Bake the naive target into a device-local ``new Date(...)`` call."""
+    d = datetime.fromisoformat(target)
+    return (
+        f"new Date({d.year}, {d.month - 1}, {d.day}, "
+        f"{d.hour}, {d.minute}, {d.second}).getTime()"
+    )
+
+
+def _build_countdown_init_js(
+    *,
+    time_id: str,
+    target: str,
+    direction: str,
+    completed_text: str,
+    show_days: bool,
+    show_hours: bool,
+    show_minutes: bool,
+    show_seconds: bool,
+) -> str:
+    def _b(flag: bool) -> str:
+        return "true" if flag else "false"
+
+    return (
+        _COUNTDOWN_INIT_JS_TEMPLATE
+        .replace("$TIME_ID_LIT", f"'{time_id}'")
+        .replace("$TARGET_EXPR", _target_expr(target))
+        .replace("$DIRECTION", direction)
+        .replace("$COMPLETED_LIT", json.dumps(completed_text))
+        .replace("$SHOW_DAYS", _b(show_days))
+        .replace("$SHOW_HOURS", _b(show_hours))
+        .replace("$SHOW_MINUTES", _b(show_minutes))
+        .replace("$SHOW_SECONDS", _b(show_seconds))
+    )
+
+
+class CountdownWidget(Widget):
+    """Live countdown-to / count-up-from a target moment."""
+
+    slug: ClassVar[str] = "countdown"
+    display_name: ClassVar[str] = "Countdown"
+    icon: ClassVar[str] = "⏳"
+    ConfigSchema: ClassVar[type[BaseModel]] = CountdownWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "target": "2030-01-01T00:00:00",
+            "direction": "down",
+            "label": "",
+            "completed_text": "",
+            "show_days": True,
+            "show_hours": True,
+            "show_minutes": True,
+            "show_seconds": False,
+            "color": "#ffffff",
+            "font_family": "sans",
+            "font_size_px": 96,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/countdown.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # Countdown has no asset deps; ctx/cell are ignored.
+        del ctx, cell
+        assert isinstance(config, CountdownWidgetConfig), (
+            "CountdownWidget.render_html expects a CountdownWidgetConfig instance"
+        )
+
+        css_class = f"cw-countdown-{instance_id}"
+        time_id = f"cw-countdown-time-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        label_html = (
+            f'<div class="{css_class}-label">{escape(config.label)}</div>'
+            if config.label
+            else ""
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f"{label_html}"
+            f'<div id="{time_id}" class="{css_class}-time"></div>'
+            f"</div>"
+        )
+
+        # Subordinate label font sized at 40% of the timer font (matches
+        # the clock widget's date treatment).
+        label_size = max(8, int(config.font_size_px * 0.4))
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"}}\n"
+            f".{css_class}-label {{\n"
+            f"  font-size: {label_size}px;\n"
+            f"  opacity: 0.8;\n"
+            f"  margin-bottom: 0.2em;\n"
+            f"}}\n"
+            f".{css_class}-time {{\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1;\n"
+            f"  white-space: nowrap;\n"
+            f"}}"
+        )
+
+        init_js = _build_countdown_init_js(
+            time_id=time_id,
+            target=config.target,
+            direction=config.direction,
+            completed_text=config.completed_text,
+            show_days=config.show_days,
+            show_hours=config.show_hours,
+            show_minutes=config.show_minutes,
+            show_seconds=config.show_seconds,
+        )
+
+        return WidgetRender(html=html_out, css=css_out, init_js=init_js)

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -311,6 +311,18 @@
     }
     .cw-prev-clock-time { line-height: 1; white-space: nowrap; }
     .cw-prev-clock-date { opacity: 0.8; margin-top: 0.25em; white-space: nowrap; }
+    .cw-prev-countdown {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        font-variant-numeric: tabular-nums;
+    }
+    .cw-prev-countdown-label { opacity: 0.8; margin-bottom: 0.2em; white-space: nowrap; }
+    .cw-prev-countdown-time { line-height: 1; white-space: nowrap; }
     .cw-prev-ticker {
         width: 100%;
         height: 100%;
@@ -935,6 +947,104 @@ registerWidget("analog_clock", {
                 <input type="checkbox" ${w.config.show_numerals?"checked":""}
                     oninput="updateSelected(x=>x.config.show_numerals=this.checked)"> Show numerals
             </label>`,
+});
+
+registerWidget("countdown", {
+    label: "Countdown", icon: "⏳", category: "Time & Date",
+    keywords: ["countdown", "countup", "timer", "event", "days", "until", "since", "deadline"],
+    defaults: () => ({target:"2030-01-01T00:00:00", direction:"down", label:"", completed_text:"",
+             show_days:true, show_hours:true, show_minutes:true, show_seconds:false,
+             color:"#ffffff", font_family:"sans", font_size_px:96}),
+    summary: (w) => (w.config.direction === "up" ? "since " : "to ") + String(w.config.target || "").slice(0, 16),
+    preview: (root, cfg) => {
+        const fmt = (cfg) => {
+            const t = new Date(String(cfg.target || "").replace(" ", "T")).getTime();
+            if (isNaN(t)) return "—";
+            const dir = cfg.direction === "up" ? "up" : "down";
+            let diff = dir === "down" ? (t - Date.now()) : (Date.now() - t);
+            let done = false;
+            if (diff <= 0) { if (dir === "down") done = true; diff = 0; }
+            if (done && (cfg.completed_text || "").length > 0) return cfg.completed_text;
+            let rem = Math.floor(diff / 1000);
+            const defs = [[!!cfg.show_days,86400,"d"],[!!cfg.show_hours,3600,"h"],
+                          [!!cfg.show_minutes,60,"m"],[!!cfg.show_seconds,1,"s"]];
+            const parts = []; let leading = true;
+            for (const [on, sec, suf] of defs) {
+                if (!on) continue;
+                const v = Math.floor(rem / sec); rem -= v * sec;
+                parts.push((leading ? String(v) : (v < 10 ? "0" + v : "" + v)) + suf);
+                leading = false;
+            }
+            return parts.length ? parts.join(" ") : "0";
+        };
+        const c = document.createElement("div");
+        c.className = "cw-prev-countdown";
+        c.style.color = cfg.color || "#ffffff";
+        c.style.fontFamily = fontStack(cfg.font_family);
+        if (cfg.label) {
+            const lab = document.createElement("div");
+            lab.className = "cw-prev-countdown-label";
+            lab.style.fontSize = cqwFont((Number(cfg.font_size_px) || 96) * 0.4);
+            lab.textContent = cfg.label;
+            c.appendChild(lab);
+        }
+        const timeEl = document.createElement("div");
+        timeEl.className = "cw-prev-countdown-time";
+        timeEl.style.fontSize = cqwFont(cfg.font_size_px);
+        timeEl.textContent = fmt(cfg);
+        c.appendChild(timeEl);
+        root.appendChild(c);
+    },
+    settings: (w) => `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Countdown widget</h4>
+            <label>Target date &amp; time</label>
+            <input type="datetime-local" step="1" value="${(w.config.target||"").slice(0,19)}"
+                   oninput="updateSelected(x=>x.config.target=this.value)">
+            <label>Direction</label>
+            <select oninput="updateSelected(x=>x.config.direction=this.value)">
+                <option value="down" ${w.config.direction!=="up"?"selected":""}>Count down to</option>
+                <option value="up" ${w.config.direction==="up"?"selected":""}>Count up from</option>
+            </select>
+            <label>Label (optional)</label>
+            <input type="text" maxlength="120" value="${(w.config.label||"").replace(/"/g,"&quot;")}"
+                   placeholder="e.g. Grand opening in"
+                   oninput="updateSelected(x=>x.config.label=this.value)">
+            <label>Completed text (optional)</label>
+            <input type="text" maxlength="120" value="${(w.config.completed_text||"").replace(/"/g,"&quot;")}"
+                   placeholder="e.g. We're open!"
+                   oninput="updateSelected(x=>x.config.completed_text=this.value)">
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.show_days?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_days=this.checked)"> Days
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_hours?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_hours=this.checked)"> Hours
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_minutes?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_minutes=this.checked)"> Minutes
+            </label>
+            <label style="font-weight:400;">
+                <input type="checkbox" ${w.config.show_seconds?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_seconds=this.checked)"> Seconds
+            </label>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <label>Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>`,
 });
 
 registerWidget("weather", {

--- a/tests/test_composed_countdown_widget.py
+++ b/tests/test_composed_countdown_widget.py
@@ -1,0 +1,184 @@
+"""Tests for cms.composed.widgets.countdown.CountdownWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.countdown import CountdownWidget, CountdownWidgetConfig
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestCountdownWidgetConfig:
+    def test_defaults(self):
+        c = CountdownWidgetConfig()
+        assert c.target == "2030-01-01T00:00:00"
+        assert c.direction == "down"
+        assert c.label == ""
+        assert c.completed_text == ""
+        assert c.show_days is True
+        assert c.show_hours is True
+        assert c.show_minutes is True
+        assert c.show_seconds is False
+        assert c.color == "#ffffff"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 96
+
+    def test_direction_allowlist(self):
+        CountdownWidgetConfig(direction="down")
+        CountdownWidgetConfig(direction="up")
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(direction="sideways")  # type: ignore[arg-type]
+
+    def test_target_accepts_minute_and_second_precision(self):
+        CountdownWidgetConfig(target="2031-12-31T23:59")
+        CountdownWidgetConfig(target="2031-12-31T23:59:30")
+
+    def test_target_rejects_garbage(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(target="next tuesday")
+
+    def test_target_rejects_timezone_aware(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(target="2030-01-01T00:00:00+00:00")
+
+    def test_font_allowlist(self):
+        for ok in ("sans", "serif", "mono"):
+            CountdownWidgetConfig(font_family=ok)
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(font_family="comic-sans")
+
+    def test_color_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(color="red")
+
+    def test_font_size_bounds(self):
+        CountdownWidgetConfig(font_size_px=8)
+        CountdownWidgetConfig(font_size_px=512)
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(font_size_px=7)
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(font_size_px=513)
+
+    def test_label_and_completed_text_length_capped(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(label="x" * 121)
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(completed_text="x" * 121)
+
+    def test_at_least_one_unit_required(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(
+                show_days=False,
+                show_hours=False,
+                show_minutes=False,
+                show_seconds=False,
+            )
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            CountdownWidgetConfig(timezone="UTC")  # type: ignore[call-arg]
+
+
+class TestCountdownWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("countdown")
+        assert isinstance(w, CountdownWidget)
+        assert w.slug == "countdown"
+
+
+class TestCountdownWidgetRender:
+    def test_no_declared_assets(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig()
+        assert w.declared_asset_ids(cfg) == []
+
+    def test_html_and_css_are_instance_scoped(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig()
+
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+
+        assert "cw-countdown-inst-A" in r1.html
+        assert "cw-countdown-inst-A" in r1.css
+        assert "cw-countdown-time-inst-A" in r1.html
+        assert "cw-countdown-inst-B" in r2.html
+        # No cross-contamination
+        assert "cw-countdown-inst-B" not in r1.html
+        assert "cw-countdown-inst-A" not in r2.html
+
+    def test_init_js_references_time_element_id_and_ticks(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig()
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert "cw-countdown-time-abc" in r.init_js
+        assert "setInterval" in r.init_js
+
+    def test_target_baked_as_device_local_date_constructor(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig(target="2030-06-15T09:30:45")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        # month is zero-indexed in JS Date constructor (June -> 5)
+        assert "new Date(2030, 5, 15, 9, 30, 45).getTime()" in r.init_js
+
+    def test_direction_propagates_to_init_js(self):
+        w = CountdownWidget()
+        r_down = w.render_html(CountdownWidgetConfig(direction="down"), _cell(), "a")
+        r_up = w.render_html(CountdownWidgetConfig(direction="up"), _cell(), "b")
+        assert "var dir = 'down'" in r_down.init_js  # type: ignore[operator]
+        assert "var dir = 'up'" in r_up.init_js  # type: ignore[operator]
+
+    def test_unit_flags_propagate_to_init_js(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig(
+            show_days=True,
+            show_hours=False,
+            show_minutes=True,
+            show_seconds=False,
+        )
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert "[true, 86400, 'd']" in r.init_js
+        assert "[false, 3600, 'h']" in r.init_js
+        assert "[true, 60, 'm']" in r.init_js
+        assert "[false, 1, 's']" in r.init_js
+
+    def test_completed_text_injected_as_json_string_literal(self):
+        w = CountdownWidget()
+        # A quote + closing-script-ish payload must be escaped, not break JS.
+        cfg = CountdownWidgetConfig(completed_text='Done! "go"')
+        r = w.render_html(cfg, _cell(), "abc")
+        assert r.init_js is not None
+        assert 'var completed = "Done! \\"go\\""' in r.init_js
+
+    def test_label_rendered_and_html_escaped(self):
+        w = CountdownWidget()
+        r_off = w.render_html(CountdownWidgetConfig(label=""), _cell(), "a")
+        r_on = w.render_html(
+            CountdownWidgetConfig(label="Sale <ends>"), _cell(), "b"
+        )
+        assert "cw-countdown-a-label" not in r_off.html
+        assert "cw-countdown-b-label" in r_on.html
+        assert "Sale &lt;ends&gt;" in r_on.html
+        assert "<ends>" not in r_on.html
+
+    def test_color_propagates_to_css(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig(color="#abcdef")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "color: #abcdef" in r.css
+
+    def test_font_size_propagates_to_css(self):
+        w = CountdownWidget()
+        cfg = CountdownWidgetConfig(font_size_px=128)
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "font-size: 128px" in r.css


### PR DESCRIPTION
## Countdown timer widget

Adds a **Countdown** composed-slide widget (Time & Date category).

- Counts **down to** or **up from** a target date/time, interpreted in
  the **device's local clock** (target baked as a `new Date(y, m-1, d,
  h, mi, s)` constructor so each device renders in its own timezone).
- Configurable: label, completed-text (shown when a countdown reaches
  zero), per-unit visibility (days/hours/minutes/seconds), color, font,
  size.
- Instance-scoped HTML/CSS/JS; highest enabled unit absorbs overflow.
- `completed_text` JSON-injected as a safe JS string literal; label
  HTML-escaped; config never executed as code (invariant preserved).

### Tests
- 22 backend unit tests (config validation, target baking, instance
  scoping, unit flags, escaping, CSS propagation).
- Frontend descriptor validated by `test_template_inline_js_syntax`.
- Appearance + bundle suites green.

Dev-only; one widget per PR.
