### PR TITLE
Fix RSS widget: sort-by-newest toggle + whitespace normalization

### DIFF
--- a/cms/composed/rss_proxy.py
+++ b/cms/composed/rss_proxy.py
@@ -43,6 +43,8 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from urllib.parse import urljoin, urlparse
 from xml.etree import ElementTree as ET
 
@@ -148,12 +150,63 @@ def clamp_item_count(raw: int | None) -> int:
     return max(1, min(_MAX_ITEM_COUNT, n))
 
 
-def parse_feed(body: bytes, *, count: int) -> list[dict[str, str]]:
+def _norm_ws(s: str) -> str:
+    """Collapse internal whitespace and strip the ends.
+
+    ``str.strip()`` only removes leading/trailing whitespace; some feeds
+    embed hard newlines or tab runs *inside* ``<title>`` text, which the
+    device renders as stray line breaks.  ``" ".join(s.split())`` collapses
+    every internal whitespace run to a single space.
+    """
+    return " ".join(s.split())
+
+
+def _parse_entry_date(value: str) -> datetime | None:
+    """Best-effort parse of a feed date string into an aware ``datetime``.
+
+    RSS ``pubDate`` is RFC 822; Atom ``published`` / ``updated`` and
+    Dublin Core ``date`` are ISO 8601.  Returns ``None`` when the value
+    can't be parsed so undated/garbage entries can be ordered last.
+    Naive datetimes are assumed UTC so every result is comparable.
+    """
+    raw = value.strip()
+    if not raw:
+        return None
+    dt: datetime | None = None
+    try:
+        dt = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        dt = None
+    if dt is None:
+        try:
+            dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def parse_feed(
+    body: bytes, *, count: int, sort_newest: bool = False
+) -> list[dict[str, str]]:
     """Parse RSS/Atom ``body`` into a list of ``{title, link, pubDate}``.
 
     Namespace-agnostic (works for RSS 2.0, RSS 1.0/RDF and Atom).  Items
     missing a title are skipped; ``link`` / ``pubDate`` are best-effort
     and omitted when absent.  Returns at most ``count`` entries.
+
+    Title and date text are whitespace-normalized (internal newlines /
+    tabs / runs of spaces collapsed to single spaces) so feeds that embed
+    hard line breaks in ``<title>`` don't render as stray line breaks on
+    the device.
+
+    When ``sort_newest`` is true, every entry is parsed first and the
+    result is ordered newest-first by parsed publication date (entries
+    with no parseable date keep their document order at the end); the
+    list is then truncated to ``count``.  When false (default), entries
+    are returned in document order and parsing stops early once ``count``
+    is reached.
     """
     try:
         root = ET.fromstring(body)
@@ -164,7 +217,7 @@ def parse_feed(body: bytes, *, count: int) -> list[dict[str, str]]:
         el for el in root.iter() if _localname(el.tag) in _ITEM_TAGS
     ]
 
-    out: list[dict[str, str]] = []
+    collected: list[tuple[dict[str, str], datetime | None]] = []
     for item in items:
         title: str | None = None
         link: str | None = None
@@ -172,14 +225,14 @@ def parse_feed(body: bytes, *, count: int) -> list[dict[str, str]]:
         for child in item:
             ln = _localname(child.tag)
             if title is None and ln in _TITLE_TAGS:
-                title = (child.text or "").strip() or None
+                title = _norm_ws(child.text or "") or None
             elif link is None and ln in _LINK_TAGS:
                 # RSS: link text. Atom: <link href="..."/> (prefer the
                 # alternate/href attribute, fall back to text).
                 href = child.get("href")
                 link = (href or (child.text or "").strip()) or None
             elif date is None and ln in _DATE_TAGS:
-                date = (child.text or "").strip() or None
+                date = _norm_ws(child.text or "") or None
         if not title:
             continue
         entry: dict[str, str] = {"title": title}
@@ -187,17 +240,35 @@ def parse_feed(body: bytes, *, count: int) -> list[dict[str, str]]:
             entry["link"] = link
         if date:
             entry["pubDate"] = date
-        out.append(entry)
-        if len(out) >= count:
+        collected.append((entry, _parse_entry_date(date) if date else None))
+        if not sort_newest and len(collected) >= count:
             break
