### PR TITLE
feat(composed): shrink-to-fit for text + date banner widgets

### DIFF
--- a/cms/composed/widgets/_autofit.py
+++ b/cms/composed/widgets/_autofit.py
@@ -1,0 +1,74 @@
+"""Shared client-side font auto-fit ("shrink to fit") helper.
+
+Exposes :data:`AUTOFIT_JS` — a self-contained, idempotent JS snippet that
+defines two globals used by text-bearing widgets whose config has
+``shrink_to_fit`` enabled:
+
+* ``window.__cwFit(inner, maxPx, minPx)`` — binary-searches the largest
+  font size (px) at which ``inner`` fits within its parent box
+  (``inner.parentElement``) in both width and height, and applies it as
+  an inline ``font-size``.
+* ``window.__cwFitObserve(inner, maxPx, minPx)`` — runs ``__cwFit`` once
+  and re-runs it whenever the box resizes (via ``ResizeObserver``, with a
+  window-resize fallback).  Returns a zero-arg refit handle so callers
+  whose content changes over time (e.g. a date that rolls over) can
+  re-fit on demand.
+
+Both globals are guarded (``window.X = window.X || function(){...}``) so
+embedding ``AUTOFIT_JS`` once per bundle is sufficient even when many
+widget instances use it; the bundle builder also de-dupes ``js`` blocks
+by content hash, so this constant embeds exactly once.
+
+The measured element's ``parentElement`` MUST be the bounded box: a
+flex-centered box with an inner content node satisfies this (text wraps
+at the box width, so overflow is detected via ``scrollWidth`` /
+``scrollHeight`` exceeding the box's client size).
+"""
+
+from __future__ import annotations
+
+# Bounds match the widget font-size schema (ge=8, le=512).  Kept here so
+# widgets and tests reference a single source of truth.
+AUTOFIT_MAX_PX = 512
+AUTOFIT_MIN_PX = 8
+
+AUTOFIT_JS = r"""
+window.__cwFit = window.__cwFit || function (inner, maxPx, minPx) {
+  if (!inner) return;
+  var box = inner.parentElement;
+  if (!box) return;
+  var hi = (typeof maxPx === 'number' && maxPx > 0) ? maxPx : 512;
+  var lo = (typeof minPx === 'number' && minPx > 0) ? minPx : 8;
+  if (hi < lo) { var t = hi; hi = lo; lo = t; }
+  if (!box.clientWidth || !box.clientHeight) return;
+  var best = lo;
+  // ~14 iterations converges to <0.1px across the 8..512px range.
+  for (var i = 0; i < 14; i++) {
+    var mid = (lo + hi) / 2;
+    inner.style.fontSize = mid + 'px';
+    if (inner.scrollWidth <= box.clientWidth &&
+        inner.scrollHeight <= box.clientHeight) {
+      best = mid; lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  inner.style.fontSize = best + 'px';
+};
+window.__cwFitObserve = window.__cwFitObserve || function (inner, maxPx, minPx) {
+  if (!inner) return function () {};
+  var refit = function () { window.__cwFit(inner, maxPx, minPx); };
+  refit();
+  var box = inner.parentElement;
+  if (box && typeof ResizeObserver !== 'undefined') {
+    try {
+      new ResizeObserver(function () { refit(); }).observe(box);
+    } catch (e) {
+      window.addEventListener('resize', refit);
+    }
+  } else {
+    window.addEventListener('resize', refit);
+  }
+  return refit;
+};
+""".strip()

--- a/cms/composed/widgets/datebanner.py
+++ b/cms/composed/widgets/datebanner.py
@@ -21,6 +21,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import (
+    AUTOFIT_JS,
+    AUTOFIT_MAX_PX,
+    AUTOFIT_MIN_PX,
+)
 
 # Font-family allowlist — kept local to this widget so it can evolve
 # typography independently of clock/text.
@@ -59,6 +64,10 @@ class DateBannerWidgetConfig(BaseModel):
     color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
     font_family: str = Field(default="sans")
     font_size_px: int = Field(default=96, ge=8, le=512)
+    # When true, font size auto-scales to fill the widget box; the manual
+    # ``font_size_px`` becomes the pre-JS starting value only.  Default
+    # false → byte-identical legacy render.
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -104,6 +113,54 @@ def _build_datebanner_init_js(
     )
 
 
