### PR TITLE
feat(composed): add date banner widget

### DIFF
--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -22,6 +22,7 @@ from cms.composed.registry import get_registry
 from cms.composed.widgets.analog_clock import AnalogClockWidget
 from cms.composed.widgets.clock import ClockWidget
 from cms.composed.widgets.countdown import CountdownWidget
+from cms.composed.widgets.datebanner import DateBannerWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.qr import QrWidget
@@ -42,6 +43,7 @@ for _widget_cls in (
     ClockWidget,
     AnalogClockWidget,
     CountdownWidget,
+    DateBannerWidget,
     TickerWidget,
     WeatherWidget,
     QrWidget,
@@ -54,6 +56,7 @@ __all__ = [
     "AnalogClockWidget",
     "ClockWidget",
     "CountdownWidget",
+    "DateBannerWidget",
     "ImageWidget",
     "MediaWidget",
     "QrWidget",

--- a/cms/composed/widgets/datebanner.py
+++ b/cms/composed/widgets/datebanner.py
@@ -1,0 +1,188 @@
+"""Date banner widget — shows the current date/day using device-local time.
+
+Pure-JS, no asset dependencies.  Re-renders every 60 s via
+``setInterval`` so the banner rolls over at local midnight without a
+page reload.  Uses the browser's ``Date`` object + ``toLocaleDateString``
+so the displayed date follows whatever the OS clock + locale + TZ are
+set to on the device (same rationale as :mod:`cms.composed.widgets.clock`).
+
+Instance scoping: every DOM ID + CSS class is suffixed with the widget
+instance UUID so two date-banner widgets in the same bundle don't
+collide.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar, Literal
+
+from markupsafe import escape
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+# Font-family allowlist — kept local to this widget so it can evolve
+# typography independently of clock/text.
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+# Each format maps to a ``toLocaleDateString`` options object literal,
+# baked into the init JS.  Keeping the mapping server-side means the
+# device never evaluates user-controlled format code — only one of
+# these fixed, CMS-authored option objects.
+_FORMAT_OPTIONS: dict[str, str] = {
+    # Monday, January 1, 2030
+    "full": "{weekday:'long', year:'numeric', month:'long', day:'numeric'}",
+    # January 1, 2030
+    "long": "{year:'numeric', month:'long', day:'numeric'}",
+    # Monday
+    "weekday": "{weekday:'long'}",
+    # Mon, Jan 1
+    "short": "{weekday:'short', month:'short', day:'numeric'}",
+    # 01/01/2030 (locale numeric)
+    "numeric": "{year:'numeric', month:'2-digit', day:'2-digit'}",
+}
+
+
+class DateBannerWidgetConfig(BaseModel):
+    """User-editable config for :class:`DateBannerWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    format: Literal["full", "long", "weekday", "short", "numeric"] = "full"
+    prefix: str = Field(default="", max_length=120)
+    uppercase: bool = False
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=96, ge=8, le=512)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+
+# Per-instance init script.  ``$NAME`` placeholders (not ``{name}``) so
+# literal ``{`` in the JS body don't need brace-doubling.
+_DATEBANNER_INIT_JS_TEMPLATE = """
+var dateEl = document.getElementById($DATE_ID_LIT);
+var prefix = $PREFIX_LIT;
+var upper = $UPPERCASE;
+function render() {
+  if (!dateEl) return;
+  var d = new Date();
+  var s = d.toLocaleDateString(undefined, $OPTIONS);
+  if (prefix) s = prefix + ' ' + s;
+  if (upper) s = s.toUpperCase();
+  dateEl.textContent = s;
+}
+render();
+setInterval(render, 60000);
+""".strip()
+
+
+def _build_datebanner_init_js(
+    *,
+    date_id: str,
+    options: str,
+    prefix: str,
+    uppercase: bool,
+) -> str:
+    return (
+        _DATEBANNER_INIT_JS_TEMPLATE
+        .replace("$DATE_ID_LIT", f"'{date_id}'")
+        .replace("$OPTIONS", options)
+        .replace("$PREFIX_LIT", json.dumps(prefix))
+        .replace("$UPPERCASE", "true" if uppercase else "false")
+    )
+
+
+class DateBannerWidget(Widget):
+    """Current date / day-of-week banner."""
+
+    slug: ClassVar[str] = "datebanner"
+    display_name: ClassVar[str] = "Date Banner"
+    icon: ClassVar[str] = "📅"
+    ConfigSchema: ClassVar[type[BaseModel]] = DateBannerWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "format": "full",
+            "prefix": "",
+            "uppercase": False,
+            "color": "#ffffff",
+            "font_family": "sans",
+            "font_size_px": 96,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/datebanner.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # No asset deps; ctx + cell unused.
+        del ctx, cell
+        assert isinstance(config, DateBannerWidgetConfig), (
+            "DateBannerWidget.render_html expects a DateBannerWidgetConfig"
+        )
+
+        css_class = f"cw-datebanner-{instance_id}"
+        date_id = f"cw-datebanner-date-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+        options = _FORMAT_OPTIONS[config.format]
+
+        # Static fallback text in the markup (escaped) so the banner is
+        # not blank for the split second before init_js runs, and so a
+        # JS-less snapshot still shows something sensible.  The runtime
+        # immediately overwrites it with the live, locale-formatted date.
+        placeholder = escape(
+            f"{config.prefix} \u2026" if config.prefix else "\u2026"
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{date_id}" class="{css_class}-date">{placeholder}</div>'
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  text-align: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"}}\n"
+            f".{css_class}-date {{\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1.1;\n"
+            f"}}"
+        )
+
+        init_js = _build_datebanner_init_js(
+            date_id=date_id,
+            options=options,
+            prefix=config.prefix,
+            uppercase=config.uppercase,
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            init_js=init_js,
+        )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -323,6 +323,17 @@
     }
     .cw-prev-countdown-label { opacity: 0.8; margin-bottom: 0.2em; white-space: nowrap; }
     .cw-prev-countdown-time { line-height: 1; white-space: nowrap; }
+    .cw-prev-datebanner {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        text-align: center;
+    }
+    .cw-prev-datebanner-date { line-height: 1.1; white-space: nowrap; }
     .cw-prev-ticker {
         width: 100%;
         height: 100%;
@@ -1028,6 +1039,74 @@ registerWidget("countdown", {
             <label style="font-weight:400;">
                 <input type="checkbox" ${w.config.show_seconds?"checked":""}
                     oninput="updateSelected(x=>x.config.show_seconds=this.checked)"> Seconds
+            </label>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <label>Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>`,
+});
+
+registerWidget("datebanner", {
+    label: "Date Banner", icon: "📅", category: "Time & Date",
+    keywords: ["date", "day", "banner", "calendar", "today", "weekday"],
+    defaults: () => ({format:"full", prefix:"", uppercase:false, color:"#ffffff", font_family:"sans", font_size_px:96}),
+    summary: (w) => w.config.format || "full",
+    preview: (root, cfg) => {
+        const OPTS = {
+            full: {weekday:'long', year:'numeric', month:'long', day:'numeric'},
+            long: {year:'numeric', month:'long', day:'numeric'},
+            weekday: {weekday:'long'},
+            short: {weekday:'short', month:'short', day:'numeric'},
+            numeric: {year:'numeric', month:'2-digit', day:'2-digit'},
+        };
+        const c = document.createElement("div");
+        c.className = "cw-prev-datebanner";
+        c.style.color = cfg.color || "#ffffff";
+        c.style.fontFamily = fontStack(cfg.font_family);
+        const dateEl = document.createElement("div");
+        dateEl.className = "cw-prev-datebanner-date";
+        dateEl.style.fontSize = cqwFont(cfg.font_size_px);
+        let txt;
+        try {
+            txt = new Date().toLocaleDateString(undefined, OPTS[cfg.format] || OPTS.full);
+        } catch (e) {
+            txt = new Date().toLocaleDateString();
+        }
+        txt = (cfg.prefix || "") + txt;
+        if (cfg.uppercase) txt = txt.toUpperCase();
+        dateEl.textContent = txt;
+        c.appendChild(dateEl);
+        root.appendChild(c);
+    },
+    settings: (w) => `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Date banner widget</h4>
+            <label>Format</label>
+            <select oninput="updateSelected(x=>x.config.format=this.value)">
+                <option value="full" ${w.config.format==="full"?"selected":""}>Full (Monday, January 1, 2025)</option>
+                <option value="long" ${w.config.format==="long"?"selected":""}>Long (January 1, 2025)</option>
+                <option value="weekday" ${w.config.format==="weekday"?"selected":""}>Weekday (Monday)</option>
+                <option value="short" ${w.config.format==="short"?"selected":""}>Short (Mon, Jan 1)</option>
+                <option value="numeric" ${w.config.format==="numeric"?"selected":""}>Numeric (2025-01-01)</option>
+            </select>
+            <label>Prefix</label>
+            <input type="text" maxlength="120" value="${(w.config.prefix||"").replace(/"/g,"&quot;")}"
+                   placeholder="e.g. Today is "
+                   oninput="updateSelected(x=>x.config.prefix=this.value)">
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.uppercase?"checked":""}
+                    oninput="updateSelected(x=>x.config.uppercase=this.checked)"> Uppercase
             </label>
             <div class="row">
                 <div>

--- a/tests/test_composed_datebanner_widget.py
+++ b/tests/test_composed_datebanner_widget.py
@@ -1,0 +1,153 @@
+"""Unit tests for the Date Banner composed-slide widget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.datebanner import (
+    DateBannerWidget,
+    DateBannerWidgetConfig,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestDateBannerWidgetConfig:
+    def test_defaults(self):
+        c = DateBannerWidgetConfig()
+        assert c.format == "full"
+        assert c.prefix == ""
+        assert c.uppercase is False
+        assert c.color == "#ffffff"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 96
+
+    @pytest.mark.parametrize(
+        "fmt", ["full", "long", "weekday", "short", "numeric"]
+    )
+    def test_valid_formats(self, fmt):
+        assert DateBannerWidgetConfig(format=fmt).format == fmt
+
+    def test_invalid_format_rejected(self):
+        with pytest.raises(ValidationError):
+            DateBannerWidgetConfig(format="fancy")
+
+    def test_prefix_length_capped(self):
+        with pytest.raises(ValidationError):
+            DateBannerWidgetConfig(prefix="x" * 121)
+        # exactly at the cap is fine
+        assert DateBannerWidgetConfig(prefix="x" * 120).prefix == "x" * 120
+
+    def test_font_allowlist(self):
+        for f in ("sans", "serif", "mono"):
+            assert DateBannerWidgetConfig(font_family=f).font_family == f
+        with pytest.raises(ValidationError):
+            DateBannerWidgetConfig(font_family="comic")
+
+    def test_color_must_be_hex6(self):
+        DateBannerWidgetConfig(color="#0aF3Cd")
+        for bad in ("ffffff", "#fff", "#gggggg", "red"):
+            with pytest.raises(ValidationError):
+                DateBannerWidgetConfig(color=bad)
+
+    def test_font_size_bounds(self):
+        DateBannerWidgetConfig(font_size_px=8)
+        DateBannerWidgetConfig(font_size_px=512)
+        for bad in (7, 513, 0, -1):
+            with pytest.raises(ValidationError):
+                DateBannerWidgetConfig(font_size_px=bad)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            DateBannerWidgetConfig(nope=1)
+
+
+class TestDateBannerWidgetRegistry:
+    def test_registered(self):
+        reg = get_registry()
+        assert reg.has("datebanner")
+        w = reg.get("datebanner")
+        assert isinstance(w, DateBannerWidget)
+        assert w.display_name == "Date Banner"
+        assert w.icon == "📅"
+
+    def test_default_config_validates(self):
+        w = DateBannerWidget()
+        cfg = DateBannerWidgetConfig(**w.default_config())
+        assert cfg.format == "full"
+
+
+class TestDateBannerWidgetRender:
+    def _render(self, **overrides):
+        w = DateBannerWidget()
+        cfg = DateBannerWidgetConfig(**{**w.default_config(), **overrides})
+        return w.render_html(cfg, _cell(), "inst-1")
+
+    def test_instance_scoped(self):
+        r = self._render()
+        assert "cw-datebanner-inst-1" in r.html
+        assert "cw-datebanner-inst-1" in r.css
+        assert "cw-datebanner-date-inst-1" in r.init_js
+
+    def test_two_instances_dont_collide(self):
+        w = DateBannerWidget()
+        cfg = DateBannerWidgetConfig(**w.default_config())
+        a = w.render_html(cfg, _cell(), "aaa")
+        b = w.render_html(cfg, _cell(), "bbb")
+        assert "cw-datebanner-aaa" in a.css
+        assert "cw-datebanner-aaa" not in b.css
+        assert "cw-datebanner-bbb" in b.css
+
+    def test_init_js_has_setinterval_and_element_lookup(self):
+        r = self._render()
+        assert "getElementById('cw-datebanner-date-inst-1')" in r.init_js
+        assert "setInterval(render, 60000)" in r.init_js
+        assert "toLocaleDateString" in r.init_js
+
+    @pytest.mark.parametrize(
+        "fmt,needle",
+        [
+            ("full", "weekday:'long'"),
+            ("long", "month:'long'"),
+            ("weekday", "{weekday:'long'}"),
+            ("short", "weekday:'short'"),
+            ("numeric", "month:'2-digit'"),
+        ],
+    )
+    def test_format_baked_into_options(self, fmt, needle):
+        r = self._render(format=fmt)
+        assert needle in r.init_js
+
+    def test_prefix_injected_as_json_string(self):
+        # A prefix containing a quote/backslash must be a safe JS literal,
+        # not break out of the string.
+        r = self._render(prefix='He said "hi"\\')
+        assert 'var prefix = "He said \\"hi\\"\\\\";' in r.init_js
+
+    def test_prefix_html_escaped_in_placeholder(self):
+        r = self._render(prefix="<b>x</b>")
+        assert "<b>x</b>" not in r.html
+        assert "&lt;b&gt;x&lt;/b&gt;" in r.html
+
+    def test_uppercase_flag_propagates(self):
+        assert "var upper = true;" in self._render(uppercase=True).init_js
+        assert "var upper = false;" in self._render(uppercase=False).init_js
+
+    def test_color_and_size_in_css(self):
+        r = self._render(color="#123456", font_size_px=144)
+        assert "color: #123456;" in r.css
+        assert "font-size: 144px;" in r.css
+
+    def test_font_family_stack_in_css(self):
+        assert "Georgia" in self._render(font_family="serif").css
+        assert "ui-monospace" in self._render(font_family="mono").css
+
+    def test_no_static_assets(self):
+        r = self._render()
+        assert r.static_assets == []
+        assert r.referenced_asset_ids == []


### PR DESCRIPTION
Adds a **Date Banner** composed-slide widget.

- 5 formats: full, long, weekday, short, numeric
- optional prefix, uppercase, color, font family, size
- re-renders every 60s on-device via init_js
- 28 unit tests; inline-JS-syntax + appearance + bundle suites green (99 passed)

Part of the issue #743 widget backlog. Dev only.