-    return out
+
+    if sort_newest:
+        # Stable newest-first: dated entries by descending timestamp,
+        # undated entries last in their original document order.
+        ordered = sorted(
+            enumerate(collected),
+            key=lambda pair: (
+                0 if pair[1][1] is not None else 1,
+                -pair[1][1].timestamp() if pair[1][1] is not None else 0.0,
+                pair[0],
+            ),
+        )
+        collected = [entry_dt for _, entry_dt in ordered]
+
+    return [entry for entry, _ in collected[:count]]
 
 
-async def fetch_feed_items(url: str, *, count: int) -> list[dict[str, str]]:
+async def fetch_feed_items(
+    url: str, *, count: int, sort_newest: bool = False
+) -> list[dict[str, str]]:
     """Fetch ``url`` (SSRF-guarded) and return parsed feed items.
 
-    Raises :class:`RssProxyError` on any scheme/host/size/timeout/parse
-    failure with an HTTP status the caller can return verbatim.
+    ``sort_newest`` is threaded through to :func:`parse_feed` to order the
+    returned items newest-first.  Raises :class:`RssProxyError` on any
+    scheme/host/size/timeout/parse failure with an HTTP status the caller
+    can return verbatim.
     """
     headers = {"User-Agent": _USER_AGENT, "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.5"}
     current = url
@@ -225,7 +296,9 @@ async def fetch_feed_items(url: str, *, count: int) -> list[dict[str, str]]:
                         if total > _MAX_RESPONSE_BYTES:
                             raise RssProxyError(502, "Feed response is too large")
                         chunks.append(chunk)
-                    return parse_feed(b"".join(chunks), count=count)
+                    return parse_feed(
+                        b"".join(chunks), count=count, sort_newest=sort_newest
+                    )
             raise RssProxyError(502, "Feed had too many redirects")
     except httpx.TimeoutException as exc:
         raise RssProxyError(504, "Feed request timed out") from exc

--- a/cms/composed/widgets/rss.py
+++ b/cms/composed/widgets/rss.py
@@ -85,6 +85,7 @@ class RssWidgetConfig(BaseModel):
     feed_url: str = Field(default=_DEFAULT_FEED_URL, max_length=2048)
     heading: str = Field(default="", max_length=80)
     item_count: int = Field(default=5, ge=1, le=30)
+    sort_newest: bool = True
     show_dates: bool = False
     color: str = Field(default="#ffffff", pattern=_HEX)
     font_family: str = Field(default="sans")
@@ -193,14 +194,19 @@ refresh();
 """.strip()
 
 
-def _proxy_url(base: str | None, feed_url: str, count: int) -> str:
+def _proxy_url(
+    base: str | None, feed_url: str, count: int, *, newest: bool = True
+) -> str:
     """Build the CMS feed-proxy URL the device fetches at runtime.
 
     Absolute when ``base`` is set (real device bundle); relative
     same-origin otherwise (CMS preview / thumbnail render).
     """
     prefix = base.rstrip("/") if base else ""
-    return f"{prefix}/composed/rss?url={quote(feed_url, safe='')}&count={count}"
+    return (
+        f"{prefix}/composed/rss?url={quote(feed_url, safe='')}"
+        f"&count={count}&newest={1 if newest else 0}"
+    )
 
 
 def _build_rss_init_js(
@@ -242,6 +248,7 @@ class RssWidget(Widget):
             "feed_url": _DEFAULT_FEED_URL,
             "heading": "",
             "item_count": 5,
+            "sort_newest": True,
             "show_dates": False,
             "color": "#ffffff",
             "font_family": "sans",
@@ -330,11 +337,19 @@ class RssWidget(Widget):
         )
 
         base = ctx.cms_base_url if ctx else None
-        cfg_fp = f"{config.feed_url}|{config.item_count}"
+        cfg_fp = (
+            f"{config.feed_url}|{config.item_count}"
+            f"|{int(config.sort_newest)}"
+        )
         init_js = _build_rss_init_js(
             root_id=root_id,
             list_id=list_id,
-            url=_proxy_url(base, config.feed_url, config.item_count),
+            url=_proxy_url(
+                base,
+                config.feed_url,
+                config.item_count,
+                newest=config.sort_newest,
+            ),
             cfg_fp=cfg_fp,
             cache_key=f"cw-rss-{instance_id}",
             refresh_ms=config.refresh_seconds * 1000,

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -80,12 +80,17 @@ public_router = APIRouter(prefix="/composed", tags=["composed"])
 
 
 @public_router.get("/rss")
-async def rss_proxy(url: str, count: int | None = None) -> Any:
+async def rss_proxy(
+    url: str, count: int | None = None, newest: bool = True
+) -> Any:
     """Unauthenticated, SSRF-guarded RSS/Atom feed proxy (CORS-enabled).
 
     Fetches and parses ``url`` server-side and returns a small JSON
     projection the composed-slide RSS widget can read cross-origin. See
     ``cms.composed.rss_proxy`` for the threat model and guard.
