### PR TITLE
RSS headlines composed-slide widget

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -163,6 +163,7 @@ def build_bundle(
     registry: WidgetRegistry | None = None,
     asset_loader: AssetLoader | None = None,
     sibling_asset_urls: dict[uuid.UUID, str] | None = None,
+    cms_base_url: str | None = None,
 ) -> BuiltBundle:
     """Render ``layout`` to a self-contained HTML bundle.
 
@@ -176,6 +177,13 @@ def build_bundle(
     shipped to the device as siblings rather than inlined.  Used for
     video assets — the bundle's ``<video src>`` points at these URLs
     and the device cache layer fetches them separately.
+
+    ``cms_base_url`` is threaded onto every widget's
+    :class:`BundleContext` so widgets that bake an absolute CMS
+    call-back URL (e.g. the RSS feed-proxy URL) can do so.  Pass the
+    public CMS base URL when building a *device* bundle; pass ``None``
+    for the same-origin live preview / thumbnail render so those bake
+    a relative URL instead.
 
     A declared asset ID must be resolvable through *either* the
     ``asset_loader`` path *or* the ``sibling_asset_urls`` mapping; if
@@ -259,6 +267,7 @@ def build_bundle(
             sibling_asset_urls={
                 aid: sib_urls[aid] for aid in declared if aid in sib_urls
             },
+            cms_base_url=cms_base_url,
         )
         render: WidgetRender = widget.render_html(
             config=config,

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -122,7 +122,8 @@ async def publish_composed_slide(
     # loop and surfaces as a PublishError.
     from cms.auth import get_settings as _get_settings
 
-    storage_dir = _get_settings().asset_storage_path
+    _settings = _get_settings()
+    storage_dir = _settings.asset_storage_path
 
     declared_ids: list[uuid.UUID] = []
     seen_declared: set[uuid.UUID] = set()
@@ -225,6 +226,11 @@ async def publish_composed_slide(
             registry,
             asset_loader=_asset_loader if asset_payloads else None,
             sibling_asset_urls=sibling_asset_urls or None,
+            # Device bundles are served from the device's own local
+            # shell HTTP server, so any CMS call-back URL (e.g. the RSS
+            # feed proxy) must be absolute.  Preview/thumbnail renders
+            # pass None and bake a same-origin relative URL instead.
+            cms_base_url=_settings.base_url,
         )
     except BundleValidationError as e:
         raise PublishError(

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -55,6 +55,18 @@ class BundleContext:
     sibling-URLs channel, never both — the publish layer buckets by
     ``asset_type``.
 
+    ``cms_base_url`` is the canonical public base URL of the CMS
+    (scheme + host, no trailing slash), or ``None``.  It exists for
+    widgets that bake an *absolute* call-back URL into the device
+    bundle — e.g. the RSS widget points the device's runtime fetch at
+    the CMS's ``/composed/rss`` feed proxy.  The device serves the
+    bundle from its own local shell HTTP server, so a relative URL
+    would hit the device, not the CMS; an absolute URL is required on
+    real hardware.  ``None`` means "bake a relative URL" — correct for
+    the same-origin CMS live preview (where the document is served by
+    the CMS itself) and for the headless thumbnail render.  Widgets
+    that make no runtime CMS call ignore this entirely.
+
     Empty defaults are intentional: trivial widgets (text, clock) that
     never touch assets can ignore the parameter entirely.
     """
@@ -62,6 +74,7 @@ class BundleContext:
     asset_bytes: dict[uuid.UUID, bytes] = field(default_factory=dict)
     asset_mimes: dict[uuid.UUID, str] = field(default_factory=dict)
     sibling_asset_urls: dict[uuid.UUID, str] = field(default_factory=dict)
+    cms_base_url: str | None = None
 
 
 @dataclass

--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -84,6 +84,7 @@ class ComposedRender:
 
     html_bytes: bytes
     has_weather: bool
+    has_rss: bool = False
 
 
 # Optional async hook called for the slide asset and every referenced
@@ -323,4 +324,11 @@ async def build_composed_html(
         ) from e
 
     has_weather = any(inst.type == "weather" for inst in layout.widgets)
-    return ComposedRender(html_bytes=built.html_bytes, has_weather=has_weather)
+    has_rss = any(inst.type == "rss" for inst in layout.widgets)
+    # NB: cms_base_url is intentionally left at its None default here.
+    # This is the same-origin preview / thumbnail path, so widgets that
+    # call back into the CMS (RSS) bake a relative URL that resolves
+    # against the preview document's own origin.
+    return ComposedRender(
+        html_bytes=built.html_bytes, has_weather=has_weather, has_rss=has_rss
+    )