+# Shrink-to-fit init: identical date logic, but refits the font after each
+# render (initial + every 60 s rollover) and on box resize.  Kept as a
+# SEPARATE template so the default (non-autofit) path stays byte-identical.
+_DATEBANNER_INIT_JS_AUTOFIT_TEMPLATE = """
+var dateEl = document.getElementById($DATE_ID_LIT);
+var prefix = $PREFIX_LIT;
+var upper = $UPPERCASE;
+function refit() {
+  if (dateEl && window.__cwFit) window.__cwFit(dateEl, $MAX_PX, $MIN_PX);
+}
+function render() {
+  if (!dateEl) return;
+  var d = new Date();
+  var s = d.toLocaleDateString(undefined, $OPTIONS);
+  if (prefix) s = prefix + ' ' + s;
+  if (upper) s = s.toUpperCase();
+  dateEl.textContent = s;
+  refit();
+}
+render();
+if (dateEl && dateEl.parentElement && typeof ResizeObserver !== 'undefined') {
+  try { new ResizeObserver(refit).observe(dateEl.parentElement); }
+  catch (e) { window.addEventListener('resize', refit); }
+} else {
+  window.addEventListener('resize', refit);
+}
+setInterval(render, 60000);
+""".strip()
+
+
+def _build_datebanner_init_js_autofit(
+    *,
+    date_id: str,
+    options: str,
+    prefix: str,
+    uppercase: bool,
+) -> str:
+    return (
+        _DATEBANNER_INIT_JS_AUTOFIT_TEMPLATE
+        .replace("$DATE_ID_LIT", f"'{date_id}'")
+        .replace("$OPTIONS", options)
+        .replace("$PREFIX_LIT", json.dumps(prefix))
+        .replace("$UPPERCASE", "true" if uppercase else "false")
+        .replace("$MAX_PX", str(AUTOFIT_MAX_PX))
+        .replace("$MIN_PX", str(AUTOFIT_MIN_PX))
+    )
+
+
 class DateBannerWidget(Widget):
     """Current date / day-of-week banner."""
 
@@ -121,6 +178,7 @@ class DateBannerWidget(Widget):
             "color": "#ffffff",
             "font_family": "sans",
             "font_size_px": 96,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -173,6 +231,20 @@ class DateBannerWidget(Widget):
             f"  line-height: 1.1;\n"
             f"}}"
         )
