### PR TITLE
feat(transcode): clear-errors button + failure notifications

### DIFF
--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -946,3 +946,77 @@ async def profiles_status_json(
         "queue": queue_out,
         "queue_count": len(queue_out),
     }
+
+
+@router.post("/clear-errors")
+async def clear_transcode_errors(
+    user=Depends(require_permission(PROFILES_WRITE)),
+    db: AsyncSession = Depends(get_db),
+):
+    """Dismiss FAILED transcode variants from the Transcoding Queue panel.
+
+    A FAILED variant is a permanent (non-retryable) transcode failure; it never
+    transitions out on its own, so without this it lingers in the queue forever.
+    This deletes the FAILED variant rows in the caller's visible scope (with
+    best-effort output-file cleanup) and removes any matching transcode-failure
+    notifications (one-way tie — clearing the queue clears the bell, but not the
+    reverse).
+
+    Composed-slide thumbnail snapshots that are still needed will be
+    re-rendered by the worker's startup backfill, so clearing them is safe.
+
+    Gated on ``profiles:write`` (Admin among built-in roles), unlike the
+    read-only status panel which is visible to Operators/Viewers too.
+    """
+    from cms.routers.assets import _visible_asset_ids
+    from cms.auth import get_settings
+    from cms.services.storage import get_storage
+    from cms.services.transcoder import TRANSCODE_FAIL_NOTIFICATION_TITLE
+    from cms.models.notification import Notification
+
+    visible = await _visible_asset_ids(user, db)
+
+    q = select(AssetVariant).where(AssetVariant.status == VariantStatus.FAILED)
+    if visible is not None:
+        if not visible:
+            return {"cleared": 0, "notifications_cleared": 0}
+        q = q.where(AssetVariant.source_asset_id.in_(visible))
+    failed = (await db.execute(q)).scalars().all()
+
+    storage = get_storage()
+    variants_dir = get_settings().asset_storage_path / "variants"
+    cleared_ids: list[str] = []
+    for variant in failed:
+        try:
+            vpath = variants_dir / variant.filename
+            if vpath.is_file():
+                vpath.unlink()
+            await storage.on_file_deleted(f"variants/{variant.filename}")
+        except Exception:
+            logger.warning(
+                "clear-errors: file cleanup failed for variant %s",
+                variant.id, exc_info=True,
+            )
+        cleared_ids.append(str(variant.id))
+        await db.delete(variant)
+
+    # One-way tie: remove any transcode-failure notifications for cleared variants.
+    notif_deleted = 0
+    if cleared_ids:
+        cleared_set = set(cleared_ids)
+        notifs = (await db.execute(
+            select(Notification).where(
+                Notification.title == TRANSCODE_FAIL_NOTIFICATION_TITLE
+            )
+        )).scalars().all()
+        for n in notifs:
+            if (n.details or {}).get("variant_id") in cleared_set:
+                await db.delete(n)
+                notif_deleted += 1
+
+    await db.commit()
+    logger.info(
+        "clear-errors: %s deleted %d failed variant(s), %d notification(s)",
+        getattr(user, "username", "?"), len(cleared_ids), notif_deleted,
+    )
+    return {"cleared": len(cleared_ids), "notifications_cleared": notif_deleted}

--- a/cms/services/transcoder.py
+++ b/cms/services/transcoder.py
@@ -1081,6 +1081,96 @@ async def reap_superseded_variants_once(db, settings=None) -> int:
     return reaped
 
 
