### PR TITLE
feat(composed): shrink-to-fit for clock, countdown, store hours, rss, weather

### DIFF
--- a/cms/composed/widgets/_autofit.py
+++ b/cms/composed/widgets/_autofit.py
@@ -10,9 +10,17 @@ defines two globals used by text-bearing widgets whose config has
   an inline ``font-size``.
 * ``window.__cwFitObserve(inner, maxPx, minPx)`` — runs ``__cwFit`` once
   and re-runs it whenever the box resizes (via ``ResizeObserver``, with a
-  window-resize fallback).  Returns a zero-arg refit handle so callers
-  whose content changes over time (e.g. a date that rolls over) can
-  re-fit on demand.
+  window-resize fallback) **or whenever the measured element's content
+  changes** (via ``MutationObserver`` watching ``childList`` +
+  ``characterData``, but NOT ``attributes`` — so the fit's own inline
+  ``font-size`` write never retriggers it).  Returns a zero-arg refit
+  handle so callers can also re-fit on demand.
+
+  The ``MutationObserver`` is what lets *dynamic* widgets (a ticking
+  clock, a counting-down timer, a rotating RSS list, a weather refresh)
+  re-fit automatically: they just paint into child nodes as usual and
+  the observer refits — **no per-widget refit wiring required**.  A
+  static widget (plain text) simply never mutates and pays nothing.
 
 Both globals are guarded (``window.X = window.X || function(){...}``) so
 embedding ``AUTOFIT_JS`` once per bundle is sufficient even when many
@@ -69,6 +77,37 @@ window.__cwFitObserve = window.__cwFitObserve || function (inner, maxPx, minPx) 
   } else {
     window.addEventListener('resize', refit);
   }
+  // Re-fit when the measured content changes (clock tick, countdown,
+  // RSS rotation, weather refresh, ...).  childList + characterData
+  // only: observing attributes would loop because __cwFit writes
+  // inner.style.fontSize on every fit.
+  if (typeof MutationObserver !== 'undefined') {
+    try {
+      new MutationObserver(function () { refit(); }).observe(inner, {
+        childList: true, characterData: true, subtree: true
+      });
+    } catch (e) { /* no-op: resize observer still covers box changes */ }
+  }
   return refit;
 };
 """.strip()
+
+
+def autofit_inner_init_js(inner_id: str) -> str:
+    """Return the standard one-line per-instance autofit init.
+
+    Every "shrink to fit" widget wraps its content in an inner element
+    (``inner_id``) and fits that element against its bounded parent box.
+    This helper emits the exact init statement that text.py's shrink path
+    has used since the feature shipped, so each widget concatenates it
+    after its own (content-painting) ``init_js`` instead of re-deriving
+    the ``__cwFitObserve`` call by hand.
+
+    ``inner_id`` is always a CMS-generated DOM id (``cw-<slug>-inner-<uuid>``)
+    so it is safe to embed as a single-quoted JS string literal.
+    """
+    return (
+        f"var el=document.getElementById('{inner_id}');"
+        f"if(el&&window.__cwFitObserve)"
+        f"window.__cwFitObserve(el,{AUTOFIT_MAX_PX},{AUTOFIT_MIN_PX});"
+    )

--- a/cms/composed/widgets/clock.py
+++ b/cms/composed/widgets/clock.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import AUTOFIT_JS, autofit_inner_init_js
 
 
 # Font-family allowlist — kept local to this widget so the clock and
@@ -44,6 +45,7 @@ class ClockWidgetConfig(BaseModel):
     color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
     font_family: str = Field(default="sans")
     font_size_px: int = Field(default=96, ge=8, le=512)
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -125,6 +127,7 @@ class ClockWidget(Widget):
             "color": "#ffffff",
             "font_family": "sans",
             "font_size_px": 96,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -147,6 +150,16 @@ class ClockWidget(Widget):
         time_id = f"cw-clock-time-{instance_id}"
         date_id = f"cw-clock-date-{instance_id}"
         font_stack = _FONT_STACKS[config.font_family]
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                config=config,
+                css_class=css_class,
+                time_id=time_id,
+                date_id=date_id,
+                font_stack=font_stack,
+                instance_id=instance_id,
+            )
 
         date_html = (
             f'<div id="{date_id}" class="{css_class}-date"></div>'
@@ -198,5 +211,92 @@ class ClockWidget(Widget):
         return WidgetRender(
             html=html_out,
             css=css_out,
+            init_js=init_js,
+        )
+
+    def _render_shrink(
+        self,
+        *,
+        config: ClockWidgetConfig,
+        css_class: str,
+        time_id: str,
+        date_id: str,
+        font_stack: str,
+        instance_id: str,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant: the time (+ optional date) auto-scales.
+
+        The time + date are wrapped in ``#cw-clock-inner-{id}`` which
+        carries the base font size; child sizes are expressed in ``em`` so
+        the whole composite scales proportionally when the shared autofit
+        JS fits the wrapper against the bounded outer box.  The existing
+        per-second render loop keeps writing the same child IDs; the
+        ``MutationObserver`` inside ``__cwFitObserve`` re-fits on each tick
+        for free.
+        """
+        inner_id = f"cw-clock-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        date_html = (
+            f'<div id="{date_id}" class="{css_class}-date"></div>'
+            if config.show_date
+            else ""
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">'
+            f'<div id="{time_id}" class="{css_class}-time"></div>'
+            f"{date_html}"
+            f"</div>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"  overflow: hidden;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            # Starting size before JS runs; immediately overridden by fit.
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"}}\n"
+            f".{css_class}-time {{\n"
+            f"  font-size: 1em;\n"
+            f"  line-height: 1;\n"
+            f"}}\n"
+            f".{css_class}-date {{\n"
+            f"  font-size: 0.4em;\n"
+            f"  opacity: 0.8;\n"
+            f"  margin-top: 0.25em;\n"
+            f"}}"
+        )
+
+        init_js = (
+            _build_clock_init_js(
+                time_id=time_id,
+                date_id=date_id if config.show_date else "",
+                format_=config.format,
+                show_seconds=config.show_seconds,
+                show_date=config.show_date,
+            )
+            + "\n"
+            + autofit_inner_init_js(inner_id)
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
             init_js=init_js,
         )

--- a/cms/composed/widgets/countdown.py
+++ b/cms/composed/widgets/countdown.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import AUTOFIT_JS, autofit_inner_init_js
 
 # Font-family allowlist — kept local so each widget evolves typography
 # independently (mirrors clock.py).
