### PR TITLE
fix(composed): hide non-cyclable slideshows from media picker

### DIFF
--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1840,6 +1840,30 @@ async def _composed_builder_context(request, db, *, asset_id=None):
         visible = list(global_ids | ga_ids | own_ids)
         media_q = media_q.where(Asset.id.in_(visible))
     media_rows = (await db.execute(media_q)).scalars().all()
+    # A SLIDESHOW is only offerable in the media-widget picker if every
+    # one of its (non-deleted) member sources is an IMAGE or VIDEO — the
+    # only types a composed media cell can cycle.  Slideshows that are
+    # empty, or that contain a COMPOSED / WEBPAGE / missing member, are
+    # filtered out so the user can't pick one that would only fail later
+    # with a 422 at preview/publish time.
+    from cms.composed.slideshow_expand import load_slideshow_members
+
+    _cyclable = {AssetType.IMAGE, AssetType.VIDEO}
+    pickable_slideshow_ids: set = set()
+    for a in media_rows:
+        if a.asset_type != AssetType.SLIDESHOW:
+            continue
+        members = await load_slideshow_members(db, a.id, exclude_deleted=True)
+        if members and all(
+            src is not None and src.asset_type in _cyclable
+            for _slide, src in members
+        ):
+            pickable_slideshow_ids.add(a.id)
+    media_rows = [
+        a
+        for a in media_rows
+        if a.asset_type != AssetType.SLIDESHOW or a.id in pickable_slideshow_ids
+    ]
     # Thumbnail/poster URLs so the editor canvas can show a live preview
     # of each image/video widget (videos get a poster frame once they've
     # been transcoded).  Assets without a ready thumbnail variant are

--- a/tests/test_composed_routes_phase2.py
+++ b/tests/test_composed_routes_phase2.py
@@ -32,6 +32,7 @@ from cms.composed.schema import (
 )
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.models.slideshow_slide import SlideshowSlide
 
 EDITOR_TEMPLATE = (
     Path(__file__).resolve().parents[1]
@@ -273,6 +274,84 @@ class TestComposedUI:
         assert resp.status_code == 200
         assert "thumbnail_url" in resp.text
         assert str(img.id) in resp.text
+
+    async def _seed_slideshow(self, db_session, member_types):
+        """Create a global SLIDESHOW with one member per entry in
+        ``member_types`` (each an AssetType). Returns (slideshow, members)."""
+        ss = Asset(
+            filename=f"show-{uuid.uuid4()}.slideshow",
+            display_name="A slideshow",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(ss)
+        await db_session.flush()
+        members = []
+        for idx, atype in enumerate(member_types):
+            m = Asset(
+                filename=f"m-{uuid.uuid4()}",
+                display_name=f"member {idx}",
+                asset_type=atype,
+                size_bytes=1,
+                checksum="x",
+                is_global=True,
+            )
+            db_session.add(m)
+            await db_session.flush()
+            db_session.add(SlideshowSlide(
+                slideshow_asset_id=ss.id,
+                source_asset_id=m.id,
+                position=idx,
+                duration_ms=4000,
+                play_to_end=False,
+                transition="fade",
+                transition_ms=600,
+            ))
+            members.append(m)
+        await db_session.commit()
+        return ss, members
+
+    async def test_media_picker_offers_image_video_only_slideshow(
+        self, client, db_session
+    ):
+        # A slideshow whose members are all IMAGE/VIDEO is a valid pick.
+        ss, _ = await self._seed_slideshow(
+            db_session, [AssetType.IMAGE, AssetType.VIDEO]
+        )
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        assert str(ss.id) in resp.text
+
+    async def test_media_picker_hides_slideshow_with_composed_member(
+        self, client, db_session
+    ):
+        # A slideshow containing a COMPOSED member cannot be cycled by a
+        # media cell, so it must NOT appear in the picker (the user would
+        # otherwise hit a 422 only at preview/publish time).
+        ss, members = await self._seed_slideshow(
+            db_session, [AssetType.IMAGE, AssetType.COMPOSED]
+        )
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        assert str(ss.id) not in resp.text
+
+    async def test_media_picker_hides_empty_slideshow(self, client, db_session):
+        # An empty slideshow can't be cycled either — hide it.
+        ss = Asset(
+            filename=f"empty-{uuid.uuid4()}.slideshow",
+            display_name="Empty show",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(ss)
+        await db_session.commit()
+        resp = await client.get("/assets/new/composed")
+        assert resp.status_code == 200
+        assert str(ss.id) not in resp.text
 
     async def test_editor_ships_live_preview_renderer(self, client, db_session):
         asset, _ = await _make_composed(db_session)


### PR DESCRIPTION
## What

Follow-up to #767. The media-widget asset picker listed **every** SLIDESHOW asset, but a composed media cell can only cycle **IMAGE/VIDEO** members. So a user could pick a slideshow that contains a COMPOSED member (slideshows can contain composed slides, per #734) — and only discover it was invalid via a 422 at preview/publish time:

> `Slideshow … slide … references asset … of type 'composed'; a composed-slide media widget can only cycle IMAGE and VIDEO slideshow members`

## Fix

Filter the picker in `_composed_builder_context` so a SLIDESHOW is offered only when it has **at least one member** and **every (non-deleted) member source is an IMAGE or VIDEO**. Empty slideshows and ones containing COMPOSED/WEBPAGE/missing members are no longer selectable, so the user can't shoot themselves in the foot.

Reuses `load_slideshow_members` so the offer rule tracks the same loader the render/publish paths already use.

## Tests

- `test_media_picker_offers_image_video_only_slideshow` — image+video slideshow IS offered
- `test_media_picker_hides_slideshow_with_composed_member` — composed member → hidden
- `test_media_picker_hides_empty_slideshow` — empty → hidden

Full `test_composed_routes_phase2.py` (22) green locally.