+
+    ``newest`` (default true) orders the returned headlines newest-first;
+    pass ``newest=0`` to preserve the feed's own document order.
     """
     from fastapi.responses import JSONResponse
 
@@ -98,7 +103,7 @@ async def rss_proxy(url: str, count: int | None = None) -> Any:
     cors = {"Access-Control-Allow-Origin": "*", "Cache-Control": "no-store"}
     n = clamp_item_count(count)
     try:
-        items = await fetch_feed_items(url, count=n)
+        items = await fetch_feed_items(url, count=n, sort_newest=newest)
     except RssProxyError as exc:
         return JSONResponse(
             status_code=exc.status_code,

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -1202,7 +1202,7 @@ registerWidget("rss", {
     label: "RSS Headlines", icon: "📰", category: "Live Data",
     keywords: ["rss", "feed", "news", "headlines", "atom", "syndication"],
     defaults: () => ({feed_url:"https://feeds.bbci.co.uk/news/world/rss.xml", heading:"",
-             item_count:5, show_dates:false, color:"#ffffff", font_family:"sans",
+             item_count:5, sort_newest:true, show_dates:false, color:"#ffffff", font_family:"sans",
              font_size_px:32, refresh_seconds:900}),
     summary: (w) => (w.config.heading || "headlines").slice(0, 24),
     preview: (root, cfg) => {
@@ -1262,6 +1262,10 @@ registerWidget("rss", {
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,256))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem;">
+                <input type="checkbox" ${w.config.sort_newest!==false?"checked":""}
+                    oninput="updateSelected(x=>x.config.sort_newest=this.checked)"> Sort by newest
+            </label>
             <label style="font-weight:400; margin-top:0.5rem;">
                 <input type="checkbox" ${w.config.show_dates?"checked":""}
                     oninput="updateSelected(x=>x.config.show_dates=this.checked)"> Show dates

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -525,6 +525,9 @@ paths:
         Fetches and parses ``url`` server-side and returns a small JSON
         projection the composed-slide RSS widget can read cross-origin. See
         ``cms.composed.rss_proxy`` for the threat model and guard.
+
+        ``newest`` (default true) orders the returned headlines newest-first;
+        pass ``newest=0`` to preserve the feed's own document order.
       operationId: rss_proxy_composed_rss_get
       parameters:
       - name: url
@@ -541,6 +544,13 @@ paths:
           - type: integer
           - type: 'null'
           title: Count
+      - name: newest
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: true
+          title: Newest
       responses:
         '200':
           description: Successful Response

--- a/tests/test_composed_rss_proxy.py
+++ b/tests/test_composed_rss_proxy.py
@@ -121,6 +121,77 @@ class TestParseFeedErrors:
         assert parse_feed(body, count=10) == []
 
 
+class TestParseFeedSortNewest:
+    SORTABLE = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Older</title>
+      <link>https://example.com/old</link>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Newer</title>
+      <link>https://example.com/new</link>
+      <pubDate>Wed, 03 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Middle</title>
+      <link>https://example.com/mid</link>
+      <pubDate>Tue, 02 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+
+    def test_default_preserves_document_order(self):
+        items = parse_feed(self.SORTABLE, count=10)
+        assert [i["title"] for i in items] == ["Older", "Newer", "Middle"]
+
+    def test_sort_newest_orders_by_date(self):
+        items = parse_feed(self.SORTABLE, count=10, sort_newest=True)
+        assert [i["title"] for i in items] == ["Newer", "Middle", "Older"]
+
+    def test_sort_newest_truncates_after_sorting(self):
+        items = parse_feed(self.SORTABLE, count=1, sort_newest=True)
+        assert len(items) == 1
+        assert items[0]["title"] == "Newer"
+
+    def test_undated_items_sort_last_in_doc_order(self):
+        body = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item><title>No date A</title><link>https://example.com/a</link></item>
+    <item>
+      <title>Dated</title><link>https://example.com/d</link>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+    <item><title>No date B</title><link>https://example.com/b</link></item>
+  </channel>
+</rss>
+"""
+        items = parse_feed(body, count=10, sort_newest=True)
+        assert [i["title"] for i in items] == ["Dated", "No date A", "No date B"]
+
+
+class TestParseFeedWhitespace:
+    def test_internal_newlines_collapsed_in_title(self):
+        body = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Breaking:
+      multi   line
+      headline</title>
+      <link>https://example.com/1</link>
+    </item>
+  </channel>
+</rss>
+"""
+        items = parse_feed(body, count=10)
+        assert items[0]["title"] == "Breaking: multi line headline"
+
+
 class TestValidateTargetScheme:
     def test_rejects_ftp(self):
         with pytest.raises(RssProxyError) as exc:
@@ -185,7 +256,7 @@ class TestValidateTargetSsrfResolution:
 @pytest.mark.asyncio
 class TestRssProxyRoute:
     async def test_returns_items_with_cors(self, unauthed_client, monkeypatch):
-        async def fake_fetch(url, *, count):
+        async def fake_fetch(url, *, count, sort_newest=True):
             return [{"title": "Hello", "link": "https://example.com/1"}]
 
         monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
@@ -198,7 +269,7 @@ class TestRssProxyRoute:
         assert resp.json() == {"items": [{"title": "Hello", "link": "https://example.com/1"}]}
 
     async def test_error_returns_status_and_message(self, unauthed_client, monkeypatch):
-        async def fake_fetch(url, *, count):
+        async def fake_fetch(url, *, count, sort_newest=True):
             raise RssProxyError(400, "Feed host is not allowed")
 
         monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
@@ -212,7 +283,7 @@ class TestRssProxyRoute:
     async def test_count_is_clamped_before_fetch(self, unauthed_client, monkeypatch):
         seen = {}
 
-        async def fake_fetch(url, *, count):
+        async def fake_fetch(url, *, count, sort_newest=True):
             seen["count"] = count
             return []
 
@@ -224,8 +295,40 @@ class TestRssProxyRoute:
         assert resp.status_code == 200
         assert seen["count"] == 30
 
+    async def test_newest_defaults_true_and_passes_through(
+        self, unauthed_client, monkeypatch
+    ):
+        seen = {}
+
+        async def fake_fetch(url, *, count, sort_newest=True):
+            seen["sort_newest"] = sort_newest
+            return []
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss",
+            params={"url": "https://example.com/feed.xml"},
+        )
+        assert resp.status_code == 200
+        assert seen["sort_newest"] is True
+
+    async def test_newest_zero_disables_sort(self, unauthed_client, monkeypatch):
+        seen = {}
+
+        async def fake_fetch(url, *, count, sort_newest=True):
+            seen["sort_newest"] = sort_newest
+            return []
+
+        monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)
+        resp = await unauthed_client.get(
+            "/composed/rss",
+            params={"url": "https://example.com/feed.xml", "newest": 0},
+        )
+        assert resp.status_code == 200
+        assert seen["sort_newest"] is False
+
     async def test_route_requires_no_auth(self, unauthed_client, monkeypatch):
-        async def fake_fetch(url, *, count):
+        async def fake_fetch(url, *, count, sort_newest=True):
             return []
 
         monkeypatch.setattr(rss_proxy, "fetch_feed_items", fake_fetch)

--- a/tests/test_composed_rss_widget.py
+++ b/tests/test_composed_rss_widget.py
@@ -26,6 +26,7 @@ class TestRssWidgetConfig:
         assert c.feed_url == _DEFAULT_FEED_URL
         assert c.heading == ""
         assert c.item_count == 5
+        assert c.sort_newest is True
         assert c.show_dates is False
         assert c.color == "#ffffff"
         assert c.font_family == "sans"
@@ -120,7 +121,16 @@ class TestProxyUrl:
         assert url.startswith("https://cms.example.org/composed/rss?url=")
         # feed url must be percent-encoded (no raw scheme separators).
         assert "https%3A%2F%2Ffeed.test%2Fx.xml" in url
-        assert url.endswith("&count=5")
+        assert "&count=5" in url
+        assert url.endswith("&newest=1")
+
+    def test_newest_flag_reflected(self):
+        on = _proxy_url("https://cms.example.org", "https://feed.test/x.xml", 5)
+        off = _proxy_url(
+            "https://cms.example.org", "https://feed.test/x.xml", 5, newest=False
+        )
+        assert on.endswith("&newest=1")
+        assert off.endswith("&newest=0")
 
     def test_relative_when_base_none(self):
         url = _proxy_url(None, "https://feed.test/x.xml", 3)


### PR DESCRIPTION
## RSS widget: sort-by-newest + whitespace fix

Follow-up to the RSS headlines widget (#753). User reported the feed "never updates," even in preview.

**Diagnosis:** not a bug — feeds like BBC order headlines editorially (not by recency) and refresh ~15 min, so the top-N projection looks frozen.

**Changes:**
1. **Sort by newest** (default ON) — new per-widget toggle. Backend parses all entries' dates (RFC822 + ISO8601), stable-sorts newest-first (undated items last in doc order), then truncates to `item_count`. Surfaces as `newest` query param on `/composed/rss`.
2. **Whitespace normalization** — multi-line source titles were rendering with literal newlines on-device (the preview hid them via `white-space:normal`). `_norm_ws` collapses internal whitespace server-side.

Editor gains a "Sort by newest" checkbox next to "Show dates". `docs/openapi.yaml` regenerated for the new param. Targeted tests green (64 passed).

**Dev only** — not for prod.
