### PR TITLE
feat(worker): emit transcode.failure-by-reason OTel counter (#474)

### DIFF
--- a/shared/metrics.py
+++ b/shared/metrics.py
@@ -1,0 +1,104 @@
+"""Custom OpenTelemetry metric registry for the Agora **worker**.
+
+Issue #474 — transcode-failure telemetry, Layer 2.
+
+This is the worker-side analogue of :mod:`cms.metrics`.  It lives in
+``shared/`` (not ``cms/``) because the worker image imports only
+``worker.*`` / ``shared.*`` and never ``cms.*``.  Keeping the worker's
+metric handles here means call sites carry no metric-name string
+literals — a typo becomes an ``AttributeError`` at import time rather
+than a silently-wrong series nobody notices.
+
+Runtime behaviour mirrors :mod:`cms.metrics`:
+
+* When ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is set and
+  :func:`shared.observability.setup_observability` has run (the worker
+  calls it as the first statement of ``main()``), the OTel SDK
+  installed by ``azure-monitor-opentelemetry`` is the global
+  ``MeterProvider`` and these counters export to App Insights as
+  custom metrics.
+* Otherwise OTel's default no-op ``MeterProvider`` is in effect and
+  ``Counter.add(...)`` is a cheap no-op — no call site needs to gate
+  on "is telemetry enabled?".
+
+The ``opentelemetry`` API package is a transitive dependency of
+``azure-monitor-opentelemetry``, which ``requirements-shared.txt`` pins
+(so it lands in the worker image), so the import below is always
+available in any supported worker install profile.
+
+Naming convention
+-----------------
+
+``agora.<subsystem>.<event>`` for counters; bounded, low-cardinality
+attribute keys carry the dimensions.  See the constants below for the
+bounded value sets.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from opentelemetry import metrics
+
+_meter = metrics.get_meter("agora.worker")
+
+
+# ----------------------------------------------------------------------
+# Transcode / job failures (worker/__main__.py dispatch)
+# ----------------------------------------------------------------------
+#
+# This counter is the durable, queryable signal for "transcodes are
+# failing" that the silent markupsafe worker-import bug (#758) lacked:
+# that failure threw on every attempt but only ever surfaced in worker
+# stdout.  Now each failed dispatch increments this counter with a
+# bounded ``reason`` so an App Insights metric alert can fire on a
+# spike of any single failure class.
+#
+# It is incremented once per failed dispatch attempt (so a job that
+# fails and re-delivers contributes one increment per attempt) at the
+# terminal-classification branches in the finalize block.  Increments
+# happen ONLY for genuine failures — SIGTERM timeouts, TerminalImager
+# failures, and unhandled-exception / handler-returned-False paths.
+# Lease loss, mid-transcode cancellation, and success do NOT count.
+
+transcode_failure_total: Final = _meter.create_counter(
+    "agora.transcode.failure",
+    description=(
+        "Worker job-dispatch attempts that ended in failure, attributed "
+        "by ``reason`` (import_error, timeout, imager_terminal, "
+        "render_error, unknown) and ``job_type`` (the JobType value). "
+        "Incremented once per failed attempt; retries of the same job "
+        "each contribute one increment."
+    ),
+)
+
+
+# Attribute keys.
+
+ATTR_REASON: Final[str] = "reason"
+ATTR_JOB_TYPE: Final[str] = "job_type"
+
+
+# Bounded value set for the ``reason`` attribute.  Keep this list short
+# — every distinct value is a separate series in App Insights.
+
+# A dependency / import failed inside a handler — e.g. a missing module
+# like the markupsafe bug.  Classified from ImportError /
+# ModuleNotFoundError (the latter is a subclass of the former).
+REASON_IMPORT_ERROR: Final[str] = "import_error"
+
+# The worker received SIGTERM mid-job and exceeded its time budget
+# (the 2-hour replica timeout path).
+REASON_TIMEOUT: Final[str] = "timeout"
+
+# A handler raised TerminalImagerError — a deterministic imager failure
+# that has already flipped the BaseImage / ProvisionedImage row FAILED.
+REASON_IMAGER_TERMINAL: Final[str] = "imager_terminal"
+
+# Any other unhandled exception during processing (ffmpeg/render error,
+# unexpected runtime error, etc.) that isn't an import failure.
+REASON_RENDER_ERROR: Final[str] = "render_error"
+
+# The handler returned False (failure) without raising, so there is no
+# exception to classify.
+REASON_UNKNOWN: Final[str] = "unknown"

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -116,9 +116,19 @@ def test_shared_top_level_imports_are_in_requirements_shared() -> None:
     # azure-* declaration as satisfying it.
     azure_satisfied = any(name.startswith("azure-") for name in declared)
 
+    # The ``opentelemetry`` API/SDK packages are pulled in by the
+    # ``azure-monitor-opentelemetry`` meta-package (that is the whole
+    # point of the meta-package — see requirements-shared.txt).  Treat
+    # its presence as satisfying a top-level ``import opentelemetry``
+    # so shared/metrics.py + shared/observability.py don't have to pin
+    # the OTel API distribution separately and risk version skew.
+    otel_satisfied = "azure-monitor-opentelemetry" in declared
+
     missing: set[str] = set()
     for dist in needed:
         if dist == "azure-storage-blob" and azure_satisfied:
+            continue
+        if dist == "opentelemetry" and otel_satisfied:
             continue
         if dist not in declared:
             missing.add(dist)

--- a/tests/test_worker_transcode_failure_metric.py
+++ b/tests/test_worker_transcode_failure_metric.py
@@ -1,0 +1,181 @@
+"""Tests for the worker transcode-failure metric (issue #474, Layer 2).
+
+Two layers of coverage:
+
+1. **Registry contract** (mirrors ``tests/test_metrics.py`` for
+   ``cms.metrics``): ``shared.metrics`` imports cleanly even with no
+   telemetry SDK configured, exposes the ``transcode_failure_total``
+   counter handle, pins the bounded ``reason`` value-set, and
+   ``.add()`` with attributes is always safe (a no-op under the
+   default no-op ``MeterProvider``).
+
+2. **Wiring guard** (static analysis of ``worker/__main__.py``, mirrors
+   ``tests/test_worker_observability_wiring.py``): the worker imports
+   the registry from ``shared`` (never ``cms.*`` — unimportable in the
+   worker image) and increments ``transcode_failure_total`` at each of
+   the three genuine-failure finalize branches.  This stops a refactor
+   from silently dropping the increments — which would re-create the
+   exact "failures only surface in worker stdout" gap that motivated
+   the feature.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_WORKER_MAIN = Path(__file__).resolve().parent.parent / "worker" / "__main__.py"
+
+
+# ----------------------------------------------------------------------
+# Registry contract
+# ----------------------------------------------------------------------
+
+
+def test_module_imports_without_telemetry_configured() -> None:
+    # Cold-import smoke in a subprocess (see test_metrics.py for the
+    # rationale — avoid reload()/identity pitfalls and exercise the
+    # real cold path).  shared.metrics is imported at module-load by
+    # worker/__main__.py; an import-time throw breaks the worker.
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import shared.metrics"],
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"cold-import of shared.metrics failed:\n"
+        f"stdout={result.stdout.decode()!r}\n"
+        f"stderr={result.stderr.decode()!r}"
+    )
+
+
+def test_transcode_failure_counter_handle_exposed() -> None:
+    from shared import metrics
+
+    handle = metrics.transcode_failure_total
+    assert hasattr(handle, "add"), (
+        "transcode_failure_total should expose an OTel-style .add() method"
+    )
+
+
+def test_attribute_key_constants() -> None:
+    from shared import metrics
+
+    assert metrics.ATTR_REASON == "reason"
+    assert metrics.ATTR_JOB_TYPE == "job_type"
+
+
+def test_failure_reason_constants_are_bounded() -> None:
+    from shared import metrics
+
+    # Bounded value set for the ``reason`` attribute — every distinct
+    # value is a separate series in App Insights, so keep this short.
+    # Pin it so a future PR adding a new reason must update this test
+    # (and any workbook KQL / metric alert filtering on reason).
+    assert {
+        metrics.REASON_IMPORT_ERROR,
+        metrics.REASON_TIMEOUT,
+        metrics.REASON_IMAGER_TERMINAL,
+        metrics.REASON_RENDER_ERROR,
+        metrics.REASON_UNKNOWN,
+    } == {
+        "import_error",
+        "timeout",
+        "imager_terminal",
+        "render_error",
+        "unknown",
+    }
+
+
+@pytest.mark.parametrize(
+    "reason_attr",
+    [
+        "REASON_IMPORT_ERROR",
+        "REASON_TIMEOUT",
+        "REASON_IMAGER_TERMINAL",
+        "REASON_RENDER_ERROR",
+        "REASON_UNKNOWN",
+    ],
+)
+def test_add_with_reason_and_job_type_is_safe(reason_attr: str) -> None:
+    from shared import metrics
+
+    # Under the default no-op MeterProvider this is a no-op; under a
+    # real SDK it records.  Either way it must not raise.
+    metrics.transcode_failure_total.add(
+        1,
+        {
+            metrics.ATTR_REASON: getattr(metrics, reason_attr),
+            metrics.ATTR_JOB_TYPE: "variant_transcode",
+        },
+    )
+
+
+# ----------------------------------------------------------------------
+# Wiring guard (static analysis of worker/__main__.py)
+# ----------------------------------------------------------------------
+
+
+def _module() -> ast.Module:
+    return ast.parse(_WORKER_MAIN.read_text(encoding="utf-8"))
+
+
+def test_worker_imports_metrics_from_shared() -> None:
+    tree = _module()
+    imported_from_shared = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "shared"
+        and any(alias.name == "metrics" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert imported_from_shared, (
+        "worker/__main__.py must import `metrics` from `shared` "
+        "(the worker image cannot import cms.*)"
+    )
+    # Guard against accidentally importing the CMS registry, which is
+    # unimportable in the worker image and would crash at startup.
+    cms_import = any(
+        isinstance(node, ast.ImportFrom)
+        and (node.module or "").startswith("cms")
+        and any(alias.name == "metrics" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert not cms_import, "metrics must not be imported from cms.*"
+
+
+def _count_failure_increments(tree: ast.Module) -> int:
+    """Count ``metrics.transcode_failure_total.add(...)`` call sites."""
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # metrics.transcode_failure_total.add(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "add"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "transcode_failure_total"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "metrics"
+        ):
+            count += 1
+    return count
+
+
+def test_worker_increments_counter_at_each_failure_branch() -> None:
+    tree = _module()
+    # Three genuine-failure finalize branches increment the counter:
+    # SIGTERM timeout, TerminalImagerError, and the generic
+    # exception / handler-returned-False retry branch.  Lease loss,
+    # cancellation, and success deliberately do NOT.
+    assert _count_failure_increments(tree) == 3, (
+        "worker/__main__.py must increment metrics.transcode_failure_total "
+        "at exactly the three genuine-failure finalize branches "
+        "(timeout, imager_terminal, failure/retry)"
+    )

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -275,6 +275,8 @@ async def _queue_mode(settings: WorkerSettings) -> None:
     )
     from sqlalchemy import select
 
+    from shared import metrics
+
     session_factory = get_session_factory()
     asset_dir = settings.asset_storage_path
 
@@ -530,6 +532,11 @@ async def _queue_mode(settings: WorkerSettings) -> None:
     success = False
     error_message: str | None = None
     terminal_failure = False
+    # Bounded reason for the agora.transcode.failure counter, set in the
+    # except handlers below and emitted at the terminal-failure branches
+    # in the finalize block.  None when the dispatch raised nothing (a
+    # handler returning False maps to REASON_UNKNOWN at emit time).
+    failure_reason: str | None = None
     try:
         logger.info(
             "Processing job %s type=%s target=%s (attempt %d)",
@@ -557,10 +564,18 @@ async def _queue_mode(settings: WorkerSettings) -> None:
         logger.error("Job %s terminal imager failure: %s", job_id, e)
         terminal_failure = True
         success = False
+        failure_reason = metrics.REASON_IMAGER_TERMINAL
     except Exception as e:
         error_message = f"{type(e).__name__}: {e}"
         logger.exception("Job %s raised an exception", job_id)
         success = False
+        # A missing/broken dependency (e.g. the markupsafe import bug)
+        # surfaces as ImportError; ModuleNotFoundError is a subclass.
+        failure_reason = (
+            metrics.REASON_IMPORT_ERROR
+            if isinstance(e, ImportError)
+            else metrics.REASON_RENDER_ERROR
+        )
 
     # Stop the heartbeat before doing any final DB/queue work.
     await _stop_heartbeat()
@@ -602,6 +617,13 @@ async def _queue_mode(settings: WorkerSettings) -> None:
                 "Job %s SIGTERM-failed but queue delete failed", job_id, exc_info=True
             )
         logger.error("Job %s failed: %s", job_id, timeout_msg)
+        metrics.transcode_failure_total.add(
+            1,
+            {
+                metrics.ATTR_REASON: metrics.REASON_TIMEOUT,
+                metrics.ATTR_JOB_TYPE: job.type.value,
+            },
+        )
     elif lease_actually_lost:
         # Another worker has (or will) pick up the re-visible message and
         # owns the job now.  Do NOT touch DB or queue — we'd stomp on the
@@ -658,6 +680,13 @@ async def _queue_mode(settings: WorkerSettings) -> None:
                 job_id, exc_info=True,
             )
         logger.info("Job %s terminal failure: %s", job_id, error_message)
+        metrics.transcode_failure_total.add(
+            1,
+            {
+                metrics.ATTR_REASON: failure_reason or metrics.REASON_IMAGER_TERMINAL,
+                metrics.ATTR_JOB_TYPE: job.type.value,
+            },
+        )
     elif success:
         async with session_factory() as db:
             await mark_done(db, job_id)
@@ -686,6 +715,13 @@ async def _queue_mode(settings: WorkerSettings) -> None:
             )
             await db.commit()
         logger.info("Job %s failed — will retry after visibility timeout", job_id)
