### PR TITLE
feat(composed): allow media widget to cycle a slideshow asset

### DIFF
--- a/cms/composed/bundle.py
+++ b/cms/composed/bundle.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 
 from cms.composed.registry import (
     BundleContext,
+    SlideshowSlidePlan,
     Widget,
     WidgetRegistry,
     WidgetRender,
@@ -164,6 +165,7 @@ def build_bundle(
     asset_loader: AssetLoader | None = None,
     sibling_asset_urls: dict[uuid.UUID, str] | None = None,
     cms_base_url: str | None = None,
+    slideshow_plans: dict[uuid.UUID, list[SlideshowSlidePlan]] | None = None,
 ) -> BuiltBundle:
     """Render ``layout`` to a self-contained HTML bundle.
 
@@ -189,6 +191,17 @@ def build_bundle(
     ``asset_loader`` path *or* the ``sibling_asset_urls`` mapping; if
     it's in neither, :class:`MissingAssetLoaderError` is raised.
 
+    ``slideshow_plans`` is the additive channel for a media widget whose
+    declared ``asset_id`` is a SLIDESHOW asset.  It maps that *container*
+    asset ID to the ordered list of :class:`SlideshowSlidePlan` the
+    caller resolved from the live slideshow.  The container ID itself has
+    no file: wherever the builder would otherwise load / prefetch /
+    scope a declared ID, a planned ID is transparently *expanded* to its
+    per-slide source asset IDs, which the caller has already routed into
+    ``asset_loader`` / ``sibling_asset_urls`` like any standalone media.
+    When ``slideshow_plans`` is ``None`` / empty the expansion is the
+    identity function and the build is byte-for-byte unchanged.
+
     Raises :class:`BundleValidationError` if the layout fails
     :func:`~cms.composed.validate.validate_layout`.  The check is
     redundant with the editor's save-time validation but kept as
@@ -199,6 +212,29 @@ def build_bundle(
     sib_urls: dict[uuid.UUID, str] = (
         dict(sibling_asset_urls) if sibling_asset_urls else {}
     )
+    plans: dict[uuid.UUID, list[SlideshowSlidePlan]] = (
+        dict(slideshow_plans) if slideshow_plans else {}
+    )
+
+    def _expand(aid: uuid.UUID) -> list[uuid.UUID]:
+        # A slideshow *container* ID has no file of its own; it stands
+        # in for its ordered per-slide source IDs.  Any non-planned ID
+        # expands to itself, so the whole pipeline is unchanged when
+        # ``slideshow_plans`` is empty.
+        plan = plans.get(aid)
+        if plan:
+            return [s.source_asset_id for s in plan]
+        return [aid]
+
+    def _expand_all(ids: list[uuid.UUID]) -> list[uuid.UUID]:
+        out: list[uuid.UUID] = []
+        seen: set[uuid.UUID] = set()
+        for aid in ids:
+            for eff in _expand(aid):
+                if eff not in seen:
+                    seen.add(eff)
+                    out.append(eff)
+        return out
 
     # 1. Defensive validation.
     errors = validate_layout(layout, reg)
@@ -225,21 +261,27 @@ def build_bundle(
                 seen_declared.add(aid)
                 all_declared_ids.append(aid)
 
+    # Expand slideshow containers to their source IDs for the
+    # loader-coverage and prefetch passes.  A container ID is never
+    # loaded as bytes itself (it has no file) — it disappears here,
+    # replaced by the per-slide sources the caller already routed.
+    all_effective_ids = _expand_all(all_declared_ids)
+
     # An ID counts as "satisfied" if we have either bytes-channel
     # coverage (asset_loader) OR a sibling-URL mapping for it.  Only
     # IDs with no coverage from either channel are missing.
-    needs_loader = [aid for aid in all_declared_ids if aid not in sib_urls]
+    needs_loader = [aid for aid in all_effective_ids if aid not in sib_urls]
     if needs_loader and asset_loader is None:
         raise MissingAssetLoaderError(needs_loader)
 
-    # 2b. Pre-fetch every declared asset exactly once.  Skip IDs
+    # 2b. Pre-fetch every effective asset exactly once.  Skip IDs
     #     that the publish layer routed to the sibling-URLs channel
     #     (videos, etc.) — those don't get inlined and don't need
     #     bytes loaded.
     asset_bytes: dict[uuid.UUID, bytes] = {}
     asset_mimes: dict[uuid.UUID, str] = {}
     if asset_loader is not None:
-        for aid in all_declared_ids:
+        for aid in all_effective_ids:
             if aid in sib_urls:
                 continue
             blob, mime = asset_loader(aid)
@@ -257,17 +299,23 @@ def build_bundle(
     seen_asset_ids: set[uuid.UUID] = set()
 
     for inst, widget, config, declared in prepped:
+        # Effective IDs visible to this widget: its declared IDs with
+        # any slideshow container expanded to its per-slide sources.
+        eff_declared = _expand_all(declared)
         ctx = BundleContext(
             asset_bytes={
-                aid: asset_bytes[aid] for aid in declared if aid in asset_bytes
+                aid: asset_bytes[aid] for aid in eff_declared if aid in asset_bytes
             },
             asset_mimes={
-                aid: asset_mimes[aid] for aid in declared if aid in asset_mimes
+                aid: asset_mimes[aid] for aid in eff_declared if aid in asset_mimes
             },
             sibling_asset_urls={
-                aid: sib_urls[aid] for aid in declared if aid in sib_urls
+                aid: sib_urls[aid] for aid in eff_declared if aid in sib_urls
             },
             cms_base_url=cms_base_url,
+            slideshow_plans={
+                aid: plans[aid] for aid in declared if aid in plans
+            },
         )
         render: WidgetRender = widget.render_html(
             config=config,
@@ -277,9 +325,11 @@ def build_bundle(
         )
 
         # Enforce the declare-before-reference invariant: every ID a
-        # widget reports in WidgetRender.referenced_asset_ids must
-        # have been declared up front.
-        declared_set = set(declared)
+        # widget reports in WidgetRender.referenced_asset_ids must have
+        # been declared up front — either directly, or (for a slideshow
+        # media widget) as one of the expanded per-slide source IDs of a
+        # declared container.
+        declared_set = set(declared) | set(eff_declared)
         for aid in render.referenced_asset_ids:
             if aid not in declared_set:
                 raise BundleValidationError(

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -32,8 +32,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.composed.bundle import BundleValidationError, build_bundle
-from cms.composed.registry import get_registry
+from cms.composed.registry import SlideshowSlidePlan, get_registry
 from cms.composed.schema import Layout
+from cms.composed.slideshow_expand import (
+    composed_cell_transition,
+    load_slideshow_members,
+)
 from cms.models.composed_slide import ComposedSlide
 from shared.models.asset import Asset, AssetType
 from shared.services.storage import get_storage
@@ -150,10 +154,53 @@ async def publish_composed_slide(
     #           to the same device groups so they land in the device's
     #           video cache through the existing per-asset sync path.
     #   anything else → reject (e.g. a composed slide can't embed
-    #           another composed slide, a webpage asset, or a slideshow)
+    #           another composed slide, a webpage asset)
+    #
+    #   SLIDESHOW → expand into its ordered member slides; each member
+    #           source is routed through the SAME image/video buckets
+    #           above, and an ordered SlideshowSlidePlan list is recorded
+    #           in slideshow_plans[container_id] so the bundle builder
+    #           and MediaWidget can cycle them client-side.
     asset_payloads: dict[uuid.UUID, tuple[bytes, str]] = {}
     sibling_asset_urls: dict[uuid.UUID, str] = {}
+    slideshow_plans: dict[uuid.UUID, list[SlideshowSlidePlan]] = {}
+    # Mutable cell so the nested closure can bump the shared counter.
     video_count = 0
+
+    def _route_media_source(ref: Asset) -> None:
+        """Route one IMAGE/VIDEO source asset into the right channel.
+
+        Shared by the top-level declared-asset loop and the slideshow
+        member expansion so both produce byte-identical routing.
+        Raises PublishError for any non-image/video source.
+        """
+        nonlocal video_count
+        if ref.id in asset_payloads or ref.id in sibling_asset_urls:
+            return
+        if ref.asset_type == AssetType.IMAGE:
+            ref_path = storage_dir / ref.filename
+            try:
+                blob = ref_path.read_bytes()
+            except FileNotFoundError as e:
+                raise PublishError(
+                    f"Asset {ref.id} file missing on disk: {ref.filename}",
+                ) from e
+            mime, _ = mimetypes.guess_type(ref.filename)
+            asset_payloads[ref.id] = (blob, mime or "application/octet-stream")
+        elif ref.asset_type == AssetType.VIDEO:
+            import urllib.parse as _urlparse
+
+            sibling_asset_urls[ref.id] = (
+                f"/assets/videos/{_urlparse.quote(ref.filename, safe='')}"
+            )
+            video_count += 1
+        else:
+            raise PublishError(
+                f"Composed slide references asset {ref.id} of type "
+                f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
+                "assets can be embedded in a composed slide",
+            )
+
     if declared_ids:
         rows = await db.execute(
             select(Asset).where(Asset.id.in_(declared_ids)),
@@ -165,38 +212,51 @@ async def publish_composed_slide(
                 raise PublishError(
                     f"Composed slide references missing asset {aid}",
                 )
-            if ref.asset_type == AssetType.IMAGE:
-                ref_path = storage_dir / ref.filename
-                try:
-                    blob = ref_path.read_bytes()
-                except FileNotFoundError as e:
+            if ref.asset_type == AssetType.SLIDESHOW:
+                # Expand the slideshow into ordered member slides.  The
+                # device-publish path keeps deleted source assets (a
+                # device bundle is a point-in-time snapshot); the editor
+                # render path excludes them.
+                members = await load_slideshow_members(
+                    db, aid, exclude_deleted=False
+                )
+                if not members:
                     raise PublishError(
-                        f"Asset {aid} file missing on disk: {ref.filename}",
-                    ) from e
-                mime, _ = mimetypes.guess_type(ref.filename)
-                asset_payloads[aid] = (blob, mime or "application/octet-stream")
-            elif ref.asset_type == AssetType.VIDEO:
-                # Device-local URL served by the Pi shell's HTTP server
-                # (port 8780, FastAPI StaticFiles mount on /assets →
-                # /opt/agora/assets/).  URL-encode the filename so files
-                # with spaces / special chars (e.g. "my video (final).mp4")
-                # produce a valid src attribute.
-                import urllib.parse as _urlparse
-
-                # ``safe=""`` so '/' in a hypothetical filename gets
-                # percent-encoded too — without it, urllib leaves '/'
-                # alone (the default ``safe="/"``) and a malicious or
-                # buggy filename could break out of the videos/ dir.
-                sibling_asset_urls[aid] = (
-                    f"/assets/videos/{_urlparse.quote(ref.filename, safe='')}"
-                )
-                video_count += 1
+                        f"Composed slide references slideshow {aid} that "
+                        "has no slides",
+                    )
+                plan: list[SlideshowSlidePlan] = []
+                for slide, source in members:
+                    if source is None:
+                        raise PublishError(
+                            f"Slideshow {aid} slide {slide.id} references a "
+                            "missing source asset",
+                        )
+                    if source.asset_type not in (
+                        AssetType.IMAGE,
+                        AssetType.VIDEO,
+                    ):
+                        raise PublishError(
+                            f"Slideshow {aid} slide {slide.id} references "
+                            f"asset {source.id} of type "
+                            f"{source.asset_type.value!r}; a composed-slide "
+                            "media widget can only cycle IMAGE and VIDEO "
+                            "slideshow members",
+                        )
+                    _route_media_source(source)
+                    plan.append(
+                        SlideshowSlidePlan(
+                            source_asset_id=source.id,
+                            duration_ms=int(slide.duration_ms),
+                            transition=composed_cell_transition(
+                                slide.transition
+                            ),
+                            transition_ms=int(slide.transition_ms),
+                        )
+                    )
+                slideshow_plans[aid] = plan
             else:
-                raise PublishError(
-                    f"Composed slide references asset {aid} of type "
-                    f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
-                    "assets can be embedded in a composed slide",
-                )
+                _route_media_source(ref)
 
     if video_count > 1:
         # No hard cap — multiple muted autoplay videos technically work
@@ -226,6 +286,7 @@ async def publish_composed_slide(
             registry,
             asset_loader=_asset_loader if asset_payloads else None,
             sibling_asset_urls=sibling_asset_urls or None,
+            slideshow_plans=slideshow_plans or None,
             # Device bundles are served from the device's own local
             # shell HTTP server, so any CMS call-back URL (e.g. the RSS
             # feed proxy) must be absolute.  Preview/thumbnail renders

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -28,6 +28,33 @@ from pydantic import BaseModel
 from cms.composed.schema import Cell
 
 
+@dataclass(frozen=True)
+class SlideshowSlidePlan:
+    """One resolved slide of a SLIDESHOW asset embedded in a media widget.
+
+    When a :class:`~cms.composed.widgets.media.MediaWidget` points its
+    ``asset_id`` at a SLIDESHOW asset, the publish / render layer
+    re-resolves the slideshow's ordered slides at build time (so the
+    composed bundle always tracks the *live* slideshow) and hands the
+    bundle builder one of these per slide, in ``position`` order.
+
+    ``source_asset_id`` is the per-slide IMAGE/VIDEO source — its bytes
+    (image) or sibling/data URL (video) are routed into the same
+    :class:`BundleContext` channels a standalone media asset would use.
+    ``duration_ms`` is how long the slide shows before advancing.
+    ``transition`` is the composed-cell transition repertoire only
+    (``"cut"`` or ``"fade"`` — the device's richer native set is
+    firmware-only and not reusable in a Chromium bundle, so callers map
+    the other transitions down to ``"fade"``).  ``transition_ms`` is the
+    cross-fade duration (ignored for ``"cut"``).
+    """
+
+    source_asset_id: uuid.UUID
+    duration_ms: int
+    transition: str = "cut"
+    transition_ms: int = 0
+
+
 @dataclass
 class BundleContext:
     """Per-build context passed into every widget's ``render_html``.
