### PR TITLE
feat(slideshow): expose loop (last to first) transition in editor

### DIFF
--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -142,7 +142,11 @@ Per-slide fields:
   of using ``duration_ms`` (default false).
 * ``transition``: how the slide enters — one of ``cut``, ``fade``,
   ``fade_black``, ``dissolve``, ``push``, ``wipe``, ``zoom``
-  (default ``cut``).
+  (default ``cut``).  The **first** slide's ``transition`` is special:
+  because the show loops continuously, it is applied every time the
+  show wraps from the last slide back to the first — i.e. it is the
+  **loop (last → first) transition**.  Set it when the operator wants
+  the wrap-around to fade/dissolve instead of cutting.
 * ``transition_ms``: transition length, 0–5000 ms (default 600).
 
 Facts (fixed):

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -253,6 +253,18 @@
     border-color: #16a085;
     color: #fff;
 }
+/* The leading gap doubles as the loop (last → first) transition control.
+   Give it a distinct accent so it doesn't read as a between-slide gap. */
+.ssb-gap-btn-loop {
+    background: #2c3e50;
+    border-color: #8e44ad;
+    color: #d6bcfa;
+}
+.ssb-gap-btn-loop:hover {
+    background: #8e44ad;
+    border-color: #8e44ad;
+    color: #fff;
+}
 /* When a draggable hovers a gap, the gap "opens up" into a slot-sized
    placeholder so the user can preview where the new slide will land.
    Reverts smoothly on dragleave or drop. */