--- a/cms/composed/rss_proxy.py
+++ b/cms/composed/rss_proxy.py
@@ -1,0 +1,233 @@
+"""SSRF-guarded RSS/Atom feed proxy for the composed-slide RSS widget.
+
+The RSS widget renders a self-contained device bundle that fetches its
+headlines *at runtime* from this proxy (mirroring how the weather widget
+fetches Open-Meteo at runtime).  The device cannot fetch arbitrary feeds
+directly: the bundle is served from the device's own local shell HTTP
+server, so a cross-origin ``fetch()`` of a third-party feed is browser
+CORS-blocked (most feeds send no ``Access-Control-Allow-Origin``).  This
+proxy fetches + parses the feed server-side and returns CORS-enabled
+JSON the device can read.
+
+Threat model & guard
+--------------------
+This endpoint is **unauthenticated** in v1 (the device has no easy way
+to authenticate a runtime ``fetch`` from inside the sandboxed bundle
+iframe, exactly like the weather widget's keyless Open-Meteo call).  To
+keep an unauthenticated outbound fetcher from becoming an SSRF pivot we:
+
+* allow only ``http`` / ``https`` schemes;
+* resolve the target host via :func:`socket.getaddrinfo` and reject the
+  request if *any* resolved address is private, loopback, link-local,
+  reserved, multicast or unspecified (this blocks ``127.0.0.1``, RFC1918,
+  ``169.254.169.254`` cloud-metadata, ``::1``, ``fc00::/7`` etc.);
+* disable httpx auto-redirects and follow them manually, re-resolving and
+  re-validating every hop (max :data:`_MAX_REDIRECTS`);
+* cap the response body size and the total request time;
+* parse the payload strictly as RSS/Atom XML via the stdlib
+  :mod:`xml.etree.ElementTree` and emit only a small, fixed JSON shape.
+
+Residual risk: classic TOCTOU DNS-rebinding (the IP we validate may
+differ from the IP httpx ultimately connects to).  Accepted for a v1 dev
+feature given the RSS-only parse, the size/time caps, and that the only
+data exfiltrated would be the parsed-XML projection of a URL the caller
+already controls.  Hardening (pin the validated IP into the connection)
+is a documented follow-up.
+
+This module is intentionally free of any FastAPI import so it can be
+unit-tested in isolation; the router maps :class:`RssProxyError` to HTTP
+status codes.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse
+from xml.etree import ElementTree as ET
+
+import httpx
+
+# Tunables (conservative defaults; v1 dev).
+_REQUEST_TIMEOUT_S = 8.0
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024  # 2 MiB
+_MAX_REDIRECTS = 3
+_DEFAULT_ITEM_COUNT = 10
+_MAX_ITEM_COUNT = 30
+_ALLOWED_SCHEMES = ("http", "https")
+_USER_AGENT = "agora-cms-rss-proxy/1.0 (+composed-slide widget)"
+
+# Child element local-names we treat as a single feed entry.
+_ITEM_TAGS = ("item", "entry")
+_TITLE_TAGS = ("title",)
+_LINK_TAGS = ("link",)
+# RSS uses pubDate; Atom uses published/updated; Dublin Core uses date.
+_DATE_TAGS = ("pubdate", "published", "updated", "date")
+
+
+class RssProxyError(Exception):
+    """A feed fetch/parse failure with an HTTP status the router echoes.
+
+    ``status_code`` is the status the proxy route should return;
+    ``detail`` is a short, user-safe message (no internal host/IP leak).
+    """
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _localname(tag: str) -> str:
+    """Strip any ``{namespace}`` prefix from an ElementTree tag."""
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _validate_target(url: str) -> None:
+    """Raise :class:`RssProxyError` if ``url`` is unsafe to fetch.
+
+    Validates scheme, then resolves the host and rejects the request if
+    any resolved IP is in a blocked range.  Called for every redirect
+    hop, not just the initial URL.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise RssProxyError(400, "Only http and https feed URLs are allowed")
+    host = parsed.hostname
+    if not host:
+        raise RssProxyError(400, "Feed URL is missing a host")
+
+    # A bare IP literal: validate it directly (getaddrinfo would echo it
+    # back anyway, but this is clearer and avoids a needless lookup).
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if _ip_is_blocked(literal):
+            raise RssProxyError(400, "Feed host is not allowed")
+        return
+
+    try:
+        infos = socket.getaddrinfo(host, parsed.port or None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise RssProxyError(400, "Feed host could not be resolved") from exc
+    if not infos:
+        raise RssProxyError(400, "Feed host could not be resolved")
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            # An address family we can't reason about — refuse rather
+            # than risk fetching something we couldn't validate.
+            raise RssProxyError(400, "Feed host is not allowed")
+        if _ip_is_blocked(ip):
+            raise RssProxyError(400, "Feed host is not allowed")
+
+
+def clamp_item_count(raw: int | None) -> int:
+    """Clamp a requested item count into the supported range."""
+    if raw is None:
+        return _DEFAULT_ITEM_COUNT
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_ITEM_COUNT
+    return max(1, min(_MAX_ITEM_COUNT, n))
+
+
+def parse_feed(body: bytes, *, count: int) -> list[dict[str, str]]:
+    """Parse RSS/Atom ``body`` into a list of ``{title, link, pubDate}``.
+
+    Namespace-agnostic (works for RSS 2.0, RSS 1.0/RDF and Atom).  Items
+    missing a title are skipped; ``link`` / ``pubDate`` are best-effort
+    and omitted when absent.  Returns at most ``count`` entries.
+    """
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as exc:
+        raise RssProxyError(502, "Feed is not valid XML") from exc
+
+    items: list[ET.Element] = [
+        el for el in root.iter() if _localname(el.tag) in _ITEM_TAGS
+    ]
+
+    out: list[dict[str, str]] = []
+    for item in items:
+        title: str | None = None
+        link: str | None = None
+        date: str | None = None
+        for child in item:
+            ln = _localname(child.tag)
+            if title is None and ln in _TITLE_TAGS:
+                title = (child.text or "").strip() or None
+            elif link is None and ln in _LINK_TAGS:
+                # RSS: link text. Atom: <link href="..."/> (prefer the
+                # alternate/href attribute, fall back to text).
+                href = child.get("href")
+                link = (href or (child.text or "").strip()) or None
+            elif date is None and ln in _DATE_TAGS:
+                date = (child.text or "").strip() or None
+        if not title:
+            continue
+        entry: dict[str, str] = {"title": title}
+        if link:
+            entry["link"] = link
+        if date:
+            entry["pubDate"] = date
+        out.append(entry)
+        if len(out) >= count:
+            break
+    return out
+
+
+async def fetch_feed_items(url: str, *, count: int) -> list[dict[str, str]]:
+    """Fetch ``url`` (SSRF-guarded) and return parsed feed items.
+
+    Raises :class:`RssProxyError` on any scheme/host/size/timeout/parse
+    failure with an HTTP status the caller can return verbatim.
+    """
+    headers = {"User-Agent": _USER_AGENT, "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.5"}
+    current = url
+    try:
+        async with httpx.AsyncClient(
+            timeout=_REQUEST_TIMEOUT_S, follow_redirects=False
+        ) as client:
+            for _hop in range(_MAX_REDIRECTS + 1):
+                _validate_target(current)
+                async with client.stream("GET", current, headers=headers) as resp:
+                    if resp.is_redirect:
+                        location = resp.headers.get("location")
+                        if not location:
+                            raise RssProxyError(502, "Feed redirect was malformed")
+                        current = urljoin(current, location)
+                        continue
+                    if resp.status_code >= 400:
+                        raise RssProxyError(
+                            502, f"Feed returned HTTP {resp.status_code}"
+                        )
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in resp.aiter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_RESPONSE_BYTES:
+                            raise RssProxyError(502, "Feed response is too large")
+                        chunks.append(chunk)
+                    return parse_feed(b"".join(chunks), count=count)
+            raise RssProxyError(502, "Feed had too many redirects")
+    except httpx.TimeoutException as exc:
+        raise RssProxyError(504, "Feed request timed out") from exc
+    except httpx.HTTPError as exc:
+        raise RssProxyError(502, "Feed could not be fetched") from exc

--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -26,6 +26,7 @@ from cms.composed.widgets.datebanner import DateBannerWidget
 from cms.composed.widgets.image import ImageWidget
 from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.qr import QrWidget
+from cms.composed.widgets.rss import RssWidget
 from cms.composed.widgets.shape import ShapeWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
@@ -47,6 +48,7 @@ for _widget_cls in (
     TickerWidget,
     WeatherWidget,
     QrWidget,
+    RssWidget,
     ShapeWidget,
 ):
     if not _reg.has(_widget_cls.slug):
@@ -60,6 +62,7 @@ __all__ = [
     "ImageWidget",
     "MediaWidget",
     "QrWidget",
+    "RssWidget",
     "ShapeWidget",
     "TextWidget",
     "TickerWidget",

--- a/cms/composed/widgets/rss.py
+++ b/cms/composed/widgets/rss.py
@@ -1,0 +1,346 @@
+"""RSS widget — live headlines from an RSS/Atom feed.
+
+Like the weather widget, this is one of the few widgets that makes a
+**runtime network call** from the device.  It does NOT fetch the feed
+directly, though: the bundle is served from the device's own local
+shell HTTP server, so a cross-origin ``fetch()`` of a third-party feed
+is browser CORS-blocked (most feeds send no
+``Access-Control-Allow-Origin``).  Instead the bundle fetches the CMS's
+own SSRF-guarded feed proxy (``GET /composed/rss``), which fetches and
+parses the feed server-side and returns CORS-enabled JSON.
+
+The proxy URL is baked in at build time.  On real hardware the device
+needs the *absolute* CMS URL (a relative ``/composed/rss`` would hit
+the device's local shell, not the CMS), so the widget reads
+``BundleContext.cms_base_url``; for the same-origin CMS live preview /
+headless thumbnail render (``cms_base_url is None``) it bakes a
+relative same-origin URL instead.
+
+Resilience mirrors the weather widget exactly:
+
+* the ``fetch`` is wrapped in an ``AbortController`` timeout +
+  ``try/catch`` so a network failure never throws — it falls back to a
+  ``localStorage`` cache (keyed by a config fingerprint) and, failing
+  that, a static "Headlines unavailable" message;
+* the bundle's static markup contains **no** external ``src=`` /
+  ``href=`` references — the proxy URL only ever exists as a JS string
+  literal, preserving the bundle's no-external-reference invariant;
+* feed titles are untrusted, so the runtime JS paints them with
+  ``textContent`` (never ``innerHTML``) — there's no markup-injection
+  surface.  No config-controlled string is interpolated into the
+  emitted JavaScript.
+
+Instance scoping: every DOM ID + CSS class is suffixed with the widget
+instance UUID; the localStorage cache key is instance-scoped and
+carries a ``{feed_url,item_count}`` fingerprint so changing the feed
+never shows stale cached headlines.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import ClassVar
+from urllib.parse import quote, urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+_HEX = r"^#[0-9a-fA-F]{6}$"
+
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+# A neutral, well-known default so a freshly-dropped widget is a *valid*
+# config (extra="forbid" + a required URL would otherwise make a
+# just-placed widget fail save/publish before the user picks a feed).
+_DEFAULT_FEED_URL = "https://feeds.bbci.co.uk/news/world/rss.xml"
+
+
+def _js_str(s: str) -> str:
+    """Serialise a Python string as a JS string literal, HTML-safe.
+
+    ``json.dumps`` handles quote/backslash/control-char escaping; we
+    additionally escape ``<>&`` so a stray ``</script>`` can never
+    terminate the embedded script block.
+    """
+    return (
+        json.dumps(s)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+class RssWidgetConfig(BaseModel):
+    """User-editable config for :class:`RssWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    feed_url: str = Field(default=_DEFAULT_FEED_URL, max_length=2048)
+    heading: str = Field(default="", max_length=80)
+    item_count: int = Field(default=5, ge=1, le=30)
+    show_dates: bool = False
+    color: str = Field(default="#ffffff", pattern=_HEX)
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=32, ge=8, le=256)
+    # Feeds update at most a few times an hour; a 5-minute floor keeps
+    # the proxy (and the upstream feed) from being hammered.
+    refresh_seconds: int = Field(default=900, ge=300, le=86400)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+    @field_validator("feed_url")
+    @classmethod
+    def _feed_url_http(cls, v: str) -> str:
+        parsed = urlparse(v.strip())
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("feed_url must be an http(s) URL")
+        return v.strip()
+
+
+_RSS_INIT_JS_TEMPLATE = """
+var root = document.getElementById($ROOT_ID_LIT);
+var listEl = document.getElementById($LIST_ID_LIT);
+var FEED_URL = $URL_LIT;
+var CFG_FP = $CFG_FP_LIT;
+var CACHE_KEY = $CACHE_KEY_LIT;
+var REFRESH_MS = $REFRESH_MS;
+var SHOW_DATES = $SHOW_DATES;
+var ITEM_CLASS = $ITEM_CLASS_LIT;
+var DATE_CLASS = $DATE_CLASS_LIT;
+function lsGet() {
+  try {
+    var raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) { return null; }
+    var o = JSON.parse(raw);
+    if (!o || o.fp !== CFG_FP) { return null; }
+    return o.items || null;
+  } catch (e) { return null; }
+}
+function lsSet(items) {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({fp: CFG_FP, items: items}));
+  } catch (e) {}
+}
+function clearList() {
+  if (!listEl) { return; }
+  while (listEl.firstChild) { listEl.removeChild(listEl.firstChild); }
+}
+function paint(items) {
+  if (!listEl) { return; }
+  clearList();
+  if (!items || !items.length) {
+    var none = document.createElement('div');
+    none.className = ITEM_CLASS;
+    none.textContent = 'Headlines unavailable';
+    listEl.appendChild(none);
+    return;
+  }
+  for (var i = 0; i < items.length; i++) {
+    var it = items[i] || {};
+    var row = document.createElement('div');
+    row.className = ITEM_CLASS;
+    var title = document.createElement('div');
+    title.textContent = it.title || '';
+    row.appendChild(title);
+    if (SHOW_DATES && it.pubDate) {
+      var d = document.createElement('div');
+      d.className = DATE_CLASS;
+      d.textContent = it.pubDate;
+      row.appendChild(d);
+    }
+    listEl.appendChild(row);
+  }
+}
+function fallback() {
+  var c = lsGet();
+  if (c) { paint(c); return; }
+  paint(null);
+}
+function schedule() {
+  if (!root || !document.body.contains(root)) { return; }
+  setTimeout(refresh, REFRESH_MS + Math.floor(Math.random() * 30000));
+}
+function refresh() {
+  if (!root || !document.body.contains(root)) { return; }
+  var ctrl = new AbortController();
+  var to = setTimeout(function () { ctrl.abort(); }, 8000);
+  fetch(FEED_URL, {signal: ctrl.signal})
+    .then(function (r) { if (!r.ok) { throw new Error('http ' + r.status); } return r.json(); })
+    .then(function (d) {
+      var items = d && d.items ? d.items : null;
+      if (!items) { throw new Error('bad shape'); }
+      paint(items);
+      lsSet(items);
+    })
+    .catch(function () { fallback(); })
+    .then(function () { clearTimeout(to); schedule(); });
+}
+fallback();
+refresh();
+""".strip()
+
+
+def _proxy_url(base: str | None, feed_url: str, count: int) -> str:
+    """Build the CMS feed-proxy URL the device fetches at runtime.
+
+    Absolute when ``base`` is set (real device bundle); relative
+    same-origin otherwise (CMS preview / thumbnail render).
+    """
+    prefix = base.rstrip("/") if base else ""
+    return f"{prefix}/composed/rss?url={quote(feed_url, safe='')}&count={count}"
+
+
+def _build_rss_init_js(
+    *,
+    root_id: str,
+    list_id: str,
+    url: str,
+    cfg_fp: str,
+    cache_key: str,
+    refresh_ms: int,
+    show_dates: bool,
+    item_class: str,
+    date_class: str,
+) -> str:
+    return (
+        _RSS_INIT_JS_TEMPLATE.replace("$ROOT_ID_LIT", _js_str(root_id))
+        .replace("$LIST_ID_LIT", _js_str(list_id))
+        .replace("$URL_LIT", _js_str(url))
+        .replace("$CFG_FP_LIT", _js_str(cfg_fp))
+        .replace("$CACHE_KEY_LIT", _js_str(cache_key))
+        .replace("$REFRESH_MS", str(refresh_ms))
+        .replace("$SHOW_DATES", "true" if show_dates else "false")
+        .replace("$ITEM_CLASS_LIT", _js_str(item_class))
+        .replace("$DATE_CLASS_LIT", _js_str(date_class))
+    )
+
+
+class RssWidget(Widget):
+    """Live RSS/Atom headlines (fetched via the CMS feed proxy)."""
+
+    slug: ClassVar[str] = "rss"
+    display_name: ClassVar[str] = "RSS Headlines"
+    icon: ClassVar[str] = "\U0001f4f0"  # newspaper
+    ConfigSchema: ClassVar[type[BaseModel]] = RssWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        return {
+            "feed_url": _DEFAULT_FEED_URL,
+            "heading": "",
+            "item_count": 5,
+            "show_dates": False,
+            "color": "#ffffff",
+            "font_family": "sans",
+            "font_size_px": 32,
+            "refresh_seconds": 900,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/rss.html"
+
+    def validate_semantic(self, config: BaseModel) -> list[str]:
+        assert isinstance(config, RssWidgetConfig)
+        return []
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        assert isinstance(config, RssWidgetConfig), (
+            "RssWidget.render_html expects a RssWidgetConfig instance"
+        )
+
+        css_class = f"cw-rss-{instance_id}"
+        root_id = f"cw-rss-root-{instance_id}"
+        list_id = f"cw-rss-list-{instance_id}"
+        item_class = f"{css_class}-item"
+        date_class = f"{css_class}-date"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        # Heading is the ONLY config-controlled string in the markup —
+        # escaped here, never passed into JS. Feed titles are painted at
+        # runtime via textContent.
+        heading_html = (
+            f'<div class="{css_class}-heading">'
+            f"{html.escape(config.heading)}</div>"
+            if config.heading.strip()
+            else ""
+        )
+        html_out = (
+            f'<div id="{root_id}" class="{css_class}">'
+            f"{heading_html}"
+            f'<div id="{list_id}" class="{css_class}-list">'
+            f'<div class="{item_class}">Loading headlines\u2026</div>'
+            f"</div>"
+            f"</div>"
+        )
+
+        heading_size = max(8, int(config.font_size_px * 1.1))
+        date_size = max(8, int(config.font_size_px * 0.6))
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  overflow: hidden;\n"
+            f"  box-sizing: border-box;\n"
+            f"}}\n"
+            f".{css_class}-heading {{\n"
+            f"  font-size: {heading_size}px;\n"
+            f"  font-weight: 700;\n"
+            f"  margin-bottom: 0.3em;\n"
+            f"  flex: 0 0 auto;\n"
+            f"}}\n"
+            f".{css_class}-list {{\n"
+            f"  flex: 1 1 auto;\n"
+            f"  overflow: hidden;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  gap: 0.4em;\n"
+            f"}}\n"
+            f".{css_class}-item {{\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1.2;\n"
+            f"}}\n"
+            f".{css_class}-date {{\n"
+            f"  font-size: {date_size}px;\n"
+            f"  opacity: 0.7;\n"
+            f"  margin-top: 0.1em;\n"
+            f"}}"
+        )
+
+        base = ctx.cms_base_url if ctx else None
+        cfg_fp = f"{config.feed_url}|{config.item_count}"
+        init_js = _build_rss_init_js(
+            root_id=root_id,
+            list_id=list_id,
+            url=_proxy_url(base, config.feed_url, config.item_count),
+            cfg_fp=cfg_fp,
+            cache_key=f"cw-rss-{instance_id}",
+            refresh_ms=config.refresh_seconds * 1000,
+            show_dates=config.show_dates,
+            item_class=item_class,
+            date_class=date_class,
+        )
+
+        return WidgetRender(html=html_out, css=css_out, init_js=init_js)

--- a/cms/main.py
+++ b/cms/main.py
@@ -996,12 +996,14 @@ from cms.routers.stream_probe import router as stream_probe_router  # noqa: E402
 from cms.routers.users import router as users_router  # noqa: E402
 from cms.routers.bootstrap import router as bootstrap_router  # noqa: E402
 from cms.routers.composed import router as composed_router  # noqa: E402
+from cms.routers.composed import public_router as composed_public_router  # noqa: E402
 from cms.routers.issue_report import router as issue_report_router  # noqa: E402
 from cms.routers.imager import router as imager_router  # noqa: E402
 from cms.ui import router as ui_router  # noqa: E402
 
 app.include_router(bootstrap_router)
 app.include_router(composed_router)
+app.include_router(composed_public_router)
 app.include_router(devices_router)
 app.include_router(devices_device_router)
 app.include_router(assets_router)

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -68,6 +68,46 @@ router = APIRouter(
 )
 
 
+# The RSS proxy is deliberately mounted on a SEPARATE router WITHOUT the
+# router-level ``require_auth`` dependency. The composed-slide device
+# bundle fetches this endpoint at runtime from inside the sandboxed
+# player iframe (served off the device's own local shell origin), so the
+# request is cross-origin and credential-less and cannot authenticate —
+# exactly like the weather widget's keyless Open-Meteo fetch. SSRF safety
+# is provided by ``cms.composed.rss_proxy`` (scheme allowlist + resolved-IP
+# range checks + redirect re-validation + size/time caps), not by auth.
+public_router = APIRouter(prefix="/composed", tags=["composed"])
+
+
+@public_router.get("/rss")
+async def rss_proxy(url: str, count: int | None = None) -> Any:
+    """Unauthenticated, SSRF-guarded RSS/Atom feed proxy (CORS-enabled).
+
+    Fetches and parses ``url`` server-side and returns a small JSON
+    projection the composed-slide RSS widget can read cross-origin. See
+    ``cms.composed.rss_proxy`` for the threat model and guard.
+    """
+    from fastapi.responses import JSONResponse
+
+    from cms.composed.rss_proxy import (
+        RssProxyError,
+        clamp_item_count,
+        fetch_feed_items,
+    )
+
+    cors = {"Access-Control-Allow-Origin": "*", "Cache-Control": "no-store"}
+    n = clamp_item_count(count)
+    try:
+        items = await fetch_feed_items(url, count=n)
+    except RssProxyError as exc:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": exc.detail},
+            headers=cors,
+        )
+    return JSONResponse(content={"items": items}, headers=cors)
+
+
 _PREVIEW_CSP = (
     "default-src 'none'; "
     "script-src 'unsafe-inline'; "
@@ -507,9 +547,18 @@ async def preview_composed_slide(
     # fallback instead of live values. Allow exactly that one origin —
     # and only when the slide actually contains a weather widget, so a
     # plain text/image slide keeps the fully-locked CSP.
+    # CSP allows only a single connect-src directive, so weather and rss
+    # must be combined into one list. Weather fetches Open-Meteo directly;
+    # the RSS widget fetches this CMS's own same-origin proxy (/composed/rss),
+    # so 'self' is sufficient for it in the preview context.
     csp = _PREVIEW_CSP
+    connect_src: list[str] = []
     if rendered.has_weather:
-        csp = csp + "; connect-src https://api.open-meteo.com"
+        connect_src.append("https://api.open-meteo.com")
+    if rendered.has_rss:
+        connect_src.append("'self'")
+    if connect_src:
+        csp = csp + "; connect-src " + " ".join(connect_src)
 
     headers = {
         "Content-Security-Policy": csp,

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -377,6 +377,18 @@
         text-transform: uppercase;
         letter-spacing: 0.05em;
     }
+    .cw-prev-rss {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        box-sizing: border-box;
+        line-height: 1.2;
+    }
+    .cw-prev-rss-heading { font-weight: 700; margin-bottom: 0.3em; flex: 0 0 auto; }
+    .cw-prev-rss-list { flex: 1 1 auto; overflow: hidden; display: flex; flex-direction: column; gap: 0.4em; }
+    .cw-prev-rss-date { opacity: 0.7; margin-top: 0.1em; }
     .wx-results { display: flex; flex-direction: column; gap: 0.2rem; margin: 0.25rem 0; }
     .wx-result {
         text-align: left;
@@ -1184,6 +1196,95 @@ registerWidget("weather", {
                 Live temperature is fetched on the device. The preview shows placeholder values.
             </p>`;
     },
+});
+
+registerWidget("rss", {
+    label: "RSS Headlines", icon: "📰", category: "Live Data",
+    keywords: ["rss", "feed", "news", "headlines", "atom", "syndication"],
+    defaults: () => ({feed_url:"https://feeds.bbci.co.uk/news/world/rss.xml", heading:"",
+             item_count:5, show_dates:false, color:"#ffffff", font_family:"sans",
+             font_size_px:32, refresh_seconds:900}),
+    summary: (w) => (w.config.heading || "headlines").slice(0, 24),
+    preview: (root, cfg) => {
+        const wrap = document.createElement("div");
+        wrap.className = "cw-prev-rss";
+        wrap.style.color = cfg.color || "#ffffff";
+        wrap.style.fontFamily = fontStack(cfg.font_family);
+        if (cfg.heading) {
+            const h = document.createElement("div");
+            h.className = "cw-prev-rss-heading";
+            h.textContent = cfg.heading;
+            h.style.fontSize = cqwFont(Math.round((Number(cfg.font_size_px)||32) * 1.1));
+            wrap.appendChild(h);
+        }
+        const list = document.createElement("div");
+        list.className = "cw-prev-rss-list";
+        const n = Math.max(1, Math.min(Number(cfg.item_count) || 5, 6));
+        const samples = ["Sample headline one", "Sample headline two",
+            "Sample headline three", "Sample headline four",
+            "Sample headline five", "Sample headline six"];
+        for (let i = 0; i < n; i++) {
+            const row = document.createElement("div");
+            const t = document.createElement("div");
+            t.textContent = samples[i % samples.length];
+            t.style.fontSize = cqwFont(cfg.font_size_px || 32);
+            row.appendChild(t);
+            if (cfg.show_dates) {
+                const d = document.createElement("div");
+                d.className = "cw-prev-rss-date";
+                d.textContent = "Mon, 01 Jan 2026";
+                d.style.fontSize = cqwFont(Math.round((Number(cfg.font_size_px)||32) * 0.6));
+                row.appendChild(d);
+            }
+            list.appendChild(row);
+        }
+        wrap.appendChild(list);
+        root.appendChild(wrap);
+    },
+    settings: (w) => `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">RSS Headlines widget</h4>
+            <label>Feed URL</label>
+            <input type="text" maxlength="2048" value="${escapeHtml(w.config.feed_url||"")}"
+                   placeholder="https://example.com/feed.xml"
+                   oninput="updateSelected(x=>x.config.feed_url=this.value)">
+            <label style="margin-top:0.5rem;">Heading (optional)</label>
+            <input type="text" maxlength="80" value="${escapeHtml(w.config.heading||"")}"
+                   oninput="updateSelected(x=>x.config.heading=this.value)">
+            <div class="row">
+                <div>
+                    <label>Headlines</label>
+                    <input type="number" min="1" max="30" value="${w.config.item_count||5}"
+                           oninput="updateSelected(x=>x.config.item_count=clampInt(this.value,1,30))">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="256" value="${w.config.font_size_px||32}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,256))">
+                </div>
+            </div>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.show_dates?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_dates=this.checked)"> Show dates
+            </label>
+            <div class="row">
+                <div>
+                    <label>Color</label>
+                    <input type="color" value="${w.config.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Font</label>
+                    <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                        ${SAFE_FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
+                    </select>
+                </div>
+            </div>
+            <label style="margin-top:0.5rem;">Refresh (seconds, 300–86400)</label>
+            <input type="number" min="300" max="86400" value="${w.config.refresh_seconds||900}"
+                   oninput="updateSelected(x=>x.config.refresh_seconds=clampInt(this.value,300,86400))">
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                Headlines are fetched on the device via the CMS feed proxy. The preview shows placeholder text.
+            </p>`,
 });
 
 registerWidget("ticker", {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -514,6 +514,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /composed/rss:
+    get:
+      tags:
+      - composed
+      summary: Rss Proxy
+      description: |-
+        Unauthenticated, SSRF-guarded RSS/Atom feed proxy (CORS-enabled).
+
+        Fetches and parses ``url`` server-side and returns a small JSON
+        projection the composed-slide RSS widget can read cross-origin. See
+        ``cms.composed.rss_proxy`` for the threat model and guard.
+      operationId: rss_proxy_composed_rss_get
+      parameters:
+      - name: url
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Url
+      - name: count
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Count
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response Rss Proxy Composed Rss Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/check-updates:
     post:
       summary: Check For Updates

--- a/tests/test_composed_extensibility_round2.py
+++ b/tests/test_composed_extensibility_round2.py
@@ -304,7 +304,12 @@ class TestExtensibilityContractGuardrail:
     def test_bundle_context_fields_pinned(self):
         assert is_dataclass(BundleContext)
         names = {f.name for f in fields(BundleContext)}
-        assert names == {"asset_bytes", "asset_mimes", "sibling_asset_urls"}, (
+        assert names == {
+            "asset_bytes",
+            "asset_mimes",
+            "sibling_asset_urls",
+            "cms_base_url",
+        }, (
             f"BundleContext fields drifted: {names!r}. Adding fields "
             "may be OK — explicitly update this pin and the contract docs."
         )

--- a/tests/test_composed_rss_proxy.py
+++ b/tests/test_composed_rss_proxy.py
@@ -1,0 +1,236 @@
+"""Tests for cms.composed.rss_proxy (SSRF-guarded RSS/Atom feed proxy)."""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from cms.composed import rss_proxy
+from cms.composed.rss_proxy import (
+    RssProxyError,
+    _validate_target,
+    clamp_item_count,
+    parse_feed,
+)
+
+RSS_2_0 = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <item>
+      <title>First headline</title>
+      <link>https://example.com/1</link>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Second headline</title>
+      <link>https://example.com/2</link>
+    </item>
+    <item>
+      <link>https://example.com/3</link>
+    </item>
+  </channel>
+</rss>
+"""
+
+ATOM = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Example</title>
+  <entry>
+    <title>Atom one</title>
+    <link href="https://example.com/a1" rel="alternate"/>
+    <published>2024-01-01T12:00:00Z</published>
+  </entry>
+  <entry>
+    <title>Atom two</title>
+    <link href="https://example.com/a2"/>
+  </entry>
+</feed>
+"""
+
+
+class TestClampItemCount:
+    def test_none_returns_default(self):
+        assert clamp_item_count(None) == 10
+
+    def test_bad_string_returns_default(self):
+        assert clamp_item_count("abc") == 10  # type: ignore[arg-type]
+
+    def test_below_floor_clamped_to_one(self):
+        assert clamp_item_count(0) == 1
+        assert clamp_item_count(-5) == 1
+
+    def test_above_ceiling_clamped(self):
+        assert clamp_item_count(99) == 30
+
+    def test_in_range_passthrough(self):
+        assert clamp_item_count(7) == 7
+
+
+class TestParseFeedRss:
+    def test_parses_title_link_pubdate(self):
+        items = parse_feed(RSS_2_0, count=10)
+        assert items[0] == {
+            "title": "First headline",
+            "link": "https://example.com/1",
+            "pubDate": "Mon, 01 Jan 2024 12:00:00 GMT",
+        }
+
+    def test_link_optional(self):
+        items = parse_feed(RSS_2_0, count=10)
+        assert items[1] == {
+            "title": "Second headline",
+            "link": "https://example.com/2",
+        }
+
+    def test_titleless_item_skipped(self):
+        items = parse_feed(RSS_2_0, count=10)
+        # Three <item>s but the last has no title -> only 2 returned.
+        assert len(items) == 2
+        assert all(i["title"] for i in items)
+
+    def test_count_caps_results(self):
+        items = parse_feed(RSS_2_0, count=1)
+        assert len(items) == 1
+        assert items[0]["title"] == "First headline"
+
+
+class TestParseFeedAtom:
+    def test_parses_entry_href_published(self):
+        items = parse_feed(ATOM, count=10)
+        assert items[0] == {
+            "title": "Atom one",
+            "link": "https://example.com/a1",
+            "pubDate": "2024-01-01T12:00:00Z",
+        }
+
+    def test_atom_link_uses_href_attribute(self):
+        items = parse_feed(ATOM, count=10)
+        assert items[1]["link"] == "https://example.com/a2"
+
+
+class TestParseFeedErrors:
+    def test_bad_xml_raises_502(self):
+        with pytest.raises(RssProxyError) as exc:
+            parse_feed(b"<not valid xml", count=10)
+        assert exc.value.status_code == 502
+
+    def test_empty_feed_returns_empty_list(self):
+        body = b'<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>'
+        assert parse_feed(body, count=10) == []
+
+
+class TestValidateTargetScheme:
+    def test_rejects_ftp(self):
+        with pytest.raises(RssProxyError) as exc:
+            _validate_target("ftp://example.com/feed.xml")
+        assert exc.value.status_code == 400
+
+    def test_rejects_no_host(self):
+        with pytest.raises(RssProxyError) as exc:
+            _validate_target("https:///feed.xml")
+        assert exc.value.status_code == 400
+
+
+class TestValidateTargetSsrfLiterals:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/feed.xml",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/feed.xml",
+            "http://192.168.1.5/feed.xml",
+            "http://[::1]/feed.xml",
+            "http://0.0.0.0/feed.xml",
+        ],
+    )
+    def test_blocks_private_and_special_ip_literals(self, url):
+        with pytest.raises(RssProxyError) as exc:
+            _validate_target(url)
+        assert exc.value.status_code == 400
+
+    def test_allows_public_ip_literal(self):
+        # 1.1.1.1 (Cloudflare) is a public address — must not raise.
+        _validate_target("https://1.1.1.1/feed.xml")
+
+
+class TestValidateTargetSsrfResolution:
+    def test_blocks_host_resolving_to_private(self, monkeypatch):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.1.2.3", 0))]
+
+        monkeypatch.setattr(rss_proxy.socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(RssProxyError) as exc:
+            _validate_target("https://evil.example.com/feed.xml")
+        assert exc.value.status_code == 400
+
+    def test_allows_host_resolving_to_public(self, monkeypatch):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr(rss_proxy.socket, "getaddrinfo", fake_getaddrinfo)
+        _validate_target("https://example.com/feed.xml")
+
+    def test_unresolvable_host_400(self, monkeypatch):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(rss_proxy.socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(RssProxyError) as exc:
+            _validate_target("https://nope.invalid/feed.xml")
+        assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestRssProxyRoute:
+    async def test_returns_items_with_cors(self, unauthed_client, monkeypatch):
+        async def fake_fetch(url, *, count):
+            return [{"title": "Hello", "link": "https://example.com/1"}]
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss", params={"url": "https://example.com/feed.xml"}
+        )
+        assert resp.status_code == 200
+        assert resp.headers["access-control-allow-origin"] == "*"
+        assert resp.headers["cache-control"] == "no-store"
+        assert resp.json() == {"items": [{"title": "Hello", "link": "https://example.com/1"}]}
+
+    async def test_error_returns_status_and_message(self, unauthed_client, monkeypatch):
+        async def fake_fetch(url, *, count):
+            raise RssProxyError(400, "Feed host is not allowed")
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss", params={"url": "http://127.0.0.1/feed.xml"}
+        )
+        assert resp.status_code == 400
+        assert resp.headers["access-control-allow-origin"] == "*"
+        assert resp.json() == {"error": "Feed host is not allowed"}
+
+    async def test_count_is_clamped_before_fetch(self, unauthed_client, monkeypatch):
+        seen = {}
+
+        async def fake_fetch(url, *, count):
+            seen["count"] = count
+            return []
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss",
+            params={"url": "https://example.com/feed.xml", "count": 999},
+        )
+        assert resp.status_code == 200
+        assert seen["count"] == 30
+
+    async def test_route_requires_no_auth(self, unauthed_client, monkeypatch):
+        async def fake_fetch(url, *, count):
+            return []
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss", params={"url": "https://example.com/feed.xml"}
+        )
+        # Unauthenticated client gets a real answer, not a 401/redirect.
+        assert resp.status_code == 200