@@ -62,6 +63,7 @@ class CountdownWidgetConfig(BaseModel):
     color: str = Field(default="#ffffff", pattern=r"^#[0-9a-fA-F]{6}$")
     font_family: str = Field(default="sans")
     font_size_px: int = Field(default=96, ge=8, le=512)
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -202,6 +204,7 @@ class CountdownWidget(Widget):
             "color": "#ffffff",
             "font_family": "sans",
             "font_size_px": 96,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -223,6 +226,15 @@ class CountdownWidget(Widget):
         css_class = f"cw-countdown-{instance_id}"
         time_id = f"cw-countdown-time-{instance_id}"
         font_stack = _FONT_STACKS[config.font_family]
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                config=config,
+                css_class=css_class,
+                time_id=time_id,
+                font_stack=font_stack,
+                instance_id=instance_id,
+            )
 
         label_html = (
             f'<div class="{css_class}-label">{html.escape(config.label)}</div>'
@@ -276,3 +288,92 @@ class CountdownWidget(Widget):
         )
 
         return WidgetRender(html=html_out, css=css_out, init_js=init_js)
+
+    def _render_shrink(
+        self,
+        *,
+        config: CountdownWidgetConfig,
+        css_class: str,
+        time_id: str,
+        font_stack: str,
+        instance_id: str,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant: optional label + timer auto-scale.
+
+        Label + timer are wrapped in ``#cw-countdown-inner-{id}`` which
+        carries the base font size; child sizes are expressed in ``em`` so
+        the composite scales proportionally when the shared autofit JS
+        fits the wrapper.  The per-second timer loop keeps writing the same
+        ``time_id``; the ``MutationObserver`` in ``__cwFitObserve`` re-fits
+        on each tick automatically.
+        """
+        inner_id = f"cw-countdown-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        label_html = (
+            f'<div class="{css_class}-label">{html.escape(config.label)}</div>'
+            if config.label
+            else ""
+        )
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">'
+            f"{label_html}"
+            f'<div id="{time_id}" class="{css_class}-time"></div>'
+            f"</div>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"  overflow: hidden;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            # Starting size before JS runs; immediately overridden by fit.
+            f"  font-size: {config.font_size_px}px;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"}}\n"
+            f".{css_class}-label {{\n"
+            f"  font-size: 0.4em;\n"
+            f"  opacity: 0.8;\n"
+            f"  margin-bottom: 0.2em;\n"
+            f"}}\n"
+            f".{css_class}-time {{\n"
+            f"  font-size: 1em;\n"
+            f"  line-height: 1;\n"
+            f"  white-space: nowrap;\n"
+            f"}}"
+        )
+
+        init_js = (
+            _build_countdown_init_js(
+                time_id=time_id,
+                target=config.target,
+                direction=config.direction,
+                completed_text=config.completed_text,
+                show_days=config.show_days,
+                show_hours=config.show_hours,
+                show_minutes=config.show_minutes,
+                show_seconds=config.show_seconds,
+            )
+            + "\n"
+            + autofit_inner_init_js(inner_id)
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
+            init_js=init_js,
+        )

--- a/cms/composed/widgets/rss.py
+++ b/cms/composed/widgets/rss.py
@@ -47,6 +47,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import AUTOFIT_JS, autofit_inner_init_js
 
 _HEX = r"^#[0-9a-fA-F]{6}$"
 
@@ -93,6 +94,7 @@ class RssWidgetConfig(BaseModel):
     # Feeds update at most a few times an hour; a 5-minute floor keeps
     # the proxy (and the upstream feed) from being hammered.
     refresh_seconds: int = Field(default=900, ge=300, le=86400)
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -254,6 +256,7 @@ class RssWidget(Widget):
             "font_family": "sans",
             "font_size_px": 32,
             "refresh_seconds": 900,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -280,6 +283,19 @@ class RssWidget(Widget):
         item_class = f"{css_class}-item"
         date_class = f"{css_class}-date"
         font_stack = _FONT_STACKS[config.font_family]
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                config=config,
+                ctx=ctx,
+                css_class=css_class,
+                root_id=root_id,
+                list_id=list_id,
+                item_class=item_class,
+                date_class=date_class,
+                font_stack=font_stack,
+                instance_id=instance_id,
+            )
 
         # Heading is the ONLY config-controlled string in the markup —
         # escaped here, never passed into JS. Feed titles are painted at
@@ -359,3 +375,124 @@ class RssWidget(Widget):
         )
 
         return WidgetRender(html=html_out, css=css_out, init_js=init_js)
+
+    def _render_shrink(
+        self,
+        *,
+        config: RssWidgetConfig,
+        ctx: BundleContext | None,
+        css_class: str,
+        root_id: str,
+        list_id: str,
+        item_class: str,
+        date_class: str,
+        font_stack: str,
+        instance_id: str,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant: the whole feed (heading + headline list)
+        auto-scales to fill the box.
+
+        ``root_id`` stays on the OUTER bounded box (the runtime JS does
+        ``document.body.contains(root)`` to stop polling once removed).  The
+        heading + list are nested in ``#cw-rss-inner-{id}`` which carries the
+        base ``px`` size and is what the shared autofit JS fits.  Unlike the
+        default render, the inner wrapper and the list do **not** clip
+        (``overflow: visible``) — the fit needs the list's true
+        ``scrollHeight`` to be measurable; only the outer box clips.  Headline
+        sizes are expressed in ``em`` so the composite scales together, and
+        the per-refresh repaint (rows appended to the list) re-fits via the
+        shared ``MutationObserver``.
+        """
+        inner_id = f"cw-rss-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        heading_html = (
+            f'<div class="{css_class}-heading">'
+            f"{html.escape(config.heading)}</div>"
+            if config.heading.strip()
+            else ""
+        )
+        html_out = (
+            f'<div id="{root_id}" class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">'
+            f"{heading_html}"
+            f'<div id="{list_id}" class="{css_class}-list">'
+            f'<div class="{item_class}">Loading headlines\u2026</div>'
+            f"</div>"
+            f"</div>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  overflow: hidden;\n"
+            f"  box-sizing: border-box;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            # Starting size before JS runs; immediately overridden by fit.
+            f"  font-size: {config.font_size_px}px;\n"
+            f"}}\n"
+            f".{css_class}-heading {{\n"
+            f"  font-size: 1.1em;\n"
+            f"  font-weight: 700;\n"
+            f"  margin-bottom: 0.3em;\n"
+            f"  flex: 0 0 auto;\n"
+            f"}}\n"
+            f".{css_class}-list {{\n"
+            f"  flex: 1 1 auto;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  gap: 0.4em;\n"
+            f"}}\n"
+            f".{css_class}-item {{\n"
+            f"  font-size: 1em;\n"
+            f"  line-height: 1.2;\n"
+            f"}}\n"
+            f".{css_class}-date {{\n"
+            f"  font-size: 0.6em;\n"
+            f"  opacity: 0.7;\n"
+            f"  margin-top: 0.1em;\n"
+            f"}}"
+        )
+
+        base = ctx.cms_base_url if ctx else None
+        cfg_fp = (
+            f"{config.feed_url}|{config.item_count}"
+            f"|{int(config.sort_newest)}"
+        )
+        init_js = (
+            _build_rss_init_js(
+                root_id=root_id,
+                list_id=list_id,
+                url=_proxy_url(
+                    base,
+                    config.feed_url,
+                    config.item_count,
+                    newest=config.sort_newest,
+                ),
+                cfg_fp=cfg_fp,
+                cache_key=f"cw-rss-{instance_id}",
+                refresh_ms=config.refresh_seconds * 1000,
+                show_dates=config.show_dates,
+                item_class=item_class,
+                date_class=date_class,
+            )
+            + "\n"
+            + autofit_inner_init_js(inner_id)
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
+            init_js=init_js,
+        )

