### PR TITLE
fix(composed-snapshot): allow SSRF-guarded live network in thumbnails

### DIFF
--- a/tests/test_composed_snapshot_network_guard.py
+++ b/tests/test_composed_snapshot_network_guard.py
@@ -1,0 +1,186 @@
+"""Guarded-network policy for composed-slide thumbnail snapshots.
+
+`render_composed_to_png` used to abort *all* network so weather /
+web-embed widgets only ever rendered their offline fallback in the
+grid thumbnail. It now allows live ``http(s)`` requests whose host
+passes the SSRF guard (``_host_is_safe``) while still aborting
+private / internal hosts and every non-``data:`` / non-http scheme.
+
+These tests exercise:
+* `_composed_scheme_action` scheme classification.
+* The real route-guard closure inside `render_composed_to_png`, driven
+  through a fake Playwright browser, with `_host_is_safe` stubbed so no
+  real DNS happens: data: continues, safe host continues, unsafe host
+  aborts, file/blob/ws abort, and each host is resolved at most once
+  (per-render cache).
+"""
+
+import pytest
+
+import worker.composed_render as wcr
+
+
+class TestComposedSchemeAction:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "data:image/png;base64,AAAA",
+            "DATA:text/html,<b>hi</b>",
+        ],
+    )
+    def test_data_allow(self, url):
+        assert wcr._composed_scheme_action(url) == "allow"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.open-meteo.com/v1/forecast",
+            "http://example.com/page",
+            "HTTPS://Example.com/X",
+        ],
+    )
+    def test_http_check_host(self, url):
+        assert wcr._composed_scheme_action(url) == "check_host"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "blob:https://x/abc",
+            "ws://example.com/socket",
+            "ftp://example.com/x",
+            "javascript:alert(1)",
+        ],
+    )
+    def test_other_abort(self, url):
+        assert wcr._composed_scheme_action(url) == "abort"
+
+
+class _FakeRoute:
+    def __init__(self, url):
+        self.request = type("Req", (), {"url": url})()
+        self.action = None
+
+    async def continue_(self):
+        self.action = "continue"
+
+    async def abort(self):
+        self.action = "abort"
+
+
+class _FakePage:
+    def __init__(self):
+        self._handler = None
+
+    async def route(self, pattern, handler):
+        self._handler = handler
+
+    def set_default_timeout(self, _ms):
+        pass
+
+    async def set_content(self, _html, **_kw):
+        pass
+
+    async def wait_for_load_state(self, _state, **_kw):
+        pass
+
+    async def evaluate(self, _js):
+        return None
+
+    async def wait_for_timeout(self, _ms):
+        pass
+
+    async def screenshot(self, **_kw):
+        return b"\x89PNG-fake"
+
+
+class _FakeContext:
+    def __init__(self, page):
+        self._page = page
+
+    async def new_page(self):
+        return self._page
+
+    async def close(self):
+        pass
+
+
+class _FakeBrowser:
+    def __init__(self, page):
+        self._page = page
+
+    async def new_context(self, **_kw):
+        return _FakeContext(self._page)
+
+
+@pytest.mark.asyncio
+class TestComposedRouteGuard:
+    async def _capture_guard(self, monkeypatch, resolved):
+        """Run render_composed_to_png with a fake browser; return the
+        captured route guard + a record of hosts passed to _host_is_safe.
+
+        ``resolved`` maps host -> bool returned by the stubbed
+        _host_is_safe.
+        """
+        page = _FakePage()
+        monkeypatch.setattr(
+            wcr, "_get_browser", lambda: _fake_async(_FakeBrowser(page)),
+        )
+
+        seen = []
+
+        def _fake_safe(host):
+            seen.append(host)
+            return resolved.get(host, True)
+
+        monkeypatch.setattr(wcr, "_host_is_safe", _fake_safe)
+
+        out = await wcr.render_composed_to_png(b"<html></html>")
+        assert out == b"\x89PNG-fake"
+        assert page._handler is not None
+        return page._handler, seen
+
+    async def test_data_uri_continues(self, monkeypatch):
+        guard, seen = await self._capture_guard(monkeypatch, {})
+        r = _FakeRoute("data:image/png;base64,AAAA")
+        await guard(r)
+        assert r.action == "continue"
+        assert seen == []  # no DNS for data:
+
+    async def test_safe_host_continues(self, monkeypatch):
+        guard, seen = await self._capture_guard(
+            monkeypatch, {"api.open-meteo.com": True},
+        )
+        r = _FakeRoute("https://api.open-meteo.com/v1/forecast")
+        await guard(r)
+        assert r.action == "continue"
+        assert seen == ["api.open-meteo.com"]
+
+    async def test_unsafe_host_aborts(self, monkeypatch):
+        guard, _ = await self._capture_guard(
+            monkeypatch, {"169.254.169.254": False},
+        )
+        r = _FakeRoute("http://169.254.169.254/latest/meta-data")
+        await guard(r)
+        assert r.action == "abort"
+
+    async def test_file_scheme_aborts(self, monkeypatch):
+        guard, seen = await self._capture_guard(monkeypatch, {})
+        r = _FakeRoute("file:///etc/passwd")
+        await guard(r)
+        assert r.action == "abort"
+        assert seen == []  # never resolved a host
+
+    async def test_host_resolved_once(self, monkeypatch):
+        guard, seen = await self._capture_guard(
+            monkeypatch, {"example.com": True},
+        )
+        for _ in range(3):
+            r = _FakeRoute("https://example.com/asset")
+            await guard(r)
+            assert r.action == "continue"
+        assert seen == ["example.com"]  # cached after first resolve
+
+
+async def _fake_async(value):
+    return value

