### PR TITLE
feat(assistant): add AI assistant to the slideshow editor

### DIFF
--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -61,7 +61,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.composed.bundle import BundleValidationError, build_bundle
 from cms.composed.registry import SlideshowSlidePlan, get_registry
-from cms.composed.schema import Layout
+from cms.composed.schema import (
+    GRID_COLS,
+    GRID_ROWS,
+    Cell,
+    Layout,
+    WidgetInstance,
+)
 from cms.composed.slideshow_expand import (
     composed_cell_transition,
     load_slideshow_members,
@@ -207,6 +213,84 @@ async def build_composed_html(
             status_code=422, detail=f"Invalid layout JSON: {e}",
         ) from e
 
+    return await _render_layout_to_html(
+        db, settings, layout, verify_asset=verify_asset
+    )
+
+
+async def build_slideshow_preview_html(
+    db: AsyncSession,
+    settings,
+    asset_id: uuid.UUID,
+    *,
+    verify_asset: VerifyAsset | None = None,
+) -> ComposedRender:
+    """Render a standalone SLIDESHOW asset to self-contained preview HTML.
+
+    Reuses the composed-slide render pipeline: wraps the slideshow in an
+    ephemeral, single full-bleed ``media`` widget layout and runs it
+    through the exact same machinery the composed preview / thumbnail
+    path uses. Because the media widget already expands a referenced
+    SLIDESHOW into per-member slides (with the device-faithful CSS
+    transitions ported in PR #772), this gives an authentic preview of
+    how the slideshow animates on a device — with zero parallel renderer.
+
+    ``verify_asset`` mirrors :func:`build_composed_html`: when supplied it
+    is awaited for the slideshow asset and for each expanded member before
+    its bytes are read, so a viewer can't preview members they can't see.
+
+    Raises ``HTTPException`` 404 (missing / not a slideshow / deleted),
+    403 (via ``verify_asset``), or 422 (empty slideshow, missing or
+    non-IMAGE/VIDEO member) — the same contract as the composed path.
+    """
+    asset = await db.get(Asset, asset_id)
+    if (
+        asset is None
+        or asset.asset_type != AssetType.SLIDESHOW
+        or asset.deleted_at is not None
+    ):
+        raise HTTPException(status_code=404, detail="Slideshow not found")
+
+    if verify_asset is not None:
+        await verify_asset(asset_id)
+
+    # Ephemeral layout: one full-bleed media widget pointing at the
+    # slideshow. The widget's slideshow-expansion branch does the rest.
+    # A deterministic instance id keeps the rendered output reproducible
+    # for a given slideshow (helps caching / golden tests).
+    instance_id = uuid.uuid5(uuid.NAMESPACE_URL, f"slideshow-preview:{asset_id}")
+    layout = Layout(
+        widgets=[
+            WidgetInstance(
+                id=instance_id,
+                type="media",
+                cell=Cell(row=1, col=1, rowspan=GRID_ROWS, colspan=GRID_COLS),
+                config={"asset_id": str(asset_id), "object_fit": "contain"},
+                config_version=1,
+            )
+        ]
+    )
+
+    return await _render_layout_to_html(
+        db, settings, layout, verify_asset=verify_asset
+    )
+
+
+async def _render_layout_to_html(
+    db: AsyncSession,
+    settings,
+    layout: Layout,
+    *,
+    verify_asset: VerifyAsset | None = None,
+) -> ComposedRender:
+    """Render an already-validated-shape :class:`Layout` to self-contained HTML.
+
+    Shared by :func:`build_composed_html` (persisted composed slides) and
+    :func:`build_slideshow_preview_html` (ephemeral single-media-widget
+    wrapper around a SLIDESHOW asset). Runs the semantic validator, inlines
+    every referenced image / video (and expands referenced slideshows into
+    per-member slides), then builds the bundle.
+    """
     # Trigger auto-registration of all built-in widgets.
     import cms.composed.widgets  # noqa: F401
 

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -75,51 +75,75 @@ _SS_TRANSITIONS: tuple[str, ...] = (
     "wipe",
     "zoom",
 )
-# Transitions driven by CSS @keyframes (enter/leave) rather than the
-# plain opacity transition (fade) or an instant swap (cut).
-_SS_KEYFRAME_TRANSITIONS: frozenset[str] = frozenset(
-    {"fade_black", "dissolve", "push", "wipe", "zoom"}
-)
-
-
-# Shared keyframe library for the keyframe-driven slideshow transitions.
-# Emitted once per bundle (de-duped by content hash).  Every keyframe
-# sets ``opacity`` explicitly so fill-mode never leaves a slide in an
-# ambiguous resting state.  The ``-in`` keyframe animates the incoming
-# slide; the ``-out`` keyframe animates the outgoing one.  Per-instance
-# ``animation-duration`` is set in JS so both halves stay in sync.
-_SS_KEYFRAME_CSS: str = (
-    "@keyframes cw-ss-fadeblack-in{0%{opacity:0}50%{opacity:0}100%{opacity:1}}\n"
-    "@keyframes cw-ss-fadeblack-out{0%{opacity:1}50%{opacity:0}100%{opacity:0}}\n"
-    "@keyframes cw-ss-dissolve-in{0%{opacity:0;transform:scale(1.06)}"
-    "100%{opacity:1;transform:scale(1)}}\n"
-    "@keyframes cw-ss-dissolve-out{0%{opacity:1}100%{opacity:0}}\n"
-    "@keyframes cw-ss-push-in{0%{opacity:1;transform:translateX(100%)}"
-    "100%{opacity:1;transform:translateX(0)}}\n"
-    "@keyframes cw-ss-push-out{0%{opacity:1;transform:translateX(0)}"
-    "100%{opacity:1;transform:translateX(-100%)}}\n"
-    "@keyframes cw-ss-wipe-in{0%{opacity:1;clip-path:inset(0 0 0 100%)}"
-    "100%{opacity:1;clip-path:inset(0 0 0 0)}}\n"
-    "@keyframes cw-ss-wipe-out{0%{opacity:1}100%{opacity:1}}\n"
-    "@keyframes cw-ss-zoom-in{0%{opacity:0;transform:scale(0.6)}"
-    "100%{opacity:1;transform:scale(1)}}\n"
-    "@keyframes cw-ss-zoom-out{0%{opacity:1}100%{opacity:0}}\n"
-    ".cw-ss-enter-fade_black,.cw-ss-leave-fade_black,"
-    ".cw-ss-enter-dissolve,.cw-ss-leave-dissolve,"
-    ".cw-ss-enter-push,.cw-ss-leave-push,"
-    ".cw-ss-enter-wipe,.cw-ss-leave-wipe,"
-    ".cw-ss-enter-zoom,.cw-ss-leave-zoom{"
-    "animation-timing-function:ease-in-out;animation-fill-mode:both}\n"
-    ".cw-ss-enter-fade_black{animation-name:cw-ss-fadeblack-in}\n"
-    ".cw-ss-leave-fade_black{animation-name:cw-ss-fadeblack-out}\n"
-    ".cw-ss-enter-dissolve{animation-name:cw-ss-dissolve-in}\n"
-    ".cw-ss-leave-dissolve{animation-name:cw-ss-dissolve-out}\n"
-    ".cw-ss-enter-push{animation-name:cw-ss-push-in}\n"
-    ".cw-ss-leave-push{animation-name:cw-ss-push-out}\n"
-    ".cw-ss-enter-wipe{animation-name:cw-ss-wipe-in}\n"
-    ".cw-ss-leave-wipe{animation-name:cw-ss-wipe-out}\n"
-    ".cw-ss-enter-zoom{animation-name:cw-ss-zoom-in}\n"
-    ".cw-ss-leave-zoom{animation-name:cw-ss-zoom-out}\n"
+# The composed media cell renders slideshow transitions by PORTING the
+# device player shell's real transition mechanism — two crossfading
+# layers plus per-mode ``tx-*`` classes flipped by JS — rather than
+# approximating them with a parallel ``@keyframes`` library.  The CSS
+# below is a near-verbatim port of ``agora/player/shell/player.css``'s
+# ``.layer`` / ``.tx-*`` rules, and the cycling JS in
+# ``_render_slideshow`` ports the ``swapTo()`` flip logic from
+# ``player.js`` (the transitions-off → commit entry state → flush →
+# flip ``.active`` dance, plus the ``fade_black`` two-stage sequenced
+# fade).  An embedded slideshow therefore animates pixel-identically to
+# a standalone one on the device.
+#
+# Device → composed class-name mapping:
+#   .layer          -> .cw-ss-slide
+#   .layer.active   -> .cw-ss-slide.cw-ss-active
+#   .no-transition  -> .cw-ss-notrans
+#   .tx-<mode>      -> .cw-tx-<mode>
+#   .tx-incoming    -> .cw-tx-incoming
+#   .tx-outgoing    -> .cw-tx-outgoing
+# The device drives timing off a ``--transition-ms`` custom property set
+# per-swap in JS; we use ``--cw-ss-ms`` for the same role.
+#
+# Emitted once per bundle (de-duped by content hash) as a shared static
+# CSS asset.  The selectors are intentionally global (not instance-
+# scoped) because the cycling JS only ever toggles the dynamic
+# ``cw-tx-*`` / ``cw-ss-active`` classes on slides inside its own
+# instance root, and the base ``.cw-ss-slide`` mechanics are identical
+# for every slideshow-media cell.
+#
+# One intentional deviation from the device's fixed two-layer DOM: an
+# N-slide stack needs explicit z-index so the transitioning incoming /
+# outgoing slides composite above the resting (opacity:0) slides, with
+# the incoming above the outgoing so wipe / push reveal correctly
+# regardless of slide order (the device relies on a fixed 2-element DOM
+# order for this).
+_SS_TRANSITION_CSS: str = (
+    ".cw-ss-slide{"
+    "position:absolute;inset:0;opacity:0;z-index:1;"
+    "transition:"
+    "opacity var(--cw-ss-ms,600ms) ease-in-out,"
+    "transform var(--cw-ss-ms,600ms) ease-in-out,"
+    "clip-path var(--cw-ss-ms,600ms) ease-in-out;"
+    "will-change:opacity,transform,clip-path}\n"
+    ".cw-ss-slide.cw-ss-active{opacity:1;z-index:2}\n"
+    ".cw-ss-slide.cw-ss-notrans{transition:none !important}\n"
+    ".cw-ss-slide.cw-tx-outgoing{z-index:3}\n"
+    ".cw-ss-slide.cw-tx-incoming{z-index:4}\n"
+    # push: incoming slides in from the right, outgoing off to the left;
+    # opacity pinned at 1 so the black gutter never shows.
+    ".cw-ss-slide.cw-tx-push{opacity:1}\n"
+    ".cw-ss-slide.cw-tx-push:not(.cw-ss-active){transform:translateX(100%)}\n"
+    ".cw-ss-slide.cw-tx-push.cw-ss-active{transform:translateX(0)}\n"
+    ".cw-ss-slide.cw-tx-push.cw-tx-outgoing:not(.cw-ss-active)"
+    "{transform:translateX(-100%)}\n"
+    # wipe: incoming reveals L->R via a clip-path inset; outgoing stays put.
+    ".cw-ss-slide.cw-tx-wipe{opacity:1}\n"
+    ".cw-ss-slide.cw-tx-wipe:not(.cw-ss-active){clip-path:inset(0 100% 0 0)}\n"
+    ".cw-ss-slide.cw-tx-wipe.cw-ss-active{clip-path:inset(0 0 0 0)}\n"
+    ".cw-ss-slide.cw-tx-wipe.cw-tx-outgoing{clip-path:inset(0 0 0 0)}\n"
+    # dissolve (Ken Burns): crossfade + outgoing scales up to 1.05.
+    ".cw-ss-slide.cw-tx-dissolve.cw-tx-outgoing:not(.cw-ss-active)"
+    "{transform:scale(1.05)}\n"
+    ".cw-ss-slide.cw-tx-dissolve.cw-tx-incoming.cw-ss-active"
+    "{transform:scale(1)}\n"
+    # zoom: incoming scales 0.9 -> 1.0 while fading in.
+    ".cw-ss-slide.cw-tx-zoom:not(.cw-ss-active){transform:scale(0.9)}\n"
+    ".cw-ss-slide.cw-tx-zoom.cw-ss-active{transform:scale(1)}\n"
+    # fade_black is sequenced JS-side (two half-duration fades through the
+    # black container background) — no extra CSS needed here.
 )
 
 
@@ -290,12 +314,18 @@ class MediaWidget(Widget):
         instance-scoped container.  Slide 0 is marked active in the
         markup so a t=0 thumbnail snapshot is deterministic.  A small
         baked-in timer advances the stack, honouring each slide's
-        entrance transition: ``cut`` is an instant swap and ``fade`` a
-        plain opacity cross-fade, while ``fade_black`` / ``dissolve`` /
-        ``push`` / ``wipe`` / ``zoom`` are driven by self-contained CSS
-        ``@keyframes`` (enter/leave animation classes applied in JS).
-        These are self-contained approximations of the device's native
-        firmware transitions, not pixel-exact reproductions.
+        entrance transition.
+
+        Transitions are a faithful PORT of the device player shell
+        (``agora/player/shell/player.{css,js}``), not approximations:
+        the shared ``_SS_TRANSITION_CSS`` asset reproduces the shell's
+        ``.layer`` / ``tx-*`` rules and the baked JS ports ``swapTo()``
+        (the transitions-off → commit entry state → flush → flip
+        ``.active`` dance for ``push`` / ``wipe`` / ``dissolve`` /
+        ``zoom``, and the two-stage ``fade_black`` sequence).  ``cut`` is
+        an instant swap and ``fade`` a plain opacity cross-fade.  An
+        embedded slideshow therefore animates pixel-identically to a
+        standalone one on the device.
         """
         plans = ctx.slideshow_plans[asset_id]
         if not plans:
@@ -329,7 +359,11 @@ class MediaWidget(Widget):
             trans_ms = 0 if transition == "cut" else int(plan.transition_ms)
             trans_codes.append(_SS_TRANSITIONS.index(transition))
             trans_durations.append(trans_ms)
-            slide_style = f"transition-duration:{trans_ms}ms"
+            # Per-slide resting default for the transition-duration custom
+            # property the shared CSS reads.  The cycling JS overrides it
+            # per-swap (and halves it for fade_black); this inline value is
+            # just a sensible default for a static t=0 snapshot.
+            slide_style = f"--cw-ss-ms:{trans_ms}ms"
 
             if source in ctx.sibling_asset_urls:
                 src = ctx.sibling_asset_urls[source]
@@ -375,10 +409,10 @@ class MediaWidget(Widget):
 
         html_out = f'<div class="{css_class}">' + "".join(slide_html) + "</div>"
 
-        uses_keyframes = any(
-            _SS_TRANSITIONS[c] in _SS_KEYFRAME_TRANSITIONS for c in trans_codes
-        )
-
+        # Instance-scoped CSS holds only the container framing + media
+        # sizing (object-fit is per-config).  The slide-transition
+        # mechanics live in the shared, global ``_SS_TRANSITION_CSS``
+        # asset emitted below.
         css_out = (
             f".{css_class} {{\n"
             f"  position: relative;\n"
@@ -386,27 +420,6 @@ class MediaWidget(Widget):
             f"  height: 100%;\n"
             f"  overflow: hidden;\n"
             f"  background: #000;\n"
-            f"}}\n"
-            f".{css_class} .cw-ss-slide {{\n"
-            f"  position: absolute;\n"
-            f"  inset: 0;\n"
-            f"  opacity: 0;\n"
-            f"  z-index: 1;\n"
-            f"  transition-property: opacity;\n"
-            f"  transition-timing-function: ease-in-out;\n"
-            f"}}\n"
-            f".{css_class} .cw-ss-slide.cw-ss-active {{\n"
-            f"  opacity: 1;\n"
-            f"  z-index: 2;\n"
-            f"}}\n"
-            # Keyframe-driven transitions own their opacity timeline, so
-            # the base opacity transition must not fight the animation.
-            f".{css_class} .cw-ss-t-fade_black,\n"
-            f".{css_class} .cw-ss-t-dissolve,\n"
-            f".{css_class} .cw-ss-t-push,\n"
-            f".{css_class} .cw-ss-t-wipe,\n"
-            f".{css_class} .cw-ss-t-zoom {{\n"
-            f"  transition: none;\n"
             f"}}\n"
             f".{css_class} img,\n"
             f".{css_class} video {{\n"
@@ -426,6 +439,16 @@ class MediaWidget(Widget):
         durations_js = "[" + ",".join(str(d) for d in durations) + "]"
         types_js = "[" + ",".join(str(c) for c in trans_codes) + "]"
         trans_ms_js = "[" + ",".join(str(d) for d in trans_durations) + "]"
+        # Ported from agora/player/shell/player.js ``swapTo()``.  Two
+        # crossfading layers on the device become an N-slide stack here,
+        # but the per-mode class choreography is identical: set the
+        # duration custom property, strip stale tx-* classes, then either
+        # cut (instant), fade (plain opacity), fade_black (two sequenced
+        # half fades through the black container), or run the single-stage
+        # commit-with-transitions-off → flush → flip-active dance for
+        # push/wipe/dissolve/zoom.  The device's _freezeOutgoingVideo
+        # DRM-overlay workaround is deliberately omitted — the composed
+        # cell composites in ordinary Chromium where it isn't needed.
         init_js = (
             "var root = document.querySelector('.cw-ss-' + instanceId);\n"
             "if (!root) { return; }\n"
@@ -434,7 +457,11 @@ class MediaWidget(Widget):
             f"var types = {types_js};\n"
             f"var transMs = {trans_ms_js};\n"
             "var TYPE = ['cut','fade','fade_black','dissolve','push','wipe','zoom'];\n"
-            "var ANIM = {fade_black:1,dissolve:1,push:1,wipe:1,zoom:1};\n"
+            # Modes whose entry/exit states live in transform / clip-path,
+            # so they need the transitions-off commit-then-flush dance.
+            "var STAGED = {dissolve:1,push:1,wipe:1,zoom:1};\n"
+            "var TX = ['cw-tx-dissolve','cw-tx-push','cw-tx-wipe','cw-tx-zoom',"
+            "'cw-tx-incoming','cw-tx-outgoing','cw-ss-notrans'];\n"
             "function startVideo(slide) {\n"
             "  var v = slide.querySelector('video');\n"
             "  if (v) { try { v.currentTime = 0; var p = v.play();"
@@ -442,62 +469,76 @@ class MediaWidget(Widget):
             "}\n"
             "if (slides.length >= 1) { startVideo(slides[0]); }\n"
             "if (slides.length <= 1) { return; }\n"
-            "function clearAnim(s) {\n"
-            "  var rm = [];\n"
-            "  s.classList.forEach(function(c){\n"
-            "    if (c.indexOf('cw-ss-enter-') === 0 || c.indexOf('cw-ss-leave-') === 0)"
-            " { rm.push(c); }\n"
-            "  });\n"
-            "  for (var i = 0; i < rm.length; i++) { s.classList.remove(rm[i]); }\n"
-            "  s.style.animationDuration = '';\n"
+            "function clearTx(s) {\n"
+            "  for (var i = 0; i < TX.length; i++) { s.classList.remove(TX[i]); }\n"
+            "  s.style.removeProperty('--cw-ss-ms');\n"
             "}\n"
             "var idx = 0;\n"
-            "function activate(n, prev) {\n"
-            "  for (var i = 0; i < slides.length; i++) { clearAnim(slides[i]); }\n"
-            "  void root.offsetWidth;\n"
+            "function swapTo(n, prev) {\n"
+            "  var incoming = slides[n];\n"
+            "  var outgoing = (prev != null && prev !== n) ? slides[prev] : null;\n"
+            "  var mode = TYPE[types[n]];\n"
+            "  var durMs = (mode === 'cut') ? 0 : transMs[n];\n"
+            "  for (var i = 0; i < slides.length; i++) { clearTx(slides[i]); }\n"
+            "  incoming.style.setProperty('--cw-ss-ms', durMs + 'ms');\n"
+            "  if (outgoing) { outgoing.style.setProperty('--cw-ss-ms', durMs + 'ms'); }\n"
+            "  if (durMs === 0) {\n"
+            "    incoming.classList.add('cw-ss-notrans');\n"
+            "    if (outgoing) { outgoing.classList.add('cw-ss-notrans'); }\n"
+            "  }\n"
+            "  if (mode === 'fade_black' && durMs > 0 && outgoing) {\n"
+            "    var half = Math.max(1, Math.floor(durMs / 2));\n"
+            "    incoming.style.setProperty('--cw-ss-ms', half + 'ms');\n"
+            "    outgoing.style.setProperty('--cw-ss-ms', half + 'ms');\n"
+            "    outgoing.classList.remove('cw-ss-active');\n"
+            "    setTimeout(function () { incoming.classList.add('cw-ss-active'); }, half);\n"
+            "    startVideo(incoming);\n"
+            "    return;\n"
+            "  }\n"
+            "  if (STAGED[mode]) {\n"
+            "    var txClass = 'cw-tx-' + mode;\n"
+            "    incoming.classList.add('cw-ss-notrans', txClass, 'cw-tx-incoming');\n"
+            "    if (outgoing) { outgoing.classList.add('cw-ss-notrans', txClass, 'cw-tx-outgoing'); }\n"
+            "    void root.offsetHeight;\n"
+            "    incoming.classList.remove('cw-ss-notrans');\n"
+            "    if (outgoing) { outgoing.classList.remove('cw-ss-notrans'); }\n"
+            "  }\n"
+            "  void root.offsetHeight;\n"
             "  for (var j = 0; j < slides.length; j++) {\n"
             "    slides[j].classList.toggle('cw-ss-active', j === n);\n"
             "  }\n"
-            "  var t = TYPE[types[n]];\n"
-            "  if (ANIM[t]) {\n"
-            "    var dur = transMs[n] + 'ms';\n"
-            "    var incoming = slides[n];\n"
-            "    incoming.classList.add('cw-ss-enter-' + t);\n"
-            "    incoming.style.animationDuration = dur;\n"
-            "    if (prev != null && prev !== n) {\n"
-            "      var outgoing = slides[prev];\n"
-            "      outgoing.classList.add('cw-ss-leave-' + t);\n"
-            "      outgoing.style.animationDuration = dur;\n"
-            "    }\n"
+            "  startVideo(incoming);\n"
+            "  if (outgoing) {\n"
+            "    var hide = outgoing;\n"
+            "    setTimeout(function () {\n"
+            "      if (!hide.classList.contains('cw-ss-active')) { clearTx(hide); }\n"
+            "    }, Math.max(durMs + 100, 50));\n"
             "  }\n"
-            "  startVideo(slides[n]);\n"
             "}\n"
             "function schedule() {\n"
             "  setTimeout(function () {\n"
             "    var prev = idx;\n"
             "    idx = (idx + 1) % slides.length;\n"
-            "    activate(idx, prev);\n"
+            "    swapTo(idx, prev);\n"
             "    schedule();\n"
             "  }, durations[idx]);\n"
             "}\n"
             "schedule();"
         )
 
-        static_assets: list[WidgetStaticAsset] = []
-        if uses_keyframes:
-            # Shared keyframe library — identical bytes for every
-            # slideshow-media instance, so the bundle builder de-dupes
-            # it to a single <style> block by content hash.  The
-            # enter/leave animation-name rules are intentionally global
-            # (not instance-scoped): JS only ever applies the classes to
-            # slides inside this instance's root during a transition.
-            static_assets.append(
-                WidgetStaticAsset(
-                    kind="css",
-                    mime="text/css",
-                    content=_SS_KEYFRAME_CSS,
-                )
+        # The shared transition CSS carries the base ``.cw-ss-slide``
+        # mechanics now, so it is ALWAYS emitted for any slideshow render
+        # (even cut/fade-only or single-slide).  Identical bytes for every
+        # instance, so the bundle builder de-dupes it to one <style> block
+        # by content hash.  Selectors are intentionally global — see the
+        # note on ``_SS_TRANSITION_CSS``.
+        static_assets: list[WidgetStaticAsset] = [
+            WidgetStaticAsset(
+                kind="css",
+                mime="text/css",
+                content=_SS_TRANSITION_CSS,
             )
+        ]
 
         return WidgetRender(
             html=html_out,

--- a/cms/models/chat_thread.py
+++ b/cms/models/chat_thread.py
@@ -45,12 +45,14 @@ class ChatThread(Base):
         default="general",
         server_default="general",
     )
-    # Binds a ``composed_editor``-mode thread to the one composed-slide
-    # asset it is editing.  NULL for general-mode threads.  The agent
-    # forces this asset id onto the composed asset-scoped tools so the
-    # editor assistant can only ever read/write *this* slide's draft,
-    # never another asset's.  ``ondelete=CASCADE``: editor chats are
-    # asset-scoped ephemera, so deleting the slide deletes its chat.
+    # Binds an editor-mode thread to the one asset it is editing.  For
+    # ``composed_editor`` threads this is the composed-slide asset; for
+    # ``slideshow_editor`` threads the same column is reused to point at
+    # the slideshow asset.  NULL for general-mode threads.  The agent
+    # forces this asset id onto the editor's asset-scoped tools so the
+    # editor assistant can only ever read/write *this* asset, never
+    # another one.  ``ondelete=CASCADE``: editor chats are asset-scoped
+    # ephemera, so deleting the asset deletes its chat.
     composed_asset_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("assets.id", ondelete="CASCADE"),

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -27,6 +27,7 @@ from cms.models.schedule import Schedule
 from cms.models.slideshow_slide import SlideshowSlide
 from cms.models.tag import AssetTag, Tag
 from cms.models.user import User
+from cms.models.chat_thread import ChatThread
 from cms.schemas.asset import (
     AssetBulkFailure,
     AssetBulkIn,
@@ -43,6 +44,8 @@ from cms.schemas.asset import (
 from cms.schemas.tag import TagOut
 from cms.services.audit_service import audit_log, compute_diff
 from cms.services.asset_readiness import composed_unpublished_reason
+from cms.services.assistant.mcp_client import MODE_SLIDESHOW_EDITOR
+from cms.services.assistant_flag import assistant_enabled_for
 from cms.services.storage import get_storage
 
 logger = logging.getLogger(__name__)
@@ -2002,7 +2005,92 @@ async def replace_slideshow_slides(
     }
 
 
-@router.patch("/{asset_id}", response_model=AssetOut)
+async def _load_slideshow_for_write(
+    asset_id: uuid.UUID, request: Request, db: AsyncSession
+) -> Asset:
+    """Load a slideshow asset, enforcing visibility + owner/admin write.
+
+    Mirrors the gating of ``replace_slideshow_slides`` so the slideshow
+    assistant-thread route and the chat re-validation hook share one
+    rule. Returns the ``Asset`` or raises 404 / 403.
+    """
+    await _verify_asset_access(asset_id, request, db)
+    asset = (
+        await db.execute(
+            select(Asset).where(Asset.id == asset_id, Asset.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if asset.asset_type != AssetType.SLIDESHOW:
+        raise HTTPException(status_code=400, detail="Asset is not a slideshow")
+
+    # require_auth populates request.state.user for this router.
+    user = getattr(request.state, "user", None)
+    user_groups = await get_user_group_ids(user, db) if user else []
+    is_admin = user_groups is None
+    if not is_admin and (user is None or asset.uploaded_by_user_id != user.id):
+        raise HTTPException(
+            status_code=403, detail="Only the slideshow owner can edit its slides"
+        )
+    return asset
+
+
+@router.post("/{asset_id}/assistant/thread")
+async def slideshow_assistant_thread(
+    asset_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Get-or-create the editor-scoped AI chat thread for this slideshow.
+
+    Powers the embedded chat panel in the slideshow builder. The thread
+    is bound to ``asset_id`` and runs in ``slideshow_editor`` mode, which
+    scopes the assistant to the slideshow read/write tools and forces
+    every slideshow tool call onto *this* slideshow.
+
+    Reuses the caller's newest existing ``slideshow_editor`` thread for
+    the slideshow if one exists (so reopening the editor resumes the same
+    conversation); otherwise creates one. Returns ``{thread_id, created}``.
+
+    Gated identically to editing the slideshow itself: requires
+    ``ASSETS_WRITE``, that the slideshow exists, is visible, and is owned
+    by the caller (or the caller is an admin), and that the Assistant
+    feature is enabled for the caller (404 otherwise, to keep the hidden
+    feature invisible).
+    """
+    asset = await _load_slideshow_for_write(asset_id, request, db)
+
+    if not await assistant_enabled_for(db, user):
+        raise HTTPException(status_code=404, detail="Not found")
+
+    existing = (
+        await db.execute(
+            select(ChatThread)
+            .where(
+                ChatThread.user_id == user.id,
+                ChatThread.composed_asset_id == asset_id,
+                ChatThread.mode == MODE_SLIDESHOW_EDITOR,
+            )
+            .order_by(ChatThread.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return {"thread_id": str(existing.id), "created": False}
+
+    asset_name = asset.display_name or asset.filename or "slideshow"
+    thread = ChatThread(
+        user_id=user.id,
+        mode=MODE_SLIDESHOW_EDITOR,
+        composed_asset_id=asset_id,
+        title=f"Editing {asset_name}"[:200],
+    )
+    db.add(thread)
+    await db.commit()
+    await db.refresh(thread)
+    return {"thread_id": str(thread.id), "created": True}
 async def update_asset(
     asset_id: uuid.UUID,
     request: Request,

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -2091,6 +2091,9 @@ async def slideshow_assistant_thread(
     await db.commit()
     await db.refresh(thread)
     return {"thread_id": str(thread.id), "created": True}
+
+
+@router.patch("/{asset_id}", response_model=AssetOut)
 async def update_asset(
     asset_id: uuid.UUID,
     request: Request,

--- a/cms/routers/chat.py
+++ b/cms/routers/chat.py
@@ -54,6 +54,7 @@ from cms.services.assistant.llm_client import (
 from cms.services.assistant.mcp_client import (
     McpUnavailableError,
     MODE_COMPOSED_EDITOR,
+    MODE_SLIDESHOW_EDITOR,
 )
 from cms.services.assistant.pricing import estimate_usd, model_for_deployment
 from cms.services.assistant_flag import assistant_enabled_for
@@ -111,26 +112,27 @@ async def _verify_composed_editor_thread(
     request: Request,
     db: AsyncSession,
 ) -> None:
-    """Re-validate a ``composed_editor`` thread at turn start.
+    """Re-validate an editor-bound thread at turn start.
 
-    No-op for general threads. For an editor-bound thread this defends
-    against state drift between the moment the editor opened the thread
-    and the moment a message is sent:
+    No-op for general threads. For a ``composed_editor`` or
+    ``slideshow_editor`` thread this defends against state drift between
+    the moment the editor opened the thread and the moment a message is
+    sent:
 
-    * orphaned thread (no bound asset) → 409 — never run the agent with a
-      composed-editor prompt but no slide to scope it to;
+    * orphaned thread (no bound asset) → 409 — never run the agent with an
+      editor prompt but no asset to scope it to;
     * the caller lost ``ASSETS_WRITE`` since the thread was created → 403;
-    * the bound slide was deleted, or is no longer visible to the caller
-      → 404 / 403, surfaced by ``_load_composed_for_write``.
+    * the bound asset was deleted, or is no longer visible to the caller
+      → 404 / 403.
 
     Without this, a stale editor thread could let the assistant attempt
-    draft writes against a slide the user can no longer edit or see.
+    writes against an asset the user can no longer edit or see.
     """
-    if thread.mode != MODE_COMPOSED_EDITOR:
+    if thread.mode not in (MODE_COMPOSED_EDITOR, MODE_SLIDESHOW_EDITOR):
         return
     if thread.composed_asset_id is None:
         raise HTTPException(
-            status_code=409, detail="Editor thread is not bound to a slide"
+            status_code=409, detail="Editor thread is not bound to an asset"
         )
     if user.role is None or not has_permission(
         user.role.permissions, ASSETS_WRITE
@@ -139,10 +141,15 @@ async def _verify_composed_editor_thread(
             status_code=403, detail=f"Missing permission: {ASSETS_WRITE}"
         )
     # Existence + visibility (raises 404 / 403). Lazy import avoids a
-    # router import cycle (composed imports nothing from chat).
-    from cms.routers.composed import _load_composed_for_write  # noqa: WPS433
+    # router import cycle (composed/assets import nothing from chat).
+    if thread.mode == MODE_COMPOSED_EDITOR:
+        from cms.routers.composed import _load_composed_for_write  # noqa: WPS433
 
-    await _load_composed_for_write(thread.composed_asset_id, request, db)
+        await _load_composed_for_write(thread.composed_asset_id, request, db)
+    else:
+        from cms.routers.assets import _load_slideshow_for_write  # noqa: WPS433
+
+        await _load_slideshow_for_write(thread.composed_asset_id, request, db)
 
 
 async def _emit_assistant_audit(
@@ -265,10 +272,11 @@ async def list_threads(
 ):
     """List the caller's general threads, newest-updated first.
 
-    Composed-editor threads (``mode == "composed_editor"``) are excluded:
-    they're asset-scoped ephemera owned by the slide editor's embedded
-    chat panel, not standalone conversations, so they must never appear
-    in the general assistant sidebar.
+    Editor threads (``mode == "composed_editor"`` or
+    ``"slideshow_editor"``) are excluded: they're asset-scoped ephemera
+    owned by an editor's embedded chat panel, not standalone
+    conversations, so they must never appear in the general assistant
+    sidebar.
     """
     await _require_feature(user, db)
     rows = (
@@ -276,7 +284,9 @@ async def list_threads(
             select(ChatThread)
             .where(
                 ChatThread.user_id == user.id,
-                ChatThread.mode != MODE_COMPOSED_EDITOR,
+                ChatThread.mode.notin_(
+                    [MODE_COMPOSED_EDITOR, MODE_SLIDESHOW_EDITOR]
+                ),
             )
             .order_by(ChatThread.updated_at.desc())
         )

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -38,7 +38,7 @@ from cms.auth import (
     require_permission,
 )
 from cms.composed.registry import get_registry
-from cms.composed.render import build_composed_html
+from cms.composed.render import build_composed_html, build_slideshow_preview_html
 from cms.composed.schema import (
     CANVAS_HEIGHT,
     CANVAS_WIDTH,
@@ -579,6 +579,49 @@ async def preview_composed_slide(
 
     headers = {
         "Content-Security-Policy": csp,
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "no-store",
+    }
+    return HTMLResponse(content=rendered.html_bytes, headers=headers)
+
+
+@router.get("/slideshow/{asset_id}/preview", response_class=HTMLResponse)
+async def preview_slideshow(
+    asset_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    settings=Depends(get_settings),
+) -> HTMLResponse:
+    """Live-render a standalone SLIDESHOW asset as a full-bleed HTML preview.
+
+    Wraps the slideshow in an ephemeral single ``media``-widget composed
+    layout and renders it through the shared composed pipeline, so the
+    preview animates with the same device-faithful CSS transitions used
+    everywhere else. Used by the asset-library kebab menus and the
+    slideshow editor's Preview button.
+
+    Returns 404 if the asset doesn't exist or isn't a slideshow, 403 if the
+    caller can't see the slideshow (or a member), and 422 if the slideshow
+    is empty or contains a non-IMAGE/VIDEO member. No disk writes; no row
+    mutations. Every member image / video is inlined as a base64 ``data:``
+    URI so the render works in an editor ``<iframe>`` under the locked-down
+    preview CSP.
+    """
+    from cms.routers.assets import _verify_asset_access  # noqa: WPS433
+
+    async def _verify(aid: uuid.UUID) -> None:
+        await _verify_asset_access(aid, request, db)
+
+    rendered = await build_slideshow_preview_html(
+        db, settings, asset_id, verify_asset=_verify,
+    )
+
+    # A slideshow preview is a single media widget cycling IMAGE/VIDEO
+    # members — none of the network-calling widgets (weather/rss/iframe)
+    # can appear here, so the base preview CSP (media-src/img-src data:)
+    # is always sufficient.
+    headers = {
+        "Content-Security-Policy": _PREVIEW_CSP,
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "no-store",
     }

--- a/cms/services/assistant/agent.py
+++ b/cms/services/assistant/agent.py
@@ -62,10 +62,20 @@ from cms.services.assistant.mcp_client import (
     McpUnavailableError,
     MODE_COMPOSED_EDITOR,
     MODE_GENERAL,
+    MODE_SLIDESHOW_EDITOR,
+    SLIDESHOW_ASSET_SCOPED_TOOLS,
     WRITE_TOOLS,
     executable_tools_for_mode,
     tools_for_mode,
 )
+
+# Asset-scoped editor tools across all editor modes: the agent forces the
+# thread's bound asset id onto these so the editor assistant can never read
+# or write an asset other than the one the user has open.
+_ASSET_SCOPED_TOOLS = COMPOSED_ASSET_SCOPED_TOOLS | SLIDESHOW_ASSET_SCOPED_TOOLS
+# Editor modes that bind the thread to a single asset (reusing the
+# ``composed_asset_id`` column as the generic bound-asset pointer).
+_EDITOR_MODES = (MODE_COMPOSED_EDITOR, MODE_SLIDESHOW_EDITOR)
 from cms.services.assistant.prompts import build_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -148,8 +158,8 @@ async def _execute_tool_call(
     args, err = _parse_tool_arguments(fn.get("arguments"))
     if err is not None:
         return json.dumps({"error": "bad_arguments", "message": err})
-    if bound_asset_id is not None and name in COMPOSED_ASSET_SCOPED_TOOLS:
-        # Force the thread's bound slide id; ignore whatever the model sent.
+    if bound_asset_id is not None and name in _ASSET_SCOPED_TOOLS:
+        # Force the thread's bound asset id; ignore whatever the model sent.
         args = dict(args or {})
         args["asset_id"] = str(bound_asset_id)
     if name not in executable_tools:
@@ -240,7 +250,7 @@ async def run_user_turn(
     mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
     bound_asset_id = (
         getattr(thread, "composed_asset_id", None)
-        if mode == MODE_COMPOSED_EDITOR
+        if mode in _EDITOR_MODES
         else None
     )
     openai_messages: list[dict[str, Any]] = [
@@ -478,7 +488,7 @@ async def run_user_turn_streaming(
     mode = getattr(thread, "mode", MODE_GENERAL) or MODE_GENERAL
     bound_asset_id = (
         getattr(thread, "composed_asset_id", None)
-        if mode == MODE_COMPOSED_EDITOR
+        if mode in _EDITOR_MODES
         else None
     )
     openai_messages: list[dict[str, Any]] = [

--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -161,7 +161,10 @@ ALLOWED_TOOLS: frozenset[str] = READ_ONLY_TOOLS | WRITE_TOOLS
 # mode selects the editor profile below.
 MODE_GENERAL = "general"
 MODE_COMPOSED_EDITOR = "composed_editor"
-VALID_MODES: frozenset[str] = frozenset({MODE_GENERAL, MODE_COMPOSED_EDITOR})
+MODE_SLIDESHOW_EDITOR = "slideshow_editor"
+VALID_MODES: frozenset[str] = frozenset(
+    {MODE_GENERAL, MODE_COMPOSED_EDITOR, MODE_SLIDESHOW_EDITOR}
+)
 
 # Composed reads — safe to run inline like any other read.
 COMPOSED_READ_TOOLS: frozenset[str] = frozenset(
@@ -196,11 +199,47 @@ COMPOSED_ASSET_SCOPED_TOOLS: frozenset[str] = frozenset(
     }
 )
 
+# ── Slideshow editor profile (mirrors the composed profile) ──
+# Slideshow reads — safe to run inline like any other read.
+SLIDESHOW_READ_TOOLS: frozenset[str] = frozenset(
+    {
+        "get_slideshow",
+    }
+)
+
+# Slideshow writes.  Unlike composed slides, a slideshow has no
+# draft/publish step — ``set_slideshow_slides`` goes live immediately.
+# We still run it inline WITHOUT an approval click because the user is
+# sitting in the slideshow editor where the Save button is already a
+# one-click live write, and the change is fully reversible by re-saving.
+SLIDESHOW_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "set_slideshow_slides",
+    }
+)
+
+# Slideshow tools that operate on one specific slideshow asset (their
+# MCP signature takes an ``asset_id``).  In ``slideshow_editor`` mode the
+# agent FORCES the thread's bound asset id onto these so the editor
+# assistant can never read or write a slideshow other than the one the
+# user has open.  ``list_assets`` / ``get_asset`` are excluded — they
+# legitimately read *other* assets (the images/videos to add as slides).
+SLIDESHOW_ASSET_SCOPED_TOOLS: frozenset[str] = frozenset(
+    {
+        "get_slideshow",
+        "set_slideshow_slides",
+    }
+)
+
 # Tools the agent may execute immediately, with no approval click.
 # Reads are inherently safe; composed draft writes are reversible and
-# device-invisible (see above).
+# device-invisible; slideshow writes are reversible editor-context saves.
 NO_APPROVAL_TOOLS: frozenset[str] = (
-    READ_ONLY_TOOLS | COMPOSED_READ_TOOLS | COMPOSED_DRAFT_WRITE_TOOLS
+    READ_ONLY_TOOLS
+    | COMPOSED_READ_TOOLS
+    | COMPOSED_DRAFT_WRITE_TOOLS
+    | SLIDESHOW_READ_TOOLS
+    | SLIDESHOW_WRITE_TOOLS
 )
 
 # The editor-mode tool profile: just enough to discover/select assets
@@ -212,6 +251,14 @@ COMPOSED_EDITOR_TOOLS: frozenset[str] = (
     | COMPOSED_DRAFT_WRITE_TOOLS
 )
 
+# The slideshow-editor tool profile: discover/select assets + read+write
+# the current slideshow's slides.
+SLIDESHOW_EDITOR_TOOLS: frozenset[str] = (
+    frozenset({"list_assets", "get_asset"})
+    | SLIDESHOW_READ_TOOLS
+    | SLIDESHOW_WRITE_TOOLS
+)
+
 
 def tools_for_mode(mode: str | None) -> frozenset[str]:
     """Return the set of tools advertised/callable for a thread ``mode``.
@@ -221,6 +268,8 @@ def tools_for_mode(mode: str | None) -> frozenset[str]:
     """
     if mode == MODE_COMPOSED_EDITOR:
         return COMPOSED_EDITOR_TOOLS
+    if mode == MODE_SLIDESHOW_EDITOR:
+        return SLIDESHOW_EDITOR_TOOLS
     return ALLOWED_TOOLS
 
 

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -107,6 +107,62 @@ Important:
 """
 
 
+SLIDESHOW_EDITOR_PROMPT_TEMPLATE = """\
+You are the Agora CMS Slideshow Assistant.  You are embedded in the
+slideshow editor and your ONLY job is to edit the slides of the one
+slideshow the operator ({username}) currently has open.  The current
+UTC time is {utc_now}.
+
+The slideshow you are editing has asset id ``{composed_asset_id}``.
+Every slideshow tool you call already operates on THIS slideshow — you
+never need to ask the user which slideshow, and you must not try to
+edit any other one.
+
+How to work:
+* Start by calling ``get_slideshow`` to see the current slides, their
+  order, durations, and transitions.  Build on what's already there
+  unless the user asks to start over.
+* To add slides, first find the asset to show with ``list_assets`` /
+  ``get_asset`` and reference it by its real ``source_asset_id`` —
+  never invent an asset id.  Slides can be IMAGE, VIDEO, or COMPOSED
+  assets.
+* Apply changes by calling ``set_slideshow_slides`` with the FULL
+  ordered list of slides you want the slideshow to have (it replaces
+  every slide).  To keep an existing slide, include it again with the
+  same ``source_asset_id`` and its current timing/transition.  To
+  reorder, change the order of the list.  To remove a slide, leave it
+  out of the list.
+
+Per-slide fields:
+* ``source_asset_id`` (required): the asset shown for the slide.
+* ``duration_ms``: how long the slide shows, 500–3,600,000 ms
+  (default 7000).  Ignored for video slides when ``play_to_end`` is
+  true.
+* ``play_to_end``: for VIDEO slides only, play the whole clip instead
+  of using ``duration_ms`` (default false).
+* ``transition``: how the slide enters — one of ``cut``, ``fade``,
+  ``fade_black``, ``dissolve``, ``push``, ``wipe``, ``zoom``
+  (default ``cut``).
+* ``transition_ms``: transition length, 0–5000 ms (default 600).
+
+Facts (fixed):
+* A slideshow can hold at most 50 slides.
+
+Important:
+* Your ``set_slideshow_slides`` calls save and go **LIVE immediately** —
+  there is no draft/publish step for slideshows.  Tell the operator
+  that the slideshow is updated as soon as you make a change.
+* Be concise.  After a change, briefly say what you changed (slides
+  added/removed/reordered, timing, transitions).
+* If a tool call fails or returns nothing, say so plainly instead of
+  pretending it worked.
+* You do NOT have access to device, schedule, group, profile, or any
+  other fleet-management tools.  If the user asks for something outside
+  editing this slideshow, explain that you can only edit the current
+  slideshow's slides.
+"""
+
+
 def build_system_prompt(
     user: User,
     *,
@@ -122,12 +178,20 @@ def build_system_prompt(
     ``mode`` selects the prompt variant.  ``"composed_editor"`` (with a
     bound ``composed_asset_id``) renders the slide-editor prompt that
     scopes the assistant to building one slide via the composed tools;
-    every other value falls back to the general fleet-assistant prompt
-    so an unknown mode can never widen the assistant's apparent remit.
+    ``"slideshow_editor"`` (with the bound slideshow id passed as
+    ``composed_asset_id``) renders the slideshow-editor prompt; every
+    other value falls back to the general fleet-assistant prompt so an
+    unknown mode can never widen the assistant's apparent remit.
     """
     when = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M UTC")
     if mode == "composed_editor" and composed_asset_id:
         return COMPOSED_EDITOR_PROMPT_TEMPLATE.format(
+            username=user.username,
+            utc_now=when,
+            composed_asset_id=composed_asset_id,
+        )
+    if mode == "slideshow_editor" and composed_asset_id:
+        return SLIDESHOW_EDITOR_PROMPT_TEMPLATE.format(
             username=user.username,
             utc_now=when,
             composed_asset_id=composed_asset_id,

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1568,10 +1568,12 @@ function previewAsset(assetId, filename, assetType) {
     }
 }
 
-function previewComposed(assetId, name) {
-    // Composed slides have no raster image -- show the live HTML render,
-    // sized to its true 1920x1080 canvas and scaled to fit via CSS
-    // container-query units (.composed-preview-frame).
+function _previewHtmlFrame(url, name) {
+    // Shared HTML-render preview modal: an iframe sized to the true
+    // 1920x1080 canvas and scaled to fit via CSS container-query units
+    // (.composed-preview-frame). Used for composed slides and standalone
+    // slideshow previews (which the server renders as a full-bleed
+    // single-media-widget composed layout).
     const { box, close } = createModal({
         closeOnBackdrop: true,
         closeOnEsc: true,
@@ -1580,7 +1582,7 @@ function previewComposed(assetId, name) {
     const header = document.createElement("div");
     header.className = "preview-header";
     const title = document.createElement("span");
-    title.textContent = name || "Composed slide";
+    title.textContent = name || "Preview";
     const closeBtn = document.createElement("button");
     closeBtn.className = "btn btn-secondary btn-sm";
     closeBtn.textContent = "Close";
@@ -1593,11 +1595,29 @@ function previewComposed(assetId, name) {
     wrap.className = "composed-preview composed-preview-modal";
     const frame = document.createElement("iframe");
     frame.className = "composed-preview-frame";
-    frame.src = "/composed/" + encodeURIComponent(assetId) + "/preview";
+    frame.src = url;
     frame.setAttribute("scrolling", "no");
     frame.setAttribute("tabindex", "-1");
     wrap.appendChild(frame);
     box.appendChild(wrap);
+}
+
+function previewComposed(assetId, name) {
+    // Composed slides have no raster image -- show the live HTML render.
+    _previewHtmlFrame(
+        "/composed/" + encodeURIComponent(assetId) + "/preview",
+        name || "Composed slide",
+    );
+}
+
+function previewSlideshow(assetId, name) {
+    // Standalone slideshow preview: the server wraps the slideshow in an
+    // ephemeral full-bleed media widget and renders it through the same
+    // composed pipeline, so members cycle with device-faithful transitions.
+    _previewHtmlFrame(
+        "/composed/slideshow/" + encodeURIComponent(assetId) + "/preview",
+        name || "Slideshow",
+    );
 }
 
 function previewVariant(variantId, filename, assetType, profileName) {

--- a/cms/static/editor_chat.js
+++ b/cms/static/editor_chat.js
@@ -1,27 +1,45 @@
-// Composed-editor AI chat drawer.
+// Shared in-editor AI chat drawer.
 //
-// Lives inside the composed-slide editor (gated on the Assistant
-// feature flag). The user describes a slide; the assistant edits the
-// *draft* layout via the composed_editor MCP tools and the canvas
-// refreshes when a write lands.
+// Powers the embedded assistant drawer on BOTH the composed-slide
+// editor and the slideshow builder. The user describes a change; the
+// assistant edits the asset via its editor-scoped MCP tools and the
+// editor refreshes when a write lands.
 //
-// It talks to the editor only through window.composedEditorBridge
-// (getAssetId / isDirty / save / refreshFromServer) and to the server
+// The page configures it via window.cwAiConfig (all fields optional;
+// the defaults reproduce the original composed-editor behaviour so
+// composed_editor.html needs no config block):
+//
+//   window.cwAiConfig = {
+//     bridge,                       // {getAssetId, isDirty, save, refreshFromServer}
+//     threadPath: (assetId) => "…", // POST get-or-create editor thread
+//     writeTools: ["set_…"],        // tool names whose success triggers a refresh
+//     mint,                         // async () => bool, or null to disable
+//   };
+//
+// It talks to the editor only through the bridge and to the server
 // through two endpoints:
-//   POST /composed/{assetId}/assistant/thread   → get-or-create the
-//        editor-scoped thread bound to this composed asset.
-//   POST /api/chat/threads/{threadId}/stream     → run one turn (SSE).
+//   POST <threadPath(assetId)>                    → get-or-create thread
+//   POST /api/chat/threads/{threadId}/stream       → run one turn (SSE).
 //
 // The SSE parser mirrors cms/static/assistant.js. No approval cards:
-// composed_editor tools run inline (draft-only), so a stray
-// approval_request is tolerated, not rendered as an interactive card.
+// editor tools run inline, so a stray approval_request is tolerated,
+// not rendered as an interactive card.
 (function () {
     "use strict";
 
     const root = document.getElementById("cw-ai");
     if (!root) return; // drawer not rendered (flag off / create mode)
 
-    const bridge = window.composedEditorBridge;
+    const cfg = window.cwAiConfig || {};
+    const bridge = cfg.bridge || window.composedEditorBridge;
+    const threadPath =
+        typeof cfg.threadPath === "function"
+            ? cfg.threadPath
+            : (id) => "/composed/" + encodeURIComponent(id) + "/assistant/thread";
+    const writeTools = Array.isArray(cfg.writeTools)
+        ? cfg.writeTools
+        : ["set_composed_widgets"];
+
     const launcher = document.getElementById("cw-ai-launcher");
     const panel = document.getElementById("cw-ai-panel");
     const closeBtn = document.getElementById("cw-ai-close");
@@ -79,7 +97,7 @@
         const id = assetId();
         if (!id) return Promise.resolve(null);
         state.threadPromise = fetch(
-            "/composed/" + encodeURIComponent(id) + "/assistant/thread",
+            threadPath(id),
             { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
         )
             .then(async (resp) => {
@@ -124,9 +142,11 @@
     }
 
     // ── Create-mode mint ─────────────────────────────────────────────
-    // On a brand-new slide there's no asset yet, so the chat can't bind to
-    // one. Mint the draft via the editor bridge (which POSTs /composed/ and
-    // PATCHes the seeded layout, no redirect), then proceed as in edit mode.
+    // On a brand-new composed slide there's no asset yet, so the chat
+    // can't bind to one. Mint the draft via the editor bridge (which
+    // POSTs /composed/ and PATCHes the seeded layout, no redirect), then
+    // proceed as in edit mode. Pages that don't support create-mode chat
+    // (e.g. the slideshow builder) pass mint: null to disable this.
 
     // A friendly, sortable default name for slides the user starts via the
     // assistant without typing one. Built from local Date parts (not
@@ -138,7 +158,7 @@
             + "-" + p(d.getDate()) + " " + p(d.getHours()) + ":" + p(d.getMinutes());
     }
 
-    async function mintDraft() {
+    async function composedMintDraft() {
         if (!bridge || typeof bridge.save !== "function") return false;
         // The create endpoint requires a name. If the user jumped straight to
         // the assistant without typing one, auto-fill a sensible default so the
@@ -162,6 +182,11 @@
         } catch (_) { /* non-fatal */ }
         return true;
     }
+
+    // Resolve the mint strategy: an explicit cfg.mint (including null to
+    // disable) wins; otherwise default to the composed-editor mint.
+    const mint =
+        "mint" in cfg ? cfg.mint : composedMintDraft;
 
     // ── Submit / stream ──────────────────────────────────────────────
     window.cwAiSubmit = function (e) {
@@ -187,7 +212,11 @@
         try {
             // Create mode: mint the draft asset so the chat can bind to it.
             if (!assetId()) {
-                const minted = await mintDraft();
+                if (typeof mint !== "function") {
+                    addMsg("error", "Save this first, then ask the assistant to make changes.");
+                    return;
+                }
+                const minted = await mint();
                 if (!minted) {
                     addMsg(
                         "error",
@@ -198,9 +227,9 @@
                 }
             }
 
-            // The assistant reads server-side draft state, so flush any
-            // unsaved manual edits first — otherwise the post-turn refresh
-            // (which clears the dirty flag) would silently drop them.
+            // The assistant reads server-side state, so flush any unsaved
+            // manual edits first — otherwise the post-turn refresh (which
+            // clears the dirty flag) would silently drop them.
             if (bridge && bridge.isDirty && bridge.isDirty()) {
                 const ok = await bridge.save();
                 if (!ok) {
@@ -244,14 +273,14 @@
                     case "tool_result": {
                         const name = (evt.data && evt.data.name) || "tool";
                         addMsg("tool", "✓ " + name);
-                        if (name === "set_composed_widgets" && !toolResultIsError(evt.data)) {
+                        if (writeTools.indexOf(name) !== -1 && !toolResultIsError(evt.data)) {
                             sawSuccessfulWrite = true;
                         }
                         break;
                     }
                     case "approval_request":
-                        // composed_editor tools never need approval; if one
-                        // arrives, note it rather than blocking the drawer.
+                        // editor tools never need approval; if one arrives,
+                        // note it rather than blocking the drawer.
                         addMsg("tool", "(skipped an approval-gated action)");
                         break;
                     case "done":

--- a/cms/templates/_assistant_drawer.html
+++ b/cms/templates/_assistant_drawer.html
@@ -1,0 +1,98 @@
+{# Shared in-editor AI assistant drawer (floating launcher + slide-up
+   panel). Included by BOTH the composed-slide editor and the slideshow
+   builder. The caller is responsible for gating the include (feature
+   flag, and — for pages without create-mode chat — edit-mode only) and
+   for defining:
+
+     * asset_id        — bound asset UUID (may be '' in composed create mode)
+     * assistant_hint  — empty-state hint HTML shown in the log (optional)
+
+   The matching behaviour lives in /static/editor_chat.js, configured per
+   page via window.cwAiConfig. #}
+<style>
+    /* ── AI assistant drawer ── */
+    #cw-ai-launcher {
+        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 60;
+        padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer;
+        border: 1px solid var(--accent, #2563eb);
+        background: var(--primary, #2563eb); color: #fff; font-size: 0.9rem;
+        box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+    }
+    #cw-ai-panel {
+        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 61;
+        width: min(380px, calc(100vw - 2rem));
+        height: min(540px, calc(100vh - 6rem));
+        display: flex; flex-direction: column;
+        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        border-radius: 12px; overflow: hidden;
+        background: var(--surface, #1a1a2e); color: var(--text, #e6e6e6);
+        box-shadow: 0 10px 34px rgba(0,0,0,0.45);
+    }
+    #cw-ai-panel[hidden] { display: none; }
+    #cw-ai-head {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 0.6rem 0.85rem;
+        border-bottom: 1px solid var(--border, rgba(255,255,255,0.18));
+        background: var(--surface-alt, #16213e);
+    }
+    #cw-ai-close {
+        background: transparent; border: none; color: var(--text, #e6e6e6);
+        font-size: 1.4rem; line-height: 1; cursor: pointer; padding: 0 0.25rem;
+    }
+    #cw-ai-log {
+        flex: 1; overflow-y: auto; padding: 0.75rem;
+        display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.88rem;
+    }
+    .cw-ai-hint { color: var(--text-muted, #b3b3c0); font-size: 0.82rem; }
+    .cw-ai-msg { padding: 0.5rem 0.7rem; border-radius: 10px; max-width: 90%; white-space: pre-wrap; word-wrap: break-word; }
+    .cw-ai-msg.user { align-self: flex-end; background: var(--primary, #2563eb); color: #fff; }
+    .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, rgba(255,255,255,0.18)); }
+    .cw-ai-msg.tool { align-self: flex-start; font-size: 0.78rem; color: var(--text-muted, #b3b3c0); font-style: italic; padding: 0.2rem 0.5rem; }
+    .cw-ai-msg.error { align-self: flex-start; background: #fee2e2; color: #991b1b; }
+    /* Rendered Markdown (assistant replies). Drop pre-wrap so marked's
+       <br> handling doesn't double up blank lines, and tame block margins
+       inside the bubble. */
+    .cw-ai-msg.is-markdown { white-space: normal; }
+    .cw-ai-msg.is-markdown > :first-child { margin-top: 0; }
+    .cw-ai-msg.is-markdown > :last-child { margin-bottom: 0; }
+    .cw-ai-msg.is-markdown p { margin: 0 0 0.5rem; }
+    .cw-ai-msg.is-markdown ul, .cw-ai-msg.is-markdown ol { margin: 0 0 0.5rem 1.15rem; padding: 0; }
+    .cw-ai-msg.is-markdown li { margin: 0.1rem 0; }
+    .cw-ai-msg.is-markdown strong { font-weight: 700; }
+    .cw-ai-msg.is-markdown code { background: rgba(255,255,255,0.12); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
+    .cw-ai-msg.is-markdown a { color: var(--accent, #60a5fa); }
+    #cw-ai-form {
+        display: flex; gap: 0.5rem; padding: 0.6rem;
+        border-top: 1px solid var(--border, rgba(255,255,255,0.18));
+    }
+    #cw-ai-input {
+        flex: 1; resize: none; padding: 0.5rem; border-radius: 8px;
+        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        background: var(--bg, #0f0f1a); color: var(--text, #e6e6e6); font: inherit;
+    }
+    #cw-ai-send:disabled { opacity: 0.55; cursor: progress; }
+</style>
+<div id="cw-ai" data-asset-id="{{ asset_id or '' }}">
+    <button type="button" id="cw-ai-launcher" onclick="cwAiToggle()"
+            aria-expanded="false" aria-controls="cw-ai-panel"
+            title="Edit with AI">✨ AI Assistant</button>
+    <section id="cw-ai-panel" role="dialog" aria-label="AI assistant" hidden>
+        <header id="cw-ai-head">
+            <strong>✨ AI Assistant</strong>
+            <button type="button" id="cw-ai-close" onclick="cwAiToggle()"
+                    aria-label="Close assistant">×</button>
+        </header>
+        <div id="cw-ai-log" aria-live="polite">
+            <div class="cw-ai-hint">
+                {{ assistant_hint | default("Describe a change and I'll make it for you.") | safe }}
+            </div>
+        </div>
+        <div id="cw-ai-usage" style="display:none;"></div>
+        <form id="cw-ai-form" onsubmit="return cwAiSubmit(event)">
+            <textarea id="cw-ai-input" rows="2"
+                      placeholder="Describe a change…"
+                      aria-label="Message the AI assistant"></textarea>
+            <button type="submit" id="cw-ai-send" class="btn btn-primary">Send</button>
+        </form>
+    </section>
+</div>

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -284,6 +284,7 @@
                     {% elif a.asset_type.value == 'stream' %}
                         <a role="menuitem" href="{{ a.url }}" target="_blank" rel="noopener">Open Stream</a>
                     {% elif a.asset_type.value == 'slideshow' %}
+                        <button type="button" role="menuitem" onclick="previewSlideshow('{{ a.id }}', {{ (a.display_name or a.original_filename or a.filename) | tojson | forceescape }})">Preview</button>
                         {% if 'assets:write' in user_perms and is_owner %}
                         <a role="menuitem" href="/assets/{{ a.id }}/slideshow">Edit slides</a>
                         {% else %}

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -1298,6 +1298,7 @@ function fallbackCopy(text, onSuccess) {
         } else if (t === 'stream') {
             if (a.url) items.push('<a role="menuitem" href="' + _escAttr(a.url) + '" target="_blank" rel="noopener">Open Stream</a>');
         } else if (t === 'slideshow') {
+            items.push('<button type="button" role="menuitem" onclick="previewSlideshow(' + _kebabArg(a.id) + ', ' + _kebabArg(name) + ')">Preview</button>');
             items.push('<a role="menuitem" href="/assets/' + _escAttr(a.id) + '/slideshow">' + ((canWrite && isOwner) ? 'Edit slides' : 'View slides') + '</a>');
         } else if (t === 'composed') {
             items.push('<button type="button" role="menuitem" onclick="previewComposed(' + _kebabArg(a.id) + ', ' + _kebabArg(name) + ')">Preview</button>');

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -106,38 +106,16 @@
         </aside>
     </div>
 {% if assistant_enabled %}
-    <!-- AI assistant chat drawer. Floating launcher + slide-up panel.
-         Gated on the Assistant feature flag. Available in BOTH create and
-         edit mode: in create mode the drawer mints the draft asset on the
-         first message (via window.composedEditorBridge) so the chat can
-         bind to it. See /static/composed_editor_chat.js. -->
-    <div id="cw-ai" data-asset-id="{{ asset_id or '' }}">
-        <button type="button" id="cw-ai-launcher" onclick="cwAiToggle()"
-                aria-expanded="false" aria-controls="cw-ai-panel"
-                title="Build this slide with AI">✨ AI Assistant</button>
-        <section id="cw-ai-panel" role="dialog" aria-label="AI slide assistant" hidden>
-            <header id="cw-ai-head">
-                <strong>✨ AI Assistant</strong>
-                <button type="button" id="cw-ai-close" onclick="cwAiToggle()"
-                        aria-label="Close assistant">×</button>
-            </header>
-            <div id="cw-ai-log" aria-live="polite">
-                <div class="cw-ai-hint">
-                    Describe the slide you want and I'll build it — e.g.
-                    “Add a big welcome heading at the top and a clock in
-                    the corner.” I edit a draft; click <strong>Publish</strong>
-                    when you're happy with it.
-                </div>
-            </div>
-            <div id="cw-ai-usage" style="display:none;"></div>
-            <form id="cw-ai-form" onsubmit="return cwAiSubmit(event)">
-                <textarea id="cw-ai-input" rows="2"
-                          placeholder="Describe a change…"
-                          aria-label="Message the AI assistant"></textarea>
-                <button type="submit" id="cw-ai-send" class="btn btn-primary">Send</button>
-            </form>
-        </section>
-    </div>
+    {# AI assistant chat drawer (shared partial). Gated on the Assistant
+       feature flag. Available in BOTH create and edit mode: in create mode
+       the drawer mints the draft asset on the first message (via
+       window.composedEditorBridge) so the chat can bind to it. Behaviour is
+       configured below via window.cwAiConfig. #}
+    {% set assistant_hint %}Describe the slide you want and I'll build it — e.g.
+        “Add a big welcome heading at the top and a clock in
+        the corner.” I edit a draft; click <strong>Publish</strong>
+        when you're happy with it.{% endset %}
+    {% include "_assistant_drawer.html" %}
 {% endif %}
 </div>
 
@@ -589,67 +567,8 @@
     .cw-modal-actions .primary { background: #2563eb; color: #fff; border-color: #2563eb; }
     .cw-modal-actions .ghost { background: transparent; color: var(--text, #e6e6e6); }
 
-    /* ── AI assistant drawer ── */
-    #cw-ai-launcher {
-        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 60;
-        padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer;
-        border: 1px solid var(--accent, #2563eb);
-        background: var(--primary, #2563eb); color: #fff; font-size: 0.9rem;
-        box-shadow: 0 4px 14px rgba(0,0,0,0.35);
-    }
-    #cw-ai-panel {
-        position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 61;
-        width: min(380px, calc(100vw - 2rem));
-        height: min(540px, calc(100vh - 6rem));
-        display: flex; flex-direction: column;
-        border: 1px solid var(--border, rgba(255,255,255,0.18));
-        border-radius: 12px; overflow: hidden;
-        background: var(--surface, #1a1a2e); color: var(--text, #e6e6e6);
-        box-shadow: 0 10px 34px rgba(0,0,0,0.45);
-    }
-    #cw-ai-panel[hidden] { display: none; }
-    #cw-ai-head {
-        display: flex; align-items: center; justify-content: space-between;
-        padding: 0.6rem 0.85rem;
-        border-bottom: 1px solid var(--border, rgba(255,255,255,0.18));
-        background: var(--surface-alt, #16213e);
-    }
-    #cw-ai-close {
-        background: transparent; border: none; color: var(--text, #e6e6e6);
-        font-size: 1.4rem; line-height: 1; cursor: pointer; padding: 0 0.25rem;
-    }
-    #cw-ai-log {
-        flex: 1; overflow-y: auto; padding: 0.75rem;
-        display: flex; flex-direction: column; gap: 0.6rem; font-size: 0.88rem;
-    }
-    .cw-ai-hint { color: var(--text-muted, #b3b3c0); font-size: 0.82rem; }
-    .cw-ai-msg { padding: 0.5rem 0.7rem; border-radius: 10px; max-width: 90%; white-space: pre-wrap; word-wrap: break-word; }
-    .cw-ai-msg.user { align-self: flex-end; background: var(--primary, #2563eb); color: #fff; }
-    .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, rgba(255,255,255,0.18)); }
-    .cw-ai-msg.tool { align-self: flex-start; font-size: 0.78rem; color: var(--text-muted, #b3b3c0); font-style: italic; padding: 0.2rem 0.5rem; }
-    .cw-ai-msg.error { align-self: flex-start; background: #fee2e2; color: #991b1b; }
-    /* Rendered Markdown (assistant replies). Drop pre-wrap so marked's
-       <br> handling doesn't double up blank lines, and tame block margins
-       inside the bubble. */
-    .cw-ai-msg.is-markdown { white-space: normal; }
-    .cw-ai-msg.is-markdown > :first-child { margin-top: 0; }
-    .cw-ai-msg.is-markdown > :last-child { margin-bottom: 0; }
-    .cw-ai-msg.is-markdown p { margin: 0 0 0.5rem; }
-    .cw-ai-msg.is-markdown ul, .cw-ai-msg.is-markdown ol { margin: 0 0 0.5rem 1.15rem; padding: 0; }
-    .cw-ai-msg.is-markdown li { margin: 0.1rem 0; }
-    .cw-ai-msg.is-markdown strong { font-weight: 700; }
-    .cw-ai-msg.is-markdown code { background: rgba(255,255,255,0.12); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
-    .cw-ai-msg.is-markdown a { color: var(--accent, #60a5fa); }
-    #cw-ai-form {
-        display: flex; gap: 0.5rem; padding: 0.6rem;
-        border-top: 1px solid var(--border, rgba(255,255,255,0.18));
-    }
-    #cw-ai-input {
-        flex: 1; resize: none; padding: 0.5rem; border-radius: 8px;
-        border: 1px solid var(--border, rgba(255,255,255,0.18));
-        background: var(--bg, #0f0f1a); color: var(--text, #e6e6e6); font: inherit;
-    }
-    #cw-ai-send:disabled { opacity: 0.55; cursor: progress; }
+    /* AI assistant drawer styles live in the shared partial
+       cms/templates/_assistant_drawer.html. */
 </style>
 
 <div id="cw-leave-modal" class="cw-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="cw-leave-title">
@@ -3277,7 +3196,7 @@ async function refreshLayoutFromServer() {
     return true;
 }
 
-// Stable surface the chat drawer (composed_editor_chat.js) talks to,
+// Stable surface the chat drawer (editor_chat.js) talks to,
 // so it never reaches into editor internals directly.
 window.composedEditorBridge = {
     getAssetId() { return ASSET_ID; },
@@ -3293,6 +3212,17 @@ window.composedEditorBridge = {
 <script src="/static/vendor/marked.min.js"></script>
 <script src="/static/vendor/purify.min.js"></script>
 <script src="/static/assistant_usage.js" defer></script>
-<script src="/static/composed_editor_chat.js" defer></script>
+<script>
+// Composed editor uses the generalized drawer's built-in defaults
+// (bridge = window.composedEditorBridge, thread path /composed/{id}/assistant/thread,
+//  write tool set_composed_widgets, create-mode draft mint). Set explicitly
+// for clarity / forward-compat.
+window.cwAiConfig = {
+    bridge: window.composedEditorBridge,
+    threadPath: (id) => `/composed/${id}/assistant/thread`,
+    writeTools: ["set_composed_widgets"],
+};
+</script>
+<script src="/static/editor_chat.js" defer></script>
 {% endif %}
 {% endblock %}

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -3005,7 +3005,9 @@ async function maybeUpdateGroups() {
 async function openPreview() {
     const ok = await saveLayout({skipRedirect: true});
     if (!ok) return;
-    window.open("/composed/" + ASSET_ID + "/preview", "_blank");
+    const el = document.getElementById("composed-name");
+    const name = (el && el.value.trim()) || COMPOSED_ORIG_NAME || "Composed slide";
+    previewComposed(ASSET_ID, name);
 }
 
 async function publishLayout() {

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -524,6 +524,19 @@
     </form>
 </div>
 
+{% if assistant_enabled and asset_id %}
+    {# AI assistant chat drawer (shared partial). Gated on the Assistant
+       feature flag AND edit mode (asset_id set): the slideshow assistant
+       edits an existing slideshow's slides, so there is no create-mode
+       mint path (unlike the composed editor). Behaviour is configured at
+       the bottom of this template via window.cwAiConfig. #}
+    {% set assistant_hint %}Tell me how to change this slideshow — e.g.
+        “Add the welcome video to the front and give every slide a
+        1-second fade,” or “Reorder so the holiday image is last.”
+        Edits are saved and go live as soon as I apply them.{% endset %}
+    {% include "_assistant_drawer.html" %}
+{% endif %}
+
 <script id="ss-initial-slides" type="application/json">{{ slides | tojson }}</script>
 <script>
 const SS_EDIT_MODE = {{ 'true' if edit_mode else 'false' }};
@@ -1254,5 +1267,49 @@ function initDirtyTracking() {
         e.returnValue = '';
     });
 }
+
+// Stable surface the chat drawer (editor_chat.js) talks to, so it never
+// reaches into builder internals directly. Edit-mode only — the slideshow
+// assistant always operates on an existing slideshow.
+window.slideshowEditorBridge = {
+    getAssetId() { return SS_ASSET_ID; },
+    isDirty() { return !!__ssDirty; },
+    async save() { return await saveSlideshow({}); },
+    async refreshFromServer() {
+        // The assistant's set_slideshow_slides tool writes the slide list
+        // server-side and it's immediately live; re-pull the canonical
+        // slides so the timeline reflects what the assistant just did.
+        if (!SS_ASSET_ID) return false;
+        const r = await fetch(`/api/assets/${SS_ASSET_ID}/slides`);
+        if (!r.ok) return false;
+        const data = await r.json().catch(() => null);
+        if (!data || !Array.isArray(data.slides)) return false;
+        slides = data.slides;
+        renderTimeline();
+        clearDirty();
+        return true;
+    },
+};
 </script>
+{% if assistant_enabled and asset_id %}
+<!-- marked + DOMPurify render the assistant's Markdown replies as HTML
+     (bold, lists, code). Non-deferred so they're ready before the
+     deferred drawer IIFE runs. -->
+<script src="/static/vendor/marked.min.js"></script>
+<script src="/static/vendor/purify.min.js"></script>
+<script src="/static/assistant_usage.js" defer></script>
+<script>
+// Slideshow builder: edit-mode-only assistant. bridge =
+// window.slideshowEditorBridge; thread path /api/assets/{id}/assistant/thread;
+// write tool set_slideshow_slides. mint=null DISABLES create-mode minting
+// (the drawer only renders when a slideshow already exists).
+window.cwAiConfig = {
+    bridge: window.slideshowEditorBridge,
+    threadPath: (id) => `/api/assets/${id}/assistant/thread`,
+    writeTools: ["set_slideshow_slides"],
+    mint: null,
+};
+</script>
+<script src="/static/editor_chat.js" defer></script>
+{% endif %}
 {% endblock %}

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -516,6 +516,9 @@
         <div id="ss-status" class="form-status" style="margin-top:0.75rem;"></div>
         <div style="display:flex; gap:0.5rem; margin-top:1rem;">
             <button type="submit" class="btn btn-primary" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
+            {% if edit_mode %}
+            <button type="button" class="btn btn-secondary" id="ss-preview-btn" onclick="previewSlideshowFromEditor()" title="Preview the saved slideshow">Preview</button>
+            {% endif %}
             <a href="/assets" class="btn btn-secondary">Cancel</a>
         </div>
     </form>
@@ -1098,6 +1101,28 @@ async function saveSlideshow(opts) {
 function openGroupPopup(id) {
     const el = document.getElementById(id);
     if (el && el.showPopover) el.showPopover();
+}
+
+async function previewSlideshowFromEditor() {
+    // Preview renders the SAVED DB state (not the in-memory timeline).
+    // If there are unsaved edits, persist them first so the preview
+    // reflects what the user is looking at; saveSlideshow() in edit mode
+    // stays on this page and clears the dirty flag.
+    setStatus('');
+    if (slides.length === 0) {
+        setStatus('Add at least one slide to preview.', true);
+        return;
+    }
+    if (__ssDirty) {
+        const ok = await saveSlideshow();
+        if (!ok) return;  // save surfaced its own error
+    }
+    if (!SS_ASSET_ID) {
+        setStatus('Save the slideshow before previewing.', true);
+        return;
+    }
+    const name = document.getElementById('ss-name').value.trim() || 'Slideshow';
+    previewSlideshow(SS_ASSET_ID, name);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1677,6 +1677,9 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
         for t in all_tags_q.scalars().all()
     ]
 
+    from cms.services.assistant_flag import assistant_enabled_for
+    assistant_on = bool(user) and await assistant_enabled_for(db, user)
+
     ctx = {
         "active_tab": "assets",
         "is_admin": is_admin,
@@ -1690,6 +1693,7 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
         "slides": [],
         "asset_groups": [],
         "asset_is_global": False,
+        "assistant_enabled": assistant_on,
     }
 
     if asset_id is not None:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1375,67 +1375,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/assets/{asset_id}:
-    patch:
-      summary: Update Asset
-      description: 'Update asset properties (currently: display_name).'
-      operationId: update_asset_api_assets__asset_id__patch
-      parameters:
-      - name: asset_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Asset Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetOut'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    get:
-      summary: Get Asset
-      operationId: get_asset_api_assets__asset_id__get
-      parameters:
-      - name: asset_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Asset Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetOut'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    delete:
-      summary: Delete Asset
+  /api/assets/{asset_id}/assistant/thread:
+    post:
+      summary: Slideshow Assistant Thread
       description: |-
-        Soft-delete an asset.
+        Get-or-create the editor-scoped AI chat thread for this slideshow.
 
-        Sets ``assets.deleted_at`` and flags any in-flight Jobs targeting this
-        asset (or its variants) with ``cancel_requested = true``.  The worker
-        heartbeat will pick up the flag and abort ffmpeg within ~15s; the
-        CMS reaper loop (``deleted_asset_reaper_loop``) later hard-deletes
-        blobs + rows once all Jobs are terminal.  Returns 200 immediately.
-      operationId: delete_asset_api_assets__asset_id__delete
+        Powers the embedded chat panel in the slideshow builder. The thread
+        is bound to ``asset_id`` and runs in ``slideshow_editor`` mode, which
+        scopes the assistant to the slideshow read/write tools and forces
+        every slideshow tool call onto *this* slideshow.
+
+        Reuses the caller's newest existing ``slideshow_editor`` thread for
+        the slideshow if one exists (so reopening the editor resumes the same
+        conversation); otherwise creates one. Returns ``{thread_id, created}``.
+
+        Gated identically to editing the slideshow itself: requires
+        ``ASSETS_WRITE``, that the slideshow exists, is visible, and is owned
+        by the caller (or the caller is an admin), and that the Assistant
+        feature is enabled for the caller (404 otherwise, to keep the hidden
+        feature invisible).
+      operationId: slideshow_assistant_thread_api_assets__asset_id__assistant_thread_post
       parameters:
       - name: asset_id
         in: path
@@ -1449,7 +1409,10 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Slideshow Assistant Thread Api Assets  Asset Id  Assistant Thread Post
         '422':
           description: Validation Error
           content:
@@ -1493,6 +1456,62 @@ paths:
         complete, etc.) so the client never has to synthesize row markup in JS.
         See issue #87.
       operationId: get_asset_row_api_assets__asset_id__row_get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/assets/{asset_id}:
+    get:
+      summary: Get Asset
+      operationId: get_asset_api_assets__asset_id__get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Asset
+      description: |-
+        Soft-delete an asset.
+
+        Sets ``assets.deleted_at`` and flags any in-flight Jobs targeting this
+        asset (or its variants) with ``cancel_requested = true``.  The worker
+        heartbeat will pick up the flag and abort ffmpeg within ~15s; the
+        CMS reaper loop (``deleted_asset_reaper_loop``) later hard-deletes
+        blobs + rows once all Jobs are terminal.  Returns 200 immediately.
+      operationId: delete_asset_api_assets__asset_id__delete
       parameters:
       - name: asset_id
         in: path
@@ -2119,10 +2138,11 @@ paths:
       description: |-
         List the caller's general threads, newest-updated first.
 
-        Composed-editor threads (``mode == "composed_editor"``) are excluded:
-        they're asset-scoped ephemera owned by the slide editor's embedded
-        chat panel, not standalone conversations, so they must never appear
-        in the general assistant sidebar.
+        Editor threads (``mode == "composed_editor"`` or
+        ``"slideshow_editor"``) are excluded: they're asset-scoped ephemera
+        owned by an editor's embedded chat panel, not standalone
+        conversations, so they must never appear in the general assistant
+        sidebar.
       operationId: list_threads_api_chat_threads_get
       responses:
         '200':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -238,6 +238,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /composed/slideshow/{asset_id}/preview:
+    get:
+      tags:
+      - composed
+      summary: Preview Slideshow
+      description: |-
+        Live-render a standalone SLIDESHOW asset as a full-bleed HTML preview.
+
+        Wraps the slideshow in an ephemeral single ``media``-widget composed
+        layout and renders it through the shared composed pipeline, so the
+        preview animates with the same device-faithful CSS transitions used
+        everywhere else. Used by the asset-library kebab menus and the
+        slideshow editor's Preview button.
+
+        Returns 404 if the asset doesn't exist or isn't a slideshow, 403 if the
+        caller can't see the slideshow (or a member), and 422 if the slideshow
+        is empty or contains a non-IMAGE/VIDEO member. No disk writes; no row
+        mutations. Every member image / video is inlined as a base64 ``data:``
+        URI so the render works in an editor ``<iframe>`` under the locked-down
+        preview CSP.
+      operationId: preview_slideshow_composed_slideshow__asset_id__preview_get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /composed/:
     post:
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1419,6 +1419,87 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/assets/{asset_id}:
+    patch:
+      summary: Update Asset
+      description: 'Update asset properties (currently: display_name).'
+      operationId: update_asset_api_assets__asset_id__patch
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      summary: Get Asset
+      operationId: get_asset_api_assets__asset_id__get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Asset
+      description: |-
+        Soft-delete an asset.
+
+        Sets ``assets.deleted_at`` and flags any in-flight Jobs targeting this
+        asset (or its variants) with ``cancel_requested = true``.  The worker
+        heartbeat will pick up the flag and abort ffmpeg within ~15s; the
+        CMS reaper loop (``deleted_asset_reaper_loop``) later hard-deletes
+        blobs + rows once all Jobs are terminal.  Returns 200 immediately.
+      operationId: delete_asset_api_assets__asset_id__delete
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/assets/{asset_id}/recapture:
     post:
       summary: Recapture Stream
@@ -1456,62 +1537,6 @@ paths:
         complete, etc.) so the client never has to synthesize row markup in JS.
         See issue #87.
       operationId: get_asset_row_api_assets__asset_id__row_get
-      parameters:
-      - name: asset_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Asset Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/assets/{asset_id}:
-    get:
-      summary: Get Asset
-      operationId: get_asset_api_assets__asset_id__get
-      parameters:
-      - name: asset_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Asset Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetOut'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    delete:
-      summary: Delete Asset
-      description: |-
-        Soft-delete an asset.
-
-        Sets ``assets.deleted_at`` and flags any in-flight Jobs targeting this
-        asset (or its variants) with ``cancel_requested = true``.  The worker
-        heartbeat will pick up the flag and abort ffmpeg within ~15s; the
-        CMS reaper loop (``deleted_asset_reaper_loop``) later hard-deletes
-        blobs + rows once all Jobs are terminal.  Returns 200 immediately.
-      operationId: delete_asset_api_assets__asset_id__delete
       parameters:
       - name: asset_id
         in: path

--- a/mcp/cms_client.py
+++ b/mcp/cms_client.py
@@ -147,6 +147,16 @@ class CMSClient:
             f"/composed/{asset_id}/layout-friendly", json=payload
         )
 
+    # ── Slideshows (AI editor) ──
+
+    async def get_slideshow(self, asset_id: str) -> dict:
+        return await self._get(f"/api/assets/{asset_id}/slides")
+
+    async def set_slideshow_slides(self, asset_id: str, payload: dict) -> dict:
+        return await self._put(
+            f"/api/assets/{asset_id}/slides", json=payload
+        )
+
     # ── Schedules ──
 
     async def list_schedules(self) -> list:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -103,6 +103,8 @@ TOOL_PERMISSIONS: dict[str, str | None] = {
     "list_composed_widget_types": "assets:read",
     "get_composed_layout": "assets:read",
     "set_composed_widgets": "assets:write",
+    "get_slideshow": "assets:read",
+    "set_slideshow_slides": "assets:write",
 }
 
 
@@ -465,6 +467,65 @@ async def set_composed_widgets(
     if background_color is not None:
         payload["background_color"] = background_color
     result = await _call_api("set_composed_widgets", asset_id, payload)
+    return _json_result(result)
+
+
+@mcp.tool()
+async def get_slideshow(asset_id: str) -> str:
+    """Get the ordered slides of a slideshow asset.
+
+    Returns ``{slideshow_id, slides}`` where each slide is
+    ``{id, position, duration_ms, play_to_end, transition,
+    transition_ms, source_asset_id, source_filename,
+    source_asset_type, source_duration_seconds, thumbnail_url}``.
+
+    ``source_asset_id`` is the IMAGE / VIDEO / COMPOSED asset shown for
+    that slide — pass these back to ``set_slideshow_slides`` to keep the
+    same members. Call this before editing so you preserve the existing
+    order and timing.
+
+    Args:
+        asset_id: UUID of the slideshow asset being edited.
+    """
+    if err := _check_permission("get_slideshow"):
+        return err
+    result = await _call_api("get_slideshow", asset_id)
+    return _json_result(result)
+
+
+@mcp.tool()
+async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
+    """Replace the ordered slides of a slideshow.
+
+    ``slides`` is the FULL replacement list in display order — include
+    every slide you want kept; omitted slides are removed. This change is
+    saved and goes LIVE immediately (slideshows have no draft/publish
+    step).
+
+    Each slide is ``{source_asset_id, duration_ms?, play_to_end?,
+    transition?, transition_ms?}``:
+      - ``source_asset_id``: UUID of an IMAGE / VIDEO / COMPOSED asset
+        (from ``list_assets`` or an existing slide's ``source_asset_id``).
+      - ``duration_ms``: how long the slide shows, 500–3,600,000
+        (default 7000). Ignored for videos when ``play_to_end`` is true.
+      - ``play_to_end``: for video slides, play the whole clip instead of
+        using ``duration_ms`` (default false; only valid for video).
+      - ``transition``: how this slide enters — one of ``cut``, ``fade``,
+        ``fade_black``, ``dissolve``, ``push``, ``wipe``, ``zoom``
+        (default ``cut``).
+      - ``transition_ms``: transition length in ms, 0–5000 (default 600).
+
+    A slideshow can hold up to 50 slides. On invalid input the call
+    returns structured errors — fix and retry.
+
+    Args:
+        asset_id: UUID of the slideshow asset being edited.
+        slides: full ordered replacement list of slide objects.
+    """
+    if err := _check_permission("set_slideshow_slides"):
+        return err
+    payload: dict = {"slides": slides}
+    result = await _call_api("set_slideshow_slides", asset_id, payload)
     return _json_result(result)
 
 

--- a/tests/test_composed_editor_assistant.py
+++ b/tests/test_composed_editor_assistant.py
@@ -323,7 +323,7 @@ class TestCreateModeDrawer:
         assert resp.status_code == 200
         text = resp.text
         assert 'id="cw-ai"' in text
-        assert '<script src="/static/composed_editor_chat.js"' in text
+        assert '<script src="/static/editor_chat.js"' in text
         # Create mode has no asset yet — the drawer must render an EMPTY
         # data-asset-id (not the string "None"), so the client treats it as
         # unbound and mints on first send.
@@ -341,4 +341,4 @@ class TestCreateModeDrawer:
         assert resp.status_code == 200
         text = resp.text
         assert 'id="cw-ai"' not in text
-        assert '<script src="/static/composed_editor_chat.js"' not in text
+        assert '<script src="/static/editor_chat.js"' not in text

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -280,7 +280,11 @@ class TestMediaWidgetSlideshowBranch:
                    "transition_ms": 600}, "img", (_TINY_PNG, "image/png"))],
         )
         r = MediaWidget().render_html(cfg, _cell(), "ssC", ctx=ctx)
-        assert "transition-duration:0ms" in r.html
+        # Duration is carried by the --cw-ss-ms custom property the
+        # ported device CSS reads (the JS overrides it per swap).
+        assert "--cw-ss-ms:0ms" in r.html
+        assert r.init_js is not None
+        assert "var transMs = [0];" in r.init_js
 
     def test_fade_transition_uses_transition_ms(self):
         container = uuid.uuid4()
@@ -296,7 +300,9 @@ class TestMediaWidgetSlideshowBranch:
             ],
         )
         r = MediaWidget().render_html(cfg, _cell(), "ssF", ctx=ctx)
-        assert "transition-duration:750ms" in r.html
+        assert "--cw-ss-ms:750ms" in r.html
+        assert r.init_js is not None
+        assert "var transMs = [750,750];" in r.init_js
 
     def test_cycling_js_bakes_durations_and_guards_single(self):
         container = uuid.uuid4()
@@ -375,17 +381,19 @@ class TestMediaWidgetSlideshowBranch:
         assert "cw-ss-" in r.html
 
     @pytest.mark.parametrize(
-        "transition,enter_kf,leave_kf",
+        "transition,css_marker",
         [
-            ("fade_black", "cw-ss-fadeblack-in", "cw-ss-fadeblack-out"),
-            ("dissolve", "cw-ss-dissolve-in", "cw-ss-dissolve-out"),
-            ("push", "cw-ss-push-in", "cw-ss-push-out"),
-            ("wipe", "cw-ss-wipe-in", "cw-ss-wipe-out"),
-            ("zoom", "cw-ss-zoom-in", "cw-ss-zoom-out"),
+            # fade_black is sequenced entirely in JS (two half fades
+            # through black) — it has no dedicated CSS tx-* rule.
+            ("fade_black", None),
+            ("dissolve", "cw-tx-dissolve"),
+            ("push", "cw-tx-push"),
+            ("wipe", "cw-tx-wipe"),
+            ("zoom", "cw-tx-zoom"),
         ],
     )
-    def test_rich_transition_emits_class_and_keyframe_library(
-        self, transition, enter_kf, leave_kf
+    def test_rich_transition_emits_class_and_shared_transition_css(
+        self, transition, css_marker
     ):
         container = uuid.uuid4()
         s1, s2 = uuid.uuid4(), uuid.uuid4()
@@ -401,25 +409,33 @@ class TestMediaWidgetSlideshowBranch:
         )
         r = MediaWidget().render_html(cfg, _cell(), "ssRich", ctx=ctx)
 
-        # Per-slide type class baked onto each slide div.
+        # Per-slide informational type class baked onto each slide div.
         assert f"cw-ss-t-{transition}" in r.html
         # The slide-count invariant still holds (type class shares no
         # "cw-ss-slide" substring).
         assert r.html.count("cw-ss-slide") == 2
         assert "cw-ss-slide cw-ss-active" in r.html
 
-        # Shared keyframe library emitted as a static CSS asset.
+        # Shared transition CSS (ported from the device player shell)
+        # emitted once as a static CSS asset.
         css_assets = [a for a in r.static_assets if a.kind == "css"]
         assert len(css_assets) == 1
         lib = css_assets[0].content
-        assert enter_kf in lib
-        assert leave_kf in lib
-        assert f"cw-ss-enter-{transition}" in lib
-        assert f"cw-ss-leave-{transition}" in lib
+        # Ported device base mechanics.
+        assert ".cw-ss-slide{" in lib
+        assert ".cw-ss-slide.cw-ss-active{opacity:1" in lib
+        assert ".cw-ss-slide.cw-ss-notrans{transition:none !important}" in lib
+        # Per-mode rule present for the staged (transform/clip-path) modes.
+        if css_marker is not None:
+            assert css_marker in lib
 
-        # Rich transitions opt out of the base opacity transition so the
-        # keyframe animation owns the timeline.
-        assert "transition: none;" in r.css
+        # The cycling JS ports swapTo(): staged modes flip dynamic tx-*
+        # classes; fade_black is sequenced by name.
+        assert r.init_js is not None
+        if transition == "fade_black":
+            assert "fade_black" in r.init_js
+        else:
+            assert css_marker in r.init_js
 
     def test_rich_transition_bakes_int_arrays_in_js(self):
         container = uuid.uuid4()
@@ -444,9 +460,11 @@ class TestMediaWidgetSlideshowBranch:
         assert "var transMs = [0,900];" in r.init_js
         assert "var durations = [3000,4000];" in r.init_js
 
-    def test_cut_fade_only_emits_no_keyframe_asset(self):
-        # A slideshow that only uses cut + fade must NOT emit the shared
-        # keyframe library (it would be dead CSS).
+    def test_cut_fade_still_emits_shared_transition_css(self):
+        # Even a cut+fade-only slideshow emits the shared transition CSS
+        # now — the base .cw-ss-slide / .cw-ss-active / fade mechanics
+        # live there (ported from the device player shell), not in
+        # per-mode keyframes.
         container = uuid.uuid4()
         s1, s2 = uuid.uuid4(), uuid.uuid4()
         cfg = MediaWidgetConfig(asset_id=container)
@@ -460,7 +478,9 @@ class TestMediaWidgetSlideshowBranch:
             ],
         )
         r = MediaWidget().render_html(cfg, _cell(), "ssCF", ctx=ctx)
-        assert [a for a in r.static_assets if a.kind == "css"] == []
+        css_assets = [a for a in r.static_assets if a.kind == "css"]
+        assert len(css_assets) == 1
+        assert ".cw-ss-slide{" in css_assets[0].content
 
     def test_unknown_transition_falls_back_to_fade(self):
         # SlideshowSlidePlan.transition is a plain str; an unexpected
@@ -476,7 +496,8 @@ class TestMediaWidgetSlideshowBranch:
         r = MediaWidget().render_html(cfg, _cell(), "ssU", ctx=ctx)
         assert "cw-ss-t-fade" in r.html
         assert "cw-ss-t-bogus" not in r.html
-        assert r.static_assets == []
+        # Shared transition CSS is always emitted (base slide mechanics).
+        assert [a for a in r.static_assets if a.kind == "css"]
 
 
 class TestComposedCellTransitionMapper:

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -1,0 +1,255 @@
+"""Tests for the slideshow-editor embedded AI assistant (PR 1).
+
+Mirrors ``tests/test_composed_editor_assistant.py`` for the slideshow
+builder.  Covers the server-side pieces that back the chat panel
+embedded in the slideshow editor:
+
+* ``POST /api/assets/{id}/assistant/thread`` — get-or-create the
+  editor-scoped, asset-bound chat thread (slideshow mode).
+* ``list_threads`` excludes ``slideshow_editor`` threads from the
+  general assistant sidebar.
+* ``build_system_prompt`` renders the slideshow-editor variant only in
+  ``slideshow_editor`` mode with a bound asset id (never widens).
+* The slideshow builder template renders the shared assistant drawer
+  only in edit mode (asset bound) when the feature flag is on, and
+  never in create mode.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.asset import Asset, AssetType
+from cms.models.chat_thread import ChatThread
+from cms.models.slideshow_slide import SlideshowSlide
+from cms.services.assistant.mcp_client import MODE_SLIDESHOW_EDITOR
+
+
+# ── fixtures / helpers ──────────────────────────────────────────────
+
+
+async def _make_slideshow(
+    db_session, *, owner_id=None, is_global: bool = True, slides: int = 0,
+) -> Asset:
+    asset = Asset(
+        filename=f"show-{uuid.uuid4().hex[:8]}",
+        display_name="Test show",
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="v1",
+        duration_seconds=10.0,
+        uploaded_by_user_id=owner_id,
+        is_global=is_global,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    if slides:
+        src = Asset(
+            filename=f"src-{uuid.uuid4().hex[:6]}.png",
+            asset_type=AssetType.IMAGE,
+            size_bytes=100,
+            is_global=True,
+        )
+        db_session.add(src)
+        await db_session.flush()
+        for i in range(slides):
+            db_session.add(SlideshowSlide(
+                slideshow_asset_id=asset.id,
+                source_asset_id=src.id,
+                position=i,
+                duration_ms=5000,
+                play_to_end=False,
+            ))
+    await db_session.commit()
+    return asset
+
+
+async def _make_image(db_session, *, is_global: bool = True) -> Asset:
+    asset = Asset(
+        filename=f"img-{uuid.uuid4().hex[:8]}.png",
+        asset_type=AssetType.IMAGE,
+        size_bytes=100,
+        checksum="v1",
+        is_global=is_global,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    return asset
+
+
+async def _disable_all(app) -> None:
+    from cms.database import get_db
+    from cms.services.assistant_flag import set_allowlist
+
+    factory = app.dependency_overrides[get_db]
+    async for db in factory():
+        await set_allowlist(db, [])
+        break
+
+
+# ── POST /api/assets/{id}/assistant/thread ──────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAssistantThreadEndpoint:
+    async def test_creates_then_reuses_same_thread(self, client, db_session):
+        asset = await _make_slideshow(db_session)
+
+        first = await client.post(f"/api/assets/{asset.id}/assistant/thread")
+        assert first.status_code == 200, first.text
+        b1 = first.json()
+        assert b1["created"] is True
+        uuid.UUID(b1["thread_id"])
+
+        second = await client.post(f"/api/assets/{asset.id}/assistant/thread")
+        assert second.status_code == 200, second.text
+        b2 = second.json()
+        assert b2["created"] is False
+        assert b2["thread_id"] == b1["thread_id"]
+
+    async def test_thread_is_bound_and_in_editor_mode(self, client, db_session):
+        asset = await _make_slideshow(db_session)
+        resp = await client.post(f"/api/assets/{asset.id}/assistant/thread")
+        assert resp.status_code == 200, resp.text
+        tid = uuid.UUID(resp.json()["thread_id"])
+
+        row = (
+            await db_session.execute(
+                select(ChatThread).where(ChatThread.id == tid)
+            )
+        ).scalar_one()
+        assert row.mode == MODE_SLIDESHOW_EDITOR
+        assert row.composed_asset_id == asset.id
+
+    async def test_missing_asset_is_404(self, client):
+        resp = await client.post(
+            f"/api/assets/{uuid.uuid4()}/assistant/thread"
+        )
+        assert resp.status_code == 404
+
+    async def test_non_slideshow_asset_is_400(self, client, db_session):
+        img = await _make_image(db_session)
+        resp = await client.post(f"/api/assets/{img.id}/assistant/thread")
+        assert resp.status_code == 400, resp.text
+
+    async def test_feature_off_is_404(self, operator_client, app, db_session):
+        # Operator owns the slideshow (so it's visible), but the Assistant
+        # feature is off → the endpoint must 404 to keep it invisible.
+        await _disable_all(app)
+        asset = await _make_slideshow(
+            db_session, owner_id=operator_client.user_id, is_global=False,
+        )
+        resp = await operator_client.post(
+            f"/api/assets/{asset.id}/assistant/thread"
+        )
+        assert resp.status_code == 404
+
+    async def test_unauth_is_401(self, unauthed_client, db_session):
+        asset = await _make_slideshow(db_session)
+        resp = await unauthed_client.post(
+            f"/api/assets/{asset.id}/assistant/thread"
+        )
+        assert resp.status_code in (401, 403)
+
+
+# ── list_threads excludes editor threads ────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestListThreadsExcludesEditor:
+    async def test_editor_thread_hidden_from_sidebar(self, client, db_session):
+        general = await client.post(
+            "/api/chat/threads", json={"title": "Promo"}
+        )
+        assert general.status_code == 201
+        general_id = general.json()["id"]
+
+        asset = await _make_slideshow(db_session)
+        editor = await client.post(f"/api/assets/{asset.id}/assistant/thread")
+        editor_id = editor.json()["thread_id"]
+
+        listing = (await client.get("/api/chat/threads")).json()
+        ids = {t["id"] for t in listing}
+        assert general_id in ids
+        assert editor_id not in ids
+
+
+# ── build_system_prompt mode awareness ──────────────────────────────
+
+
+class TestBuildSystemPrompt:
+    def _user(self):
+        return types.SimpleNamespace(username="alice", email="alice@test.com")
+
+    def test_slideshow_mode_renders_editor_prompt_with_bound_id(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        assert aid in prompt
+        assert "Slideshow Assistant" in prompt
+        assert "set_slideshow_slides" in prompt
+        # Editor prompt must NOT advertise fleet tooling.
+        assert "create_schedule" not in prompt
+
+    def test_slideshow_mode_without_id_falls_back_to_general(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=None
+        )
+        assert "Slideshow Assistant" not in prompt
+
+    def test_default_mode_is_general(self):
+        from cms.services.assistant.prompts import build_system_prompt
+
+        prompt = build_system_prompt(self._user())
+        assert "Slideshow Assistant" not in prompt
+
+
+# ── builder template drawer gating (edit-mode-only) ─────────────────
+
+
+@pytest.mark.asyncio
+class TestBuilderDrawerGating:
+    async def test_edit_page_shows_drawer_for_enabled_user(
+        self, client, db_session
+    ):
+        # ``client`` is an admin (settings:write), so the assistant flag is
+        # always on regardless of the allowlist.
+        asset = await _make_slideshow(db_session, slides=1)
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        text = resp.text
+        assert 'id="cw-ai"' in text
+        assert '<script src="/static/editor_chat.js"' in text
+        assert f'data-asset-id="{asset.id}"' in text
+
+    async def test_create_page_hides_drawer(self, client):
+        # v1 is edit-mode-only: a brand-new slideshow has no bound asset,
+        # so the drawer (and its scripts) must not render even for an
+        # admin with the feature on.
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        text = resp.text
+        assert 'id="cw-ai"' not in text
+        assert '<script src="/static/editor_chat.js"' not in text
+
+    async def test_edit_page_hides_drawer_for_disabled_user(
+        self, operator_client, app, db_session
+    ):
+        await _disable_all(app)
+        asset = await _make_slideshow(
+            db_session, owner_id=operator_client.user_id, is_global=False,
+        )
+        resp = await operator_client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        text = resp.text
+        assert 'id="cw-ai"' not in text
+        assert '<script src="/static/editor_chat.js"' not in text

--- a/tests/test_slideshow_preview.py
+++ b/tests/test_slideshow_preview.py
@@ -1,0 +1,185 @@
+"""Tests for the bare-slideshow live preview endpoint.
+
+``GET /composed/slideshow/{asset_id}/preview`` wraps a SLIDESHOW asset in
+an ephemeral single full-bleed ``media`` widget Layout and reuses the
+composed render pipeline so a slideshow previews with the same
+CSS-transition cycling the device uses. No persisted ComposedSlide is
+involved.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from cms.models.asset import Asset, AssetType
+from cms.models.slideshow_slide import SlideshowSlide
+
+# A 1x1 PNG (valid header is enough — we only inline bytes).
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+)
+
+
+def _storage_dir(tmp_path):
+    # Mirrors the conftest ``app`` fixture: asset_storage_path = tmp_path/"assets".
+    d = tmp_path / "assets"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.mark.asyncio
+class TestSlideshowPreview:
+    async def _make_image(self, db_session, storage, name, *, is_global=True):
+        (storage / name).write_bytes(_PNG_BYTES)
+        img = Asset(
+            filename=name,
+            asset_type=AssetType.IMAGE,
+            size_bytes=len(_PNG_BYTES),
+            checksum="x",
+            is_global=is_global,
+        )
+        db_session.add(img)
+        await db_session.flush()
+        return img
+
+    async def _make_slideshow(self, db_session, members, *, is_global=True):
+        ss = Asset(
+            filename=f"show-{uuid.uuid4()}.slideshow",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=is_global,
+        )
+        db_session.add(ss)
+        await db_session.flush()
+        for idx, src in enumerate(members):
+            db_session.add(
+                SlideshowSlide(
+                    slideshow_asset_id=ss.id,
+                    source_asset_id=src.id,
+                    position=idx,
+                    duration_ms=4000,
+                    play_to_end=False,
+                    transition="fade",
+                    transition_ms=600,
+                )
+            )
+        await db_session.flush()
+        await db_session.commit()
+        return ss
+
+    async def test_404_when_asset_missing(self, client):
+        resp = await client.get(f"/composed/slideshow/{uuid.uuid4()}/preview")
+        assert resp.status_code == 404
+
+    async def test_404_when_wrong_asset_type(self, client, db_session):
+        asset = Asset(
+            filename="not_a_slideshow.mp4",
+            asset_type=AssetType.VIDEO,
+            size_bytes=100,
+            checksum="abc",
+        )
+        db_session.add(asset)
+        await db_session.commit()
+
+        resp = await client.get(f"/composed/slideshow/{asset.id}/preview")
+        assert resp.status_code == 404
+
+    async def test_404_when_slideshow_deleted(self, client, db_session, tmp_path):
+        storage = _storage_dir(tmp_path)
+        img = await self._make_image(db_session, storage, "del.png")
+        ss = await self._make_slideshow(db_session, [img])
+        ss.deleted_at = datetime.now(timezone.utc)
+        await db_session.commit()
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 404
+
+    async def test_happy_path_inlines_each_member(
+        self, client, db_session, tmp_path
+    ):
+        storage = _storage_dir(tmp_path)
+        img1 = await self._make_image(db_session, storage, "a.png")
+        img2 = await self._make_image(db_session, storage, "b.png")
+        ss = await self._make_slideshow(db_session, [img1, img2])
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert "<html" in body.lower()
+        # Both members inlined as data URIs; ported CSS-transition markup present.
+        assert body.count("data:image/png;base64,") == 2
+        assert "cw-ss-slide" in body
+        # No device-local sibling path should leak into a preview.
+        assert "/assets/videos/" not in body
+
+    async def test_empty_slideshow_is_422(self, client, db_session, tmp_path):
+        _storage_dir(tmp_path)
+        ss = await self._make_slideshow(db_session, [])
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 422, resp.text
+        assert "has no slides" in resp.text
+
+    async def test_non_media_member_is_422(self, client, db_session, tmp_path):
+        _storage_dir(tmp_path)
+        web = Asset(
+            filename="page.url",
+            asset_type=AssetType.WEBPAGE,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(web)
+        await db_session.flush()
+        ss = await self._make_slideshow(db_session, [web])
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 422, resp.text
+        assert "can only cycle IMAGE and VIDEO" in resp.text
+
+    async def test_csp_header_is_locked_down(self, client, db_session, tmp_path):
+        storage = _storage_dir(tmp_path)
+        img = await self._make_image(db_session, storage, "csp.png")
+        ss = await self._make_slideshow(db_session, [img])
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 200, resp.text
+        csp = resp.headers.get("content-security-policy", "")
+        assert "default-src 'none'" in csp
+        assert "frame-ancestors 'self'" in csp
+        # A slideshow can't contain weather/rss/iframe widgets, so no
+        # external connect/frame origins should ever leak in.
+        assert "http:" not in csp
+        assert "https:" not in csp
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+
+    async def test_no_cache_header_set(self, client, db_session, tmp_path):
+        storage = _storage_dir(tmp_path)
+        img = await self._make_image(db_session, storage, "nc.png")
+        ss = await self._make_slideshow(db_session, [img])
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 200, resp.text
+        assert resp.headers.get("cache-control") == "no-store"
+
+    async def test_unauthorized_user_cannot_preview(
+        self, operator_client, client, db_session, tmp_path
+    ):
+        # A non-admin Operator with no group memberships can only see
+        # global assets; a personal/un-shared slideshow must 403/404.
+        storage = _storage_dir(tmp_path)
+        img = await self._make_image(
+            db_session, storage, "priv.png", is_global=False
+        )
+        ss = await self._make_slideshow(db_session, [img], is_global=False)
+
+        resp = await operator_client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code in (403, 404), resp.text
+        # Admin can still see it (sanity).
+        ok = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert ok.status_code == 200, ok.text


### PR DESCRIPTION
Brings the reusable in-CMS AI assistant drawer to the slideshow builder (edit-mode only for v1) and adds slideshow-editing MCP tools so the assistant can add/remove/reorder slides and set per-slide transition, transition duration, and display duration.

## Reuse
- Generalized composed_editor_chat.js into config-driven static/editor_chat.js (`window.cwAiConfig`: bridge, threadPath, writeTools, mint). Both editors now drive the same shared `_assistant_drawer.html` partial.
- Composed editor refactored onto the shared drawer (no behavior change).

## Slideshow editing
- MCP tools `get_slideshow` + `set_slideshow_slides` (mcp/server.py, mcp/cms_client.py).
- New `slideshow_editor` assistant mode + tool profiles (mcp_client.py). Writes run inline (no approval) and apply immediately (no draft/publish).

## Server wiring
- `POST /api/assets/{asset_id}/assistant/thread` get-or-create the editor-scoped, asset-bound thread (slideshow mode); gated on ASSETS_WRITE + owner/admin + assistant flag.
- chat.py re-validates slideshow editor threads and hides them from the general sidebar; agent.py forces the bound slideshow id onto asset-scoped tools; prompts.py renders the slideshow editor prompt only in `slideshow_editor` mode with a bound id.
- ui.py exposes `assistant_enabled` to the slideshow builder context.

## Tests
- `tests/test_slideshow_editor_assistant.py` (13) mirrors the composed suite. Regenerated `docs/openapi.yaml` for the new route. Existing composed assistant + slideshow suites green locally.

Goodwill **dev only**.