### PR TITLE
Fix worker transcode crash: use stdlib html.escape in widgets

### DIFF
--- a/cms/composed/widgets/countdown.py
+++ b/cms/composed/widgets/countdown.py
@@ -26,11 +26,11 @@ DOM ID + CSS class is suffixed with the widget instance UUID.
 
 from __future__ import annotations
 
+import html
 import json
 from datetime import datetime
 from typing import ClassVar, Literal
 
-from markupsafe import escape
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
@@ -225,7 +225,7 @@ class CountdownWidget(Widget):
         font_stack = _FONT_STACKS[config.font_family]
 
         label_html = (
-            f'<div class="{css_class}-label">{escape(config.label)}</div>'
+            f'<div class="{css_class}-label">{html.escape(config.label)}</div>'
             if config.label
             else ""
         )

--- a/cms/composed/widgets/datebanner.py
+++ b/cms/composed/widgets/datebanner.py
@@ -13,10 +13,10 @@ collide.
 
 from __future__ import annotations
 
+import html
 import json
 from typing import ClassVar, Literal
 
-from markupsafe import escape
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
@@ -148,7 +148,7 @@ class DateBannerWidget(Widget):
         # not blank for the split second before init_js runs, and so a
         # JS-less snapshot still shows something sensible.  The runtime
         # immediately overwrites it with the live, locale-formatted date.
