### PR TITLE
feat(composed): honor all slideshow transitions in media widget

### DIFF
--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -42,11 +42,11 @@ class SlideshowSlidePlan:
     (image) or sibling/data URL (video) are routed into the same
     :class:`BundleContext` channels a standalone media asset would use.
     ``duration_ms`` is how long the slide shows before advancing.
-    ``transition`` is the composed-cell transition repertoire only
-    (``"cut"`` or ``"fade"`` — the device's richer native set is
-    firmware-only and not reusable in a Chromium bundle, so callers map
-    the other transitions down to ``"fade"``).  ``transition_ms`` is the
-    cross-fade duration (ignored for ``"cut"``).
+    ``transition`` is the slide's entrance transition — the composed
+    media cell renders the full slideshow set as self-contained CSS/JS
+    (``cut`` / ``fade`` / ``fade_black`` / ``dissolve`` / ``push`` /
+    ``wipe`` / ``zoom``).  ``transition_ms`` is the transition duration
+    (ignored for ``"cut"``).
     """
 
     source_asset_id: uuid.UUID

--- a/cms/composed/slideshow_expand.py
+++ b/cms/composed/slideshow_expand.py
@@ -29,20 +29,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.models.asset import Asset
 from shared.models.slideshow_slide import SlideshowSlide
+from cms.schemas.asset import SLIDE_TRANSITIONS
 
 
 def composed_cell_transition(transition: str) -> str:
-    """Map a slideshow transition to the composed-cell CSS repertoire.
+    """Map a slideshow transition into the composed-cell repertoire.
 
-    The composed media cell implements only an instant ``"cut"`` and an
-    opacity ``"fade"`` cross-fade.  Every non-cut transition
-    (``fade_black`` / ``dissolve`` / ``push`` / ``wipe`` / ``zoom``)
-    degrades to a cross-fade — the closest visual match available inside
-    a self-contained HTML cell.  (The device's native slideshow player
-    renders the richer set in firmware; that code is not reusable inside
-    a Chromium bundle.)
+    The composed media cell now renders the **full** slideshow
+    transition set as self-contained CSS keyframes / JS inside the
+    Chromium bundle: ``cut`` (instant), ``fade`` (cross-fade),
+    ``fade_black`` (through-black), ``dissolve`` (Ken Burns),
+    ``push`` (slide), ``wipe`` (clip reveal) and ``zoom``.  These are
+    self-contained approximations of the device's native firmware
+    renderer — close enough that an embedded slideshow reads the same
+    as the standalone one.
+
+    Any value outside :data:`~cms.schemas.asset.SLIDE_TRANSITIONS`
+    (should be impossible — the slide schema validates it) falls back
+    to ``"fade"`` so the cell still cycles rather than emitting an
+    unknown class.
     """
