### PR TITLE
fix: allow slideshow AI assistant to create an empty draft

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1767,9 +1767,19 @@ async def create_slideshow_asset(
         raise HTTPException(status_code=400, detail=f"Invalid slide payload: {e}")
 
     visible = await _visible_asset_ids(user, db)
-    sources_by_id, source_groups = await _load_and_validate_slide_sources(
-        slides, db, visible_ids=visible
-    )
+    if slides:
+        sources_by_id, source_groups = await _load_and_validate_slide_sources(
+            slides, db, visible_ids=visible
+        )
+    else:
+        # Allow a 0-slide draft slideshow. The AI assistant's create-mode
+        # mint POSTs the builder's current in-memory slides, which is empty
+        # for a brand-new slideshow; without this the create always 400s and
+        # the assistant can never create a slideshow on a fresh page. The
+        # empty draft is populated immediately by the assistant, and the
+        # resolver treats a 0-slide slideshow as not-ready so it is never
+        # pushed to a device.
+        sources_by_id, source_groups = {}, {}
 
     # Resolve groups (mirror create_webpage_asset)
     resolved_groups: list[uuid.UUID] = []

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -123,7 +123,11 @@ class SlideshowPlan:
 
     @property
     def ready(self) -> bool:
-        return not self.blockers
+        # A 0-slide slideshow is never ready: a draft (e.g. just created by
+        # the AI assistant) with no slides must not be pushed to a device,
+        # which would render an empty manifest. Manual saves require >=1
+        # slide client-side, so this only guards the empty-draft case.
+        return bool(self.slides) and not self.blockers
 
 
 # Sentinel returned by :func:`_plan_composed_siblings` when at least one

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -200,13 +200,18 @@ class TestSlideshowCreate:
         # is_global=True since admin + no groups
         assert body["is_global"] is True
 
-    async def test_rejects_empty_slides(self, client, db_session):
+    async def test_allows_empty_slides_creates_draft(self, client, db_session):
+        # A 0-slide slideshow is a valid draft (the AI assistant mints one
+        # on a fresh page before adding any slides). It must create a 201.
         resp = await client.post(
             "/api/assets/slideshow",
-            json={"name": "x", "slides": []},
+            json={"name": "Empty draft", "slides": []},
         )
-        assert resp.status_code == 400
-        assert "at least one" in resp.json()["detail"].lower()
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["asset_type"] == "slideshow"
+        assert body["filename"] == "Empty draft"
+        assert body["duration_seconds"] == 0
 
     async def test_rejects_too_many_slides(self, client, db_session):
         img = await _seed_image(db_session, is_global=True)

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -219,7 +219,26 @@ class TestSlideshowResolver:
         assert [s.duration_ms for s in plan.slides] == [5000, 8000]
         assert plan.slides[1].play_to_end is True
 
-    async def test_plan_picks_latest_ready_variant(self, db_session):
+    async def test_empty_slideshow_is_not_ready(self, db_session):
+        """A 0-slide slideshow (e.g. a fresh AI-assistant draft) must never
+        be ready, so it can't be pushed to a device as an empty manifest."""
+        from cms.services.slideshow_resolver import (
+            plan_slideshow,
+            resolved_slideshow_checksum,
+        )
+
+        profile = await _seed_profile(db_session, "pempty")
+        ss = await _seed_slideshow(
+            db_session, name="ss-empty", slides_data=[], checksum="empty-base",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.slides == []
+        assert plan.ready is False
+        # The device-facing checksum is None for a not-ready plan, so the
+        # empty draft never lands in a ScheduleEntry / default-asset.
+        assert await resolved_slideshow_checksum(ss, profile.id, db_session) is None
+
+
         """When multiple READY variants exist for the same (asset,profile),
         the resolver picks the latest one (created_at DESC, id DESC tiebreak)."""
         from cms.services.slideshow_resolver import plan_slideshow


### PR DESCRIPTION
## Problem
On a fresh slideshow builder page (no slides yet), sending the first message to the AI assistant failed with the generic, invisible error `Couldn't create the slide — see the message at the top of the page, then send again.` — but no message appeared.

## Root cause
The assistant mints a draft via `POST /api/assets/slideshow` before any slides exist, sending `slides: []`. The create route hard-rejected empty slides with a 400 → mint returned false → generic assistant error. The 400 detail was written to `#ss-status` (toolbar), not a top banner, so it was invisible.

## Fix
1. **Create route** (`cms/routers/assets.py`): accept an empty slides list and create a 0-slide draft (empty sources/groups, duration 0). The >50 cap and empty-slides rejection still apply to the slides-update path and other callers of `_load_and_validate_slide_sources`.
2. **Resolver guard** (`cms/services/slideshow_resolver.py`): `SlideshowPlan.ready` now requires ≥1 slide, so a 0-slide draft is never ready and can never push a broken empty manifest to a device. Device consumers already skip not-ready plans.

## Tests
- Inverted `test_rejects_empty_slides` → `test_allows_empty_slides_creates_draft` (asserts 201 draft, duration 0).
- Added `test_empty_slideshow_is_not_ready` (resolver).
- Full `test_slideshow_assets.py` + `test_slideshow_resolver.py` green (63 passed).