### PR TITLE
fix(slideshow): give visible feedback when picking the loop transition

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -329,6 +329,14 @@
 }
 .ssb-trans-opt-sel {
     background: rgba(22,160,133,0.25);
+    box-shadow: inset 3px 0 0 #1abc9c;
+    font-weight: 600;
+}
+.ssb-trans-opt-sel::after {
+    content: '\2713';
+    margin-left: auto;
+    color: #1abc9c;
+    font-size: 0.85rem;
 }
 .ssb-trans-opt-sel .ssb-trans-opt-icon {
     color: #1abc9c;
@@ -796,7 +804,7 @@ function buildTransitionGap(gap, slideIdx, isLoop) {
     if (isLoop) gap.classList.add('ssb-gap-loop');
     gap.innerHTML = `
             <button type="button" class="ssb-gap-btn${isLoop ? ' ssb-gap-btn-loop' : ''}"
-                    title="${current.label}${titleSuffix} — click to change">${isLoop ? '\u21BA' : current.icon}</button>
+                    title="${current.label}${titleSuffix} — click to change">${current.icon}</button>
             <div class="ssb-trans-menu" popover="auto" role="menu"></div>`;
         const btn = gap.querySelector('.ssb-gap-btn');
         const menu = gap.querySelector('.ssb-trans-menu');
@@ -823,7 +831,7 @@ function buildTransitionGap(gap, slideIdx, isLoop) {
                         markDirty();
                     }
                 }
-                btn.textContent = isLoop ? '\u21BA' : t.icon;
+                btn.textContent = t.icon;
                 btn.title = `${t.label}${isLoop ? ' — loop (last → first)' : ''} — click to change`;
                 // Refresh duration input enabled state without closing the popover.
                 const di = menu.querySelector('.ssb-trans-dur-input');


### PR DESCRIPTION
## Problem

Picking a transition from the loop (last->first) control in the slideshow editor felt like a no-op: the menu popped up, you clicked an option, and nothing visibly changed. Under the hood it *was* working (it set `slides[0].transition` and marked the show dirty), but:

- The loop button's icon was hardcoded to the loop glyph (U+21BA), so unlike the between-slide gaps it never reflected your choice.
- The 'selected' option highlight was almost identical to the hover highlight, so while the cursor sat on the option you just clicked, there was no perceptible change.

## Fix

- Loop button now shows the chosen transition's icon, just like the between-slide gaps that already feel responsive. It keeps its purple `ssb-gap-btn-loop` styling and 'loop (last -> first)' tooltip so it's still recognizable as the loop control.
- Selected option is now clearly distinct from hover: inset left accent bar, bold text, and a checkmark.

CMS-template-only; no model/route/schema change. Loop control still binds to `slides[0].transition` and the duration field stays in the popover.

## Tests

`tests/test_slideshow_builder_ui.py` 12 passed (loop control bakes + gating still asserted).