--- a/tests/test_composed_rss_widget.py
+++ b/tests/test_composed_rss_widget.py
@@ -1,0 +1,217 @@
+"""Tests for cms.composed.widgets.rss.RssWidget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import cms.composed.widgets  # noqa: F401
+from cms.composed.registry import BundleContext, get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.rss import (
+    RssWidget,
+    RssWidgetConfig,
+    _DEFAULT_FEED_URL,
+    _proxy_url,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestRssWidgetConfig:
+    def test_defaults(self):
+        c = RssWidgetConfig()
+        assert c.feed_url == _DEFAULT_FEED_URL
+        assert c.heading == ""
+        assert c.item_count == 5
+        assert c.show_dates is False
+        assert c.color == "#ffffff"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 32
+        assert c.refresh_seconds == 900
+
+    def test_default_config_matches_schema(self):
+        # A freshly-placed widget must immediately be a valid config.
+        w = RssWidget()
+        RssWidgetConfig(**w.default_config())
+
+    def test_font_allowlist(self):
+        for ok in ("sans", "serif", "mono"):
+            RssWidgetConfig(font_family=ok)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(font_family="display")
+
+    def test_feed_url_must_be_http(self):
+        RssWidgetConfig(feed_url="http://example.com/feed.xml")
+        RssWidgetConfig(feed_url="https://example.com/feed.xml")
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(feed_url="ftp://example.com/feed.xml")
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(feed_url="javascript:alert(1)")
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(feed_url="not-a-url")
+
+    def test_feed_url_stripped(self):
+        c = RssWidgetConfig(feed_url="  https://example.com/feed.xml  ")
+        assert c.feed_url == "https://example.com/feed.xml"
+
+    def test_feed_url_max_length(self):
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(feed_url="https://e.com/" + "a" * 2048)
+
+    def test_item_count_bounds(self):
+        RssWidgetConfig(item_count=1)
+        RssWidgetConfig(item_count=30)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(item_count=0)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(item_count=31)
+
+    def test_font_size_bounds(self):
+        RssWidgetConfig(font_size_px=8)
+        RssWidgetConfig(font_size_px=256)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(font_size_px=7)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(font_size_px=257)
+
+    def test_refresh_floor(self):
+        RssWidgetConfig(refresh_seconds=300)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(refresh_seconds=299)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(refresh_seconds=86401)
+
+    def test_heading_max_length(self):
+        RssWidgetConfig(heading="x" * 80)
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(heading="x" * 81)
+
+    def test_color_must_be_hex_6(self):
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(color="white")
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            RssWidgetConfig(api_key="secret")  # type: ignore[call-arg]
+
+
+class TestRssWidgetRegistry:
+    def test_registered(self):
+        w = get_registry().get("rss")
+        assert isinstance(w, RssWidget)
+        assert w.slug == "rss"
+        assert w.display_name == "RSS Headlines"
+
+    def test_no_declared_assets(self):
+        w = RssWidget()
+        assert w.declared_asset_ids(RssWidgetConfig()) == []
+
+    def test_validate_semantic_passes(self):
+        w = RssWidget()
+        assert w.validate_semantic(RssWidgetConfig()) == []
+
+
+class TestProxyUrl:
+    def test_absolute_when_base_set(self):
+        url = _proxy_url("https://cms.example.org", "https://feed.test/x.xml", 5)
+        assert url.startswith("https://cms.example.org/composed/rss?url=")
+        # feed url must be percent-encoded (no raw scheme separators).
+        assert "https%3A%2F%2Ffeed.test%2Fx.xml" in url
+        assert url.endswith("&count=5")
+
+    def test_relative_when_base_none(self):
+        url = _proxy_url(None, "https://feed.test/x.xml", 3)
+        assert url.startswith("/composed/rss?url=")
+
+    def test_trailing_slash_stripped(self):
+        url = _proxy_url("https://cms.example.org/", "https://feed.test/x.xml", 5)
+        assert url.startswith("https://cms.example.org/composed/rss?")
+        assert "//composed" not in url.split("?")[0]
+
+
+class TestRssWidgetRender:
+    def test_html_and_css_are_instance_scoped(self):
+        w = RssWidget()
+        cfg = RssWidgetConfig()
+        r1 = w.render_html(cfg, _cell(), "inst-A")
+        r2 = w.render_html(cfg, _cell(), "inst-B")
+        assert "cw-rss-inst-A" in r1.html
+        assert "cw-rss-inst-A" in r1.css
+        assert "cw-rss-inst-B" in r2.html
+        assert "inst-B" not in r1.html
+        assert "inst-A" not in r2.html
+
+    def test_init_js_has_fetch_cache_and_abort(self):
+        w = RssWidget()
+        r = w.render_html(RssWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        js = r.init_js
+        assert "fetch(" in js
+        assert "localStorage" in js
+        assert "AbortController" in js
+        # Untrusted feed titles must be painted via textContent, never innerHTML.
+        assert "textContent" in js
+        assert "innerHTML" not in js
+
+    def test_init_js_uses_absolute_proxy_url_with_ctx(self):
+        w = RssWidget()
+        ctx = BundleContext(cms_base_url="https://cms.example.org")
+        cfg = RssWidgetConfig(feed_url="https://feed.test/x.xml", item_count=7)
+        r = w.render_html(cfg, _cell(), "abc", ctx)
+        assert r.init_js is not None
+        assert "https://cms.example.org/composed/rss?url=" in r.init_js
+        # The proxy URL is embedded via _js_str, which HTML-escapes "&" to
+        # "\u0026" so a stray "</script>"-style break can't terminate the
+        # script block. The count param is therefore present in escaped form.
+        assert "count=7" in r.init_js
+        assert "\\u0026count=7" in r.init_js
+
+    def test_init_js_uses_relative_proxy_url_without_ctx(self):
+        w = RssWidget()
+        r = w.render_html(RssWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        # No ctx -> relative same-origin proxy URL (preview/thumbnail).
+        assert '"/composed/rss?url=' in r.init_js
+        assert "https://cms" not in r.init_js
+
+    def test_heading_html_escaped_not_in_js(self):
+        w = RssWidget()
+        cfg = RssWidgetConfig(heading="<b>News</b> & Co")
+        r = w.render_html(cfg, _cell(), "abc")
+        assert "&lt;b&gt;News&lt;/b&gt; &amp; Co" in r.html
+        assert "<b>News</b>" not in r.html
+        # Heading is never passed into JS.
+        assert r.init_js is not None
+        assert "News" not in r.init_js
+
+    def test_no_heading_markup_when_blank(self):
+        w = RssWidget()
+        r = w.render_html(RssWidgetConfig(heading=""), _cell(), "abc")
+        assert "cw-rss-abc-heading" not in r.html
+
+    def test_cache_key_is_instance_scoped(self):
+        w = RssWidget()
+        r = w.render_html(RssWidgetConfig(), _cell(), "abc")
+        assert r.init_js is not None
+        assert "cw-rss-abc" in r.init_js
+
+    def test_show_dates_flag_baked_in(self):
+        w = RssWidget()
+        r_on = w.render_html(RssWidgetConfig(show_dates=True), _cell(), "abc")
+        r_off = w.render_html(RssWidgetConfig(show_dates=False), _cell(), "abc")
+        assert r_on.init_js is not None and r_off.init_js is not None
+        assert "var SHOW_DATES = true" in r_on.init_js
+        assert "var SHOW_DATES = false" in r_off.init_js
+
+    def test_no_external_src_or_href_in_markup(self):
+        w = RssWidget()
+        cfg = RssWidgetConfig(feed_url="https://feed.test/x.xml")
+        r = w.render_html(cfg, _cell(), "abc")
+        # The proxy URL must only live as a JS string literal, not as a
+        # static src=/href= reference in the markup.
+        assert "src=" not in r.html
+        assert "href=" not in r.html
+        assert "feed.test" not in r.html


### PR DESCRIPTION
## RSS Headlines composed-slide widget

Adds an **RSS Headlines** live-data widget to the composed-slide builder.

### Architecture: CMS RSS-proxy

Device bundles can't fetch arbitrary feeds directly (browser CORS), so
the CMS exposes an **unauthenticated, SSRF-guarded** proxy that fetches
and parses the feed server-side and returns a small CORS-enabled JSON
projection. This mirrors the weather widget's keyless device-fetch
pattern.

- **`cms/composed/rss_proxy.py`** (new, pure / fastapi-free):
  - Scheme allowlist (`http`/`https`).
  - Blocks private / loopback / link-local / reserved / multicast /
    unspecified IPs — both bare-IP literals and post-DNS-resolution.
  - Manual redirect loop (`follow_redirects=False`, max 3) with per-hop
    re-validation, 2 MiB response cap, 8 s timeout.
  - Namespace-agnostic RSS 2.0 **and** Atom parsing; titleless items
    skipped; bad XML → 502.
- **`cms/routers/composed.py`**: auth-exempt `public_router` with
  `GET /composed/rss` (`Access-Control-Allow-Origin: *`, `no-store`).
  Preview CSP combines weather + rss origins.

### Widget

- **`cms/composed/widgets/rss.py`** (new): `RssWidget`. The heading is
  the only config string in markup (`html.escape`); **feed titles are
  painted at runtime via `textContent`, never `innerHTML`**. Proxy URL
  is absolute when `cms_base_url` is set (device bundle), relative for
  preview/thumbnail. init_js: 8 s AbortController, localStorage cache
  keyed by `{feed_url}|{item_count}`, "Headlines unavailable" fallback,
  jittered refresh.
- `cms_base_url` threaded through `BundleContext` → bundle → publish →
  render (extensibility guardrail pin updated).
- **`composed_editor.html`**: RSS palette descriptor (Live Data
  category) + preview CSS.

### Tests

- `tests/test_composed_rss_proxy.py`: clamp, RSS+Atom parse, SSRF
  literal/resolution blocks, route (CORS, error shape, no-auth).
- `tests/test_composed_rss_widget.py`: config validation, registry,
  render scoping, absolute/relative proxy URL, heading escaping.

133 targeted tests green locally.

Dev-only ship.