--- a/cms/composed/widgets/store_hours.py
+++ b/cms/composed/widgets/store_hours.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import AUTOFIT_JS, autofit_inner_init_js
 
 # Font-family allowlist — kept local so typography can evolve independently.
 _FONT_STACKS: dict[str, str] = {
@@ -204,6 +205,7 @@ class StoreHoursWidgetConfig(BaseModel):
     closed_color: str = Field(default="#f85149", pattern=r"^#[0-9a-fA-F]{6}$")
     font_family: str = Field(default="sans")
     font_size_px: int = Field(default=48, ge=8, le=512)
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -418,6 +420,7 @@ class StoreHoursWidget(Widget):
             "closed_color": "#f85149",
             "font_family": "sans",
             "font_size_px": 48,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -440,6 +443,16 @@ class StoreHoursWidget(Widget):
         status_id = f"cw-storehours-status-{instance_id}"
         body_id = f"cw-storehours-body-{instance_id}"
         font_stack = _FONT_STACKS[config.font_family]
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                config=config,
+                css_class=css_class,
+                status_id=status_id,
+                body_id=body_id,
+                font_stack=font_stack,
+                instance_id=instance_id,
+            )
 
         heading_html = ""
         if config.heading:
@@ -519,5 +532,124 @@ class StoreHoursWidget(Widget):
         return WidgetRender(
             html=html_out,
             css=css_out,
+            init_js=init_js,
+        )
+
+    def _render_shrink(
+        self,
+        *,
+        config: StoreHoursWidgetConfig,
+        css_class: str,
+        status_id: str,
+        body_id: str,
+        font_stack: str,
+        instance_id: str,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant.
+
+        The widget content is already fully ``em`` / inherit-relative (the
+        outer box normally carries the only ``px`` font-size and children
+        scale off it).  So the only change here is to move that base ``px``
+        onto an inner wrapper (``#cw-storehours-inner-{id}``) and let the
+        shared autofit JS scale that wrapper to fit the bounded outer box.
+
+        The per-minute status/body repaint mutates ``status_id`` / ``body_id``
+        (both inside the wrapper); the ``MutationObserver`` in
+        ``__cwFitObserve`` re-fits on each repaint automatically.
+        """
+        inner_id = f"cw-storehours-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        heading_html = ""
+        if config.heading:
+            heading_html = (
+                f'<div class="{css_class}-heading">{html.escape(config.heading)}</div>'
+            )
+        status_html = ""
+        if config.show_status:
+            status_html = f'<div id="{status_id}" class="{css_class}-status">\u2026</div>'
+
+        html_out = (
+            f'<div class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">'
+            f"{heading_html}"
+            f"{status_html}"
+            f'<div id="{body_id}" class="{css_class}-body"></div>'
+            f"</div>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  box-sizing: border-box;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  overflow: hidden;\n"
+            f"  text-align: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  line-height: 1.25;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            # Starting size before JS runs; immediately overridden by fit.
+            f"  font-size: {config.font_size_px}px;\n"
+            f"}}\n"
+            f".{css_class}-heading {{\n"
+            f"  font-weight: 700;\n"
+            f"  margin-bottom: 0.25em;\n"
+            f"}}\n"
+            f".{css_class}-status {{\n"
+            f"  margin-bottom: 0.35em;\n"
+            f"}}\n"
+            f".{css_class}-status .cw-storehours-pill {{\n"
+            f"  font-weight: 700;\n"
+            f"}}\n"
+            f".{css_class}-status .cw-storehours-hint {{\n"
+            f"  opacity: 0.85;\n"
+            f"}}\n"
+            f".{css_class}-body {{\n"
+            f"  width: 100%;\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  gap: 0.15em;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-row {{\n"
+            f"  display: flex;\n"
+            f"  justify-content: space-between;\n"
+            f"  gap: 1em;\n"
+            f"  white-space: nowrap;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-row-today {{\n"
+            f"  font-weight: 700;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-day {{\n"
+            f"  text-align: left;\n"
+            f"}}\n"
+            f".{css_class}-body .cw-storehours-hrs {{\n"
+            f"  text-align: right;\n"
+            f"}}"
+        )
+
+        init_js = (
+            _build_storehours_init_js(
+                status_id=status_id,
+                body_id=body_id,
+                config=config,
+            )
+            + "\n"
+            + autofit_inner_init_js(inner_id)
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
             init_js=init_js,
         )

--- a/cms/composed/widgets/text.py
+++ b/cms/composed/widgets/text.py
@@ -26,8 +26,7 @@ from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
 from cms.composed.widgets._autofit import (
     AUTOFIT_JS,
-    AUTOFIT_MAX_PX,
-    AUTOFIT_MIN_PX,
+    autofit_inner_init_js,
 )
 
 
@@ -207,11 +206,7 @@ class TextWidget(Widget):
             f"}}"
         )
 
-        init_js = (
-            f"var el = document.getElementById('{inner_id}');\n"
-            f"if (el && window.__cwFitObserve) "
-            f"window.__cwFitObserve(el, {AUTOFIT_MAX_PX}, {AUTOFIT_MIN_PX});"
-        )
+        init_js = autofit_inner_init_js(inner_id)
 
         return WidgetRender(
             html=html_out,

--- a/cms/composed/widgets/weather.py
+++ b/cms/composed/widgets/weather.py
@@ -45,6 +45,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from cms.composed.registry import BundleContext, Widget, WidgetRender
 from cms.composed.schema import Cell
+from cms.composed.widgets._autofit import AUTOFIT_JS, autofit_inner_init_js
 
 _HEX = r"^#[0-9a-fA-F]{6}$"
 
@@ -98,6 +99,7 @@ class WeatherWidgetConfig(BaseModel):
     # conditions update at most a few times an hour upstream, so a
     # 10-minute floor is plenty and keeps us a good citizen.
     refresh_seconds: int = Field(default=900, ge=600, le=86400)
+    shrink_to_fit: bool = False
 
     @field_validator("font_family")
     @classmethod
@@ -275,6 +277,7 @@ class WeatherWidget(Widget):
             "font_family": "sans",
             "font_size_px": 64,
             "refresh_seconds": 900,
+            "shrink_to_fit": False,
         }
 
     def editor_template(self) -> str:
@@ -307,6 +310,18 @@ class WeatherWidget(Widget):
         cond_id = f"cw-weather-cond-{instance_id}"
         font_stack = _FONT_STACKS[config.font_family]
         symbol = "\u00b0F" if config.units == "imperial" else "\u00b0C"
+
+        if config.shrink_to_fit:
+            return self._render_shrink(
+                config=config,
+                css_class=css_class,
+                root_id=root_id,
+                temp_id=temp_id,
+                cond_id=cond_id,
+                font_stack=font_stack,
+                symbol=symbol,
+                instance_id=instance_id,
+            )
 
         # Location label is the ONLY config-controlled string in the
         # markup — escaped here, never passed into JS.
@@ -373,3 +388,112 @@ class WeatherWidget(Widget):
         )
 
         return WidgetRender(html=html_out, css=css_out, init_js=init_js)
+
+    def _render_shrink(
+        self,
+        *,
+        config: WeatherWidgetConfig,
+        css_class: str,
+        root_id: str,
+        temp_id: str,
+        cond_id: str,
+        font_stack: str,
+        symbol: str,
+        instance_id: str,
+    ) -> WidgetRender:
+        """Shrink-to-fit variant: location + temperature + condition
+        auto-scale together to fill the box.
+
+        ``root_id`` stays on the OUTER bounded box (the runtime JS does
+        ``document.body.contains(root)`` to stop polling once removed).  The
+        three lines are nested in ``#cw-weather-inner-{id}`` which carries the
+        base ``px`` size and is what the shared autofit JS fits; child sizes
+        are expressed in ``em`` so they scale as a unit.  The per-refresh
+        temperature/condition repaint mutates child text nodes, so the shared
+        ``MutationObserver`` re-fits automatically.
+        """
+        inner_id = f"cw-weather-inner-{instance_id}"
+        inner_class = f"{css_class}-inner"
+
+        loc_html = (
+            f'<div class="{css_class}-loc">'
+            f"{html.escape(config.location_label)}</div>"
+            if config.show_location
+            else ""
+        )
+        cond_html = (
+            f'<div id="{cond_id}" class="{css_class}-cond"></div>'
+            if config.show_condition
+            else ""
+        )
+        html_out = (
+            f'<div id="{root_id}" class="{css_class}">'
+            f'<div id="{inner_id}" class="{inner_class}">'
+            f"{loc_html}"
+            f'<div id="{temp_id}" class="{css_class}-temp">--{symbol}</div>'
+            f"{cond_html}"
+            f"</div>"
+            f"</div>"
+        )
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: flex;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  color: {config.color};\n"
+            f"  font-family: {font_stack};\n"
+            f"  text-align: center;\n"
+            f"  overflow: hidden;\n"
+            f"  box-sizing: border-box;\n"
+            f"}}\n"
+            f".{inner_class} {{\n"
+            f"  display: flex;\n"
+            f"  flex-direction: column;\n"
+            f"  align-items: center;\n"
+            f"  justify-content: center;\n"
+            f"  font-size: {config.font_size_px}px;\n"
+            f"}}\n"
+            f".{css_class}-loc {{\n"
+            f"  font-size: 0.4em;\n"
+            f"  opacity: 0.85;\n"
+            f"  margin-bottom: 0.1em;\n"
+            f"}}\n"
+            f".{css_class}-temp {{\n"
+            f"  font-size: 1em;\n"
+            f"  line-height: 1;\n"
+            f"  font-variant-numeric: tabular-nums;\n"
+            f"}}\n"
+            f".{css_class}-cond {{\n"
+            f"  font-size: 0.45em;\n"
+            f"  opacity: 0.9;\n"
+            f"  margin-top: 0.1em;\n"
+            f"}}"
+        )
+
+        cfg_fp = f"{config.latitude},{config.longitude},{config.units}"
+        init_js = (
+            _build_weather_init_js(
+                root_id=root_id,
+                temp_id=temp_id,
+                cond_id=cond_id if config.show_condition else "",
+                url=_forecast_url(
+                    config.latitude, config.longitude, config.units
+                ),
+                symbol=symbol,
+                cfg_fp=cfg_fp,
+                cache_key=f"cw-weather-{instance_id}",
+                refresh_ms=config.refresh_seconds * 1000,
+            )
+            + "\n"
+            + autofit_inner_init_js(inner_id)
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            js=AUTOFIT_JS,
+            init_js=init_js,
+        )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -964,24 +964,37 @@ registerWidget("qr", {
 registerWidget("clock", {
     label: "Clock", icon: "🕒", category: "Time & Date",
     keywords: ["clock", "time", "digital", "hour", "date"],
-    defaults: () => ({format:"24h", show_seconds:true, show_date:false, color:"#ffffff", font_family:"sans", font_size_px:96}),
+    defaults: () => ({format:"24h", show_seconds:true, show_date:false, color:"#ffffff", font_family:"sans", font_size_px:96, shrink_to_fit:false}),
     summary: (w) => w.config.format || "24h",
     preview: (root, cfg) => {
         const c = document.createElement("div");
         c.className = "cw-prev-clock";
         c.style.color = cfg.color || "#ffffff";
         c.style.fontFamily = fontStack(cfg.font_family);
+        const fit = !!cfg.shrink_to_fit;
+        let host = c;
+        if (fit) {
+            host = document.createElement("div");
+            host.style.display = "flex";
+            host.style.flexDirection = "column";
+            host.style.alignItems = "center";
+            host.style.fontSize = "24px";
+            host.classList.add("cw-fit");
+            host.dataset.fitMax = "512";
+            host.dataset.fitMin = "8";
+            c.appendChild(host);
+        }
         const timeEl = document.createElement("div");
         timeEl.className = "cw-prev-clock-time";
-        timeEl.style.fontSize = cqwFont(cfg.font_size_px);
+        timeEl.style.fontSize = fit ? "1em" : cqwFont(cfg.font_size_px);
         timeEl.dataset.format = cfg.format || "24h";
         timeEl.dataset.showSeconds = cfg.show_seconds ? "1" : "0";
-        c.appendChild(timeEl);
+        host.appendChild(timeEl);
         if (cfg.show_date) {
             const dateEl = document.createElement("div");
             dateEl.className = "cw-prev-clock-date";
-            dateEl.style.fontSize = cqwFont((Number(cfg.font_size_px) || 96) * 0.4);
-            c.appendChild(dateEl);
+            dateEl.style.fontSize = fit ? "0.4em" : cqwFont((Number(cfg.font_size_px) || 96) * 0.4);
+            host.appendChild(dateEl);
         }
         root.appendChild(c);
         updateClockEl(timeEl);
@@ -1010,10 +1023,15 @@ registerWidget("clock", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                    <input type="number" id="cw-clock-size" min="8" max="512" value="${w.config.font_size_px||96}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-clock-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <label>Font</label>
             <select oninput="updateSelected(x=>x.config.font_family=this.value)">
                 ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
@@ -1063,7 +1081,7 @@ registerWidget("countdown", {
     keywords: ["countdown", "countup", "timer", "event", "days", "until", "since", "deadline"],
     defaults: () => ({target:"2030-01-01T00:00:00", direction:"down", label:"", completed_text:"",
              show_days:true, show_hours:true, show_minutes:true, show_seconds:false,
-             color:"#ffffff", font_family:"sans", font_size_px:96}),
+             color:"#ffffff", font_family:"sans", font_size_px:96, shrink_to_fit:false}),
     summary: (w) => (w.config.direction === "up" ? "since " : "to ") + String(w.config.target || "").slice(0, 16),
     preview: (root, cfg) => {
         const fmt = (cfg) => {
@@ -1090,18 +1108,31 @@ registerWidget("countdown", {
         c.className = "cw-prev-countdown";
         c.style.color = cfg.color || "#ffffff";
         c.style.fontFamily = fontStack(cfg.font_family);
+        const fit = !!cfg.shrink_to_fit;
+        let host = c;
+        if (fit) {
+            host = document.createElement("div");
+            host.style.display = "flex";
+            host.style.flexDirection = "column";
+            host.style.alignItems = "center";
+            host.style.fontSize = "24px";
+            host.classList.add("cw-fit");
+            host.dataset.fitMax = "512";
+            host.dataset.fitMin = "8";
+            c.appendChild(host);
+        }
         if (cfg.label) {
             const lab = document.createElement("div");
             lab.className = "cw-prev-countdown-label";
-            lab.style.fontSize = cqwFont((Number(cfg.font_size_px) || 96) * 0.4);
+            lab.style.fontSize = fit ? "0.4em" : cqwFont((Number(cfg.font_size_px) || 96) * 0.4);
             lab.textContent = cfg.label;
-            c.appendChild(lab);
+            host.appendChild(lab);
         }
         const timeEl = document.createElement("div");
         timeEl.className = "cw-prev-countdown-time";
-        timeEl.style.fontSize = cqwFont(cfg.font_size_px);
+        timeEl.style.fontSize = fit ? "1em" : cqwFont(cfg.font_size_px);
         timeEl.textContent = fmt(cfg);
-        c.appendChild(timeEl);
+        host.appendChild(timeEl);
         root.appendChild(c);
     },
     settings: (w) => `
@@ -1146,10 +1177,15 @@ registerWidget("countdown", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${w.config.font_size_px||96}"
+                    <input type="number" id="cw-countdown-size" min="8" max="512" value="${w.config.font_size_px||96}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-countdown-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <label>Font</label>
             <select oninput="updateSelected(x=>x.config.font_family=this.value)">
                 ${FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
@@ -1241,7 +1277,7 @@ registerWidget("weather", {
     keywords: ["weather", "temperature", "forecast", "climate", "degrees"],
     defaults: () => ({latitude:47.6062, longitude:-122.3321, location_label:"Seattle", units:"imperial",
              show_condition:true, show_location:true, color:"#ffffff", font_family:"sans",
-             font_size_px:64, refresh_seconds:900}),
+             font_size_px:64, refresh_seconds:900, shrink_to_fit:false}),
     summary: (w) => (w.config.location_label || "weather").slice(0, 24),
     preview: (root, cfg) => { root.appendChild(buildWeatherPreview(cfg)); },
     settings: (w) => {
@@ -1279,10 +1315,15 @@ registerWidget("weather", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${w.config.font_size_px||64}"
+                    <input type="number" id="cw-weather-size" min="8" max="512" value="${w.config.font_size_px||64}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-weather-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <label>Font</label>
             <select oninput="updateSelected(x=>x.config.font_family=this.value)">
                 ${SAFE_FONT_OPTIONS.map(f=>`<option value="${f}" ${w.config.font_family===f?"selected":""}>${f}</option>`).join("")}
@@ -1301,22 +1342,36 @@ registerWidget("rss", {
     keywords: ["rss", "feed", "news", "headlines", "atom", "syndication"],
     defaults: () => ({feed_url:"https://feeds.bbci.co.uk/news/world/rss.xml", heading:"",
              item_count:5, sort_newest:true, show_dates:false, color:"#ffffff", font_family:"sans",
-             font_size_px:32, refresh_seconds:900}),
+             font_size_px:32, refresh_seconds:900, shrink_to_fit:false}),
     summary: (w) => (w.config.heading || "headlines").slice(0, 24),
     preview: (root, cfg) => {
         const wrap = document.createElement("div");
         wrap.className = "cw-prev-rss";
         wrap.style.color = cfg.color || "#ffffff";
         wrap.style.fontFamily = fontStack(cfg.font_family);
+        const fit = !!cfg.shrink_to_fit;
+        let host = wrap;
+        if (fit) {
+            host = document.createElement("div");
+            host.style.display = "flex";
+            host.style.flexDirection = "column";
+            host.style.alignSelf = "center";
+            host.style.fontSize = "24px";
+            host.classList.add("cw-fit");
+            host.dataset.fitMax = "256";
+            host.dataset.fitMin = "8";
+            wrap.appendChild(host);
+        }
         if (cfg.heading) {
             const h = document.createElement("div");
             h.className = "cw-prev-rss-heading";
             h.textContent = cfg.heading;
-            h.style.fontSize = cqwFont(Math.round((Number(cfg.font_size_px)||32) * 1.1));
-            wrap.appendChild(h);
+            h.style.fontSize = fit ? "1.1em" : cqwFont(Math.round((Number(cfg.font_size_px)||32) * 1.1));
+            host.appendChild(h);
         }
         const list = document.createElement("div");
         list.className = "cw-prev-rss-list";
+        if (fit) { list.style.flex = "0 0 auto"; list.style.overflow = "visible"; }
         const n = Math.max(1, Math.min(Number(cfg.item_count) || 5, 6));
         const samples = ["Sample headline one", "Sample headline two",
             "Sample headline three", "Sample headline four",
@@ -1325,18 +1380,18 @@ registerWidget("rss", {
             const row = document.createElement("div");
             const t = document.createElement("div");
             t.textContent = samples[i % samples.length];
-            t.style.fontSize = cqwFont(cfg.font_size_px || 32);
+            t.style.fontSize = fit ? "1em" : cqwFont(cfg.font_size_px || 32);
             row.appendChild(t);
             if (cfg.show_dates) {
                 const d = document.createElement("div");
                 d.className = "cw-prev-rss-date";
                 d.textContent = "Mon, 01 Jan 2026";
-                d.style.fontSize = cqwFont(Math.round((Number(cfg.font_size_px)||32) * 0.6));
+                d.style.fontSize = fit ? "0.6em" : cqwFont(Math.round((Number(cfg.font_size_px)||32) * 0.6));
                 row.appendChild(d);
             }
             list.appendChild(row);
         }
-        wrap.appendChild(list);
+        host.appendChild(list);
         root.appendChild(wrap);
     },
     settings: (w) => `
@@ -1356,7 +1411,8 @@ registerWidget("rss", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="256" value="${w.config.font_size_px||32}"
+                    <input type="number" id="cw-rss-size" min="8" max="256" value="${w.config.font_size_px||32}"
+                           ${w.config.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,256))">
                 </div>
             </div>
@@ -1367,6 +1423,10 @@ registerWidget("rss", {
             <label style="font-weight:400; margin-top:0.5rem;">
                 <input type="checkbox" ${w.config.show_dates?"checked":""}
                     oninput="updateSelected(x=>x.config.show_dates=this.checked)"> Show dates
+            </label>
+            <label style="font-weight:400; margin-top:0.5rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${w.config.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-rss-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
             </label>
             <div class="row">
                 <div>
@@ -1552,7 +1612,7 @@ registerWidget("storehours", {
         friday:[{open:"09:00",close:"17:00"}], saturday:[{open:"10:00",close:"16:00"}],
         sunday:[], holidays:[], display_mode:"today", heading:"", show_status:true,
         time_format:"12h", color:"#ffffff", open_color:"#3fb950", closed_color:"#f85149",
-        font_family:"sans", font_size_px:48,
+        font_family:"sans", font_size_px:48, shrink_to_fit:false,
     }),
     summary: (w) => (w.config.heading || (w.config.display_mode === "week" ? "weekly hours" : "today's hours")).slice(0, 24),
     preview: (root, cfg) => {
@@ -1562,12 +1622,27 @@ registerWidget("storehours", {
         wrap.style.color = cfg.color || "#ffffff";
         wrap.style.fontFamily = fontStack(cfg.font_family);
         const baseFont = Number(cfg.font_size_px) || 48;
+        const fit = !!cfg.shrink_to_fit;
+        let host = wrap;
+        if (fit) {
+            host = document.createElement("div");
+            host.style.display = "flex";
+            host.style.flexDirection = "column";
+            host.style.alignItems = "center";
+            host.style.alignSelf = "center";
+            host.style.gap = "0.25em";
+            host.style.fontSize = "24px";
+            host.classList.add("cw-fit");
+            host.dataset.fitMax = "512";
+            host.dataset.fitMin = "8";
+            wrap.appendChild(host);
+        }
         if (cfg.heading) {
             const h = document.createElement("div");
             h.className = "cw-prev-storehours-heading";
             h.textContent = cfg.heading;
-            h.style.fontSize = cqwFont(Math.round(baseFont * 1.05));
-            wrap.appendChild(h);
+            h.style.fontSize = fit ? "1.05em" : cqwFont(Math.round(baseFont * 1.05));
+            host.appendChild(h);
         }
         // Resolve today's intervals from the weekly schedule (preview
         // ignores holiday date-matching; runtime handles real dates).
@@ -1583,18 +1658,18 @@ registerWidget("storehours", {
             }
             const st = document.createElement("div");
             st.className = "cw-prev-storehours-status";
-            st.style.fontSize = cqwFont(baseFont);
+            st.style.fontSize = fit ? "1em" : cqwFont(baseFont);
             const pill = document.createElement("span");
             pill.className = "cw-prev-storehours-pill";
             pill.textContent = open ? "Open" : "Closed";
             pill.style.background = (open ? (cfg.open_color || "#3fb950") : (cfg.closed_color || "#f85149"));
             st.appendChild(pill);
-            wrap.appendChild(st);
+            host.appendChild(st);
         }
         if (cfg.display_mode === "week") {
             const wk = document.createElement("div");
             wk.className = "cw-prev-storehours-week";
-            wk.style.fontSize = cqwFont(Math.round(baseFont * 0.55));
+            wk.style.fontSize = fit ? "0.55em" : cqwFont(Math.round(baseFont * 0.55));
             for (const f of SH_DAY_FIELDS) {
                 const row = document.createElement("div");
                 row.className = "cw-prev-storehours-row";
@@ -1602,13 +1677,13 @@ registerWidget("storehours", {
                 const v = document.createElement("span"); v.textContent = shFmtIntervals(cfg[f], fmt24);
                 row.appendChild(d); row.appendChild(v); wk.appendChild(row);
             }
-            wrap.appendChild(wk);
+            host.appendChild(wk);
         } else {
             const body = document.createElement("div");
             body.className = "cw-prev-storehours-body";
-            body.style.fontSize = cqwFont(Math.round(baseFont * 0.7));
+            body.style.fontSize = fit ? "0.7em" : cqwFont(Math.round(baseFont * 0.7));
             body.textContent = "Today: " + shFmtIntervals(todayIntervals, fmt24);
-            wrap.appendChild(body);
+            host.appendChild(body);
         }
         root.appendChild(wrap);
     },
@@ -1713,10 +1788,15 @@ registerWidget("storehours", {
                 </div>
                 <div>
                     <label>Size (px)</label>
-                    <input type="number" min="8" max="512" value="${c.font_size_px||48}"
+                    <input type="number" id="cw-storehours-size" min="8" max="512" value="${c.font_size_px||48}"
+                           ${c.shrink_to_fit?"disabled":""}
                            oninput="updateSelected(x=>x.config.font_size_px=clampInt(this.value,8,512))">
                 </div>
             </div>
+            <label style="font-weight:400; margin-top:0.4rem; display:flex; align-items:center; gap:0.35rem;">
+                <input type="checkbox" ${c.shrink_to_fit?"checked":""}
+                    oninput="document.getElementById('cw-storehours-size').disabled=this.checked; updateSelected(x=>x.config.shrink_to_fit=this.checked)"> Shrink to fit
+            </label>
             <div class="row" style="margin-top:0.3rem;">
                 <div>
                     <label>Open color</label>
@@ -2306,24 +2386,37 @@ function buildWeatherPreview(cfg) {
     wrap.className = "cw-prev-weather";
     wrap.style.color = cfg.color || "#ffffff";
     wrap.style.fontFamily = fontStack(cfg.font_family);
+    const fit = !!cfg.shrink_to_fit;
+    let host = wrap;
+    if (fit) {
+        host = document.createElement("div");
+        host.style.display = "flex";
+        host.style.flexDirection = "column";
+        host.style.alignItems = "center";
+        host.style.fontSize = "24px";
+        host.classList.add("cw-fit");
+        host.dataset.fitMax = "512";
+        host.dataset.fitMin = "8";
+        wrap.appendChild(host);
+    }
     if (cfg.show_location) {
         const loc = document.createElement("div");
         loc.className = "cw-prev-weather-loc";
         loc.textContent = cfg.location_label || "";
-        loc.style.fontSize = cqwFont((Number(cfg.font_size_px) || 64) * 0.4);
-        wrap.appendChild(loc);
+        loc.style.fontSize = fit ? "0.4em" : cqwFont((Number(cfg.font_size_px) || 64) * 0.4);
+        host.appendChild(loc);
     }
     const temp = document.createElement("div");
     temp.className = "cw-prev-weather-temp";
     temp.textContent = "72" + (cfg.units === "metric" ? "°C" : "°F");
-    temp.style.fontSize = cqwFont(cfg.font_size_px);
-    wrap.appendChild(temp);
+    temp.style.fontSize = fit ? "1em" : cqwFont(cfg.font_size_px);
+    host.appendChild(temp);
     if (cfg.show_condition) {
         const cond = document.createElement("div");
         cond.className = "cw-prev-weather-cond";
         cond.textContent = "⛅ Partly cloudy";
-        cond.style.fontSize = cqwFont((Number(cfg.font_size_px) || 64) * 0.45);
-        wrap.appendChild(cond);
+        cond.style.fontSize = fit ? "0.45em" : cqwFont((Number(cfg.font_size_px) || 64) * 0.45);
+        host.appendChild(cond);
     }
     return wrap;
 }

--- a/tests/test_composed_autofit.py
+++ b/tests/test_composed_autofit.py
@@ -1,0 +1,73 @@
+"""Tests for the shared shrink-to-fit helper cms.composed.widgets._autofit.
+
+These pin the cross-widget contract: a single binary-search fitter, a
+ResizeObserver + MutationObserver wiring (so dynamic widgets refit on
+content change without per-widget code), and a compact one-line
+per-instance init emitter reused verbatim by every shrink-to-fit widget.
+"""
+
+from __future__ import annotations
+
+from cms.composed.widgets._autofit import (
+    AUTOFIT_JS,
+    AUTOFIT_MAX_PX,
+    AUTOFIT_MIN_PX,
+    autofit_inner_init_js,
+)
+
+
+class TestAutofitConstants:
+    def test_bounds_match_widget_schema(self):
+        # Widgets declare font_size_px Field(ge=8, le=512); the fitter's
+        # bounds must be the same single source of truth.
+        assert AUTOFIT_MAX_PX == 512
+        assert AUTOFIT_MIN_PX == 8
+
+
+class TestAutofitJs:
+    def test_defines_both_globals(self):
+        assert "window.__cwFit" in AUTOFIT_JS
+        assert "window.__cwFitObserve" in AUTOFIT_JS
+
+    def test_globals_are_idempotent_guarded(self):
+        # Embedding the snippet once per bundle must be safe even with
+        # many instances: the globals self-guard.
+        assert "window.__cwFit = window.__cwFit ||" in AUTOFIT_JS
+        assert "window.__cwFitObserve = window.__cwFitObserve ||" in AUTOFIT_JS
+
+    def test_observes_resize_and_mutations(self):
+        assert "ResizeObserver" in AUTOFIT_JS
+        assert "MutationObserver" in AUTOFIT_JS
+
+    def test_mutation_observer_excludes_attributes(self):
+        # Observing attributes would loop: __cwFit writes inner.style
+        # .fontSize on every fit, which would retrigger the observer.
+        assert "childList: true, characterData: true, subtree: true" in AUTOFIT_JS
+        assert "attributes: true" not in AUTOFIT_JS
+
+    def test_fits_against_parent_box(self):
+        assert "inner.parentElement" in AUTOFIT_JS
+        assert "scrollWidth" in AUTOFIT_JS
+        assert "scrollHeight" in AUTOFIT_JS
+
+
+class TestAutofitInnerInitJs:
+    def test_emits_observe_call_for_inner_id(self):
+        out = autofit_inner_init_js("cw-text-inner-abcd")
+        assert "document.getElementById('cw-text-inner-abcd')" in out
+        assert "window.__cwFitObserve" in out
+
+    def test_passes_shared_bounds(self):
+        out = autofit_inner_init_js("cw-clock-inner-x")
+        assert f"{AUTOFIT_MAX_PX},{AUTOFIT_MIN_PX}" in out
+
+    def test_guards_missing_element_and_helper(self):
+        out = autofit_inner_init_js("cw-rss-inner-x")
+        assert "if(el&&window.__cwFitObserve)" in out
+
+    def test_is_single_statement_line(self):
+        # Reused as a concatenated suffix after each widget's own init_js,
+        # so it must be a single self-contained statement (no newline).
+        out = autofit_inner_init_js("cw-weather-inner-x")
+        assert "\n" not in out
+        assert out.endswith(";")

--- a/tests/test_composed_clock_widget.py
+++ b/tests/test_composed_clock_widget.py
@@ -137,3 +137,37 @@ class TestClockWidgetRender:
         cfg = ClockWidgetConfig(font_size_px=128)
         r = w.render_html(cfg, _cell(), "abc")
         assert "font-size: 128px" in r.css
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        w = ClockWidget()
+        a = w.render_html(ClockWidgetConfig(font_size_px=64), _cell(), "x")
+        b = w.render_html(ClockWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = ClockWidget()
+        out = w.render_html(ClockWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert out.js == ""
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in (out.init_js or "")
+        assert "cw-clock-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = ClockWidget()
+        out = w.render_html(ClockWidgetConfig(font_size_px=64, shrink_to_fit=True), _cell(), "abcd")
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        inner_id = "cw-clock-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        assert "font-size: 64px" in out.css
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert ClockWidget().default_config()["shrink_to_fit"] is False

--- a/tests/test_composed_countdown_widget.py
+++ b/tests/test_composed_countdown_widget.py
@@ -182,3 +182,37 @@ class TestCountdownWidgetRender:
         cfg = CountdownWidgetConfig(font_size_px=128)
         r = w.render_html(cfg, _cell(), "abc")
         assert "font-size: 128px" in r.css
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        w = CountdownWidget()
+        a = w.render_html(CountdownWidgetConfig(font_size_px=64), _cell(), "x")
+        b = w.render_html(CountdownWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = CountdownWidget()
+        out = w.render_html(CountdownWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert out.js == ""
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in (out.init_js or "")
+        assert "cw-countdown-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = CountdownWidget()
+        out = w.render_html(CountdownWidgetConfig(font_size_px=64, shrink_to_fit=True), _cell(), "abcd")
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        inner_id = "cw-countdown-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        assert "font-size: 64px" in out.css
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert CountdownWidget().default_config()["shrink_to_fit"] is False

--- a/tests/test_composed_rss_widget.py
+++ b/tests/test_composed_rss_widget.py
@@ -225,3 +225,37 @@ class TestRssWidgetRender:
         assert "src=" not in r.html
         assert "href=" not in r.html
         assert "feed.test" not in r.html
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        w = RssWidget()
+        a = w.render_html(RssWidgetConfig(font_size_px=64), _cell(), "x")
+        b = w.render_html(RssWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = RssWidget()
+        out = w.render_html(RssWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert out.js == ""
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in (out.init_js or "")
+        assert "cw-rss-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = RssWidget()
+        out = w.render_html(RssWidgetConfig(font_size_px=64, shrink_to_fit=True), _cell(), "abcd")
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        inner_id = "cw-rss-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        assert "font-size: 64px" in out.css
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert RssWidget().default_config()["shrink_to_fit"] is False

--- a/tests/test_composed_store_hours_widget.py
+++ b/tests/test_composed_store_hours_widget.py
@@ -283,3 +283,37 @@ class TestStoreHoursWidgetRender:
         r = self._render()
         assert r.static_assets == []
         assert r.referenced_asset_ids == []
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        w = StoreHoursWidget()
+        a = w.render_html(StoreHoursWidgetConfig(font_size_px=64), _cell(), "x")
+        b = w.render_html(StoreHoursWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = StoreHoursWidget()
+        out = w.render_html(StoreHoursWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert out.js == ""
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in (out.init_js or "")
+        assert "cw-storehours-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = StoreHoursWidget()
+        out = w.render_html(StoreHoursWidgetConfig(font_size_px=64, shrink_to_fit=True), _cell(), "abcd")
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        inner_id = "cw-storehours-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        assert "font-size: 64px" in out.css
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert StoreHoursWidget().default_config()["shrink_to_fit"] is False

--- a/tests/test_composed_weather_widget.py
+++ b/tests/test_composed_weather_widget.py
@@ -194,3 +194,37 @@ class TestWeatherWidgetRender:
         assert a.html == b.html
         assert a.css == b.css
         assert a.init_js == b.init_js
+
+
+class TestShrinkToFit:
+    def test_default_off_is_byte_identical_to_no_field(self):
+        w = WeatherWidget()
+        a = w.render_html(WeatherWidgetConfig(font_size_px=64), _cell(), "x")
+        b = w.render_html(WeatherWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert a.html == b.html
+        assert a.css == b.css
+        assert a.js == b.js
+        assert a.init_js == b.init_js
+
+    def test_default_off_emits_no_autofit_code(self):
+        w = WeatherWidget()
+        out = w.render_html(WeatherWidgetConfig(font_size_px=64, shrink_to_fit=False), _cell(), "x")
+        assert out.js == ""
+        assert "__cwFit" not in out.html
+        assert "__cwFit" not in out.css
+        assert "__cwFit" not in (out.init_js or "")
+        assert "cw-weather-inner-" not in out.html
+
+    def test_on_path_emits_autofit_js_and_init(self):
+        w = WeatherWidget()
+        out = w.render_html(WeatherWidgetConfig(font_size_px=64, shrink_to_fit=True), _cell(), "abcd")
+        assert "window.__cwFit" in out.js
+        assert "window.__cwFitObserve" in out.js
+        inner_id = "cw-weather-inner-abcd"
+        assert inner_id in out.html
+        assert inner_id in out.init_js
+        assert "__cwFitObserve" in out.init_js
+        assert "font-size: 64px" in out.css
+
+    def test_default_config_includes_shrink_to_fit_false(self):
+        assert WeatherWidget().default_config()["shrink_to_fit"] is False


### PR DESCRIPTION
Extends the opt-in **Shrink to fit** font toggle (shipped for text + date banner in #762) to the remaining five text-bearing composed widgets: **clock, countdown, store hours, rss, weather**.

Per the shared-code directive, this reuses the autofit infrastructure rather than copy-pasting:
- New shared `autofit_inner_init_js()` helper in `_autofit.py`; `text.py` refactored onto it.
- `__cwFitObserve` now also re-fits on **content mutations** (MutationObserver), so dynamic widgets (ticking clock, countdown, rotating rss, weather refresh) auto-refit with zero per-widget wiring. Static widgets never mutate and pay nothing.

Each widget gets a `shrink_to_fit` config + `_render_shrink` path. **Default-off render is byte-identical** server-side and in the editor preview, so existing substring tests + bundle hashes stay green.

Editor: per-widget preview wraps content in a `.cw-fit` host when shrink is on, disables the manual Size input, and adds a Shrink to fit checkbox mirroring the date banner.

Tests: 232 widget + autofit tests green locally; editor JS `node --check` clean.

Dev-only (not deploying to prod).
