### PR TITLE
Composed editor UX nits: bigger panels, delete-button layout, palette deselect

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -163,10 +163,22 @@
     }
     .composed-editor {
         display: grid;
-        grid-template-columns: 200px 1fr 280px;
+        grid-template-columns: 220px 1fr 320px;
         gap: 1rem;
         margin-top: 1rem;
         align-items: start;
+    }
+    /* Page-scoped breakout: on wide viewports let the editor extend past the
+       global `main` max-width (1400px) so the canvas/editor panel gets more
+       room. The fixed side columns stay modest; the 1fr canvas soaks up the
+       extra width. Does not affect the <=800px single-column layout below. */
+    @media (min-width: 1500px) {
+        .composed-editor {
+            width: min(1820px, 94vw);
+            position: relative;
+            left: 50%;
+            transform: translateX(-50%);
+        }
     }
     .palette, .settings {
         padding: 0.75rem;
@@ -1901,6 +1913,13 @@ function selectPaletteType(t) {
     document.getElementById("palette-status").textContent = "Placing: " + t + ". Click a cell.";
 }
 
+function clearPaletteType() {
+    selectedPaletteType = null;
+    document.querySelectorAll(".palette-btn").forEach(b => b.classList.remove("active"));
+    const status = document.getElementById("palette-status");
+    if (status) status.textContent = "";
+}
+
 function setBgColor(c) {
     ensureLayoutShape();
     LAYOUT.background.color = c;
@@ -2387,6 +2406,10 @@ function placeAt(row, col) {
         config_version: 1,
     });
     selectedWidgetId = id;
+    // Deselect the palette tool after a drop so a subsequent click in the
+    // editor selects/edits widgets instead of dropping another one. The
+    // just-placed widget stays selected (selectedWidgetId) for editing.
+    clearPaletteType();
     markDirty();
     renderCanvas();
     renderSettings();
@@ -2531,13 +2554,15 @@ function renderSettings() {
         <label style="margin-top:0.5rem;">Opacity: <span id="frame-op-val">${Math.round((fr.opacity ?? 1)*100)}</span>%</label>
         <input type="range" min="0" max="100" value="${Math.round((fr.opacity ?? 1)*100)}" style="width:100%;"
                oninput="document.getElementById('frame-op-val').textContent=this.value; updateSelected(x=>frameSet(x,'opacity',clampInt(this.value,0,100)/100))">
-        <label style="display:block; margin-top:0.5rem;">
-            <input type="checkbox" id="frame-bg-toggle" ${frBgOn ? "checked" : ""}
-                   oninput="updateSelected(x=>frameSet(x,'background', this.checked ? (document.getElementById('frame-bg-color').value || '#000000') : null))">
-            Background fill
-        </label>
-        <input type="color" id="frame-bg-color" value="${escapeHtml(frBgColor)}"
-               oninput="updateSelected(x=>{ if (document.getElementById('frame-bg-toggle').checked) frameSet(x,'background',this.value); })">`;
+        <div class="row" style="align-items:center; margin-top:0.5rem;">
+            <label style="display:flex; align-items:center; gap:0.35rem; margin:0; flex:0 0 auto;">
+                <input type="checkbox" id="frame-bg-toggle" ${frBgOn ? "checked" : ""}
+                       oninput="document.getElementById('frame-bg-color').disabled=!this.checked; updateSelected(x=>frameSet(x,'background', this.checked ? (document.getElementById('frame-bg-color').value || '#000000') : null))">
+                Background fill
+            </label>
+            <input type="color" id="frame-bg-color" value="${escapeHtml(frBgColor)}" ${frBgOn ? "" : "disabled"}
+                   oninput="updateSelected(x=>{ if (document.getElementById('frame-bg-toggle').checked) frameSet(x,'background',this.value); })">
+        </div>`;
 
     panel.innerHTML = `
         ${renderLayersHtml()}
@@ -2552,7 +2577,9 @@ function renderSettings() {
         ${cellHtml}
         ${configHtml}
         ${appearanceHtml}
-        <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>`;
+        <div style="text-align:center;">
+            <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>
+        </div>`;
 }
 
 function clampInt(v, lo, hi) {


### PR DESCRIPTION
Three client-side polish changes to the composed slide editor (all in `composed_editor.html`), from user review:

1. **Background-fill row + delete button layout** — the *Background fill* checkbox and its color picker now share one row; the color input is **disabled when the checkbox is unchecked** (with live toggle); the **Delete widget** button is centered on its own line at the very bottom of the settings panel.
2. **Larger editor area** — wider side columns (220px / 320px) and a page-scoped breakout on screens >=1500px so the editor escapes the global 1400px `main` max-width, growing the 16:9 canvas. The <=800px single-column layout is unchanged.
3. **Palette deselect after drop** — dropping a widget clears the selected palette tool so a subsequent click in the canvas doesn't drop a second widget. The just-placed widget stays selected for editing.

Pure client-side template/JS/CSS; no server or schema changes.

Tests: `tests/test_composed_routes_phase2.py` + `tests/test_composed_preview.py` (37 passed).

Note: a fourth requested nit (shrink-to-fit font option) is deferred to a separate PR because it spans the server-side widget renderers + tests.