--- a/worker/composed_render.py
+++ b/worker/composed_render.py
@@ -6,12 +6,18 @@ leaks):
 
 * :func:`render_composed_to_png` — renders the self-contained
   composed-slide HTML produced by
-  :func:`cms.composed.render.build_composed_html` with **all network
-  blocked**: only ``data:`` URIs (already-inlined images / videos /
-  fonts) ever load, so a slide can never make the worker reach out to an
-  arbitrary origin while it is being snapshotted. The weather widget's
-  live Open-Meteo fetch is blocked too, so it renders its offline
-  fallback in the thumbnail — acceptable for a static snapshot.
+  :func:`cms.composed.render.build_composed_html`. Inlined ``data:``
+  URIs (already-embedded images / videos / fonts) always load. Live
+  ``http(s)`` requests from widgets — the weather widget's Open-Meteo
+  fetch, a web-embed iframe's page — are allowed **only** when the
+  target host passes the same SSRF guard used by
+  :func:`render_url_to_png` (rejecting private / loopback / link-local /
+  reserved / multicast / unspecified addresses, which covers the
+  169.254.169.254 cloud-metadata endpoint). Everything else
+  (``file`` / ``blob`` / ``ws`` / unsafe hosts) is aborted. This lets
+  the thumbnail reflect live widget content (real weather, embedded
+  pages) while keeping the worker from reaching arbitrary internal
+  origins.
 
 * :func:`render_url_to_png` — navigates to a live webpage URL and
   screenshots it, so network **must** be allowed. To keep this from
@@ -37,9 +43,13 @@ logger = logging.getLogger("agora.worker.composed_render")
 _VIEWPORT = {"width": 1920, "height": 1080}
 _NAV_TIMEOUT_MS = 15000
 _READY_TIMEOUT_MS = 8000
+# Bounded wait for live widget requests (weather fetch, embed iframe) to
+# settle once network is allowed. Wrapped in try/except so a page that
+# keeps a connection open can't hang the render past this budget.
+_NETWORK_IDLE_TIMEOUT_MS = 6000
 # Short settle after readiness so late CSS transitions / clock paints land
 # before the screenshot.
-_SETTLE_MS = 200
+_SETTLE_MS = 300
 
 # Lazy singletons — created on first render, reused thereafter.
 _pw = None
@@ -73,6 +83,21 @@ async () => {
       setTimeout(res, 3000);
     });
   }));
+  const frames = Array.from(document.querySelectorAll('iframe'));
+  await Promise.all(frames.map(f => {
+    try {
+      if (f.contentDocument && f.contentDocument.readyState === 'complete') {
+        return Promise.resolve();
+      }
+    } catch (e) {
+      // Cross-origin frame: can't inspect readiness, treat as settled.
+      return Promise.resolve();
+    }
+    return new Promise(res => {
+      f.addEventListener('load', res, {once: true});
+      setTimeout(res, 4000);
+    });
+  }));
 }
 """
 
@@ -103,10 +128,14 @@ async def _get_browser():
 async def render_composed_to_png(html_bytes: bytes) -> bytes:
     """Render self-contained composed-slide HTML to a 1920×1080 PNG.
 