-        placeholder = escape(
+        placeholder = html.escape(
             f"{config.prefix} \u2026" if config.prefix else "\u2026"
         )
         html_out = (

--- a/cms/composed/widgets/store_hours.py
+++ b/cms/composed/widgets/store_hours.py
@@ -26,10 +26,10 @@ instance UUID so two store-hours widgets in the same bundle don't collide.
 
 from __future__ import annotations
 
+import html
 import json
 from typing import ClassVar, Literal
 
-from markupsafe import escape
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
@@ -444,7 +444,7 @@ class StoreHoursWidget(Widget):
         heading_html = ""
         if config.heading:
             heading_html = (
-                f'<div class="{css_class}-heading">{escape(config.heading)}</div>'
+                f'<div class="{css_class}-heading">{html.escape(config.heading)}</div>'
             )
         status_html = ""
         if config.show_status:

--- a/tests/test_widget_worker_dependencies.py
+++ b/tests/test_widget_worker_dependencies.py
@@ -1,0 +1,125 @@
+"""Guard: composed-slide widgets may only import worker-available deps.
+
+THE BUG THIS CATCHES
+--------------------
+Composed-slide widgets (``cms/composed/widgets/*.py``) are executed in
+**two** images with **different** dependency sets:
+
+* the **CMS** image installs ``requirements.txt`` (FastAPI, Jinja2, …),
+* the **worker** image installs only ``requirements-shared.txt`` +
+  Playwright (it renders Chromium thumbnails of every slide).
+
+A widget that imports a package present in the CMS image but *not* in
+``requirements-shared.txt`` works fine in the CMS (and in this test
+suite, which runs with the full CMS deps) yet blows up at transcode
+time in the worker with ``ModuleNotFoundError: No module named '…'``.
+
+That is exactly what happened with ``markupsafe`` (a transitive dep of
+Jinja2, so present in the CMS but never declared for the worker): three
+widgets did ``from markupsafe import escape`` and silently broke worker
+transcode for any slide containing them.
+
+A plain "import every widget" smoke test does **not** catch this,
+because the test environment has the CMS deps installed too. So this
+test is deliberately a **static AST scan** — it never imports the
+modules and never depends on what happens to be installed. It asserts
+each widget's top-level imports resolve to either the standard library,
+a first-party package, or a third-party package that is declared in
+``requirements-shared.txt`` (and therefore guaranteed in the worker).
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+WIDGETS_DIR = Path(__file__).resolve().parent.parent / "cms" / "composed" / "widgets"
+
+# First-party top-level packages (always importable in both images).
+_FIRST_PARTY = {"cms", "shared", "worker"}
+
+# Third-party packages that requirements-shared.txt installs, expressed
+# as their *import* root names (NOT their pip distribution names). Keep
+# this in sync with requirements-shared.txt:
+#
+#   pydantic>=…              -> pydantic
+#   pydantic-settings>=…     -> pydantic_settings
+#   sqlalchemy[asyncio]>=…   -> sqlalchemy
+#   asyncpg>=…               -> asyncpg
+#   httpx>=…                 -> httpx
+#   azure-storage-blob>=…    -> azure
+#   aiohttp>=…               -> aiohttp
+#   segno>=…                 -> segno
+#
+# A widget importing anything outside this set + the stdlib + first-party
+# is a worker-transcode failure waiting to happen.
+_WORKER_SHARED = {
+    "pydantic",
+    "pydantic_settings",
+    "sqlalchemy",
+    "asyncpg",
+    "httpx",
+    "azure",
+    "aiohttp",
+    "segno",
+}
+
+_ALLOWED_ROOTS = sys.stdlib_module_names | _FIRST_PARTY | _WORKER_SHARED
+
+
+def _import_roots(tree: ast.AST) -> set[str]:
+    """Top-level import root names used by a module (absolute imports)."""
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            # Relative imports (level > 0) are first-party by definition;
+            # node.module is None for ``from . import x``.
+            if node.level == 0 and node.module:
+                roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+def _widget_files() -> list[Path]:
+    return sorted(
+        p
+        for p in WIDGETS_DIR.glob("*.py")
+        if p.name != "__init__.py"
+    )
+
+
+def test_widgets_directory_is_discovered():
+    # Sanity: if the path ever moves, fail loudly rather than vacuously
+    # passing because the glob matched nothing.
+    files = _widget_files()
+    assert files, f"no widget modules found under {WIDGETS_DIR}"
+
+
+def test_widgets_only_import_worker_available_dependencies():
+    violations: dict[str, set[str]] = {}
+    for path in _widget_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        bad = {
+            root
+            for root in _import_roots(tree)
+            if root not in _ALLOWED_ROOTS
+        }
+        if bad:
+            violations[path.name] = bad
+
+    assert not violations, (
+        "Widget(s) import packages that are NOT guaranteed in the worker "
+        "image (requirements-shared.txt). These will raise "
+        "ModuleNotFoundError during worker transcode even though the CMS "
+        "and this test suite have them installed transitively:\n"
+        + "\n".join(
+            f"  - {name}: {', '.join(sorted(roots))}"
+            for name, roots in sorted(violations.items())
+        )
+        + "\n\nFix: use a stdlib equivalent (e.g. html.escape instead of "
+        "markupsafe.escape), or add the package to requirements-shared.txt "
+        "AND to _WORKER_SHARED in this test."
+    )


### PR DESCRIPTION
## Problem
A composed-slide transcode failed with `No module named 'markupsafe'`.

Three widgets (`countdown`, `datebanner`, `store_hours`) did
`from markupsafe import escape`. `markupsafe` is only a **transitive**
dependency of Jinja2, which lives in the CMS-only `requirements.txt`. The
**worker** image installs `requirements-shared.txt` + Playwright only, so it
has no markupsafe. Widget `render_html` runs in the worker during thumbnail
transcode, so every slide using these widgets crashed there. The CMS (and the
test suite) have markupsafe transitively, which is why it went unnoticed.

## Fix
- Replace `markupsafe.escape` with stdlib `html.escape` in the 3 widgets
  (functionally equivalent for escaping element text). No new dependency.

## Test guard (the real ask)
- New `tests/test_widget_worker_dependencies.py`: a **static AST** scan of
  `cms/composed/widgets/*.py` that fails if any widget imports a package
  outside (stdlib ∪ first-party ∪ `requirements-shared.txt`). It does **not**
  import the widgets, so it catches the bug regardless of what is installed in
  the test env. Verified it fails on an injected `import markupsafe` and
  passes on this fix.

## Validation
- `test_widget_worker_dependencies.py` + countdown/datebanner/store_hours
  widget tests: 105 passed locally.

Dev-only; one fix per PR.