### PR TITLE
Wire transcode worker to App Insights (issue #474)

### DIFF
--- a/cms/main.py
+++ b/cms/main.py
@@ -55,8 +55,8 @@ logging.getLogger().addHandler(_buf_handler)
 # Must run BEFORE the FastAPI app is constructed so the auto-
 # instrumentation can hook the framework at import time.  No-op when
 # APPLICATIONINSIGHTS_CONNECTION_STRING is unset — see
-# cms/observability.py.  Issue #474, Phase 0 / A1.
-from cms.observability import setup_observability  # noqa: E402
+# shared/observability.py.  Issue #474, Phase 0 / A1.
+from shared.observability import setup_observability  # noqa: E402
 
 setup_observability()
 

--- a/cms/metrics.py
+++ b/cms/metrics.py
@@ -14,7 +14,7 @@ benefits:
 Runtime behaviour:
 
 * When ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is set and
-  :func:`cms.observability.setup_observability` has run, the OTel SDK
+  :func:`shared.observability.setup_observability` has run, the OTel SDK
   installed by ``azure-monitor-opentelemetry`` becomes the global
   ``MeterProvider`` and these counters export to App Insights as
   custom metrics.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,8 +6,10 @@ Issue [#474](../../../issues/474) — Phase 0 (A1 + A1.5).
 
 The CMS app is auto-instrumented at process start by the
 [`azure-monitor-opentelemetry`](https://pypi.org/project/azure-monitor-opentelemetry/)
-distro.  See `cms/observability.py` for the bootstrap; it runs from
-`cms/main.py` before the FastAPI app is constructed.
+distro.  See `shared/observability.py` for the bootstrap; it runs from
+`cms/main.py` before the FastAPI app is constructed, and from
+`worker/__main__.py` (as `setup_observability(role_name="agora-worker")`)
+so transcode-worker exceptions also reach the `exceptions` table.
 
 Auto-instrumentations active:
 

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -313,7 +313,7 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               // Picked up by azure-monitor-opentelemetry's
               // configure_azure_monitor() at process start (see
-              // cms/observability.py).  When unset (e.g. local dev,
+              // shared/observability.py).  When unset (e.g. local dev,
               // docker-compose) telemetry export is silently disabled.
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               secretRef: 'app-insights-connection-string'

--- a/requirements-shared.txt
+++ b/requirements-shared.txt
@@ -19,3 +19,14 @@ aiohttp>=3.9,<4.0
 # thumbnail render) execute the widget's render_html, so segno must be
 # present in both images.
 segno>=1.6,<2.0
+
+# Telemetry — Application Insights via OpenTelemetry (issue #474).
+# Meta-package that pulls in opentelemetry-api/sdk + the Azure Monitor
+# exporter.  A no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset
+# (see shared/observability.py).  Both the CMS and the worker call
+# setup_observability() so worker transcode failures reach the App
+# Insights exceptions table, and so the worker can emit the
+# agora.transcode.failure OTel counter (shared/metrics.py).  Duplicated
+# from requirements.txt (CMS image installs requirements.txt only, not
+# the shared file) — keep the version pins in sync.
+azure-monitor-opentelemetry>=1.6,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ azure-messaging-webpubsubservice>=1.2,<2.0
 # Meta-package that pulls in opentelemetry-api/sdk + the Azure Monitor exporter
 # + auto-instrumentations for FastAPI, SQLAlchemy, HTTPX, urllib3, requests.
 # A no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset — see
-# cms/observability.py for the wiring.
+# shared/observability.py for the wiring.
 azure-monitor-opentelemetry>=1.6,<2.0
 
 # Azure OpenAI client for the Assistant feature (issue #5xx).

--- a/shared/observability.py
+++ b/shared/observability.py
@@ -1,4 +1,4 @@
-"""Application Insights / OpenTelemetry bootstrap for the CMS.
+"""Application Insights / OpenTelemetry bootstrap for the CMS and worker.
 
 Issue #474, Phase 0 / A1 — telemetry roadmap.
 
@@ -11,12 +11,22 @@ auto-instrumentation for:
 * HTTPX / requests / urllib3 (``dependencies`` rows for outbound HTTP)
 
 Unhandled exceptions raised inside instrumented frames are also captured
-into the ``exceptions`` table.
+into the ``exceptions`` table.  This is the whole point of also wiring the
+**transcode worker** up to this bootstrap: a transcode failure (a missing
+module, a render crash, a timeout) raised in the worker now surfaces in the
+App Insights ``exceptions`` table and trips the fleet exception alert,
+instead of dying silently in container stdout.
+
+Pass ``role_name`` to set the ``cloud_RoleName`` dimension (via
+``OTEL_SERVICE_NAME``) so CMS and worker telemetry are distinguishable in
+Application Insights — e.g. the worker passes ``"agora-worker"``.  When
+omitted the azure-monitor default role name is used (the CMS keeps its
+existing default so dashboards / alerts that key on it are unaffected).
 
 The function is a **no-op** when ``APPLICATIONINSIGHTS_CONNECTION_STRING``
 is unset — that's the expected state for local development, docker-compose
 runs, and the unit-test suite.  This means we can call it unconditionally
-from ``cms.main`` without breaking anything.
+from ``cms.main`` (and ``worker.__main__``) without breaking anything.
 
 It is also safe to call multiple times in the same process: the underlying
 ``configure_azure_monitor`` short-circuits on the second invocation.
@@ -28,10 +38,16 @@ import logging
 import os
 from typing import Final
 
-logger = logging.getLogger("agora.cms.observability")
+logger = logging.getLogger("agora.observability")
 
 _CONN_STRING_ENV: Final[str] = "APPLICATIONINSIGHTS_CONNECTION_STRING"
-_DISABLE_ENV: Final[str] = "AGORA_CMS_DISABLE_OBSERVABILITY"
+# Honour both the historical CMS-specific kill switch and a process-neutral
+# one so the worker can be silenced independently if ever needed.
+_DISABLE_ENVS: Final[tuple[str, ...]] = (
+    "AGORA_DISABLE_OBSERVABILITY",
+    "AGORA_CMS_DISABLE_OBSERVABILITY",
+)
+_ROLE_NAME_ENV: Final[str] = "OTEL_SERVICE_NAME"
 
 # Process-level flag so repeated calls don't double-initialize the
 # OpenTelemetry exporter.  ``configure_azure_monitor`` itself is
@@ -39,8 +55,12 @@ _DISABLE_ENV: Final[str] = "AGORA_CMS_DISABLE_OBSERVABILITY"
 _initialised: bool = False
 
 
-def setup_observability() -> bool:
+def setup_observability(role_name: str | None = None) -> bool:
     """Initialise Application Insights / OpenTelemetry export.
+
+    ``role_name`` sets the ``cloud_RoleName`` telemetry dimension so each
+    process (``agora-cms`` vs ``agora-worker``) is distinguishable in
+    Application Insights.  When ``None`` the azure-monitor default is used.
 
     Returns ``True`` when telemetry export was enabled (connection string
     present and SDK loaded successfully), ``False`` otherwise.  Callers
@@ -51,10 +71,18 @@ def setup_observability() -> bool:
     if _initialised:
         return True
 
-    if os.environ.get(_DISABLE_ENV, "").lower() in {"1", "true", "yes"}:
+    disabled_via = next(
+        (
+            env
+            for env in _DISABLE_ENVS
+            if os.environ.get(env, "").lower() in {"1", "true", "yes"}
+        ),
+        None,
+    )
+    if disabled_via is not None:
         logger.info(
             "observability disabled via %s; skipping App Insights init",
-            _DISABLE_ENV,
+            disabled_via,
         )
         return False
 
@@ -83,19 +111,24 @@ def setup_observability() -> bool:
         return False
 
     try:
+        if role_name:
+            # azure-monitor reads the cloud_RoleName from OTEL_SERVICE_NAME.
+            # setdefault so an explicit env override (deploy-time) still wins.
+            os.environ.setdefault(_ROLE_NAME_ENV, role_name)
         configure_azure_monitor(connection_string=conn)
     except Exception:  # pragma: no cover — defensive: never let a
-        # telemetry init failure crash the CMS process
+        # telemetry init failure crash the process
         logger.exception(
-            "configure_azure_monitor() failed; CMS will continue without "
+            "configure_azure_monitor() failed; process will continue without "
             "telemetry export"
         )
         return False
 
     _initialised = True
     logger.info(
-        "App Insights observability enabled (FastAPI / SQLAlchemy / "
-        "HTTPX auto-instrumentation active)"
+        "App Insights observability enabled (role=%s; FastAPI / SQLAlchemy / "
+        "HTTPX auto-instrumentation active)",
+        os.environ.get(_ROLE_NAME_ENV) or "default",
     )
     return True
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,4 +1,4 @@
-"""Tests for cms.observability — App Insights bootstrap wrapper.
+"""Tests for shared.observability — App Insights bootstrap wrapper.
 
 Issue #474, Phase 0 / A1.
 
@@ -10,13 +10,14 @@ the wrapper's lazy import resolves to a controllable mock.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import types
 from unittest import mock
 
 import pytest
 
-from cms import observability
+from shared import observability
 
 
 def _install_fake_azure_monitor(
@@ -49,13 +50,15 @@ def _reset_module_state(monkeypatch: pytest.MonkeyPatch):
     """Clear the conn string env var and reset the init flag for each test."""
     monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
     monkeypatch.delenv("AGORA_CMS_DISABLE_OBSERVABILITY", raising=False)
+    monkeypatch.delenv("AGORA_DISABLE_OBSERVABILITY", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
     observability._reset_for_tests()
     yield
     observability._reset_for_tests()
 
 
 def test_no_op_when_conn_string_unset(caplog: pytest.LogCaptureFixture) -> None:
-    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+    caplog.set_level(logging.INFO, logger="agora.observability")
 
     result = observability.setup_observability()
 
@@ -82,7 +85,7 @@ def test_disable_env_var_short_circuits(
         "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
     )
     monkeypatch.setenv("AGORA_CMS_DISABLE_OBSERVABILITY", "1")
-    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+    caplog.set_level(logging.INFO, logger="agora.observability")
     mocked = _install_fake_azure_monitor(monkeypatch)
 
     result = observability.setup_observability()
@@ -99,7 +102,7 @@ def test_calls_configure_azure_monitor_when_conn_set(
 ) -> None:
     conn = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example/"
     monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", conn)
-    caplog.set_level(logging.INFO, logger="agora.cms.observability")
+    caplog.set_level(logging.INFO, logger="agora.observability")
     mocked = _install_fake_azure_monitor(monkeypatch)
 
     result = observability.setup_observability()
@@ -109,6 +112,51 @@ def test_calls_configure_azure_monitor_when_conn_set(
     assert any(
         "enabled" in rec.message for rec in caplog.records
     )
+
+
+def test_role_name_sets_otel_service_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """role_name must populate cloud_RoleName via OTEL_SERVICE_NAME."""
+    conn = "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", conn)
+    mocked = _install_fake_azure_monitor(monkeypatch)
+
+    result = observability.setup_observability(role_name="agora-worker")
+
+    assert result is True
+    mocked.assert_called_once_with(connection_string=conn)
+    assert os.environ.get("OTEL_SERVICE_NAME") == "agora-worker"
+
+
+def test_role_name_does_not_override_explicit_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit OTEL_SERVICE_NAME (deploy-time) wins over role_name."""
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "preset-role")
+    _install_fake_azure_monitor(monkeypatch)
+
+    assert observability.setup_observability(role_name="agora-worker") is True
+    assert os.environ.get("OTEL_SERVICE_NAME") == "preset-role"
+
+
+def test_neutral_disable_env_var_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The process-neutral kill switch also beats a present conn string."""
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
+    )
+    monkeypatch.setenv("AGORA_DISABLE_OBSERVABILITY", "true")
+    mocked = _install_fake_azure_monitor(monkeypatch)
+
+    assert observability.setup_observability() is False
+    mocked.assert_not_called()
 
 
 def test_idempotent_repeated_calls_only_init_once(
@@ -135,7 +183,7 @@ def test_missing_sdk_does_not_crash(
         "APPLICATIONINSIGHTS_CONNECTION_STRING",
         "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
     )
-    caplog.set_level(logging.WARNING, logger="agora.cms.observability")
+    caplog.set_level(logging.WARNING, logger="agora.observability")
 
     # Make sure the module is NOT in sys.modules — and block re-import.
     for name in (

--- a/tests/test_worker_observability_wiring.py
+++ b/tests/test_worker_observability_wiring.py
@@ -1,0 +1,84 @@
+"""Regression guard: the transcode worker MUST wire up Application
+Insights / OpenTelemetry at startup.
+
+Background (issue #474): ``setup_observability()`` is what hands the
+process to ``azure-monitor-opentelemetry`` so unhandled exceptions are
+exported to the App Insights ``exceptions`` table.  The CMS process
+calls it from ``cms/main.py``; for a long time the **worker** never
+did, so transcode failures (e.g. the ``markupsafe`` worker-import bug)
+died silently in worker stdout and never surfaced in telemetry.
+
+This test enforces the invariant by static analysis so it can't be
+re-broken by a refactor that drops the call:
+
+* ``worker/__main__.py`` imports ``setup_observability`` from
+  ``shared.observability`` (NOT ``cms.observability`` — the worker
+  image cannot import ``cms.*``).
+* ``async def main()`` invokes ``setup_observability(...)`` as its
+  FIRST statement, passing ``role_name="agora-worker"`` so worker
+  exceptions are tagged with a distinct ``cloud_RoleName``.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_WORKER_MAIN = Path(__file__).resolve().parent.parent / "worker" / "__main__.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(_WORKER_MAIN.read_text(encoding="utf-8"))
+
+
+def test_worker_imports_setup_observability_from_shared() -> None:
+    tree = _module()
+    imported_from_shared = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "shared.observability"
+        and any(alias.name == "setup_observability" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert imported_from_shared, (
+        "worker/__main__.py must import setup_observability from "
+        "shared.observability (the worker image cannot import cms.*)"
+    )
+    # Guard against accidentally importing it from cms.* (unimportable
+    # in the worker image and would crash at startup).
+    cms_import = any(
+        isinstance(node, ast.ImportFrom)
+        and (node.module or "").startswith("cms.")
+        and any(alias.name == "setup_observability" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert not cms_import, "setup_observability must not be imported from cms.*"
+
+
+def test_main_calls_setup_observability_first_with_worker_role() -> None:
+    tree = _module()
+    main_fn = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "main"
+        ),
+        None,
+    )
+    assert main_fn is not None, "worker/__main__.py must define `async def main()`"
+
+    # First *statement* of main() must be the setup_observability call.
+    first_stmt = main_fn.body[0]
+    assert isinstance(first_stmt, ast.Expr) and isinstance(
+        first_stmt.value, ast.Call
+    ), "setup_observability(...) must be the first statement in main()"
+
+    call = first_stmt.value
+    assert (
+        isinstance(call.func, ast.Name) and call.func.id == "setup_observability"
+    ), "first statement of main() must call setup_observability(...)"
+
+    role = next(
+        (kw.value for kw in call.keywords if kw.arg == "role_name"), None
+    )
+    assert (
+        isinstance(role, ast.Constant) and role.value == "agora-worker"
+    ), 'worker must call setup_observability(role_name="agora-worker")'

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -23,6 +23,7 @@ from shared.models import AssetVariant, VariantStatus
 
 from shared.config import SharedSettings
 from shared.database import init_db, get_session_factory, dispose_db
+from shared.observability import setup_observability
 from shared.services.storage import (
     AzureStorageBackend,
     LocalStorageBackend,
@@ -713,6 +714,11 @@ async def _wait_for_schema(max_retries: int = 30, delay: float = 2.0) -> None:
 
 
 async def main() -> None:
+    # Wire Application Insights / OpenTelemetry first so any exception
+    # raised during startup or transcoding reaches the App Insights
+    # exceptions table (issue #474).  No-op without a connection string.
+    setup_observability(role_name="agora-worker")
+
     settings = WorkerSettings()
     init_db(settings)
 


### PR DESCRIPTION
## What

Wire the **transcode worker** process to Application Insights so its
exceptions are exported. Part of the telemetry roadmap (issue #474).

## Why

`setup_observability()` (the `azure-monitor-opentelemetry` bootstrap
that auto-instruments unhandled exceptions into the App Insights
`exceptions` table) was only ever called from `cms/main.py`. The
**worker never called it**, so transcode failures — like the recent
`markupsafe` worker-import bug (#758) — died silently in worker stdout
and never showed up in telemetry. The only way we caught that one was a
user noticing a broken transcode.

## How

- **Move** `cms/observability.py` → `shared/observability.py`. The
  worker image can import `shared.*` but never `cms.*`, so the
  bootstrap had to live in `shared/` to be reused.
- Add a `role_name` parameter. The worker calls
  `setup_observability(role_name="agora-worker")`, which sets
  `OTEL_SERVICE_NAME` (→ `cloud_RoleName`) via `setdefault` so a
  deploy-time explicit override still wins. **CMS calls it argless**, so
  its default role name is unchanged — zero impact on existing
  dashboards/alerts.
- Worker calls it as the **first statement** of `main()`.
- Add `azure-monitor-opentelemetry>=1.6,<2.0` to
  `requirements-shared.txt` (affects **only the worker image**; CMS
  already pins it in `requirements.txt`).
- Add a neutral `AGORA_DISABLE_OBSERVABILITY` kill switch (keeps
  `AGORA_CMS_DISABLE_OBSERVABILITY` for back-compat).

## Safety

- **No-op without `APPLICATIONINSIGHTS_CONNECTION_STRING`** — local/dev
  and tests are unaffected.
- Telemetry init is wrapped so a failure never crashes the worker.
- **Dev-only.** Not deploying to prod.

## Tests

- `role_name` → `OTEL_SERVICE_NAME` behavior + explicit-override wins.
- Neutral disable env short-circuits.
- New AST guard (`tests/test_worker_observability_wiring.py`) pins that
  the worker imports the bootstrap from `shared.observability` (not
  `cms.*`) and calls `setup_observability(role_name="agora-worker")`
  as the first statement of `main()`.

Follow-up (PR B, Layer 2): a `transcode.failure`-by-reason OTel counter.