-    return "cut" if transition == "cut" else "fade"
+    return transition if transition in SLIDE_TRANSITIONS else "fade"
 
 
 async def load_slideshow_members(

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -41,7 +41,12 @@ from typing import ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from cms.composed.registry import BundleContext, Widget, WidgetRender
+from cms.composed.registry import (
+    BundleContext,
+    Widget,
+    WidgetRender,
+    WidgetStaticAsset,
+)
 from cms.composed.schema import Cell
 
 
@@ -52,6 +57,70 @@ log = logging.getLogger(__name__)
 # ImageWidget threshold — we hit this on a re-uploaded 4K photo that
 # someone dropped into a 200px cell.
 _LARGE_IMAGE_WARN_BYTES: int = 2 * 1024 * 1024
+
+
+# The slideshow transition repertoire the composed media cell renders,
+# in a fixed order.  The renderer bakes ONLY the integer index of each
+# slide's transition into the runtime JS (never the raw string), and
+# the JS maps the index back through an identical hard-coded array.
+# The class-name suffix (used in CSS) is the validated transition token
+# itself.  Keep this list in sync with the JS ``CW_SS_TYPES`` array in
+# ``_render_slideshow``.
+_SS_TRANSITIONS: tuple[str, ...] = (
+    "cut",
+    "fade",
+    "fade_black",
+    "dissolve",
+    "push",
+    "wipe",
+    "zoom",
+)
+# Transitions driven by CSS @keyframes (enter/leave) rather than the
+# plain opacity transition (fade) or an instant swap (cut).
+_SS_KEYFRAME_TRANSITIONS: frozenset[str] = frozenset(
+    {"fade_black", "dissolve", "push", "wipe", "zoom"}
+)
+
+
+# Shared keyframe library for the keyframe-driven slideshow transitions.
+# Emitted once per bundle (de-duped by content hash).  Every keyframe
+# sets ``opacity`` explicitly so fill-mode never leaves a slide in an
+# ambiguous resting state.  The ``-in`` keyframe animates the incoming
+# slide; the ``-out`` keyframe animates the outgoing one.  Per-instance
+# ``animation-duration`` is set in JS so both halves stay in sync.
+_SS_KEYFRAME_CSS: str = (
+    "@keyframes cw-ss-fadeblack-in{0%{opacity:0}50%{opacity:0}100%{opacity:1}}\n"
+    "@keyframes cw-ss-fadeblack-out{0%{opacity:1}50%{opacity:0}100%{opacity:0}}\n"
+    "@keyframes cw-ss-dissolve-in{0%{opacity:0;transform:scale(1.06)}"
+    "100%{opacity:1;transform:scale(1)}}\n"
+    "@keyframes cw-ss-dissolve-out{0%{opacity:1}100%{opacity:0}}\n"
+    "@keyframes cw-ss-push-in{0%{opacity:1;transform:translateX(100%)}"
+    "100%{opacity:1;transform:translateX(0)}}\n"
+    "@keyframes cw-ss-push-out{0%{opacity:1;transform:translateX(0)}"
+    "100%{opacity:1;transform:translateX(-100%)}}\n"
+    "@keyframes cw-ss-wipe-in{0%{opacity:1;clip-path:inset(0 0 0 100%)}"
+    "100%{opacity:1;clip-path:inset(0 0 0 0)}}\n"
+    "@keyframes cw-ss-wipe-out{0%{opacity:1}100%{opacity:1}}\n"
+    "@keyframes cw-ss-zoom-in{0%{opacity:0;transform:scale(0.6)}"
+    "100%{opacity:1;transform:scale(1)}}\n"
+    "@keyframes cw-ss-zoom-out{0%{opacity:1}100%{opacity:0}}\n"
+    ".cw-ss-enter-fade_black,.cw-ss-leave-fade_black,"
+    ".cw-ss-enter-dissolve,.cw-ss-leave-dissolve,"
+    ".cw-ss-enter-push,.cw-ss-leave-push,"
+    ".cw-ss-enter-wipe,.cw-ss-leave-wipe,"
+    ".cw-ss-enter-zoom,.cw-ss-leave-zoom{"
+    "animation-timing-function:ease-in-out;animation-fill-mode:both}\n"
+    ".cw-ss-enter-fade_black{animation-name:cw-ss-fadeblack-in}\n"
+    ".cw-ss-leave-fade_black{animation-name:cw-ss-fadeblack-out}\n"
+    ".cw-ss-enter-dissolve{animation-name:cw-ss-dissolve-in}\n"
+    ".cw-ss-leave-dissolve{animation-name:cw-ss-dissolve-out}\n"
+    ".cw-ss-enter-push{animation-name:cw-ss-push-in}\n"
+    ".cw-ss-leave-push{animation-name:cw-ss-push-out}\n"
+    ".cw-ss-enter-wipe{animation-name:cw-ss-wipe-in}\n"
+    ".cw-ss-leave-wipe{animation-name:cw-ss-wipe-out}\n"
+    ".cw-ss-enter-zoom{animation-name:cw-ss-zoom-in}\n"
+    ".cw-ss-leave-zoom{animation-name:cw-ss-zoom-out}\n"
+)
 
 
 class MediaWidgetConfig(BaseModel):
@@ -220,8 +289,13 @@ class MediaWidget(Widget):
         device-local sibling URL), stacked absolutely inside an
         instance-scoped container.  Slide 0 is marked active in the
         markup so a t=0 thumbnail snapshot is deterministic.  A small