+
+        if config.shrink_to_fit:
+            init_js = _build_datebanner_init_js_autofit(
+                date_id=date_id,
+                options=options,
+                prefix=config.prefix,
+                uppercase=config.uppercase,
+            )
+            return WidgetRender(
+                html=html_out,
+                css=css_out,
+                js=AUTOFIT_JS,
+                init_js=init_js,
+            )
 
         init_js = _build_datebanner_init_js(
             date_id=date_id,

--- a/cms/composed/widgets/text.py
+++ b/cms/composed/widgets/text.py
@@ -24,6 +24,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import (
+    AUTOFIT_JS,
+    AUTOFIT_MAX_PX,
+    AUTOFIT_MIN_PX,
+)
 
 
 # Allowlist of font-family slugs → emitted CSS font stack.  Keeping
@@ -53,6 +58,10 @@ class TextWidgetConfig(BaseModel):
     # output toggles, no core contract changes.
     bold: bool = False
     italic: bool = False
+    # When true, font size auto-scales to fill the widget box and the
+    # manual ``font_size_px`` is ignored at render time (kept only as the
+    # pre-JS starting value).  Default false → byte-identical legacy render.
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -82,6 +91,7 @@ class TextWidget(Widget):
             "font_family": "sans",
             "bold": False,
             "italic": False,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -109,10 +119,21 @@ class TextWidget(Widget):
         css_class = f"cw-text-{instance_id}"
         font_stack = _FONT_STACKS[config.font_family]
 
-        html_out = f'<div class="{css_class}">{escaped_text}</div>'
-
         font_weight = "700" if config.bold else "400"
         font_style = "italic" if config.italic else "normal"
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                escaped_text=escaped_text,
+                css_class=css_class,
+                instance_id=instance_id,
+                font_stack=font_stack,
+                font_weight=font_weight,
+                font_style=font_style,
+                config=config,
+            )
+
+        html_out = f'<div class="{css_class}">{escaped_text}</div>'
 
         css_out = (
             f".{css_class} {{\n"
@@ -135,4 +156,66 @@ class TextWidget(Widget):
         return WidgetRender(
             html=html_out,
             css=css_out,
+        )
+
+    def _render_shrink(
+        self,
+        *,
+        escaped_text: str,
+        css_class: str,
+        instance_id: str,
+        font_stack: str,
+        font_weight: str,
+        font_style: str,
+        config: TextWidgetConfig,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant: text auto-scales to fill the box.
+
+        Outer ``.{css_class}`` is the bounded, flex-centered box; an inner
+        ``#cw-text-inner-{instance_id}`` holds the text and is the element
+        whose font size the autofit JS binary-searches.
+        """
+        inner_id = f"cw-text-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">{escaped_text}</div>'
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  text-align: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-weight: {font_weight};\n"
+            f"  font-style: {font_style};\n"
+            f"  overflow: hidden;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            # Starting size before JS runs; immediately overridden by fit.
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  max-width: 100%;\n"
+            f"  line-height: 1.1;\n"
+            f"  word-wrap: break-word;\n"
+            f"}}"
+        )
+
+        init_js = (
+            f"var el = document.getElementById('{inner_id}');\n"
+            f"if (el && window.__cwFitObserve) "
+            f"window.__cwFitObserve(el, {AUTOFIT_MAX_PX}, {AUTOFIT_MIN_PX});"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
+            init_js=init_js,
         )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -163,10 +163,22 @@
     }
     .composed-editor {
         display: grid;
-        grid-template-columns: 200px 1fr 280px;
+        grid-template-columns: 220px 1fr 320px;
         gap: 1rem;
         margin-top: 1rem;
         align-items: start;
+    }
+    /* Page-scoped breakout: on wide viewports let the editor extend past the
+       global `main` max-width (1400px) so the canvas/editor panel gets more
+       room. The fixed side columns stay modest; the 1fr canvas soaks up the
+       extra width. Does not affect the <=800px single-column layout below. */
+    @media (min-width: 1500px) {
+        .composed-editor {
+            width: min(1820px, 94vw);
+            position: relative;
+            left: 50%;
+            transform: translateX(-50%);
+        }
     }
     .palette, .settings {
         padding: 0.75rem;
@@ -1901,6 +1913,13 @@ function selectPaletteType(t) {
     document.getElementById("palette-status").textContent = "Placing: " + t + ". Click a cell.";
 }
 
+function clearPaletteType() {
+    selectedPaletteType = null;
+    document.querySelectorAll(".palette-btn").forEach(b => b.classList.remove("active"));
+    const status = document.getElementById("palette-status");
+    if (status) status.textContent = "";
+}
+
 function setBgColor(c) {
     ensureLayoutShape();
     LAYOUT.background.color = c;
@@ -2387,6 +2406,10 @@ function placeAt(row, col) {
         config_version: 1,
     });
     selectedWidgetId = id;
+    // Deselect the palette tool after a drop so a subsequent click in the
+    // editor selects/edits widgets instead of dropping another one. The
+    // just-placed widget stays selected (selectedWidgetId) for editing.
+    clearPaletteType();
     markDirty();
     renderCanvas();
     renderSettings();
@@ -2531,13 +2554,15 @@ function renderSettings() {
         <label style="margin-top:0.5rem;">Opacity: <span id="frame-op-val">${Math.round((fr.opacity ?? 1)*100)}</span>%</label>
         <input type="range" min="0" max="100" value="${Math.round((fr.opacity ?? 1)*100)}" style="width:100%;"
                oninput="document.getElementById('frame-op-val').textContent=this.value; updateSelected(x=>frameSet(x,'opacity',clampInt(this.value,0,100)/100))">
-        <label style="display:block; margin-top:0.5rem;">
-            <input type="checkbox" id="frame-bg-toggle" ${frBgOn ? "checked" : ""}
-                   oninput="updateSelected(x=>frameSet(x,'background', this.checked ? (document.getElementById('frame-bg-color').value || '#000000') : null))">
-            Background fill
-        </label>
-        <input type="color" id="frame-bg-color" value="${escapeHtml(frBgColor)}"
-               oninput="updateSelected(x=>{ if (document.getElementById('frame-bg-toggle').checked) frameSet(x,'background',this.value); })">`;
+        <div class="row" style="align-items:center; margin-top:0.5rem;">
+            <label style="display:flex; align-items:center; gap:0.35rem; margin:0; flex:0 0 auto;">
+                <input type="checkbox" id="frame-bg-toggle" ${frBgOn ? "checked" : ""}
+                       oninput="document.getElementById('frame-bg-color').disabled=!this.checked; updateSelected(x=>frameSet(x,'background', this.checked ? (document.getElementById('frame-bg-color').value || '#000000') : null))">
+                Background fill
+            </label>
+            <input type="color" id="frame-bg-color" value="${escapeHtml(frBgColor)}" ${frBgOn ? "" : "disabled"}
+                   oninput="updateSelected(x=>{ if (document.getElementById('frame-bg-toggle').checked) frameSet(x,'background',this.value); })">
+        </div>`;
 
     panel.innerHTML = `
         ${renderLayersHtml()}
@@ -2552,7 +2577,9 @@ function renderSettings() {
         ${cellHtml}
         ${configHtml}
         ${appearanceHtml}
-        <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>`;
+        <div style="text-align:center;">
+            <button type="button" class="delete-btn" onclick="deleteSelected()">Delete widget</button>
+        </div>`;
 }
 
 function clampInt(v, lo, hi) {

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -738,6 +738,38 @@ function cqwFont(px) {
     const n = Number(px);
     return ((isFinite(n) ? n : 48) / 19.2).toFixed(3) + "cqw";
 }
+// Shrink-to-fit preview: binary-search the largest font size (in real
+// rendered px) at which `inner` still fits inside its parent box, then
+// pin it. Mirrors the on-device __cwFit algorithm in cms/composed/
+// widgets/_autofit.py (the device fits in design-space px; the editor
+// preview fits in the smaller on-screen box, so the visual is an
+// approximation — the published bundle does the real fit on hardware).
+function cwFitEl(inner, maxPx, minPx) {
+    const box = inner.parentElement;
+    if (!box) return;
+    if (box.clientWidth <= 0 || box.clientHeight <= 0) return;
+    let lo = minPx, hi = maxPx, best = minPx;
+    for (let i = 0; i < 14; i++) {
+        const mid = (lo + hi) / 2;
+        inner.style.fontSize = mid + "px";
+        if (inner.scrollWidth <= box.clientWidth && inner.scrollHeight <= box.clientHeight) {
+            best = mid; lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    inner.style.fontSize = best.toFixed(2) + "px";
+}
+// Run after renderCanvas paints: fit every shrink-to-fit preview element.
+// Must run in rAF — the .cw-fit nodes only exist once the placed-widget
+// loop has appended them and the browser has laid them out.
+function fitMarkedPreviews() {
+    document.querySelectorAll("#canvas .cw-fit").forEach(el => {
+        const mx = Number(el.dataset.fitMax) || 512;
+        const mn = Number(el.dataset.fitMin) || 8;
+        cwFitEl(el, mx, mn);
+    });
+}
 // Appearance frame lengths (corner radius / border / inset) are also in
 // 1920x1080 design-space px; convert to cqw so the editor preview scales
 // the same way the published bundle does on the device.
@@ -787,17 +819,30 @@ const WIDGETS = {
 registerWidget("text", {
     label: "Text", icon: "🅰", category: "Text & Media",
     keywords: ["text", "label", "heading", "caption", "title", "words"],
-    defaults: () => ({text:"Text", color:"#ffffff", font_size_px:48, font_family:"sans", bold:false, italic:false}),
+    defaults: () => ({text:"Text", color:"#ffffff", font_size_px:48, font_family:"sans", bold:false, italic:false, shrink_to_fit:false}),
     summary: (w) => (w.config.text || "").slice(0, 24),
     preview: (root, cfg) => {
         const d = document.createElement("div");
         d.className = "cw-prev-text";
-        d.textContent = cfg.text || "";
         d.style.color = cfg.color || "#ffffff";
         d.style.fontFamily = fontStack(cfg.font_family);
-        d.style.fontSize = cqwFont(cfg.font_size_px);
         d.style.fontWeight = cfg.bold ? "700" : "400";
         d.style.fontStyle = cfg.italic ? "italic" : "normal";
+        if (cfg.shrink_to_fit) {
+            const inner = document.createElement("span");
+            inner.textContent = cfg.text || "";
+            inner.style.display = "inline-block";
+            inner.style.maxWidth = "100%";
+            inner.style.wordWrap = "break-word";
+            inner.style.fontSize = "24px";
+            inner.classList.add("cw-fit");
+            inner.dataset.fitMax = "512";
+            inner.dataset.fitMin = "8";
+            d.appendChild(inner);
+        } else {
+            d.textContent = cfg.text || "";
+            d.style.fontSize = cqwFont(cfg.font_size_px);
+        }
         root.appendChild(d);
     },
     settings: (w) => `
@@ -812,10 +857,15 @@ registerWidget("text", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${w.config.font_size_px||48}"
+                    <input type="number" id="cw-text-size" min="8" max="512" value="${w.config.font_size_px||48}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-text-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <label>Font</label>
             <select oninput="updateSelected(x=>x.config.font_family=this.value)">
                 ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
@@ -1109,7 +1159,7 @@ registerWidget("countdown", {
 registerWidget("datebanner", {
     label: "Date Banner", icon: "📅", category: "Time & Date",
     keywords: ["date", "day", "banner", "calendar", "today", "weekday"],
-    defaults: () => ({format:"full", prefix:"", uppercase:false, color:"#ffffff", font_family:"sans", font_size_px:96}),
+    defaults: () => ({format:"full", prefix:"", uppercase:false, color:"#ffffff", font_family:"sans", font_size_px:96, shrink_to_fit:false}),
     summary: (w) => w.config.format || "full",
     preview: (root, cfg) => {
         const OPTS = {
@@ -1125,7 +1175,14 @@ registerWidget("datebanner", {
         c.style.fontFamily = fontStack(cfg.font_family);
         const dateEl = document.createElement("div");
         dateEl.className = "cw-prev-datebanner-date";
-        dateEl.style.fontSize = cqwFont(cfg.font_size_px);
+        if (cfg.shrink_to_fit) {
+            dateEl.style.fontSize = "24px";
+            dateEl.classList.add("cw-fit");
+            dateEl.dataset.fitMax = "512";
+            dateEl.dataset.fitMin = "8";
+        } else {
+            dateEl.style.fontSize = cqwFont(cfg.font_size_px);
+        }
         let txt;
         try {
             txt = new Date().toLocaleDateString(undefined, OPTS[cfg.format] || OPTS.full);
@@ -1164,10 +1221,15 @@ registerWidget("datebanner", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                    <input type="number" id="cw-datebanner-size" min="8" max="512" value="${w.config.font_size_px||96}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-datebanner-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <label>Font</label>
             <select oninput="updateSelected(x=>x.config.font_family=this.value)">
                 ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
@@ -1992,6 +2054,8 @@ function renderCanvas() {
         }
         canvas.appendChild(el);
     });
+    // Fit shrink-to-fit previews after the browser lays out the new nodes.
+    requestAnimationFrame(fitMarkedPreviews);
 }
 
 // ── Live in-editor widget previews ──────────────────────────────────

--- a/tests/test_composed_datebanner_widget.py
+++ b/tests/test_composed_datebanner_widget.py
@@ -151,3 +151,43 @@ class TestDateBannerWidgetRender:
         r = self._render()
         assert r.static_assets == []
         assert r.referenced_asset_ids == []
+
+
+class TestDateBannerShrinkToFit:
+    def _render(self, **overrides):
+        w = DateBannerWidget()
+        cfg = DateBannerWidgetConfig(**{**w.default_config(), **overrides})
+        return w.render_html(cfg, _cell(), "inst-1")
+
+    def test_default_off_is_byte_identical(self):
+        w = DateBannerWidget()
+        base = w.default_config()
+        cfg_implicit = DateBannerWidgetConfig(**{k: v for k, v in base.items() if k != "shrink_to_fit"})
+        cfg_explicit = DateBannerWidgetConfig(**{**base, "shrink_to_fit": False})
+        a = w.render_html(cfg_implicit, _cell(), "x")
+        b = w.render_html(cfg_explicit, _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        r = self._render(shrink_to_fit=False)
+        assert "__cwFit" not in r.js
+        assert "__cwFit" not in r.init_js
+        assert r.js == ""
+
+    def test_on_path_emits_autofit_js_and_refit(self):
+        r = self._render(shrink_to_fit=True)
+        # Shared fit helper present in js.
+        assert "window.__cwFit" in r.js
+        # init wires a refit into render + a ResizeObserver.
+        assert "function refit()" in r.init_js
+        assert "window.__cwFit(dateEl" in r.init_js
+        assert "ResizeObserver" in r.init_js
+        # Date logic still intact on the autofit path.
+        assert "setInterval(render, 60000)" in r.init_js
+        assert "getElementById('cw-datebanner-date-inst-1')" in r.init_js
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert DateBannerWidget().default_config()["shrink_to_fit"] is False

--- a/tests/test_composed_text_widget.py
+++ b/tests/test_composed_text_widget.py
@@ -183,3 +183,59 @@ class TestRegistration:
         importlib.reload(widgets_pkg)
         reg = get_registry()
         assert reg.has("text")
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        # A config that omits shrink_to_fit and one that sets it False
+        # must render byte-for-byte identical output — the legacy path.
+        w = TextWidget()
+        cfg_implicit = TextWidgetConfig(text="hi", color="#abcdef", font_size_px=64)
+        cfg_explicit = TextWidgetConfig(
+            text="hi", color="#abcdef", font_size_px=64, shrink_to_fit=False
+        )
+        a = w.render_html(cfg_implicit, _cell(), "x")
+        b = w.render_html(cfg_explicit, _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(text="hi", shrink_to_fit=False)
+        out = w.render_html(cfg, _cell(), "x")
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in out.js
+        assert out.js == ""
+        assert out.init_js is None
+        # The legacy box carries the literal font-size; no inner element.
+        assert "cw-text-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(text="hi", font_size_px=64, shrink_to_fit=True)
+        out = w.render_html(cfg, _cell(), "abcd")
+        # Shared fit helper is emitted in js.
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        # Per-instance init wires the inner element to the observer.
+        inner_id = "cw-text-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        # The starting (pre-JS) size is preserved on the inner element.
+        assert "font-size: 64px" in out.css
+
+    def test_on_path_still_escapes_text(self):
+        w = TextWidget()
+        cfg = TextWidgetConfig(
+            text='<script>alert(1)</script>', shrink_to_fit=True
+        )
+        out = w.render_html(cfg, _cell(), "x")
+        assert "<script>" not in out.html
+        assert "&lt;script&gt;" in out.html
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert TextWidget().default_config()["shrink_to_fit"] is False


### PR DESCRIPTION
Adds an opt-in **Shrink to fit** toggle to the **text box** and **date banner** widgets in the composed slide editor (Nit 2 of the recent editor polish batch).

## Behavior
- When **on**, the widget's text auto-scales (binary-search fit, 8-512px) to fill its box, and the manual font-size input is **disabled**.
- When **off** (default), the render path is **byte-identical** to before this PR -- existing published bundles, bundle hashes, and substring tests are unaffected.

## Changes
- `cms/composed/widgets/_autofit.py` (new) -- shared idempotent fit JS (`window.__cwFit` / `__cwFitObserve`) + bounds.
- `text.py` / `datebanner.py` -- `shrink_to_fit` config field (default `False`), gated shrink render path emitting the autofit JS + per-instance init.
- `composed_editor.html` -- settings checkbox (disables the size input inline when on), preview-side `cwFitEl`/`fitMarkedPreviews` run in `requestAnimationFrame` after `renderCanvas`.

## Scope
This is **PR 1** -- text + date banner only (the two widgets the user named). A follow-up PR 2 will replicate the same pattern to clock, countdown, store hours, rss, and weather using the shared `_autofit.py` helper.

## Tests
9 new shrink-to-fit tests across both widget test files (default-off byte-identical, on-path emits autofit JS + init, `default_config` gate). `60 passed` locally for the two widget suites; editor JS `node --check` clean; Jinja parse OK.