+# ── Transcode-failure notifications ──────────────────────────────
+#
+# Title used to tag (and later find/prune) transcode-failure notifications.
+# Kept as a module constant so the clear-errors endpoint can match on it.
+TRANSCODE_FAIL_NOTIFICATION_TITLE = "Transcode failed"
+
+
+async def reconcile_transcode_failure_notifications_once(db) -> int:
+    """Push permanent transcode failures into the notification bell.
+
+    Centralized, push-based reconciler: for every currently-FAILED (and not
+    soft-deleted) transcode variant that doesn't already have a notification,
+    create a ``scope="system"``, ``level="error"`` notification.  Conversely,
+    prune notifications whose variant is no longer FAILED (recovered, deleted,
+    or cleared via the clear-errors endpoint) so the bell self-heals.
+
+    Running this in the reaper loop (single replica, under advisory lock) means
+    we never double-emit, and it covers *every* path a variant can reach FAILED
+    (worker ``_mark_failed``, the 2-hour-timeout bulk update, retry exhaustion)
+    without hooking each site — and without the worker needing to import the
+    CMS-only ``Notification`` model.
+
+    Dedup key is ``details['variant_id']``.  Returns the number of
+    notifications created this pass.
+    """
+    from cms.models.asset import AssetVariant, VariantStatus
+    from cms.models.notification import Notification
+    from cms.models.asset import Asset
+
+    failed_rows = (await db.execute(
+        select(
+            AssetVariant.id,
+            AssetVariant.source_asset_id,
+            AssetVariant.error_message,
+        ).where(
+            AssetVariant.status == VariantStatus.FAILED,
+            AssetVariant.deleted_at.is_(None),
+        )
+    )).all()
+    failed_ids = {str(r[0]) for r in failed_rows}
+
+    existing = (await db.execute(
+        select(Notification).where(
+            Notification.title == TRANSCODE_FAIL_NOTIFICATION_TITLE
+        )
+    )).scalars().all()
+
+    notified_ids: set[str] = set()
+    stale: list[Notification] = []
+    for n in existing:
+        vid = (n.details or {}).get("variant_id")
+        if vid is None:
+            continue
+        if vid in failed_ids:
+            notified_ids.add(vid)
+        else:
+            stale.append(n)
+
+    for n in stale:
+        await db.delete(n)
+
+    to_create = [r for r in failed_rows if str(r[0]) not in notified_ids]
+    created = 0
+    if to_create:
+        asset_ids = {r[1] for r in to_create}
+        name_rows = (await db.execute(
+            select(Asset.id, Asset.filename).where(Asset.id.in_(asset_ids))
+        )).all()
+        names = {a_id: fn for a_id, fn in name_rows}
+        for vid_u, src_id, err in to_create:
+            filename = names.get(src_id) or "asset"
+            db.add(Notification(
+                scope="system",
+                level="error",
+                title=TRANSCODE_FAIL_NOTIFICATION_TITLE,
+                message=f"Transcoding failed for {filename}.",
+                details={
+                    "variant_id": str(vid_u),
+                    "asset_id": str(src_id),
+                    "filename": filename,
+                    "error": (err or "")[:500],
+                },
+            ))
+            created += 1
+
+    if created or stale:
+        await db.commit()
+    return created
+
+
 async def deleted_asset_reaper_loop() -> None:
     """Background loop: hard-delete soft-deleted assets whose jobs are terminal.
 
@@ -1138,6 +1228,18 @@ async def deleted_asset_reaper_loop() -> None:
                             )
                     except Exception:
                         logger.exception("Reaper: variant hard-delete sweep failed")
+                async for db in get_db():
+                    try:
+                        emitted = await reconcile_transcode_failure_notifications_once(db)
+                        if emitted:
+                            logger.info(
+                                "Reaper: emitted %d transcode-failure notification(s)",
+                                emitted,
+                            )
+                    except Exception:
+                        logger.exception(
+                            "Reaper: transcode-failure notification sweep failed"
+                        )
         except asyncio.CancelledError:
             logger.info("Deleted asset reaper shutting down")
             raise

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -405,7 +405,7 @@
     </div>
 </div>
 
-{# ── Transcoding Queue (collapsible, live-updating) — admin-only ── #}
+{# ── Transcoding Queue (collapsible, live-updating) ── #}
 {% if 'profiles:read' in user_perms %}
 <div class="card" id="queue-card" style="display:none;">
     <div style="display:flex; align-items:center; justify-content:space-between; cursor:pointer;"
@@ -415,6 +415,13 @@
             Transcoding Queue
             <span class="badge badge-muted" id="queue-count-badge" style="margin-left:0.5rem;">0</span>
         </h2>
+        {% if 'profiles:write' in user_perms %}
+        <button type="button" id="queue-clear-errors" class="btn btn-sm btn-danger"
+                style="display:none;"
+                onclick="event.stopPropagation(); clearTranscodeErrors();">
+            Clear errors
+        </button>
+        {% endif %}
     </div>
     <div id="queue-body-wrap" style="display:none; margin-top:0.75rem;">
         <div class="table-wrap">
@@ -1018,6 +1025,9 @@ function fallbackCopy(text, onSuccess) {
 
             const count = data.queue_count || 0;
             badge.textContent = count;
+            const clearBtn = document.getElementById('queue-clear-errors');
+            const hasErrors = (data.queue || []).some(v => v.status === 'failed');
+            if (clearBtn) clearBtn.style.display = hasErrors ? '' : 'none';
             if (count > 0) {
                 card.style.display = '';
                 body.innerHTML = data.queue.map(buildQueueRow).join('');
@@ -1027,6 +1037,23 @@ function fallbackCopy(text, onSuccess) {
             }
         } catch (e) { /* ignore */ }
     }
+
+    window.clearTranscodeErrors = async function() {
+        if (!confirm('Dismiss all failed transcodes from the queue? This cannot be undone.')) return;
+        const btn = document.getElementById('queue-clear-errors');
+        if (btn) { btn.disabled = true; btn.textContent = 'Clearing…'; }
+        try {
+            const res = await fetch('/api/profiles/clear-errors', { method: 'POST' });
+            if (!res.ok) {
+                alert('Failed to clear transcode errors.');
+            }
+        } catch (e) {
+            alert('Failed to clear transcode errors.');
+        } finally {
+            if (btn) { btn.disabled = false; btn.textContent = 'Clear errors'; }
+            refreshQueue();
+        }
+    };
 
     applyExpand();
     refreshQueue();

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -1039,16 +1039,17 @@ function fallbackCopy(text, onSuccess) {
     }
 
     window.clearTranscodeErrors = async function() {
-        if (!confirm('Dismiss all failed transcodes from the queue? This cannot be undone.')) return;
+        const ok = await showConfirm('Dismiss all failed transcodes from the queue? This cannot be undone.');
+        if (!ok) return;
         const btn = document.getElementById('queue-clear-errors');
         if (btn) { btn.disabled = true; btn.textContent = 'Clearing…'; }
         try {
             const res = await fetch('/api/profiles/clear-errors', { method: 'POST' });
             if (!res.ok) {
-                alert('Failed to clear transcode errors.');
+                showToast('Failed to clear transcode errors.', true);
             }
         } catch (e) {
-            alert('Failed to clear transcode errors.');
+            showToast('Failed to clear transcode errors.', true);
         } finally {
             if (btn) { btn.disabled = false; btn.textContent = 'Clear errors'; }
             refreshQueue();

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2743,6 +2743,31 @@ paths:
           content:
             application/json:
               schema: {}
+  /api/profiles/clear-errors:
+    post:
+      summary: Clear Transcode Errors
+      description: |-
+        Dismiss FAILED transcode variants from the Transcoding Queue panel.
+
+        A FAILED variant is a permanent (non-retryable) transcode failure; it never
+        transitions out on its own, so without this it lingers in the queue forever.
+        This deletes the FAILED variant rows in the caller's visible scope (with
+        best-effort output-file cleanup) and removes any matching transcode-failure
+        notifications (one-way tie — clearing the queue clears the bell, but not the
+        reverse).
+
+        Composed-slide thumbnail snapshots that are still needed will be
+        re-rendered by the worker's startup backfill, so clearing them is safe.
+
+        Gated on ``profiles:write`` (Admin among built-in roles), unlike the
+        read-only status panel which is visible to Operators/Viewers too.
+      operationId: clear_transcode_errors_api_profiles_clear_errors_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /api/cms/logs:
     get:
       summary: Download Cms Logs

--- a/tests/test_profile_clear_errors.py
+++ b/tests/test_profile_clear_errors.py
@@ -1,0 +1,140 @@
+"""Tests for the POST /api/profiles/clear-errors endpoint.
+
+The Transcoding Queue panel surfaces FAILED variants (permanent,
+non-retryable transcode failures) that never transition out on their own.
+This endpoint lets a ``profiles:write`` holder dismiss them: it deletes the
+FAILED variant rows (best-effort output-file cleanup) and removes any
+matching transcode-failure notifications (one-way tie).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+
+def _mk_asset_variant(status):
+    from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+    from cms.models.device_profile import DeviceProfile
+
+    asset = Asset(
+        filename=f"{uuid.uuid4().hex}.mp4", asset_type=AssetType.VIDEO,
+        size_bytes=1000, checksum=uuid.uuid4().hex[:8],
+    )
+    profile = DeviceProfile(name=f"clr-{uuid.uuid4().hex[:8]}", video_codec="h264")
+    variant = AssetVariant(
+        filename=f"{uuid.uuid4()}.mp4", status=status,
+    )
+    return asset, profile, variant
+
+
+@pytest.mark.asyncio
+class TestClearTranscodeErrors:
+    async def test_clears_failed_variants(self, client, db_session):
+        from cms.models.asset import VariantStatus
+
+        asset, profile, variant = _mk_asset_variant(VariantStatus.FAILED)
+        db_session.add_all([asset, profile])
+        await db_session.flush()
+        variant.source_asset_id = asset.id
+        variant.profile_id = profile.id
+        variant.error_message = "ffmpeg exploded"
+        db_session.add(variant)
+        await db_session.commit()
+        variant_id = variant.id
+
+        resp = await client.post("/api/profiles/clear-errors")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["cleared"] == 1
+
+        db_session.expunge_all()
+        from cms.models.asset import AssetVariant
+        gone = (await db_session.execute(
+            select(AssetVariant).where(AssetVariant.id == variant_id)
+        )).scalar_one_or_none()
+        assert gone is None
+
+    async def test_does_not_touch_non_failed_variants(self, client, db_session):
+        from cms.models.asset import AssetVariant, VariantStatus
+
+        asset, profile, _ = _mk_asset_variant(VariantStatus.READY)
+        db_session.add_all([asset, profile])
+        await db_session.flush()
+        ready = AssetVariant(
+            source_asset_id=asset.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.mp4", status=VariantStatus.READY,
+        )
+        pending = AssetVariant(
+            source_asset_id=asset.id, profile_id=profile.id,
+            filename=f"{uuid.uuid4()}.mp4", status=VariantStatus.PENDING,
+        )
+        db_session.add_all([ready, pending])
+        await db_session.commit()
+        ready_id, pending_id = ready.id, pending.id
+
+        resp = await client.post("/api/profiles/clear-errors")
+        assert resp.status_code == 200
+        assert resp.json()["cleared"] == 0
+
+        db_session.expunge_all()
+        remaining = (await db_session.execute(
+            select(AssetVariant.id).where(
+                AssetVariant.id.in_([ready_id, pending_id])
+            )
+        )).scalars().all()
+        assert set(remaining) == {ready_id, pending_id}
+
+    async def test_deletes_matching_notifications_one_way_tie(self, client, db_session):
+        from cms.models.asset import VariantStatus
+        from cms.models.notification import Notification
+        from cms.services.transcoder import TRANSCODE_FAIL_NOTIFICATION_TITLE
+
+        asset, profile, variant = _mk_asset_variant(VariantStatus.FAILED)
+        db_session.add_all([asset, profile])
+        await db_session.flush()
+        variant.source_asset_id = asset.id
+        variant.profile_id = profile.id
+        db_session.add(variant)
+        await db_session.flush()
+
+        matching = Notification(
+            scope="system", level="error",
+            title=TRANSCODE_FAIL_NOTIFICATION_TITLE,
+            message="boom",
+            details={"variant_id": str(variant.id), "asset_id": str(asset.id)},
+        )
+        # An unrelated notification (different variant) must survive.
+        unrelated = Notification(
+            scope="system", level="error",
+            title=TRANSCODE_FAIL_NOTIFICATION_TITLE,
+            message="other",
+            details={"variant_id": str(uuid.uuid4())},
+        )
+        db_session.add_all([matching, unrelated])
+        await db_session.commit()
+        unrelated_id = unrelated.id
+
+        resp = await client.post("/api/profiles/clear-errors")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cleared"] == 1
+        assert body["notifications_cleared"] == 1
+
+        db_session.expunge_all()
+        survivors = (await db_session.execute(select(Notification.id))).scalars().all()
+        assert unrelated_id in survivors
+
+    async def test_requires_profiles_write(self, operator_client, db_session):
+        """Operator holds profiles:read but NOT profiles:write → 403."""
+        from cms.models.asset import VariantStatus
+
+        asset, profile, variant = _mk_asset_variant(VariantStatus.FAILED)
+        db_session.add_all([asset, profile])
+        await db_session.flush()
+        variant.source_asset_id = asset.id
+        variant.profile_id = profile.id
+        db_session.add(variant)
+        await db_session.commit()
+
+        resp = await operator_client.post("/api/profiles/clear-errors")
+        assert resp.status_code == 403, resp.text