@@ -753,17 +765,38 @@ function makeGap(index, isLeading) {
     gap.className = 'ssb-gap';
     gap.dataset.dropIndex = String(index);
     if (isLeading) {
-        // Leading drop zone is small + invisible; no transition button there
-        gap.innerHTML = '';
-        gap.style.flex = '0 0 12px';
+        // The leading gap doubles as the loop (last → first) transition control.
+        // On a looping slideshow the device shows slides[0] both on first play and
+        // on every wrap, applying slides[0].transition each time — so editing
+        // slides[0].transition here configures how the show loops back to the start.
+        // Only meaningful with ≥2 slides; for 0–1 slides keep the small invisible
+        // drop zone (a single-slide show never wraps with a visible transition).
+        if (slides.length >= 2) {
+            buildTransitionGap(gap, 0, /*isLoop*/ true);
+        } else {
+            gap.innerHTML = '';
+            gap.style.flex = '0 0 12px';
+        }
     } else {
         // index here is the gap position (1..slides.length-1 for between-slot gaps).
         // The transition belongs to the slide on the right (slides[index]).
-        const slideIdx = index;
-        const current = transitionDef((slides[slideIdx] && slides[slideIdx].transition) || 'cut');
-        gap.innerHTML = `
-            <button type="button" class="ssb-gap-btn"
-                    title="${current.label} transition — click to change">${current.icon}</button>
+        buildTransitionGap(gap, index, /*isLoop*/ false);
+    }
+    wireDropZone(gap, index);
+    return gap;
+}
+
+// Builds the transition picker popover (icon button + options + duration input)
+// into ``gap`` bound to ``slides[slideIdx]``. ``isLoop`` only changes the labels /
+// styling so the leading slides[0] control reads as the last → first loop
+// transition rather than a between-slide transition.
+function buildTransitionGap(gap, slideIdx, isLoop) {
+    const current = transitionDef((slides[slideIdx] && slides[slideIdx].transition) || 'cut');
+    const titleSuffix = isLoop ? ' — loop (last → first)' : '';
+    if (isLoop) gap.classList.add('ssb-gap-loop');
+    gap.innerHTML = `
+            <button type="button" class="ssb-gap-btn${isLoop ? ' ssb-gap-btn-loop' : ''}"
+                    title="${current.label}${titleSuffix} — click to change">${isLoop ? '\u21BA' : current.icon}</button>
             <div class="ssb-trans-menu" popover="auto" role="menu"></div>`;
         const btn = gap.querySelector('.ssb-gap-btn');
         const menu = gap.querySelector('.ssb-trans-menu');
@@ -790,8 +823,8 @@ function makeGap(index, isLeading) {
                         markDirty();
                     }
                 }
-                btn.textContent = t.icon;
-                btn.title = `${t.label} transition — click to change`;
+                btn.textContent = isLoop ? '\u21BA' : t.icon;
+                btn.title = `${t.label}${isLoop ? ' — loop (last → first)' : ''} — click to change`;
                 // Refresh duration input enabled state without closing the popover.
                 const di = menu.querySelector('.ssb-trans-dur-input');
                 if (di) {
@@ -845,9 +878,6 @@ function makeGap(index, isLeading) {
             menu.style.transform = 'translateX(-50%)';
             try { menu.showPopover(); } catch {}
         });
-    }
-    wireDropZone(gap, index);
-    return gap;
 }
 
 function wireDropZone(el, dropIndex) {

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -140,3 +140,30 @@ class TestSlideshowBuilderRoutes:
         assert resp.status_code == 200
         # Badge text from _macros.html
         assert "3 slides" in resp.text
+
+
+class TestSlideshowLoopTransitionUI:
+    """The leading timeline gap doubles as the loop (last → first)
+    transition control bound to slides[0]. Behavior is implemented in the
+    baked builder JS, so assert the source ships and is gated correctly."""
+
+    async def test_builder_bakes_loop_transition_control(self, client):
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Shared popover builder reused for both between-slide and loop gaps.
+        assert "function buildTransitionGap(" in body
+        # Distinct loop styling + accessible label.
+        assert "ssb-gap-btn-loop" in body
+        assert "loop (last \u2192 first)" in body
+
+    async def test_loop_control_gated_on_two_or_more_slides(self, client):
+        """The leading gap only becomes the loop control with >=2 slides;
+        a 0–1 slide show never wraps with a visible transition."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # The gating branch in makeGap's leading path.
+        assert "slides.length >= 2" in body
+        # Loop control binds to slides[0].
+        assert "buildTransitionGap(gap, 0, /*isLoop*/ true)" in body

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -198,6 +198,17 @@ class TestBuildSystemPrompt:
         # Editor prompt must NOT advertise fleet tooling.
         assert "create_schedule" not in prompt
 
+    def test_editor_prompt_documents_loop_transition(self):
+        """The first slide's transition is the loop (last → first)
+        transition; the assistant must be told so it can configure wraps."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        assert "loop (last \u2192 first) transition" in prompt
+
     def test_slideshow_mode_without_id_falls_back_to_general(self):
         from cms.services.assistant.prompts import build_system_prompt
 


### PR DESCRIPTION
## What

The first slide's transition already governs the device's last->first wrap (the player shows `slides[0]` with `slides[0].transition` on every loop), but the editor's leading timeline gap was an invisible 12px drop zone with no control. So the loop transition silently defaulted to `cut` and couldn't be changed from the UI.

This makes the leading gap a real transition picker bound to `slides[0]`:
- Rendered only when there are >=2 slides (a 0-1 slide show never wraps with a visible transition).
- Distinct loop styling (the U+21BA loop glyph + purple accent) and a `loop (last -> first)` tooltip so it reads differently from between-slide gaps.
- The popover builder is extracted into a shared `buildTransitionGap()` reused by both the between-slide gaps and the loop gap, so duration clamping, the `cut` -> 0ms rule, and `markDirty()` behave identically.

Also updates the slideshow assistant prompt so the AI knows slide 0's transition is the loop transition and can configure wraps via `set_slideshow_slides`.

## Scope

CMS-only. No model, migration, manifest-schema, resolver, or firmware change -- `slides[0].transition` already threads end to end (model -> PUT `/{id}/slides` -> `plan_slideshow` -> `SlideDescriptor` -> manifest v1.2 -> firmware wrap) and is covered by existing PUT/resolver/manifest round-trip tests.

## Tests

- `test_slideshow_builder_ui.py`: loop control JS ships + gating (>=2 slides, binds to `slides[0]`).
- `test_slideshow_editor_assistant.py`: editor prompt documents the loop transition.
- Re-verified existing transition round-trip + manifest-hash-flip tests (`test_slideshow_assets.py -k transition` 10 passed).
- OpenAPI regenerated: no diff (no new route).