@@ -67,6 +94,17 @@ class BundleContext:
     the CMS itself) and for the headless thumbnail render.  Widgets
     that make no runtime CMS call ignore this entirely.
 
+    ``slideshow_plans`` is the additive channel for a media widget whose
+    ``asset_id`` points at a SLIDESHOW asset.  It maps that container
+    asset ID to the ordered list of :class:`SlideshowSlidePlan` the
+    publish / render layer resolved from the live slideshow.  The
+    per-slide *source* asset IDs are routed into ``asset_bytes`` /
+    ``sibling_asset_urls`` exactly like standalone media; the plan adds
+    the ordering, per-slide duration, and transition metadata the media
+    widget needs to emit its client-side cycling markup.  Empty for
+    every layout that contains no slideshow-backed media widget — in
+    which case the whole build is byte-for-byte unchanged.
+
     Empty defaults are intentional: trivial widgets (text, clock) that
     never touch assets can ignore the parameter entirely.
     """
@@ -75,6 +113,9 @@ class BundleContext:
     asset_mimes: dict[uuid.UUID, str] = field(default_factory=dict)
     sibling_asset_urls: dict[uuid.UUID, str] = field(default_factory=dict)
     cms_base_url: str | None = None
+    slideshow_plans: dict[uuid.UUID, list[SlideshowSlidePlan]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass

--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -60,8 +60,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.composed.bundle import BundleValidationError, build_bundle
-from cms.composed.registry import get_registry
+from cms.composed.registry import SlideshowSlidePlan, get_registry
 from cms.composed.schema import Layout
+from cms.composed.slideshow_expand import (
+    composed_cell_transition,
+    load_slideshow_members,
+)
 from cms.composed.validate import validate_layout
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
@@ -241,6 +245,7 @@ async def build_composed_html(
 
     asset_payloads: dict[uuid.UUID, tuple[bytes, str]] = {}
     sibling_asset_urls: dict[uuid.UUID, str] = {}
+    slideshow_plans: dict[uuid.UUID, list[SlideshowSlidePlan]] = {}
 
     if declared_ids:
         storage_dir = settings.asset_storage_path
@@ -250,6 +255,61 @@ async def build_composed_html(
             ),
         )
         by_id = {a.id: a for a in rows.scalars().all()}
+
+        async def _route_media_source(ref: Asset, slugs: set[str]) -> None:
+            """Inline one IMAGE/VIDEO source for the preview/snapshot path.
+
+            Images inline as data URIs; videos inline as base64 ``data:``
+            URIs (the preview CSP only allows ``media-src data:``).  Shared
+            by the top-level declared loop and slideshow expansion so both
+            produce identical inlining.  Raises 422 for non-image/video.
+            """
+            if ref.id in asset_payloads or ref.id in sibling_asset_urls:
+                return
+            if ref.asset_type == AssetType.IMAGE:
+                blob = await _read_inline_asset(storage_dir, ref)
+                mime, _ = mimetypes.guess_type(ref.filename)
+                asset_payloads[ref.id] = (
+                    blob,
+                    mime or "application/octet-stream",
+                )
+            elif ref.asset_type == AssetType.VIDEO:
+                if not slugs.issubset(_VIDEO_CAPABLE_SLUGS):
+                    bad = sorted(slugs - _VIDEO_CAPABLE_SLUGS)
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Asset {ref.id} is a video but is used by "
+                            f"widget(s) {', '.join(bad)} that cannot render "
+                            "video"
+                        ),
+                    )
+                if (ref.size_bytes or 0) > _MAX_INLINE_VIDEO_BYTES:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Video asset {ref.id} is too large to render "
+                            f"({ref.size_bytes} bytes; cap "
+                            f"{_MAX_INLINE_VIDEO_BYTES})"
+                        ),
+                    )
+                blob = await _read_inline_asset(
+                    storage_dir, ref, max_bytes=_MAX_INLINE_VIDEO_BYTES,
+                )
+                mime, _ = mimetypes.guess_type(ref.filename)
+                b64 = base64.b64encode(blob).decode("ascii")
+                sibling_asset_urls[ref.id] = (
+                    f"data:{mime or 'video/mp4'};base64,{b64}"
+                )
+            else:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Composed slide references asset {ref.id} of type "
+                        f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
+                        "assets can be embedded in a composed slide"
+                    ),
+                )
 
         for aid in declared_ids:
             ref = by_id.get(aid)
@@ -264,46 +324,63 @@ async def build_composed_html(
             if verify_asset is not None:
                 await verify_asset(aid)
 
-            if ref.asset_type == AssetType.IMAGE:
-                blob = await _read_inline_asset(storage_dir, ref)
-                mime, _ = mimetypes.guess_type(ref.filename)
-                asset_payloads[aid] = (blob, mime or "application/octet-stream")
-            elif ref.asset_type == AssetType.VIDEO:
-                slugs = declaring_slugs.get(aid, set())
-                if not slugs.issubset(_VIDEO_CAPABLE_SLUGS):
-                    bad = sorted(slugs - _VIDEO_CAPABLE_SLUGS)
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Asset {aid} is a video but is used by widget(s) "
-                            f"{', '.join(bad)} that cannot render video"
-                        ),
-                    )
-                # Fast reject on recorded size before reading anything.
-                if (ref.size_bytes or 0) > _MAX_INLINE_VIDEO_BYTES:
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Video asset {aid} is too large to render "
-                            f"({ref.size_bytes} bytes; cap "
-                            f"{_MAX_INLINE_VIDEO_BYTES})"
-                        ),
-                    )
-                blob = await _read_inline_asset(
-                    storage_dir, ref, max_bytes=_MAX_INLINE_VIDEO_BYTES,
+            if ref.asset_type == AssetType.SLIDESHOW:
+                # The render/preview path excludes deleted source assets
+                # (it reflects the live editor state, not a frozen device
+                # snapshot).
+                members = await load_slideshow_members(
+                    db, aid, exclude_deleted=True
                 )
-                mime, _ = mimetypes.guess_type(ref.filename)
-                b64 = base64.b64encode(blob).decode("ascii")
-                sibling_asset_urls[aid] = f"data:{mime or 'video/mp4'};base64,{b64}"
+                if not members:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Composed slide references slideshow {aid} "
+                            "that has no slides"
+                        ),
+                    )
+                plan: list[SlideshowSlidePlan] = []
+                for slide, source in members:
+                    if source is None:
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Slideshow {aid} slide {slide.id} "
+                                "references a missing source asset"
+                            ),
+                        )
+                    if verify_asset is not None:
+                        await verify_asset(source.id)
+                    if source.asset_type not in (
+                        AssetType.IMAGE,
+                        AssetType.VIDEO,
+                    ):
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Slideshow {aid} slide {slide.id} "
+                                f"references asset {source.id} of type "
+                                f"{source.asset_type.value!r}; a composed-"
+                                "slide media widget can only cycle IMAGE "
+                                "and VIDEO slideshow members"
+                            ),
+                        )
+                    # Slideshow members are always rendered by the media
+                    # widget, which is video-capable.
+                    await _route_media_source(source, {"media"})
+                    plan.append(
+                        SlideshowSlidePlan(
+                            source_asset_id=source.id,
+                            duration_ms=int(slide.duration_ms),
+                            transition=composed_cell_transition(
+                                slide.transition
+                            ),
+                            transition_ms=int(slide.transition_ms),
+                        )
+                    )
+                slideshow_plans[aid] = plan
             else:
-                raise HTTPException(
-                    status_code=422,
-                    detail=(
-                        f"Composed slide references asset {aid} of type "
-                        f"{ref.asset_type.value!r}; only IMAGE and VIDEO "
-                        "assets can be embedded in a composed slide"
-                    ),
-                )
+                await _route_media_source(ref, declaring_slugs.get(aid, set()))
 
     def _asset_loader(aid: uuid.UUID) -> tuple[bytes, str]:
         return asset_payloads[aid]
@@ -314,6 +391,7 @@ async def build_composed_html(
             registry,
             asset_loader=_asset_loader if asset_payloads else None,
             sibling_asset_urls=sibling_asset_urls or None,
+            slideshow_plans=slideshow_plans or None,
         )
     except BundleValidationError as e:
         raise HTTPException(

--- a/cms/composed/slideshow_expand.py
+++ b/cms/composed/slideshow_expand.py
@@ -1,0 +1,79 @@
+"""Shared helpers for embedding a SLIDESHOW asset in a media widget.
+
+A :class:`~cms.composed.widgets.media.MediaWidget` may point its single
+``asset_id`` at a SLIDESHOW asset.  A slideshow has no file of its own —
+it is an ordered sequence of IMAGE/VIDEO *source* assets.  Both the
+device-publish path (:mod:`cms.composed.publish`) and the preview /
+thumbnail path (:mod:`cms.composed.render`) need to:
+
+* load the slideshow's slides in ``position`` order, and
+* route each slide's source asset into the bundle exactly the way a
+  standalone media asset of that type would be routed.
+
+The per-source routing differs between the two callers (publish ships
+videos as device-local sibling URLs; render inlines them as base64
+``data:`` URIs), so this module deliberately does **not** do the
+routing — it only loads the ordered ``(slide, source_asset)`` pairs and
+maps the slide's transition into the composed-cell repertoire.  Each
+caller then loops the sources through its own existing image/video
+routing and builds the
+:class:`~cms.composed.registry.SlideshowSlidePlan` list.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.models.asset import Asset
+from shared.models.slideshow_slide import SlideshowSlide
+
+
+def composed_cell_transition(transition: str) -> str:
+    """Map a slideshow transition to the composed-cell CSS repertoire.
+
+    The composed media cell implements only an instant ``"cut"`` and an
+    opacity ``"fade"`` cross-fade.  Every non-cut transition
+    (``fade_black`` / ``dissolve`` / ``push`` / ``wipe`` / ``zoom``)
+    degrades to a cross-fade — the closest visual match available inside
+    a self-contained HTML cell.  (The device's native slideshow player
+    renders the richer set in firmware; that code is not reusable inside
+    a Chromium bundle.)
+    """
+    return "cut" if transition == "cut" else "fade"
+
+
+async def load_slideshow_members(
+    db: AsyncSession,
+    slideshow_asset_id: uuid.UUID,
+    *,
+    exclude_deleted: bool,
+) -> list[tuple[SlideshowSlide, Asset | None]]:
+    """Return the slideshow's slides in ``position`` order with their sources.
+
+    Each tuple is ``(slide, source_asset)``; ``source_asset`` is ``None``
+    when the slide's source row is missing (or, with
+    ``exclude_deleted=True``, soft-deleted).  Callers decide whether a
+    missing source is an error.  Returns an empty list when the slideshow
+    has no slides.
+    """
+    slide_rows = (
+        await db.execute(
+            select(SlideshowSlide)
+            .where(SlideshowSlide.slideshow_asset_id == slideshow_asset_id)
+            .order_by(SlideshowSlide.position.asc())
+        )
+    ).scalars().all()
+    if not slide_rows:
+        return []
+
+    src_ids = [s.source_asset_id for s in slide_rows]
+    src_q = select(Asset).where(Asset.id.in_(src_ids))
+    if exclude_deleted:
+        src_q = src_q.where(Asset.deleted_at.is_(None))
+    src_rows = (await db.execute(src_q)).scalars().all()
+    by_id = {a.id: a for a in src_rows}
+
+    return [(s, by_id.get(s.source_asset_id)) for s in slide_rows]

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -121,6 +121,21 @@ class MediaWidget(Widget):
         css_class = f"cw-media-{instance_id}"
         alt_escaped = _html.escape(config.alt)
 