-        baked-in timer toggles the active class to advance; CSS opacity
-        transitions handle the cut / cross-fade.
+        baked-in timer advances the stack, honouring each slide's
+        entrance transition: ``cut`` is an instant swap and ``fade`` a
+        plain opacity cross-fade, while ``fade_black`` / ``dissolve`` /
+        ``push`` / ``wipe`` / ``zoom`` are driven by self-contained CSS
+        ``@keyframes`` (enter/leave animation classes applied in JS).
+        These are self-contained approximations of the device's native
+        firmware transitions, not pixel-exact reproductions.
         """
         plans = ctx.slideshow_plans[asset_id]
         if not plans:
@@ -237,6 +311,8 @@ class MediaWidget(Widget):
         slide_html: list[str] = []
         referenced: list[uuid.UUID] = []
         durations: list[int] = []
+        trans_codes: list[int] = []
+        trans_durations: list[int] = []
 
         for idx, plan in enumerate(plans):
             source = plan.source_asset_id
@@ -244,9 +320,15 @@ class MediaWidget(Widget):
             durations.append(int(plan.duration_ms))
 
             active = " cw-ss-active" if idx == 0 else ""
-            # Per-slide transition duration overrides the container's
-            # default; a "cut" slide is baked as 0ms (instant swap).
-            trans_ms = int(plan.transition_ms) if plan.transition == "fade" else 0
+            # Per-slide entrance transition. "cut" is an instant swap
+            # (0ms); every other transition animates over transition_ms.
+            # The transition type is validated against SLIDE_TRANSITIONS
+            # upstream; fall back to "fade" for anything unexpected so
+            # the cell still cycles rather than emitting an unknown class.
+            transition = plan.transition if plan.transition in _SS_TRANSITIONS else "fade"
+            trans_ms = 0 if transition == "cut" else int(plan.transition_ms)
+            trans_codes.append(_SS_TRANSITIONS.index(transition))
+            trans_durations.append(trans_ms)
             slide_style = f"transition-duration:{trans_ms}ms"
 
             if source in ctx.sibling_asset_urls:
@@ -285,12 +367,17 @@ class MediaWidget(Widget):
                     "asset_bytes nor sibling_asset_urls)"
                 )
 
+            slide_classes = f"cw-ss-slide{active} cw-ss-t-{transition}"
             slide_html.append(
-                f'<div class="cw-ss-slide{active}" style="{slide_style}">'
+                f'<div class="{slide_classes}" style="{slide_style}">'
                 f"{inner}</div>"
             )
 
         html_out = f'<div class="{css_class}">' + "".join(slide_html) + "</div>"
+
+        uses_keyframes = any(
+            _SS_TRANSITIONS[c] in _SS_KEYFRAME_TRANSITIONS for c in trans_codes
+        )
 
         css_out = (
             f".{css_class} {{\n"
@@ -304,11 +391,22 @@ class MediaWidget(Widget):
             f"  position: absolute;\n"
             f"  inset: 0;\n"
             f"  opacity: 0;\n"
+            f"  z-index: 1;\n"
             f"  transition-property: opacity;\n"
             f"  transition-timing-function: ease-in-out;\n"
             f"}}\n"
             f".{css_class} .cw-ss-slide.cw-ss-active {{\n"
             f"  opacity: 1;\n"
+            f"  z-index: 2;\n"
+            f"}}\n"
+            # Keyframe-driven transitions own their opacity timeline, so
+            # the base opacity transition must not fight the animation.
+            f".{css_class} .cw-ss-t-fade_black,\n"
+            f".{css_class} .cw-ss-t-dissolve,\n"
+            f".{css_class} .cw-ss-t-push,\n"
+            f".{css_class} .cw-ss-t-wipe,\n"
+            f".{css_class} .cw-ss-t-zoom {{\n"
+            f"  transition: none;\n"
             f"}}\n"
             f".{css_class} img,\n"
             f".{css_class} video {{\n"
@@ -321,14 +419,22 @@ class MediaWidget(Widget):
             f"}}"
         )
 
-        # Bake ONLY integer durations into the runtime — never
-        # interpolate raw config strings into JS.
+        # Bake ONLY integer arrays into the runtime — never interpolate
+        # raw config strings into JS.  ``types`` are indices into the JS
+        # ``TYPE`` array (kept in sync with ``_SS_TRANSITIONS``);
+        # ``transMs`` are the per-slide transition durations.
         durations_js = "[" + ",".join(str(d) for d in durations) + "]"
+        types_js = "[" + ",".join(str(c) for c in trans_codes) + "]"
+        trans_ms_js = "[" + ",".join(str(d) for d in trans_durations) + "]"
         init_js = (
             "var root = document.querySelector('.cw-ss-' + instanceId);\n"
             "if (!root) { return; }\n"
             "var slides = root.querySelectorAll('.cw-ss-slide');\n"
             f"var durations = {durations_js};\n"
+            f"var types = {types_js};\n"
+            f"var transMs = {trans_ms_js};\n"
+            "var TYPE = ['cut','fade','fade_black','dissolve','push','wipe','zoom'];\n"
+            "var ANIM = {fade_black:1,dissolve:1,push:1,wipe:1,zoom:1};\n"
             "function startVideo(slide) {\n"
             "  var v = slide.querySelector('video');\n"
             "  if (v) { try { v.currentTime = 0; var p = v.play();"
@@ -336,26 +442,67 @@ class MediaWidget(Widget):
             "}\n"
             "if (slides.length >= 1) { startVideo(slides[0]); }\n"
             "if (slides.length <= 1) { return; }\n"
+            "function clearAnim(s) {\n"
+            "  var rm = [];\n"
+            "  s.classList.forEach(function(c){\n"
+            "    if (c.indexOf('cw-ss-enter-') === 0 || c.indexOf('cw-ss-leave-') === 0)"
+            " { rm.push(c); }\n"
+            "  });\n"
+            "  for (var i = 0; i < rm.length; i++) { s.classList.remove(rm[i]); }\n"
+            "  s.style.animationDuration = '';\n"
+            "}\n"
             "var idx = 0;\n"
-            "function activate(n) {\n"
-            "  for (var i = 0; i < slides.length; i++) {\n"
-            "    slides[i].classList.toggle('cw-ss-active', i === n);\n"
+            "function activate(n, prev) {\n"
+            "  for (var i = 0; i < slides.length; i++) { clearAnim(slides[i]); }\n"
+            "  void root.offsetWidth;\n"
+            "  for (var j = 0; j < slides.length; j++) {\n"
+            "    slides[j].classList.toggle('cw-ss-active', j === n);\n"
+            "  }\n"
+            "  var t = TYPE[types[n]];\n"
+            "  if (ANIM[t]) {\n"
+            "    var dur = transMs[n] + 'ms';\n"
+            "    var incoming = slides[n];\n"
+            "    incoming.classList.add('cw-ss-enter-' + t);\n"
+            "    incoming.style.animationDuration = dur;\n"
+            "    if (prev != null && prev !== n) {\n"
+            "      var outgoing = slides[prev];\n"
+            "      outgoing.classList.add('cw-ss-leave-' + t);\n"
+            "      outgoing.style.animationDuration = dur;\n"
+            "    }\n"
             "  }\n"
             "  startVideo(slides[n]);\n"
             "}\n"
             "function schedule() {\n"
             "  setTimeout(function () {\n"
+            "    var prev = idx;\n"
             "    idx = (idx + 1) % slides.length;\n"
-            "    activate(idx);\n"
+            "    activate(idx, prev);\n"
             "    schedule();\n"
             "  }, durations[idx]);\n"
             "}\n"
             "schedule();"
         )
 
+        static_assets: list[WidgetStaticAsset] = []
+        if uses_keyframes:
+            # Shared keyframe library — identical bytes for every
+            # slideshow-media instance, so the bundle builder de-dupes
+            # it to a single <style> block by content hash.  The
+            # enter/leave animation-name rules are intentionally global
+            # (not instance-scoped): JS only ever applies the classes to
+            # slides inside this instance's root during a transition.
+            static_assets.append(
+                WidgetStaticAsset(
+                    kind="css",
+                    mime="text/css",
+                    content=_SS_KEYFRAME_CSS,
+                )
+            )
+
         return WidgetRender(
             html=html_out,
             css=css_out,
             init_js=init_js,
             referenced_asset_ids=referenced,
+            static_assets=static_assets,
         )

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -374,3 +374,127 @@ class TestMediaWidgetSlideshowBranch:
         r = MediaWidget().render_html(cfg, _cell(), "ssP", ctx=ctx)
         assert "cw-ss-" in r.html
 
+    @pytest.mark.parametrize(
+        "transition,enter_kf,leave_kf",
+        [
+            ("fade_black", "cw-ss-fadeblack-in", "cw-ss-fadeblack-out"),
+            ("dissolve", "cw-ss-dissolve-in", "cw-ss-dissolve-out"),
+            ("push", "cw-ss-push-in", "cw-ss-push-out"),
+            ("wipe", "cw-ss-wipe-in", "cw-ss-wipe-out"),
+            ("zoom", "cw-ss-zoom-in", "cw-ss-zoom-out"),
+        ],
+    )
+    def test_rich_transition_emits_class_and_keyframe_library(
+        self, transition, enter_kf, leave_kf
+    ):
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                (s1, {"duration_ms": 4000, "transition": transition,
+                      "transition_ms": 800}, "img", (_TINY_PNG, "image/png")),
+                (s2, {"duration_ms": 4000, "transition": transition,
+                      "transition_ms": 800}, "img", (_TINY_PNG, "image/png")),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssRich", ctx=ctx)
+
+        # Per-slide type class baked onto each slide div.
+        assert f"cw-ss-t-{transition}" in r.html
+        # The slide-count invariant still holds (type class shares no
+        # "cw-ss-slide" substring).
+        assert r.html.count("cw-ss-slide") == 2
+        assert "cw-ss-slide cw-ss-active" in r.html
+
+        # Shared keyframe library emitted as a static CSS asset.
+        css_assets = [a for a in r.static_assets if a.kind == "css"]
+        assert len(css_assets) == 1
+        lib = css_assets[0].content
+        assert enter_kf in lib
+        assert leave_kf in lib
+        assert f"cw-ss-enter-{transition}" in lib
+        assert f"cw-ss-leave-{transition}" in lib
+
+        # Rich transitions opt out of the base opacity transition so the
+        # keyframe animation owns the timeline.
+        assert "transition: none;" in r.css
+
+    def test_rich_transition_bakes_int_arrays_in_js(self):
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                # cut -> type index 0, transMs 0
+                (s1, {"duration_ms": 3000, "transition": "cut"},
+                 "img", (_TINY_PNG, "image/png")),
+                # zoom -> type index 6, transMs 900
+                (s2, {"duration_ms": 4000, "transition": "zoom",
+                      "transition_ms": 900}, "img", (_TINY_PNG, "image/png")),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssArr", ctx=ctx)
+        assert r.init_js is not None
+        # Only integer arrays are baked into the runtime — never raw
+        # config strings.
+        assert "var types = [0,6];" in r.init_js
+        assert "var transMs = [0,900];" in r.init_js
+        assert "var durations = [3000,4000];" in r.init_js
+
+    def test_cut_fade_only_emits_no_keyframe_asset(self):
+        # A slideshow that only uses cut + fade must NOT emit the shared
+        # keyframe library (it would be dead CSS).
+        container = uuid.uuid4()
+        s1, s2 = uuid.uuid4(), uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [
+                (s1, {"duration_ms": 3000, "transition": "cut"},
+                 "img", (_TINY_PNG, "image/png")),
+                (s2, {"duration_ms": 3000, "transition": "fade",
+                      "transition_ms": 600}, "img", (_TINY_PNG, "image/png")),
+            ],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssCF", ctx=ctx)
+        assert [a for a in r.static_assets if a.kind == "css"] == []
+
+    def test_unknown_transition_falls_back_to_fade(self):
+        # SlideshowSlidePlan.transition is a plain str; an unexpected
+        # value must degrade to "fade" rather than emit an unknown class.
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 3000, "transition": "bogus",
+                   "transition_ms": 500}, "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssU", ctx=ctx)
+        assert "cw-ss-t-fade" in r.html
+        assert "cw-ss-t-bogus" not in r.html
+        assert r.static_assets == []
+
+
+class TestComposedCellTransitionMapper:
+    """``composed_cell_transition`` now passes the full validated
+    repertoire through (was: collapse everything but cut -> fade)."""
+
+    @pytest.mark.parametrize(
+        "t",
+        ["cut", "fade", "fade_black", "dissolve", "push", "wipe", "zoom"],
+    )
+    def test_known_transition_passes_through(self, t):
+        from cms.composed.slideshow_expand import composed_cell_transition
+
+        assert composed_cell_transition(t) == t
+
+    def test_unknown_transition_degrades_to_fade(self):
+        from cms.composed.slideshow_expand import composed_cell_transition
+
+        assert composed_cell_transition("bogus") == "fade"
+        assert composed_cell_transition("") == "fade"
+


### PR DESCRIPTION
Embedded SLIDESHOW assets in a composed-slide media widget now honor **all** slideshow transitions, not just `cut`/`fade`.

## What changed
- **`slideshow_expand.composed_cell_transition`** now passes the full validated transition repertoire through (`cut`, `fade`, `fade_black`, `dissolve`, `push`, `wipe`, `zoom`). Previously it collapsed everything but `cut` to `fade`. Unknown values still degrade to `fade`.
- **`media._render_slideshow`**:
  - bakes a per-slide `cw-ss-t-<type>` class
  - emits a shared keyframe library as a content-hash-deduped `WidgetStaticAsset` (only when a rich transition is actually used)
  - rewrites the cycling JS to apply enter/leave animation classes with a forced reflow so each advance replays
  - rich types opt out of the base opacity transition so the keyframe animation owns the timeline
  - only **integer arrays** (type indices + durations) are baked into runtime JS — never raw config strings

The composed-cell renderings are self-contained **approximations** of the device firmware transitions (firmware code isn't reusable in a Chromium bundle), close enough that an embedded slideshow reads the same as the standalone one.

## Tests
- 5 parametrized rich-transition tests (class + keyframe library + opt-out CSS)
- int-array baking, cut/fade-only emits no keyframe asset, unknown-transition fallback
- mapper pass-through (full repertoire + degrade-to-fade)
- Existing slideshow/publish/preview/bundle/snapshot suites still green locally.

**Goodwill dev only.**