-    Blocks all network (only inline ``data:`` URIs load), waits for fonts
-    and media to settle, then screenshots the full canvas. Raises on a
-    hard render failure (browser launch / navigation timeout) — the caller
-    marks the variant failed.
+    Inline ``data:`` URIs always load. Live ``http(s)`` requests from
+    widgets (weather fetch, web-embed iframe) load **only** when the
+    target host passes the SSRF guard (:func:`_host_is_safe`); unsafe
+    hosts and all other schemes (``file`` / ``blob`` / ``ws``) are
+    aborted. Waits for fonts, media, and iframes to settle, then
+    screenshots the full canvas. Raises on a hard render failure
+    (browser launch / navigation timeout) — the caller marks the
+    variant failed.
     """
     html = html_bytes.decode("utf-8")
     browser = await _get_browser()
@@ -118,20 +147,49 @@ async def render_composed_to_png(html_bytes: bytes) -> bytes:
     try:
         page = await context.new_page()
 
-        async def _block(route):
-            # Inline data: URIs are resolved internally and rarely hit this
-            # handler; everything else (http/https/file/blob/ws) is aborted
-            # so the snapshot render is fully offline and side-effect free.
+        # Per-render cache of host -> is-safe so we resolve each host once.
+        safe_hosts: dict[str, bool] = {}
+
+        async def _guard(route):
             url = route.request.url
-            if url.startswith("data:"):
+            action = _composed_scheme_action(url)
+            if action == "allow":
+                await route.continue_()
+                return
+            if action == "abort":
+                await route.abort()
+                return
+            # action == "check_host": http/https — gate on SSRF safety.
+            host = _host_of(url)
+            if not host:
+                await route.abort()
+                return
+            ok = safe_hosts.get(host)
+            if ok is None:
+                ok = await asyncio.to_thread(_host_is_safe, host)
+                safe_hosts[host] = ok
+            if ok:
                 await route.continue_()
             else:
+                logger.warning(
+                    "composed snapshot blocked unsafe host %r (%s)", host, url,
+                )
                 await route.abort()
 
-        await page.route("**/*", _block)
+        await page.route("**/*", _guard)
         page.set_default_timeout(_NAV_TIMEOUT_MS)
 
         await page.set_content(html, wait_until="load", timeout=_NAV_TIMEOUT_MS)
+
+        # Let live widget requests (weather fetch, embed iframe subresources)
+        # settle. Bounded + best-effort: a page holding a long-lived
+        # connection must not stall the snapshot past this budget.
+        try:
+            await page.wait_for_load_state(
+                "networkidle", timeout=_NETWORK_IDLE_TIMEOUT_MS,
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         try:
             await asyncio.wait_for(
@@ -205,6 +263,24 @@ def _host_of(url: str) -> str:
     from urllib.parse import urlsplit
 
     return (urlsplit(url).hostname or "").strip()
+
+
+def _composed_scheme_action(url: str) -> str:
+    """Classify a composed-snapshot subresource request by scheme.
+
+    Returns one of:
+    * ``"allow"`` — inline ``data:`` URIs (already CMS-embedded); load.
+    * ``"check_host"`` — ``http``/``https``; caller must gate on
+      :func:`_host_is_safe`.
+    * ``"abort"`` — every other scheme (``file`` / ``blob`` / ``ws`` /
+      ``ftp`` / …); never allowed in a snapshot.
+    """
+    lowered = url.strip().lower()
+    if lowered.startswith("data:"):
+        return "allow"
+    if lowered.startswith("http://") or lowered.startswith("https://"):
+        return "check_host"
+    return "abort"
 
 
 async def render_url_to_png(url: str) -> bytes:


### PR DESCRIPTION
## What & why

Composed-slide grid thumbnails are rendered headless in the worker by `render_composed_to_png`. It previously **aborted all network** (SSRF defense — only inline `data:` URIs loaded), so **live widgets never appeared in the snapshot**: the weather widget showed its `-- F` offline fallback and web embeds were blank. They render fine in the live `/preview` (network-allowed CMS page), which is why this only showed up in the grid thumbnail.

Reframed nit 3 from the editor batch: it was **not** a snapshot-timing bug.

## Change

- Replace the all-abort route handler with a **guarded** one: `data:` always loads; `http(s)` loads **only** when the host passes the existing `_host_is_safe` SSRF guard (reused verbatim from `render_url_to_png`) — private / loopback / link-local (`169.254.169.254` metadata) / reserved / multicast / unspecified hosts are rejected; `file` / `blob` / `ws` and other schemes are aborted. Hosts resolved once per render (`safe_hosts` cache).
- Bounded `wait_for_load_state("networkidle")` (6s, best-effort) after `set_content` so the weather fetch + embed subresources settle.
- Readiness JS now also awaits iframe `load` events (cross-origin → treated as settled; 4s fallback). Settle bumped 200→300ms.
- Updated module + function docstrings (they claimed network was fully blocked).

## Tests

New `tests/test_composed_snapshot_network_guard.py` drives the **real** route-guard closure through a fake Playwright browser with `_host_is_safe` stubbed (no real DNS): data: continues, safe host continues, unsafe host aborts, file/blob/ws abort, host resolved once. Existing `test_composed_thumbnail_snapshot.py` + `test_webpage_thumbnail_snapshot.py` still green (40 passed).

## Notes

- Default render path of every widget is unchanged — no config keys touched. Snapshots now reach live origins; failures fall back to the same offline state as today, just slower.
- Dev-only deploy.
