### PR TITLE
feat(composed): add Store Hours widget

### DIFF
--- a/cms/composed/widgets/__init__.py
+++ b/cms/composed/widgets/__init__.py
@@ -28,6 +28,7 @@ from cms.composed.widgets.media import MediaWidget
 from cms.composed.widgets.qr import QrWidget
 from cms.composed.widgets.rss import RssWidget
 from cms.composed.widgets.shape import ShapeWidget
+from cms.composed.widgets.store_hours import StoreHoursWidget
 from cms.composed.widgets.text import TextWidget
 from cms.composed.widgets.ticker import TickerWidget
 from cms.composed.widgets.weather import WeatherWidget
@@ -50,6 +51,7 @@ for _widget_cls in (
     QrWidget,
     RssWidget,
     ShapeWidget,
+    StoreHoursWidget,
 ):
     if not _reg.has(_widget_cls.slug):
         _reg.register(_widget_cls())
@@ -64,6 +66,7 @@ __all__ = [
     "QrWidget",
     "RssWidget",
     "ShapeWidget",
+    "StoreHoursWidget",
     "TextWidget",
     "TickerWidget",
     "WeatherWidget",

--- a/cms/composed/widgets/store_hours.py
+++ b/cms/composed/widgets/store_hours.py
@@ -1,0 +1,523 @@
+"""Store hours widget — shows weekly opening hours + live open/closed status.
+
+Pure-JS, no asset dependencies and no network fetch.  The weekly
+schedule, holiday overrides, colours and layout are all baked into the
+config at author time.  At runtime a per-minute ``setInterval`` re-evaluates
+the device-local clock against the schedule to flip an Open / Closed badge
+and compute a "Closes 7:00 PM" / "Opens Mon 9:00 AM" hint.
+
+Like :mod:`cms.composed.widgets.clock` and
+:mod:`cms.composed.widgets.datebanner`, all time logic uses the browser's
+``Date`` object, so the displayed state follows whatever the OS clock + TZ
+are set to on the device (offline-safe, no IANA tz handling needed).
+
+Two scheduling layers, both evaluated client-side:
+
+* **Weekly schedule** — each weekday is a list of ``{open, close}``
+  intervals (supports split / lunch hours, e.g. ``09:00-12:00`` +
+  ``13:00-17:00``).  An empty list means closed that day.
+* **Holiday overrides** — one-off (``YYYY-MM-DD``) or recurring annual
+  (``MM-DD``) date matches that either close the store or replace that
+  day's intervals with special hours.
+
+Instance scoping: every DOM ID + CSS class is suffixed with the widget
+instance UUID so two store-hours widgets in the same bundle don't collide.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar, Literal
+
+from markupsafe import escape
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.schema import Cell
+
+# Font-family allowlist — kept local so typography can evolve independently.
+_FONT_STACKS: dict[str, str] = {
+    "sans": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+    "serif": "Georgia, Cambria, 'Times New Roman', serif",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+}
+
+# JS-``getDay()`` order: index 0 == Sunday … 6 == Saturday.
+_DAY_FIELDS_JS_ORDER: tuple[str, ...] = (
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+)
+_DAY_FULL_JS_ORDER: list[str] = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+]
+_DAY_SHORT_JS_ORDER: list[str] = [
+    "Sun",
+    "Mon",
+    "Tue",
+    "Wed",
+    "Thu",
+    "Fri",
+    "Sat",
+]
+# Display order for the week table — Monday first, Sunday last (JS indices).
+_WEEK_TABLE_ORDER: list[int] = [1, 2, 3, 4, 5, 6, 0]
+
+
+def _parse_hhmm(value: str) -> int:
+    """Parse ``"HH:MM"`` → minutes since midnight.
+
+    Hours may be ``0``-``24``; ``24:00`` (== 1440) is permitted only as a
+    closing time meaning "midnight / end of day".
+    """
+    parts = value.split(":")
+    if len(parts) != 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        raise ValueError(f"time must be 'HH:MM', got {value!r}")
+    hours, minutes = int(parts[0]), int(parts[1])
+    if not (0 <= hours <= 24) or not (0 <= minutes <= 59):
+        raise ValueError(f"time out of range: {value!r}")
+    total = hours * 60 + minutes
+    if total > 1440:
+        raise ValueError(f"time may not exceed 24:00, got {value!r}")
+    return total
+
+
+class Interval(BaseModel):
+    """A single open→close span within a day."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    open: str = Field(default="09:00")
+    close: str = Field(default="17:00")
+
+    @field_validator("open", "close")
+    @classmethod
+    def _valid_hhmm(cls, v: str) -> str:
+        _parse_hhmm(v)
+        return v
+
+    @model_validator(mode="after")
+    def _close_after_open(self) -> Interval:
+        if _parse_hhmm(self.close) <= _parse_hhmm(self.open):
+            raise ValueError(
+                f"close ({self.close}) must be after open ({self.open})"
+            )
+        return self
+
+
+def _validate_no_overlap(intervals: list[Interval]) -> list[Interval]:
+    """Ensure a day's intervals don't overlap (order-independent)."""
+    spans = sorted(
+        ((_parse_hhmm(i.open), _parse_hhmm(i.close)) for i in intervals),
+        key=lambda s: s[0],
+    )
+    for prev, cur in zip(spans, spans[1:]):
+        if cur[0] < prev[1]:
+            raise ValueError("intervals within a day must not overlap")
+    return intervals
+
+
+class HolidayOverride(BaseModel):
+    """A date-specific override of the weekly schedule.
+
+    ``date`` is either a one-off ``YYYY-MM-DD`` or a recurring annual
+    ``MM-DD``.  ``closed=True`` ignores ``intervals``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    label: str = Field(default="", max_length=80)
+    closed: bool = True
+    intervals: list[Interval] = Field(default_factory=list)
+
+    @field_validator("date")
+    @classmethod
+    def _valid_date(cls, v: str) -> str:
+        parts = v.split("-")
+        if len(parts) == 3:
+            y, m, d = parts
+            if not (len(y) == 4 and y.isdigit()):
+                raise ValueError("date year must be 4 digits (YYYY-MM-DD)")
+        elif len(parts) == 2:
+            m, d = parts
+        else:
+            raise ValueError("date must be 'YYYY-MM-DD' or 'MM-DD'")
+        if not (m.isdigit() and d.isdigit() and 1 <= int(m) <= 12 and 1 <= int(d) <= 31):
+            raise ValueError(f"invalid month/day in date: {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def _check_intervals(self) -> HolidayOverride:
+        if not self.closed:
+            _validate_no_overlap(self.intervals)
+        return self
+
+
+def _default_week() -> dict[str, list[dict[str, str]]]:
+    """Mon–Fri 9–5, Sat 10–4, Sun closed."""
+    weekday = [{"open": "09:00", "close": "17:00"}]
+    saturday = [{"open": "10:00", "close": "16:00"}]
+    return {
+        "monday": list(weekday),
+        "tuesday": list(weekday),
+        "wednesday": list(weekday),
+        "thursday": list(weekday),
+        "friday": list(weekday),
+        "saturday": list(saturday),
+        "sunday": [],
+    }
+
+
+class StoreHoursWidgetConfig(BaseModel):
+    """User-editable config for :class:`StoreHoursWidget`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    monday: list[Interval] = Field(default_factory=list)
+    tuesday: list[Interval] = Field(default_factory=list)
+    wednesday: list[Interval] = Field(default_factory=list)
+    thursday: list[Interval] = Field(default_factory=list)
+    friday: list[Interval] = Field(default_factory=list)
+    saturday: list[Interval] = Field(default_factory=list)
+    sunday: list[Interval] = Field(default_factory=list)
+
+    holidays: list[HolidayOverride] = Field(default_factory=list, max_length=60)
+
+    display_mode: Literal["today", "week"] = "today"
+    heading: str = Field(default="", max_length=80)
+    show_status: bool = True
+    time_format: Literal["12h", "24h"] = "12h"
+
+    color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
+    open_color: str = Field(default="#3fb950", pattern=r"^#[0-9a-fA-F]{6}$")
+    closed_color: str = Field(default="#f85149", pattern=r"^#[0-9a-fA-F]{6}$")
+    font_family: str = Field(default="sans")
+    font_size_px: int = Field(default=48, ge=8, le=512)
+
+    @field_validator("font_family")
+    @classmethod
+    def _font_in_allowlist(cls, v: str) -> str:
+        if v not in _FONT_STACKS:
+            allowed = ", ".join(sorted(_FONT_STACKS))
+            raise ValueError(f"font_family must be one of: {allowed}")
+        return v
+
+    @model_validator(mode="after")
+    def _days_no_overlap(self) -> StoreHoursWidgetConfig:
+        for field in _DAY_FIELDS_JS_ORDER:
+            _validate_no_overlap(getattr(self, field))
+        return self
+
+
+def _intervals_js(intervals: list[Interval]) -> str:
+    """``[[540,1020], ...]`` minute-pair literal for the runtime."""
+    pairs = ",".join(
+        f"[{_parse_hhmm(i.open)},{_parse_hhmm(i.close)}]" for i in intervals
+    )
+    return f"[{pairs}]"
+
+
+def _schedule_js(config: StoreHoursWidgetConfig) -> str:
+    """Weekly schedule as a JS array indexed by ``getDay()``."""
+    days = ",".join(
+        _intervals_js(getattr(config, field)) for field in _DAY_FIELDS_JS_ORDER
+    )
+    return f"[{days}]"
+
+
+def _holidays_js(config: StoreHoursWidgetConfig) -> str:
+    entries = ",".join(
+        "{{match:{m},label:{l},closed:{c},intervals:{iv}}}".format(
+            m=json.dumps(h.date),
+            l=json.dumps(h.label),
+            c="true" if h.closed else "false",
+            iv=_intervals_js(h.intervals),
+        )
+        for h in config.holidays
+    )
+    return f"[{entries}]"
+
+
+# ``$NAME`` placeholders (not ``{name}``) so literal ``{`` in the JS body
+# don't need brace-doubling.
+_STOREHOURS_INIT_JS_TEMPLATE = """
+var statusEl = document.getElementById($STATUS_ID);
+var bodyEl = document.getElementById($BODY_ID);
+var SCHEDULE = $SCHEDULE;
+var HOLIDAYS = $HOLIDAYS;
+var DAY_FULL = $DAY_FULL;
+var DAY_SHORT = $DAY_SHORT;
+var WEEK_ORDER = $WEEK_ORDER;
+var MODE = $MODE;
+var SHOW_STATUS = $SHOW_STATUS;
+var FMT24 = $FMT24;
+var OPEN_COLOR = $OPEN_COLOR;
+var CLOSED_COLOR = $CLOSED_COLOR;
+
+function pad2(n) { return (n < 10 ? '0' : '') + n; }
+
+function fmtTime(mins) {
+  if (FMT24) { return mins >= 1440 ? '24:00' : pad2(Math.floor(mins / 60)) + ':' + pad2(mins % 60); }
+  if (mins >= 1440) return '12:00 AM';
+  var h = Math.floor(mins / 60), m = mins % 60;
+  var suf = h >= 12 ? 'PM' : 'AM';
+  var hh = h % 12; if (hh === 0) hh = 12;
+  return hh + ':' + pad2(m) + ' ' + suf;
+}
+
+function fmtSpan(iv) { return fmtTime(iv[0]) + ' \u2013 ' + fmtTime(iv[1]); }
+function fmtDay(ivs) { return ivs.length ? ivs.map(fmtSpan).join(', ') : 'Closed'; }
+
+function holidayFor(date) {
+  var mmdd = pad2(date.getMonth() + 1) + '-' + pad2(date.getDate());
+  var ymd = date.getFullYear() + '-' + mmdd;
+  for (var i = 0; i < HOLIDAYS.length; i++) {
+    if (HOLIDAYS[i].match === ymd || HOLIDAYS[i].match === mmdd) return HOLIDAYS[i];
+  }
+  return null;
+}
+
+function intervalsFor(date) {
+  var h = holidayFor(date);
+  if (h) return h.closed ? [] : h.intervals;
+  return SCHEDULE[date.getDay()] || [];
+}
+
+function renderStatus(now) {
+  if (!statusEl) return;
+  while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
+  var nowMin = now.getHours() * 60 + now.getMinutes();
+  var today = intervalsFor(now);
+  var openNow = false, closesAt = null;
+  for (var i = 0; i < today.length; i++) {
+    if (nowMin >= today[i][0] && nowMin < today[i][1]) { openNow = true; closesAt = today[i][1]; break; }
+  }
+  var pill = document.createElement('span');
+  pill.className = 'cw-storehours-pill';
+  var hint = document.createElement('span');
+  hint.className = 'cw-storehours-hint';
+  var hol = holidayFor(now);
+  if (openNow) {
+    pill.textContent = 'Open';
+    pill.style.color = OPEN_COLOR;
+    hint.textContent = ' \u00b7 Closes ' + fmtTime(closesAt);
+  } else {
+    pill.textContent = 'Closed';
+    pill.style.color = CLOSED_COLOR;
+    var next = null;
+    for (var j = 0; j < today.length; j++) {
+      if (today[j][0] > nowMin) { next = { off: 0, min: today[j][0] }; break; }
+    }
+    if (!next) {
+      for (var off = 1; off <= 7; off++) {
+        var d = new Date(now.getTime() + off * 86400000);
+        var ivs = intervalsFor(d);
+        if (ivs.length) { next = { off: off, min: ivs[0][0], day: d.getDay() }; break; }
+      }
+    }
+    if (next && next.off === 0) {
+      hint.textContent = ' \u00b7 Opens ' + fmtTime(next.min);
+    } else if (next) {
+      hint.textContent = ' \u00b7 Opens ' + DAY_SHORT[next.day] + ' ' + fmtTime(next.min);
+    } else if (hol && hol.label) {
+      hint.textContent = ' \u00b7 ' + hol.label;
+    }
+  }
+  if (hol && hol.label && pill.textContent === 'Closed' && !hint.textContent) {
+    hint.textContent = ' \u00b7 ' + hol.label;
+  }
+  statusEl.appendChild(pill);
+  statusEl.appendChild(hint);
+}
+
+function renderBody(now) {
+  if (!bodyEl) return;
+  while (bodyEl.firstChild) bodyEl.removeChild(bodyEl.firstChild);
+  if (MODE === 'week') {
+    for (var k = 0; k < WEEK_ORDER.length; k++) {
+      var idx = WEEK_ORDER[k];
+      var row = document.createElement('div');
+      row.className = 'cw-storehours-row' + (idx === now.getDay() ? ' cw-storehours-row-today' : '');
+      var name = document.createElement('span');
+      name.className = 'cw-storehours-day';
+      name.textContent = DAY_FULL[idx];
+      var hrs = document.createElement('span');
+      hrs.className = 'cw-storehours-hrs';
+      hrs.textContent = fmtDay(SCHEDULE[idx] || []);
+      row.appendChild(name);
+      row.appendChild(hrs);
+      bodyEl.appendChild(row);
+    }
+  } else {
+    var line = document.createElement('div');
+    line.className = 'cw-storehours-today';
+    line.textContent = 'Today: ' + fmtDay(intervalsFor(now));
+    bodyEl.appendChild(line);
+  }
+}
+
+function render() {
+  var now = new Date();
+  if (SHOW_STATUS) renderStatus(now);
+  renderBody(now);
+}
+render();
+setInterval(render, 60000);
+""".strip()
+
+
+def _build_storehours_init_js(*, status_id: str, body_id: str, config: StoreHoursWidgetConfig) -> str:
+    return (
+        _STOREHOURS_INIT_JS_TEMPLATE
+        .replace("$STATUS_ID", f"'{status_id}'")
+        .replace("$BODY_ID", f"'{body_id}'")
+        .replace("$SCHEDULE", _schedule_js(config))
+        .replace("$HOLIDAYS", _holidays_js(config))
+        .replace("$DAY_FULL", json.dumps(_DAY_FULL_JS_ORDER))
+        .replace("$DAY_SHORT", json.dumps(_DAY_SHORT_JS_ORDER))
+        .replace("$WEEK_ORDER", json.dumps(_WEEK_TABLE_ORDER))
+        .replace("$MODE", json.dumps(config.display_mode))
+        .replace("$SHOW_STATUS", "true" if config.show_status else "false")
+        .replace("$FMT24", "true" if config.time_format == "24h" else "false")
+        .replace("$OPEN_COLOR", json.dumps(config.open_color))
+        .replace("$CLOSED_COLOR", json.dumps(config.closed_color))
+    )
+
+
+class StoreHoursWidget(Widget):
+    """Weekly store hours + live open/closed status."""
+
+    slug: ClassVar[str] = "storehours"
+    display_name: ClassVar[str] = "Store Hours"
+    icon: ClassVar[str] = "🕗"
+    ConfigSchema: ClassVar[type[BaseModel]] = StoreHoursWidgetConfig
+    config_version: ClassVar[int] = 1
+
+    def default_config(self) -> dict:
+        week = _default_week()
+        return {
+            **week,
+            "holidays": [],
+            "display_mode": "today",
+            "heading": "",
+            "show_status": True,
+            "time_format": "12h",
+            "color": "#ffffff",
+            "open_color": "#3fb950",
+            "closed_color": "#f85149",
+            "font_family": "sans",
+            "font_size_px": 48,
+        }
+
+    def editor_template(self) -> str:
+        return "composed/widgets/store_hours.html"
+
+    def render_html(
+        self,
+        config: BaseModel,
+        cell: Cell,
+        instance_id: str,
+        ctx: BundleContext | None = None,
+    ) -> WidgetRender:
+        # No asset deps; ctx + cell unused.
+        del ctx, cell
+        assert isinstance(config, StoreHoursWidgetConfig), (
+            "StoreHoursWidget.render_html expects a StoreHoursWidgetConfig"
+        )
+
+        css_class = f"cw-storehours-{instance_id}"
+        status_id = f"cw-storehours-status-{instance_id}"
+        body_id = f"cw-storehours-body-{instance_id}"
+        font_stack = _FONT_STACKS[config.font_family]
+
+        heading_html = ""
+        if config.heading:
+            heading_html = (
+                f'<div class="{css_class}-heading">{escape(config.heading)}</div>'
+            )
+        status_html = ""
+        if config.show_status:
+            status_html = f'<div id="{status_id}" class="{css_class}-status">\u2026</div>'
+
+        html_out = (
+            f'<div class="{css_class}">'
+            f"{heading_html}"
+            f"{status_html}"
+            f'<div id="{body_id}" class="{css_class}-body"></div>'
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  box-sizing: border-box;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  overflow: hidden;\n"
+            f"  text-align: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  line-height: 1.25;\n"
+            f"}}\n"
+            f".{css_class}-heading {{\n"
+            f"  font-weight: 700;\n"
+            f"  margin-bottom: 0.25em;\n"
+            f"}}\n"
+            f".{css_class}-status {{\n"
+            f"  margin-bottom: 0.35em;\n"
+            f"}}\n"
+            f".{css_class}-status .cw-storehours-pill {{\n"
+            f"  font-weight: 700;\n"
+            f"}}\n"
+            f".{css_class}-status .cw-storehours-hint {{\n"
+            f"  opacity: 0.85;\n"
+            f"}}\n"
+            f".{css_class}-body {{\n"
+            f"  width: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  gap: 0.15em;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-row {{\n"
+            f"  display: flex;\n"
+            f"  justify-content: space-between;\n"
+            f"  gap: 1em;\n"
+            f"  white-space: nowrap;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-row-today {{\n"
+            f"  font-weight: 700;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-day {{\n"
+            f"  text-align: left;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-hrs {{\n"
+            f"  text-align: right;\n"
+            f"}}"
+        )
+
+        init_js = _build_storehours_init_js(
+            status_id=status_id,
+            body_id=body_id,
+            config=config,
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            init_js=init_js,
+        )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -389,6 +389,30 @@
     .cw-prev-rss-heading { font-weight: 700; margin-bottom: 0.3em; flex: 0 0 auto; }
     .cw-prev-rss-list { flex: 1 1 auto; overflow: hidden; display: flex; flex-direction: column; gap: 0.4em; }
     .cw-prev-rss-date { opacity: 0.7; margin-top: 0.1em; }
+    .cw-prev-storehours {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        box-sizing: border-box;
+        line-height: 1.2;
+        text-align: center;
+        gap: 0.25em;
+    }
+    .cw-prev-storehours-heading { font-weight: 700; flex: 0 0 auto; }
+    .cw-prev-storehours-status { font-weight: 700; }
+    .cw-prev-storehours-pill {
+        display: inline-block; border-radius: 0.4em; padding: 0.05em 0.4em;
+        color: #0d1117;
+    }
+    .cw-prev-storehours-body { opacity: 0.95; }
+    .cw-prev-storehours-week { display: flex; flex-direction: column; gap: 0.15em; width: 100%; }
+    .cw-prev-storehours-row { display: flex; justify-content: space-between; gap: 1em; }
+    .cw-prev-storehours-row .d { font-weight: 600; }
+    .cw-prev-storehours-hint { opacity: 0.75; }
     .wx-results { display: flex; flex-direction: column; gap: 0.2rem; margin: 0.25rem 0; }
     .wx-result {
         text-align: left;
@@ -1285,6 +1309,286 @@ registerWidget("rss", {
             <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
                 Headlines are fetched on the device via the CMS feed proxy. The preview shows placeholder text.
             </p>`,
+});
+
+// ── Store Hours widget editor helpers ──────────────────────────────
+// The settings panel is the most structural in the editor: it edits
+// per-day open intervals and a holiday-override list. Mutating those
+// arrays must re-render the panel (mirrors setTickerTransparent's
+// pattern of updateSelected + renderSettings).
+const SH_DAY_FIELDS = ["monday","tuesday","wednesday","thursday","friday","saturday","sunday"];
+const SH_DAY_LABELS = {monday:"Mon", tuesday:"Tue", wednesday:"Wed", thursday:"Thu", friday:"Fri", saturday:"Sat", sunday:"Sun"};
+const SH_DAY_JS_INDEX = {sunday:0, monday:1, tuesday:2, wednesday:3, thursday:4, friday:5, saturday:6};
+
+function shParseHHMM(v) {
+    const m = /^(\d{1,2}):(\d{2})$/.exec(String(v || "").trim());
+    if (!m) return null;
+    const mins = (+m[1]) * 60 + (+m[2]);
+    return (mins >= 0 && mins <= 1440) ? mins : null;
+}
+function shFmtTime(mins, fmt24) {
+    if (mins >= 1440) mins = 0;
+    let h = Math.floor(mins / 60), mm = mins % 60;
+    const pad = (n) => (n < 10 ? "0" + n : "" + n);
+    if (fmt24) return pad(h) + ":" + pad(mm);
+    const ap = h < 12 ? "AM" : "PM";
+    let hr = h % 12; if (hr === 0) hr = 12;
+    return hr + ":" + pad(mm) + " " + ap;
+}
+function shFmtIntervals(intervals, fmt24) {
+    if (!intervals || !intervals.length) return "Closed";
+    return intervals.map(iv => {
+        const o = shParseHHMM(iv.open), c = shParseHHMM(iv.close);
+        if (o == null || c == null) return "—";
+        return shFmtTime(o, fmt24) + "–" + shFmtTime(c, fmt24);
+    }).join(", ");
+}
+function shAddInterval(day) {
+    updateSelected(x => { (x.config[day] = x.config[day] || []).push({open:"09:00", close:"17:00"}); });
+    renderSettings();
+}
+function shRemoveInterval(day, idx) {
+    updateSelected(x => { if (x.config[day]) x.config[day].splice(idx, 1); });
+    renderSettings();
+}
+function shSetInterval(day, idx, field, val) {
+    updateSelected(x => { if (x.config[day] && x.config[day][idx]) x.config[day][idx][field] = val; });
+}
+function shAddHoliday() {
+    updateSelected(x => { (x.config.holidays = x.config.holidays || []).push({date:"", label:"", closed:true, intervals:[]}); });
+    renderSettings();
+}
+function shRemoveHoliday(idx) {
+    updateSelected(x => { if (x.config.holidays) x.config.holidays.splice(idx, 1); });
+    renderSettings();
+}
+function shSetHoliday(idx, field, val) {
+    updateSelected(x => { if (x.config.holidays && x.config.holidays[idx]) x.config.holidays[idx][field] = val; });
+}
+function shToggleHolidayClosed(idx, closed) {
+    updateSelected(x => {
+        const h = x.config.holidays && x.config.holidays[idx];
+        if (!h) return;
+        h.closed = closed;
+        if (!closed && (!h.intervals || !h.intervals.length)) h.intervals = [{open:"09:00", close:"17:00"}];
+    });
+    renderSettings();
+}
+function shAddHolidayInterval(hidx) {
+    updateSelected(x => {
+        const h = x.config.holidays && x.config.holidays[hidx];
+        if (h) (h.intervals = h.intervals || []).push({open:"09:00", close:"17:00"});
+    });
+    renderSettings();
+}
+function shRemoveHolidayInterval(hidx, iidx) {
+    updateSelected(x => {
+        const h = x.config.holidays && x.config.holidays[hidx];
+        if (h && h.intervals) h.intervals.splice(iidx, 1);
+    });
+    renderSettings();
+}
+function shSetHolidayInterval(hidx, iidx, field, val) {
+    updateSelected(x => {
+        const h = x.config.holidays && x.config.holidays[hidx];
+        if (h && h.intervals && h.intervals[iidx]) h.intervals[iidx][field] = val;
+    });
+}
+
+registerWidget("storehours", {
+    label: "Store Hours", icon: "🕗", category: "Time & Date",
+    keywords: ["store", "hours", "open", "closed", "schedule", "opening", "business"],
+    defaults: () => ({
+        monday:[{open:"09:00",close:"17:00"}], tuesday:[{open:"09:00",close:"17:00"}],
+        wednesday:[{open:"09:00",close:"17:00"}], thursday:[{open:"09:00",close:"17:00"}],
+        friday:[{open:"09:00",close:"17:00"}], saturday:[{open:"10:00",close:"16:00"}],
+        sunday:[], holidays:[], display_mode:"today", heading:"", show_status:true,
+        time_format:"12h", color:"#ffffff", open_color:"#3fb950", closed_color:"#f85149",
+        font_family:"sans", font_size_px:48,
+    }),
+    summary: (w) => (w.config.heading || (w.config.display_mode === "week" ? "weekly hours" : "today's hours")).slice(0, 24),
+    preview: (root, cfg) => {
+        const fmt24 = cfg.time_format === "24h";
+        const wrap = document.createElement("div");
+        wrap.className = "cw-prev-storehours";
+        wrap.style.color = cfg.color || "#ffffff";
+        wrap.style.fontFamily = fontStack(cfg.font_family);
+        const baseFont = Number(cfg.font_size_px) || 48;
+        if (cfg.heading) {
+            const h = document.createElement("div");
+            h.className = "cw-prev-storehours-heading";
+            h.textContent = cfg.heading;
+            h.style.fontSize = cqwFont(Math.round(baseFont * 1.05));
+            wrap.appendChild(h);
+        }
+        // Resolve today's intervals from the weekly schedule (preview
+        // ignores holiday date-matching; runtime handles real dates).
+        const todayIdx = new Date().getDay();
+        const todayField = SH_DAY_FIELDS.find(f => SH_DAY_JS_INDEX[f] === todayIdx) || "monday";
+        const todayIntervals = cfg[todayField] || [];
+        if (cfg.show_status) {
+            const nowMin = new Date().getHours() * 60 + new Date().getMinutes();
+            let open = false;
+            for (const iv of todayIntervals) {
+                const o = shParseHHMM(iv.open), c = shParseHHMM(iv.close);
+                if (o != null && c != null && nowMin >= o && nowMin < c) { open = true; break; }
+            }
+            const st = document.createElement("div");
+            st.className = "cw-prev-storehours-status";
+            st.style.fontSize = cqwFont(baseFont);
+            const pill = document.createElement("span");
+            pill.className = "cw-prev-storehours-pill";
+            pill.textContent = open ? "Open" : "Closed";
+            pill.style.background = (open ? (cfg.open_color || "#3fb950") : (cfg.closed_color || "#f85149"));
+            st.appendChild(pill);
+            wrap.appendChild(st);
+        }
+        if (cfg.display_mode === "week") {
+            const wk = document.createElement("div");
+            wk.className = "cw-prev-storehours-week";
+            wk.style.fontSize = cqwFont(Math.round(baseFont * 0.55));
+            for (const f of SH_DAY_FIELDS) {
+                const row = document.createElement("div");
+                row.className = "cw-prev-storehours-row";
+                const d = document.createElement("span"); d.className = "d"; d.textContent = SH_DAY_LABELS[f];
+                const v = document.createElement("span"); v.textContent = shFmtIntervals(cfg[f], fmt24);
+                row.appendChild(d); row.appendChild(v); wk.appendChild(row);
+            }
+            wrap.appendChild(wk);
+        } else {
+            const body = document.createElement("div");
+            body.className = "cw-prev-storehours-body";
+            body.style.fontSize = cqwFont(Math.round(baseFont * 0.7));
+            body.textContent = "Today: " + shFmtIntervals(todayIntervals, fmt24);
+            wrap.appendChild(body);
+        }
+        root.appendChild(wrap);
+    },
+    settings: (w) => {
+        const c = w.config;
+        const fmt24 = c.time_format === "24h";
+        const dayRows = SH_DAY_FIELDS.map(day => {
+            const ivs = c[day] || [];
+            const ivHtml = ivs.length ? ivs.map((iv, i) => `
+                <div class="row" style="align-items:center; gap:0.25rem; margin-bottom:0.2rem;">
+                    <input type="time" value="${escapeHtml(iv.open || "")}"
+                           oninput="shSetInterval('${day}',${i},'open',this.value)">
+                    <span style="opacity:0.6;">–</span>
+                    <input type="time" value="${escapeHtml(iv.close || "")}"
+                           oninput="shSetInterval('${day}',${i},'close',this.value)">
+                    <button type="button" title="Remove" style="background:none; border:none; color:var(--text-muted); cursor:pointer; font-size:0.9rem; padding:0 0.2rem;"
+                            onclick="shRemoveInterval('${day}',${i})">✕</button>
+                </div>`).join("") : `<div style="opacity:0.6; font-size:0.8rem; margin-bottom:0.2rem;">Closed</div>`;
+            return `
+            <div style="border:1px solid var(--border); border-radius:0.4rem; padding:0.4rem 0.5rem; margin-bottom:0.4rem;">
+                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.25rem;">
+                    <strong style="font-size:0.85rem;">${SH_DAY_LABELS[day]}</strong>
+                    <button type="button" class="btn-secondary" style="padding:0.1rem 0.5rem; font-size:0.75rem;"
+                            onclick="shAddInterval('${day}')">+ Hours</button>
+                </div>
+                ${ivHtml}
+            </div>`;
+        }).join("");
+        const holidays = c.holidays || [];
+        const holidayHtml = holidays.length ? holidays.map((h, i) => {
+            const ivEditor = h.closed ? "" : `
+                <div style="margin-top:0.3rem;">
+                    ${(h.intervals || []).map((iv, j) => `
+                    <div class="row" style="align-items:center; gap:0.25rem; margin-bottom:0.2rem;">
+                        <input type="time" value="${escapeHtml(iv.open || "")}"
+                               oninput="shSetHolidayInterval(${i},${j},'open',this.value)">
+                        <span style="opacity:0.6;">–</span>
+                        <input type="time" value="${escapeHtml(iv.close || "")}"
+                               oninput="shSetHolidayInterval(${i},${j},'close',this.value)">
+                        <button type="button" title="Remove" style="background:none; border:none; color:var(--text-muted); cursor:pointer; font-size:0.9rem; padding:0 0.2rem;"
+                                onclick="shRemoveHolidayInterval(${i},${j})">✕</button>
+                    </div>`).join("")}
+                    <button type="button" class="btn-secondary" style="padding:0.1rem 0.5rem; font-size:0.75rem;"
+                            onclick="shAddHolidayInterval(${i})">+ Hours</button>
+                </div>`;
+            return `
+            <div style="border:1px solid var(--border); border-radius:0.4rem; padding:0.4rem 0.5rem; margin-bottom:0.4rem;">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:0.3rem;">
+                    <input type="text" maxlength="10" placeholder="MM-DD or YYYY-MM-DD"
+                           value="${escapeHtml(h.date || "")}" style="flex:1 1 auto;"
+                           oninput="shSetHoliday(${i},'date',this.value)">
+                    <button type="button" title="Remove holiday" style="background:none; border:none; color:var(--text-muted); cursor:pointer; font-size:0.9rem; padding:0 0.2rem;"
+                            onclick="shRemoveHoliday(${i})">✕</button>
+                </div>
+                <input type="text" maxlength="80" placeholder="Label (e.g. Christmas Day)"
+                       value="${escapeHtml(h.label || "")}" style="width:100%; margin-top:0.25rem;"
+                       oninput="shSetHoliday(${i},'label',this.value)">
+                <label style="font-weight:400; margin-top:0.25rem;">
+                    <input type="checkbox" ${h.closed ? "checked" : ""}
+                        onchange="shToggleHolidayClosed(${i}, this.checked)"> Closed all day
+                </label>
+                ${ivEditor}
+            </div>`;
+        }).join("") : `<div style="opacity:0.6; font-size:0.8rem; margin-bottom:0.4rem;">No holidays added.</div>`;
+        return `
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Store Hours widget</h4>
+            <label>Heading (optional)</label>
+            <input type="text" maxlength="80" value="${escapeHtml(c.heading || "")}"
+                   placeholder="e.g. Store Hours"
+                   oninput="updateSelected(x=>x.config.heading=this.value)">
+            <div class="row" style="margin-top:0.5rem;">
+                <div>
+                    <label>Display</label>
+                    <select oninput="updateSelected(x=>x.config.display_mode=this.value); renderSettings();">
+                        <option value="today" ${c.display_mode==="today"?"selected":""}>Today only</option>
+                        <option value="week" ${c.display_mode==="week"?"selected":""}>Full week</option>
+                    </select>
+                </div>
+                <div>
+                    <label>Time format</label>
+                    <select oninput="updateSelected(x=>x.config.time_format=this.value)">
+                        <option value="12h" ${c.time_format==="12h"?"selected":""}>12-hour</option>
+                        <option value="24h" ${c.time_format==="24h"?"selected":""}>24-hour</option>
+                    </select>
+                </div>
+            </div>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${c.show_status?"checked":""}
+                    oninput="updateSelected(x=>x.config.show_status=this.checked)"> Show open/closed status
+            </label>
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Weekly hours</h4>
+            ${dayRows}
+            <h4 style="margin:0.75rem 0 0.25rem; font-size:0.85rem;">Holiday overrides</h4>
+            ${holidayHtml}
+            <button type="button" class="btn-secondary" style="padding:0.2rem 0.6rem; font-size:0.8rem;"
+                    onclick="shAddHoliday()">+ Add holiday</button>
+            <div class="row" style="margin-top:0.6rem;">
+                <div>
+                    <label>Text color</label>
+                    <input type="color" value="${c.color||"#ffffff"}"
+                           oninput="updateSelected(x=>x.config.color=this.value)">
+                </div>
+                <div>
+                    <label>Size (px)</label>
+                    <input type="number" min="8" max="512" value="${c.font_size_px||48}"
+                           oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
+                </div>
+            </div>
+            <div class="row" style="margin-top:0.3rem;">
+                <div>
+                    <label>Open color</label>
+                    <input type="color" value="${c.open_color||"#3fb950"}"
+                           oninput="updateSelected(x=>x.config.open_color=this.value)">
+                </div>
+                <div>
+                    <label>Closed color</label>
+                    <input type="color" value="${c.closed_color||"#f85149"}"
+                           oninput="updateSelected(x=>x.config.closed_color=this.value)">
+                </div>
+            </div>
+            <label style="margin-top:0.3rem;">Font</label>
+            <select oninput="updateSelected(x=>x.config.font_family=this.value)">
+                ${FONT_OPTIONS.map(f=>`<option value="${f}" ${c.font_family===f?"selected":""}>${f}</option>`).join("")}
+            </select>
+            <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
+                Hours are evaluated on the device using its local clock. Holiday dates match by MM-DD (every year) or YYYY-MM-DD (one-off).
+            </p>`;
+    },
 });
 
 registerWidget("ticker", {

--- a/tests/test_composed_store_hours_widget.py
+++ b/tests/test_composed_store_hours_widget.py
@@ -1,0 +1,285 @@
+"""Unit tests for the Store Hours composed-slide widget."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cms.composed.registry import get_registry
+from cms.composed.schema import Cell
+from cms.composed.widgets.store_hours import (
+    HolidayOverride,
+    Interval,
+    StoreHoursWidget,
+    StoreHoursWidgetConfig,
+)
+
+
+def _cell() -> Cell:
+    return Cell(row=1, col=1, rowspan=2, colspan=3)
+
+
+class TestInterval:
+    def test_defaults(self):
+        iv = Interval()
+        assert iv.open == "09:00"
+        assert iv.close == "17:00"
+
+    def test_close_must_be_after_open(self):
+        with pytest.raises(ValidationError):
+            Interval(open="17:00", close="09:00")
+        with pytest.raises(ValidationError):
+            Interval(open="09:00", close="09:00")
+
+    @pytest.mark.parametrize("bad", ["0900", "09-00", "25:00", "09:60", "24:30"])
+    def test_invalid_hhmm_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            Interval(open=bad)
+
+    def test_midnight_close_allowed(self):
+        assert Interval(open="18:00", close="24:00").close == "24:00"
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            Interval(nope=1)
+
+
+class TestHolidayOverride:
+    def test_one_off_and_recurring_dates(self):
+        assert HolidayOverride(date="2026-12-25").date == "2026-12-25"
+        assert HolidayOverride(date="12-25").date == "12-25"
+
+    @pytest.mark.parametrize("bad", ["2026/12/25", "26-12-25", "13-01", "12-32", "xx-01"])
+    def test_invalid_date_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            HolidayOverride(date=bad)
+
+    def test_closed_default_true(self):
+        assert HolidayOverride(date="12-25").closed is True
+
+    def test_open_holiday_keeps_intervals(self):
+        h = HolidayOverride(
+            date="12-24", closed=False, intervals=[Interval(open="09:00", close="13:00")]
+        )
+        assert len(h.intervals) == 1
+
+    def test_open_holiday_rejects_overlap(self):
+        with pytest.raises(ValidationError):
+            HolidayOverride(
+                date="12-24",
+                closed=False,
+                intervals=[
+                    Interval(open="09:00", close="13:00"),
+                    Interval(open="12:00", close="17:00"),
+                ],
+            )
+
+    def test_label_length_capped(self):
+        with pytest.raises(ValidationError):
+            HolidayOverride(date="12-25", label="x" * 81)
+        assert HolidayOverride(date="12-25", label="x" * 80).label == "x" * 80
+
+
+class TestStoreHoursWidgetConfig:
+    def test_defaults(self):
+        c = StoreHoursWidgetConfig()
+        assert c.display_mode == "today"
+        assert c.heading == ""
+        assert c.show_status is True
+        assert c.time_format == "12h"
+        assert c.color == "#ffffff"
+        assert c.open_color == "#3fb950"
+        assert c.closed_color == "#f85149"
+        assert c.font_family == "sans"
+        assert c.font_size_px == 48
+        assert c.holidays == []
+        assert c.monday == []
+
+    def test_multi_interval_day(self):
+        c = StoreHoursWidgetConfig(
+            monday=[
+                Interval(open="09:00", close="12:00"),
+                Interval(open="13:00", close="17:00"),
+            ]
+        )
+        assert len(c.monday) == 2
+
+    def test_overlapping_intervals_rejected(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(
+                monday=[
+                    Interval(open="09:00", close="13:00"),
+                    Interval(open="12:00", close="17:00"),
+                ]
+            )
+
+    def test_holidays_max_length(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(
+                holidays=[HolidayOverride(date="12-25")] * 61
+            )
+
+    @pytest.mark.parametrize("mode", ["today", "week"])
+    def test_valid_display_modes(self, mode):
+        assert StoreHoursWidgetConfig(display_mode=mode).display_mode == mode
+
+    def test_invalid_display_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(display_mode="month")
+
+    @pytest.mark.parametrize("fmt", ["12h", "24h"])
+    def test_valid_time_formats(self, fmt):
+        assert StoreHoursWidgetConfig(time_format=fmt).time_format == fmt
+
+    def test_invalid_time_format_rejected(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(time_format="36h")
+
+    def test_heading_length_capped(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(heading="x" * 81)
+        assert StoreHoursWidgetConfig(heading="x" * 80).heading == "x" * 80
+
+    def test_font_allowlist(self):
+        for f in ("sans", "serif", "mono"):
+            assert StoreHoursWidgetConfig(font_family=f).font_family == f
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(font_family="comic")
+
+    @pytest.mark.parametrize("field", ["color", "open_color", "closed_color"])
+    def test_colors_must_be_hex6(self, field):
+        StoreHoursWidgetConfig(**{field: "#0aF3Cd"})
+        for bad in ("ffffff", "#fff", "#gggggg", "red"):
+            with pytest.raises(ValidationError):
+                StoreHoursWidgetConfig(**{field: bad})
+
+    def test_font_size_bounds(self):
+        StoreHoursWidgetConfig(font_size_px=8)
+        StoreHoursWidgetConfig(font_size_px=512)
+        for bad in (7, 513, 0, -1):
+            with pytest.raises(ValidationError):
+                StoreHoursWidgetConfig(font_size_px=bad)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            StoreHoursWidgetConfig(nope=1)
+
+
+class TestStoreHoursWidgetRegistry:
+    def test_registered(self):
+        reg = get_registry()
+        assert reg.has("storehours")
+        w = reg.get("storehours")
+        assert isinstance(w, StoreHoursWidget)
+        assert w.display_name == "Store Hours"
+        assert w.icon == "🕗"
+
+    def test_default_config_validates(self):
+        w = StoreHoursWidget()
+        cfg = StoreHoursWidgetConfig(**w.default_config())
+        # Mon-Fri 9-5, Sat 10-4, Sun closed.
+        assert len(cfg.monday) == 1
+        assert cfg.monday[0].open == "09:00"
+        assert cfg.saturday[0].close == "16:00"
+        assert cfg.sunday == []
+
+
+class TestStoreHoursWidgetRender:
+    def _render(self, **overrides):
+        w = StoreHoursWidget()
+        cfg = StoreHoursWidgetConfig(**{**w.default_config(), **overrides})
+        return w.render_html(cfg, _cell(), "inst-1")
+
+    def test_instance_scoped(self):
+        r = self._render()
+        assert "cw-storehours-inst-1" in r.html
+        assert "cw-storehours-inst-1" in r.css
+        assert "cw-storehours-status-inst-1" in r.init_js
+        assert "cw-storehours-body-inst-1" in r.init_js
+
+    def test_two_instances_dont_collide(self):
+        w = StoreHoursWidget()
+        cfg = StoreHoursWidgetConfig(**w.default_config())
+        a = w.render_html(cfg, _cell(), "aaa")
+        b = w.render_html(cfg, _cell(), "bbb")
+        assert "cw-storehours-aaa" in a.css
+        assert "cw-storehours-aaa" not in b.css
+        assert "cw-storehours-bbb" in b.css
+
+    def test_init_js_has_setinterval(self):
+        r = self._render()
+        assert "setInterval(render, 60000)" in r.init_js
+        assert "getElementById('cw-storehours-status-inst-1')" in r.init_js
+        assert "getElementById('cw-storehours-body-inst-1')" in r.init_js
+
+    def test_schedule_baked_as_getday_array(self):
+        # Default: Sun closed (index 0 == []), Mon 9-5 == [[540,1020]].
+        r = self._render()
+        assert "var SCHEDULE = [[],[[540,1020]]" in r.init_js
+
+    def test_holidays_baked_into_js(self):
+        r = self._render(
+            holidays=[HolidayOverride(date="12-25", label="Xmas", closed=True)]
+        )
+        assert '"12-25"' in r.init_js
+        assert '"Xmas"' in r.init_js
+        assert "closed:true" in r.init_js
+
+    def test_open_holiday_intervals_in_js(self):
+        r = self._render(
+            holidays=[
+                HolidayOverride(
+                    date="12-24",
+                    label="Eve",
+                    closed=False,
+                    intervals=[Interval(open="09:00", close="13:00")],
+                )
+            ]
+        )
+        assert "closed:false" in r.init_js
+        assert "intervals:[[540,780]]" in r.init_js
+
+    def test_display_mode_baked(self):
+        assert 'var MODE = "today"' in self._render(display_mode="today").init_js
+        assert 'var MODE = "week"' in self._render(display_mode="week").init_js
+
+    def test_show_status_flag(self):
+        assert "var SHOW_STATUS = true;" in self._render(show_status=True).init_js
+        assert "var SHOW_STATUS = false;" in self._render(show_status=False).init_js
+
+    def test_status_element_omitted_when_disabled(self):
+        on = self._render(show_status=True)
+        off = self._render(show_status=False)
+        assert "cw-storehours-status-inst-1" in on.html
+        assert 'id="cw-storehours-status-inst-1"' not in off.html
+
+    def test_time_format_flag(self):
+        assert "var FMT24 = true;" in self._render(time_format="24h").init_js
+        assert "var FMT24 = false;" in self._render(time_format="12h").init_js
+
+    def test_heading_html_escaped(self):
+        r = self._render(heading="<b>Hi & Bye</b>")
+        assert "<b>Hi & Bye</b>" not in r.html
+        assert "&lt;b&gt;Hi &amp; Bye&lt;/b&gt;" in r.html
+
+    def test_no_heading_when_empty(self):
+        assert "cw-storehours-inst-1-heading" not in self._render(heading="").html
+
+    def test_colors_in_css_and_js(self):
+        r = self._render(
+            color="#123456", open_color="#0a0b0c", closed_color="#fefefe"
+        )
+        assert "color: #123456;" in r.css
+        assert '"#0a0b0c"' in r.init_js
+        assert '"#fefefe"' in r.init_js
+
+    def test_size_and_font_in_css(self):
+        r = self._render(font_size_px=144, font_family="serif")
+        assert "font-size: 144px;" in r.css
+        assert "Georgia" in r.css
+        assert "ui-monospace" in self._render(font_family="mono").css
+
+    def test_no_static_assets(self):
+        r = self._render()
+        assert r.static_assets == []
+        assert r.referenced_asset_ids == []


### PR DESCRIPTION
## Store Hours widget

Config-driven weekly store-hours widget for composed slides. **Pure JS, no network fetch** — the schedule, holiday overrides, colors, and layout are baked into the widget config at author time. A per-minute `setInterval` re-evaluates the device-local clock to flip an Open/Closed badge and show a "Closes 7:00 PM" / "Opens Mon 9:00 AM" hint.

### Features
- Per-day **multi-interval** schedule (split/lunch hours); an empty day = closed
- **Holiday overrides**: one-off (`YYYY-MM-DD`) or recurring annual (`MM-DD`); either close the store or replace that day's intervals
- `display_mode` today/week, 12h/24h, configurable open/closed colors, font allowlist, font size
- Instance-scoped DOM IDs + CSS classes; no referenced assets
- Editor descriptor wired into the **Time & Date** palette category

### Tests
- 53 new unit tests (`tests/test_composed_store_hours_widget.py`) — all green locally

Part of #743 overnight widget backlog. **Dev only.**