+        metrics.transcode_failure_total.add(
+            1,
+            {
+                metrics.ATTR_REASON: failure_reason or metrics.REASON_UNKNOWN,
+                metrics.ATTR_JOB_TYPE: job.type.value,
+            },
+        )
 
 
 async def _wait_for_schema(max_retries: int = 30, delay: float = 2.0) -> None:


### PR DESCRIPTION
## Layer 2 of transcode-failure telemetry (#474)

Builds on **PR A (#759)** which wired the worker process to App Insights via `setup_observability()`. This PR adds a bounded-cardinality OTel counter so a recurring transcode failure class shows up as a **metric spike per reason** instead of dying silently in worker stdout — exactly the gap that let the `No module named 'markupsafe'` ImportError go unnoticed for a while.

### What ships
- **`shared/metrics.py`** (new) — worker OTel metric registry. `agora.transcode.failure` counter (	ranscode_failure_total) with `reason` + `job_type` attributes and **5 bounded reason constants**: `import_error`, `timeout`, `imager_terminal`, `render_error`, `unknown`. Mirrors the `cms/metrics.py` registry pattern.
- **`worker/__main__.py`** — classify failures in the dispatch except handlers and increment the counter once per failed attempt at the three genuine-failure finalize branches:
  - `ImportError` (incl. `ModuleNotFoundError`) → `import_error`
  - `TerminalImagerError` → `imager_terminal`
  - any other exception → `render_error`
  - SIGTERM/timeout finalize → `timeout`
  - **Retries each count**, by design — a recurring import_error across retries is the desired signal. Lease-loss / cancel / success branches deliberately do **not** increment.
- **Tests** — registry behavioral contract (cold-import subprocess smoke, handle/.add() presence, bounded-reason value-set pin, safe-add) + AST wiring guard (counter incremented at **exactly 3** call sites, imported from `shared` not `cms`).
- **`tests/test_worker_dependencies.py`** — treat the `azure-monitor-opentelemetry` meta-package as satisfying a top-level `import opentelemetry` in `shared/` (mirrors the existing `azure-*` special-case). No new pin needed; the OTel API is a guaranteed transitive of the meta-package PR A added.

### Scope / safety
- **Goodwill dev only.** No prod deploy.
- `get_meter` returns a no-op when telemetry is disabled, so `.add()` is a cheap no-op in dev/tests — no call-site gating required.
- No firmware / device impact.

### Tests
`test_worker_transcode_failure_metric.py`, `test_worker_dependencies.py`, `test_widget_worker_dependencies.py` → **18 passed** locally (`-p no:timeout`). Worker import smoke clean.