+        # Slideshow branch: the declared asset is a SLIDESHOW container.
+        # The publish / render layer resolved its ordered slides into
+        # ctx.slideshow_plans and routed each per-slide source into
+        # asset_bytes (image) or sibling_asset_urls (video).  Emit a
+        # stack of absolutely-positioned slides and a small timer that
+        # cross-fades / cuts between them client-side.
+        if ctx.slideshow_plans and asset_id in ctx.slideshow_plans:
+            return self._render_slideshow(
+                config=config,
+                instance_id=instance_id,
+                asset_id=asset_id,
+                alt_escaped=alt_escaped,
+                ctx=ctx,
+            )
+
         # Video branch: publish layer routed this ID to the sibling
         # URL channel.  Emit a <video> tag pointing at the device-local
         # URL; the bundle stays small and the device cache fetches the
@@ -188,4 +203,159 @@ class MediaWidget(Widget):
             html=html_out,
             css=css_out,
             referenced_asset_ids=[asset_id],
+        )
+
+    def _render_slideshow(
+        self,
+        config: MediaWidgetConfig,
+        instance_id: str,
+        asset_id: uuid.UUID,
+        alt_escaped: str,
+        ctx: BundleContext,
+    ) -> WidgetRender:
+        """Render a SLIDESHOW asset as a self-cycling stack of slides.
+
+        Each member slide is rendered exactly like a standalone media
+        widget (image inlined as a data URI, video pointed at its
+        device-local sibling URL), stacked absolutely inside an
+        instance-scoped container.  Slide 0 is marked active in the
+        markup so a t=0 thumbnail snapshot is deterministic.  A small
+        baked-in timer toggles the active class to advance; CSS opacity
+        transitions handle the cut / cross-fade.
+        """
+        plans = ctx.slideshow_plans[asset_id]
+        if not plans:
+            # Should never happen — publish/render reject empty
+            # slideshows up front — but fail loud rather than emit an
+            # empty, never-advancing container.
+            raise RuntimeError(
+                f"MediaWidget instance {instance_id}: slideshow asset "
+                f"{asset_id} expanded to zero slides"
+            )
+
+        css_class = f"cw-ss-{instance_id}"
+        slide_html: list[str] = []
+        referenced: list[uuid.UUID] = []
+        durations: list[int] = []
+
+        for idx, plan in enumerate(plans):
+            source = plan.source_asset_id
+            referenced.append(source)
+            durations.append(int(plan.duration_ms))
+
+            active = " cw-ss-active" if idx == 0 else ""
+            # Per-slide transition duration overrides the container's
+            # default; a "cut" slide is baked as 0ms (instant swap).
+            trans_ms = int(plan.transition_ms) if plan.transition == "fade" else 0
+            slide_style = f"transition-duration:{trans_ms}ms"
+
+            if source in ctx.sibling_asset_urls:
+                src = ctx.sibling_asset_urls[source]
+                src_escaped = _html.escape(src, quote=True)
+                inner = (
+                    f'<video src="{src_escaped}" '
+                    f"muted loop playsinline "
+                    f'aria-label="{alt_escaped}"></video>'
+                )
+            elif source in ctx.asset_bytes:
+                blob = ctx.asset_bytes[source]
+                mime = ctx.asset_mimes[source]
+                if len(blob) > _LARGE_IMAGE_WARN_BYTES:
+                    log.warning(
+                        "composed media widget %s: slideshow image asset "
+                        "%s is %d bytes (>%d) — inlined bundle will be large",
+                        instance_id,
+                        source,
+                        len(blob),
+                        _LARGE_IMAGE_WARN_BYTES,
+                    )
+                b64 = base64.b64encode(blob).decode("ascii")
+                data_uri = f"data:{mime};base64,{b64}"
+                inner = (
+                    f'<img src="{data_uri}" '
+                    f'alt="{alt_escaped}" draggable="false" />'
+                )
+            else:
+                # Same contract violation as the standalone else branch:
+                # the build layer must route every per-slide source into
+                # one of the two channels.
+                raise RuntimeError(
+                    f"MediaWidget instance {instance_id}: slideshow source "
+                    f"{source} missing from BundleContext (neither "
+                    "asset_bytes nor sibling_asset_urls)"
+                )
+
+            slide_html.append(
+                f'<div class="cw-ss-slide{active}" style="{slide_style}">'
+                f"{inner}</div>"
+            )
+
+        html_out = f'<div class="{css_class}">' + "".join(slide_html) + "</div>"
+
+        css_out = (
+            f".{css_class} {{\n"
+            f"  position: relative;\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  overflow: hidden;\n"
+            f"  background: #000;\n"
+            f"}}\n"
+            f".{css_class} .cw-ss-slide {{\n"
+            f"  position: absolute;\n"
+            f"  inset: 0;\n"
+            f"  opacity: 0;\n"
+            f"  transition-property: opacity;\n"
+            f"  transition-timing-function: ease-in-out;\n"
+            f"}}\n"
+            f".{css_class} .cw-ss-slide.cw-ss-active {{\n"
+            f"  opacity: 1;\n"
+            f"}}\n"
+            f".{css_class} img,\n"
+            f".{css_class} video {{\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  display: block;\n"
+            f"  object-fit: {config.object_fit};\n"
+            f"  object-position: center;\n"
+            f"  user-select: none;\n"
+            f"}}"
+        )
+
+        # Bake ONLY integer durations into the runtime — never
+        # interpolate raw config strings into JS.
+        durations_js = "[" + ",".join(str(d) for d in durations) + "]"
+        init_js = (
+            "var root = document.querySelector('.cw-ss-' + instanceId);\n"
+            "if (!root) { return; }\n"
+            "var slides = root.querySelectorAll('.cw-ss-slide');\n"
+            f"var durations = {durations_js};\n"
+            "function startVideo(slide) {\n"
+            "  var v = slide.querySelector('video');\n"
+            "  if (v) { try { v.currentTime = 0; var p = v.play();"
+            " if (p && p.catch) { p.catch(function(){}); } } catch (e) {} }\n"
+            "}\n"
+            "if (slides.length >= 1) { startVideo(slides[0]); }\n"
+            "if (slides.length <= 1) { return; }\n"
+            "var idx = 0;\n"
+            "function activate(n) {\n"
+            "  for (var i = 0; i < slides.length; i++) {\n"
+            "    slides[i].classList.toggle('cw-ss-active', i === n);\n"
+            "  }\n"
+            "  startVideo(slides[n]);\n"
+            "}\n"
+            "function schedule() {\n"
+            "  setTimeout(function () {\n"
+            "    idx = (idx + 1) % slides.length;\n"
+            "    activate(idx);\n"
+            "    schedule();\n"
+            "  }, durations[idx]);\n"
+            "}\n"
+            "schedule();"
+        )
+
+        return WidgetRender(
+            html=html_out,
+            css=css_out,
+            init_js=init_js,
+            referenced_asset_ids=referenced,
         )

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -883,9 +883,11 @@ registerWidget("media", {
     preview: (root, cfg) => { root.appendChild(renderMediaPreview(cfg)); },
     settings: (w) => {
         const currentId = w.config.asset_id || NULL_UUID;
-        const opts = [`<option value="${NULL_UUID}" ${currentId===NULL_UUID?"selected":""}>— pick an image or video —</option>`]
+        const opts = [`<option value="${NULL_UUID}" ${currentId===NULL_UUID?"selected":""}>— pick an image, video, or slideshow —</option>`]
             .concat(MEDIA_ASSETS.map(a => {
-                const label = `${a.asset_type === "video" ? "🎞" : "🖼"} ${escapeHtml(a.name)}`;
+                const icon = a.asset_type === "video" ? "🎞"
+                    : a.asset_type === "slideshow" ? "🎠" : "🖼";
+                const label = `${icon} ${escapeHtml(a.name)}`;
                 return `<option value="${a.id}" ${a.id===currentId?"selected":""}>${label}</option>`;
             }))
             .join("");
@@ -904,6 +906,7 @@ registerWidget("media", {
                    oninput="updateSelected(x=>x.config.alt=this.value)">
             <p style="font-size:0.75rem; color:var(--text-muted); margin-top:0.5rem;">
                 For videos: assign the asset to the same device groups so it lands in the device's video cache.
+                Slideshows cycle through their slides on the device (cut / cross-fade only).
             </p>`;
     },
 });
@@ -2229,6 +2232,8 @@ function renderMediaPreview(cfg) {
     const wrap = document.createElement("div");
     wrap.className = "cw-prev-media";
     const isVideo = a.asset_type === "video";
+    const isSlideshow = a.asset_type === "slideshow";
+    const fallbackIcon = isSlideshow ? "🎠" : (isVideo ? "🎬" : "🖼");
     if (a.thumbnail_url) {
         const img = document.createElement("img");
         img.src = a.thumbnail_url;
@@ -2236,18 +2241,18 @@ function renderMediaPreview(cfg) {
         img.style.objectFit = cfg.object_fit || "cover";
         img.onerror = () => {
             wrap.replaceChildren(
-                mediaPlaceholder(isVideo ? "🎬" : "🖼", a.name || "")
+                mediaPlaceholder(fallbackIcon, a.name || "")
             );
         };
         wrap.appendChild(img);
-        if (isVideo) {
+        if (isVideo || isSlideshow) {
             const badge = document.createElement("div");
             badge.className = "cw-prev-media-badge";
-            badge.textContent = "▶";
+            badge.textContent = isSlideshow ? "🎠" : "▶";
             wrap.appendChild(badge);
         }
     } else {
-        wrap.appendChild(mediaPlaceholder(isVideo ? "🎬" : "🖼", a.name || ""));
+        wrap.appendChild(mediaPlaceholder(fallbackIcon, a.name || ""));
     }
     return wrap;
 }

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1807,14 +1807,14 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         groups_q = None
     user_groups = groups_q.scalars().all() if groups_q else []
 
-    # Query IMAGE + VIDEO assets the user can pick in the editor's
-    # media-widget asset picker.  Visibility filter mirrors the
+    # Query IMAGE + VIDEO + SLIDESHOW assets the user can pick in the
+    # editor's media-widget asset picker.  Visibility filter mirrors the
     # schedules-page pattern: globals + group-assigned + own uploads
     # (not yet assigned to any group).  Admins see everything.
     media_q = (
         select(Asset)
         .where(Asset.deleted_at.is_(None))
-        .where(Asset.asset_type.in_((AssetType.IMAGE, AssetType.VIDEO)))
+        .where(Asset.asset_type.in_((AssetType.IMAGE, AssetType.VIDEO, AssetType.SLIDESHOW)))
         .order_by(Asset.filename)
     )
     if not is_admin:

--- a/tests/test_composed_extensibility_round2.py
+++ b/tests/test_composed_extensibility_round2.py
@@ -309,6 +309,7 @@ class TestExtensibilityContractGuardrail:
             "asset_mimes",
             "sibling_asset_urls",
             "cms_base_url",
+            "slideshow_plans",
         }, (
             f"BundleContext fields drifted: {names!r}. Adding fields "
             "may be OK — explicitly update this pin and the contract docs."

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -18,7 +18,7 @@ from pydantic import ValidationError
 
 # Side-effect import: triggers global registry population
 import cms.composed.widgets  # noqa: F401
-from cms.composed.registry import BundleContext, get_registry
+from cms.composed.registry import BundleContext, SlideshowSlidePlan, get_registry
 from cms.composed.schema import Cell
 from cms.composed.widgets.media import (
     MediaWidget,
@@ -212,3 +212,165 @@ class TestMediaWidgetScoping:
         ctx = _vid_ctx(aid, "/assets/videos/x.mp4")
         r = MediaWidget().render_html(cfg, _cell(), "vid", ctx=ctx)
         assert "object-fit: contain" in r.css
+
+
+class TestMediaWidgetSlideshowBranch:
+    """A media widget whose asset_id is a SLIDESHOW container cycles
+    its ordered member slides client-side."""
+
+    def _ss_ctx(self, container, sources):
+        """Build a ctx with a slideshow plan + per-source channels.
+
+        ``sources`` is a list of (source_id, plan_kwargs, kind, payload):
+          kind == "img" -> payload is (bytes, mime) -> asset_bytes
+          kind == "vid" -> payload is url           -> sibling_asset_urls
+        """
+        asset_bytes = {}
+        asset_mimes = {}
+        sibling = {}
+        plan = []
+        for sid, pk, kind, payload in sources:
+            if kind == "img":
+                asset_bytes[sid] = payload[0]
+                asset_mimes[sid] = payload[1]
+            else:
+                sibling[sid] = payload
+            plan.append(SlideshowSlidePlan(source_asset_id=sid, **pk))
+        return BundleContext(
+            asset_bytes=asset_bytes,
+            asset_mimes=asset_mimes,
+            sibling_asset_urls=sibling,
+            slideshow_plans={container: plan},
+        )
+
+    def test_renders_stacked_slides_first_active(self):
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                (s1, {"duration_ms": 4000, "transition": "fade",
+                      "transition_ms": 600}, "img", (_TINY_PNG, "image/png")),
+                (s2, {"duration_ms": 5000, "transition": "cut"},
+                 "vid", "/assets/videos/clip.mp4"),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ss1", ctx=ctx)
+
+        # Instance-scoped container.
+        assert 'class="cw-ss-ss1"' in r.html
+        # Two stacked slides, first active.
+        assert r.html.count("cw-ss-slide") == 2
+        assert "cw-ss-slide cw-ss-active" in r.html
+        # Image slide is a data URI; video slide is a sibling <video>.
+        b64 = base64.b64encode(_TINY_PNG).decode("ascii")
+        assert f"data:image/png;base64,{b64}" in r.html
+        assert 'src="/assets/videos/clip.mp4"' in r.html
+        # Both source ids referenced, in order.
+        assert r.referenced_asset_ids == [s1, s2]
+
+    def test_cut_transition_baked_zero_ms(self):
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 3000, "transition": "cut",
+                   "transition_ms": 600}, "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssC", ctx=ctx)
+        assert "transition-duration:0ms" in r.html
+
+    def test_fade_transition_uses_transition_ms(self):
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                (s1, {"duration_ms": 3000, "transition": "fade",
+                      "transition_ms": 750}, "img", (_TINY_PNG, "image/png")),
+                (s2, {"duration_ms": 3000, "transition": "fade",
+                      "transition_ms": 750}, "img", (_TINY_PNG, "image/png")),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssF", ctx=ctx)
+        assert "transition-duration:750ms" in r.html
+
+    def test_cycling_js_bakes_durations_and_guards_single(self):
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                (s1, {"duration_ms": 4000, "transition": "cut"},
+                 "img", (_TINY_PNG, "image/png")),
+                (s2, {"duration_ms": 5000, "transition": "cut"},
+                 "img", (_TINY_PNG, "image/png")),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssJ", ctx=ctx)
+        assert r.init_js is not None
+        assert "[4000,5000]" in r.init_js
+        assert "slides.length <= 1" in r.init_js
+        # Selector is instance-scoped via the runtime instanceId arg.
+        assert "'.cw-ss-' + instanceId" in r.init_js
+
+    def test_single_slide_still_renders_one_slide(self):
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 4000, "transition": "cut"},
+              "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssS", ctx=ctx)
+        assert r.html.count("cw-ss-slide") == 1
+        assert r.referenced_asset_ids == [s1]
+
+    def test_missing_source_channel_raises(self):
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        # Plan references s1 but neither channel carries it.
+        ctx = BundleContext(
+            slideshow_plans={
+                container: [SlideshowSlidePlan(
+                    source_asset_id=s1, duration_ms=3000, transition="cut")]
+            }
+        )
+        with pytest.raises(RuntimeError, match="missing from BundleContext"):
+            MediaWidget().render_html(cfg, _cell(), "ssM", ctx=ctx)
+
+    def test_alt_escaped_in_slideshow_slides(self):
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container, alt='<x>"q"')
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 3000, "transition": "cut"},
+              "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssA", ctx=ctx)
+        assert "<x>" not in r.html
+        assert "&lt;x&gt;" in r.html
+
+    def test_slideshow_branch_preferred_over_image_channel(self):
+        # If the container id ALSO appears in asset_bytes (shouldn't in
+        # practice), the slideshow branch still wins so we cycle.
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 3000, "transition": "cut"},
+              "img", (_TINY_PNG, "image/png"))],
+        )
+        ctx.asset_bytes[container] = _TINY_PNG
+        ctx.asset_mimes[container] = "image/png"
+        r = MediaWidget().render_html(cfg, _cell(), "ssP", ctx=ctx)
+        assert "cw-ss-" in r.html
+

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -9,6 +9,7 @@ import pytest
 from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.models.slideshow_slide import SlideshowSlide
 
 
 def _text_layout(text: str = "hello preview") -> Layout:
@@ -442,3 +443,106 @@ class TestComposedPreviewMedia:
         # Admin can still see it (sanity).
         ok = await client.get(f"/composed/{asset.id}/preview")
         assert ok.status_code == 200, ok.text
+
+
+@pytest.mark.asyncio
+class TestComposedPreviewSlideshowMedia:
+    async def _make_composed_with(self, db_session, layout: Layout):
+        asset = Asset(
+            filename=f"composed-{uuid.uuid4()}",
+            asset_type=AssetType.COMPOSED,
+            size_bytes=0,
+            checksum="",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+        cs = ComposedSlide(
+            asset_id=asset.id, layout_json=layout.model_dump(mode="json")
+        )
+        db_session.add(cs)
+        await db_session.commit()
+        return asset
+
+    async def _make_image(self, db_session, storage, name):
+        (storage / name).write_bytes(_PNG_BYTES)
+        img = Asset(
+            filename=name,
+            asset_type=AssetType.IMAGE,
+            size_bytes=len(_PNG_BYTES),
+            checksum="x",
+            is_global=True,
+        )
+        db_session.add(img)
+        await db_session.flush()
+        return img
+
+    async def _make_slideshow(self, db_session, members):
+        ss = Asset(
+            filename=f"show-{uuid.uuid4()}.slideshow",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(ss)
+        await db_session.flush()
+        for idx, src in enumerate(members):
+            db_session.add(SlideshowSlide(
+                slideshow_asset_id=ss.id,
+                source_asset_id=src.id,
+                position=idx,
+                duration_ms=4000,
+                play_to_end=False,
+                transition="fade",
+                transition_ms=600,
+            ))
+        await db_session.flush()
+        return ss
+
+    async def test_preview_slideshow_member_inlines_each_source(
+        self, client, db_session, tmp_path
+    ):
+        storage = _storage_dir(tmp_path)
+        img1 = await self._make_image(db_session, storage, "a.png")
+        img2 = await self._make_image(db_session, storage, "b.png")
+        ss = await self._make_slideshow(db_session, [img1, img2])
+        asset = await self._make_composed_with(db_session, _media_layout(ss.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Both member images inlined; no device-local sibling path.
+        assert body.count("data:image/png;base64,") == 2
+        assert "cw-ss-slide" in body
+        assert "/assets/videos/" not in body
+
+    async def test_preview_empty_slideshow_is_422(
+        self, client, db_session, tmp_path
+    ):
+        _storage_dir(tmp_path)
+        ss = await self._make_slideshow(db_session, [])
+        asset = await self._make_composed_with(db_session, _media_layout(ss.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+        assert "has no slides" in resp.text
+
+    async def test_preview_slideshow_with_non_media_member_is_422(
+        self, client, db_session, tmp_path
+    ):
+        _storage_dir(tmp_path)
+        web = Asset(
+            filename="page.url",
+            asset_type=AssetType.WEBPAGE,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(web)
+        await db_session.flush()
+        ss = await self._make_slideshow(db_session, [web])
+        asset = await self._make_composed_with(db_session, _media_layout(ss.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 422, resp.text
+        assert "can only cycle IMAGE and VIDEO" in resp.text

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -20,6 +20,7 @@ from cms.composed.schema import (
 )
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.models.slideshow_slide import SlideshowSlide
 
 
 def _text_layout(text: str = "hello world") -> Layout:
@@ -445,3 +446,109 @@ async def test_publish_mixed_image_and_video_uses_both_channels(
 
     await db_session.refresh(cs)
     assert {str(x) for x in cs.bundle_source_asset_ids} == {str(img.id), str(vid.id)}
+
+
+# --- Slideshow-in-media-widget publish tests -----------------------------
+
+
+async def _make_slideshow_asset(db_session, members, filename="show.slideshow") -> Asset:
+    """Seed a SLIDESHOW container asset + ordered member slides.
+
+    ``members`` is a list of (source_asset, duration_ms, transition,
+    transition_ms).
+    """
+    ss = Asset(
+        filename=filename,
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(ss)
+    await db_session.flush()
+    for idx, (src, dur, trans, trans_ms) in enumerate(members):
+        db_session.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            source_asset_id=src.id,
+            position=idx,
+            duration_ms=dur,
+            play_to_end=False,
+            transition=trans,
+            transition_ms=trans_ms,
+        ))
+    await db_session.flush()
+    return ss
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_member_expands_image_sources(
+    db_session, mock_storage_and_dir
+):
+    _, tmp_path = mock_storage_and_dir
+    img1 = await _make_image_asset(db_session, tmp_path, "a.png")
+    img2 = await _make_image_asset(db_session, tmp_path, "b.png")
+    ss = await _make_slideshow_asset(
+        db_session,
+        [(img1, 4000, "fade", 600), (img2, 5000, "cut", 600)],
+    )
+    asset, cs = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # Two stacked slides cycling client-side — both image sources inlined.
+    assert bundle_html.count("data:image/png;base64,") == 2
+    assert "cw-ss-slide" in bundle_html
+
+    await db_session.refresh(cs)
+    sources = {str(x) for x in cs.bundle_source_asset_ids}
+    # Per-slide SOURCE ids are tracked, NOT the slideshow container id.
+    assert sources == {str(img1.id), str(img2.id)}
+    assert str(ss.id) not in sources
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_member_mixed_image_video(
+    db_session, mock_storage_and_dir
+):
+    _, tmp_path = mock_storage_and_dir
+    img = await _make_image_asset(db_session, tmp_path, "a.png")
+    vid = await _make_video_asset(db_session, "clip.mp4")
+    ss = await _make_slideshow_asset(
+        db_session,
+        [(img, 4000, "cut", 600), (vid, 6000, "fade", 600)],
+    )
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    assert "data:image/png;base64," in bundle_html
+    assert "/assets/videos/clip.mp4" in bundle_html
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_empty_slideshow(db_session, mock_storage_and_dir):
+    ss = await _make_slideshow_asset(db_session, [])
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    with pytest.raises(PublishError, match="has no slides"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_slideshow_with_non_media_member(
+    db_session, mock_storage_and_dir
+):
+    web = Asset(
+        filename="page.url",
+        asset_type=AssetType.WEBPAGE,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(web)
+    await db_session.flush()
+    ss = await _make_slideshow_asset(db_session, [(web, 4000, "cut", 600)])
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    with pytest.raises(PublishError, match="can only cycle IMAGE and VIDEO"):
+        await publish_composed_slide(asset.id, db_session)


### PR DESCRIPTION
## What

Lets the **media** composed-slide widget point its single `asset_id` at a **SLIDESHOW** asset, not just IMAGE/VIDEO. When it references a slideshow, the composed cell cycles through the slideshow's ordered member slides client-side (timer-driven JS + CSS opacity cross-fade).

This is the inverse of the already-shipped composed-in-slideshow feature (#734): now a slideshow can live *inside* a composed slide cell.

## Behavior

- **Transitions:** cut and cross-fade are honored per-slide; the other five slideshow transitions map to cross-fade.
- **Members:** only IMAGE and VIDEO slideshow members are allowed. Empty slideshows and non-media members are rejected (`PublishError` on the device path, HTTP 422 on the preview path).
- **Delivery:** IMAGE members inline as data URIs; VIDEO members ride the existing sibling-URL channel on publish, and inline as `data:` URIs in preview.

## Hard constraint honored

Purely additive — **no config-key renames**. When no slideshow is referenced, slideshow expansion is a no-op, so the default IMAGE/VIDEO bundle is **byte-identical** on rebuild.

## Changes

- `registry.py` — `SlideshowSlidePlan` + `BundleContext.slideshow_plans`
- `slideshow_expand.py` (new) — member loader + transition mapping
- `bundle.py` — declare-before-reference expansion (container id → per-slide source ids); container never loaded as bytes
- `publish.py` / `render.py` — SLIDESHOW branch (device + preview)
- `widgets/media.py` — `_render_slideshow` markup + init JS
- `ui.py` — editor media picker now lists SLIDESHOW assets
- `composed_editor.html` — picker icon/label + preview affordance

## Tests

93 targeted composed tests pass locally (publish/preview/media-widget/bundle), incl. new slideshow publish + preview integration tests. Jinja parse + editor JS reviewed clean.