--- a/tests/test_transcode_failure_notifications.py
+++ b/tests/test_transcode_failure_notifications.py
@@ -1,0 +1,124 @@
+"""Tests for reconcile_transcode_failure_notifications_once.
+
+The reconciler (run in the CMS reaper loop) pushes permanent transcode
+failures into the notification bell: one ``scope="system"``, ``level="error"``
+notification per currently-FAILED, non-soft-deleted variant, deduped on
+``details['variant_id']``.  It self-heals — notifications whose variant is no
+longer FAILED are pruned.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+
+async def _mk_failed_variant(db, *, deleted=False, error="kaboom"):
+    from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+    from cms.models.device_profile import DeviceProfile
+    from datetime import datetime, timezone
+
+    asset = Asset(
+        filename=f"{uuid.uuid4().hex}.mp4", asset_type=AssetType.VIDEO,
+        size_bytes=1000, checksum=uuid.uuid4().hex[:8],
+    )
+    profile = DeviceProfile(name=f"rec-{uuid.uuid4().hex[:8]}", video_codec="h264")
+    db.add_all([asset, profile])
+    await db.flush()
+    variant = AssetVariant(
+        source_asset_id=asset.id, profile_id=profile.id,
+        filename=f"{uuid.uuid4()}.mp4", status=VariantStatus.FAILED,
+        error_message=error,
+        deleted_at=datetime.now(timezone.utc) if deleted else None,
+    )
+    db.add(variant)
+    await db.commit()
+    return asset, variant
+
+
+@pytest.mark.asyncio
+class TestReconcileTranscodeFailureNotifications:
+    async def test_creates_one_notification_per_failed(self, db_session):
+        from cms.models.notification import Notification
+        from cms.services.transcoder import (
+            TRANSCODE_FAIL_NOTIFICATION_TITLE,
+            reconcile_transcode_failure_notifications_once,
+        )
+
+        _, variant = await _mk_failed_variant(db_session)
+
+        created = await reconcile_transcode_failure_notifications_once(db_session)
+        assert created == 1
+
+        db_session.expunge_all()
+        notifs = (await db_session.execute(
+            select(Notification).where(
+                Notification.title == TRANSCODE_FAIL_NOTIFICATION_TITLE
+            )
+        )).scalars().all()
+        assert len(notifs) == 1
+        n = notifs[0]
+        assert n.scope == "system"
+        assert n.level == "error"
+        assert n.details["variant_id"] == str(variant.id)
+
+    async def test_idempotent_no_duplicate(self, db_session):
+        from cms.models.notification import Notification
+        from cms.services.transcoder import (
+            TRANSCODE_FAIL_NOTIFICATION_TITLE,
+            reconcile_transcode_failure_notifications_once,
+        )
+
+        await _mk_failed_variant(db_session)
+
+        first = await reconcile_transcode_failure_notifications_once(db_session)
+        second = await reconcile_transcode_failure_notifications_once(db_session)
+        assert first == 1
+        assert second == 0
+
+        db_session.expunge_all()
+        count = len((await db_session.execute(
+            select(Notification).where(
+                Notification.title == TRANSCODE_FAIL_NOTIFICATION_TITLE
+            )
+        )).scalars().all())
+        assert count == 1
+
+    async def test_ignores_soft_deleted_variants(self, db_session):
+        from cms.services.transcoder import (
+            reconcile_transcode_failure_notifications_once,
+        )
+
+        await _mk_failed_variant(db_session, deleted=True)
+
+        created = await reconcile_transcode_failure_notifications_once(db_session)
+        assert created == 0
+
+    async def test_prunes_stale_notifications(self, db_session):
+        """A notification whose variant is no longer FAILED is pruned."""
+        from cms.models.asset import AssetVariant, VariantStatus
+        from cms.models.notification import Notification
+        from cms.services.transcoder import (
+            TRANSCODE_FAIL_NOTIFICATION_TITLE,
+            reconcile_transcode_failure_notifications_once,
+        )
+
+        _, variant = await _mk_failed_variant(db_session)
+        created = await reconcile_transcode_failure_notifications_once(db_session)
+        assert created == 1
+
+        # Variant recovers to READY → its notification should be pruned.
+        variant.status = VariantStatus.READY
+        db_session.add(variant)
+        await db_session.commit()
+
+        created2 = await reconcile_transcode_failure_notifications_once(db_session)
+        assert created2 == 0
+
+        db_session.expunge_all()
+        notifs = (await db_session.execute(
+            select(Notification).where(
+                Notification.title == TRANSCODE_FAIL_NOTIFICATION_TITLE
+            )
+        )).scalars().all()
+        assert notifs == []


### PR DESCRIPTION
## What

Two related transcoding improvements (Goodwill **dev** only):

### Phase 1 — "Clear errors" button
A new `POST /api/profiles/clear-errors` endpoint and a button on the
Transcoding Queue card of the assets page. FAILED transcode variants
never transition out on their own, so errors accumulate forever; this
gives Admins an ongoing way to dismiss them. The button appears only
when the live queue feed contains a failed variant. Gated on
`profiles:write` (Admin).

Clearing errors **one-way-ties** into Phase 2: it also deletes the
matching bell notifications. (Dismissing a bell notification does NOT
mutate asset/variant state.)

### Phase 2 — Transcode-failure notifications
`reconcile_transcode_failure_notifications_once()` runs in the
existing reaper loop (under its advisory lock — single emitter) and
posts one `scope=system` / `level=error` notification per FAILED
variant lacking one. Self-heals: prunes the notification when a
variant later recovers. Lives entirely in CMS (no worker changes), so
it naturally covers every FAILED path.

## Tests
- `tests/test_profile_clear_errors.py` (4)
- `tests/test_transcode_failure_notifications.py` (4)

8 passed locally. OpenAPI regenerated for `openapi-check`.

## Scope
Goodwill **dev** only. Not for prod.
