### PR TITLE
fix(slideshow): unblock AI-assistant slide creation (duration default, empty-draft ACL, MCP error surfacing)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1800,7 +1800,15 @@ async def create_slideshow_asset(
             raise HTTPException(status_code=403, detail="You are not a member of this group")
         resolved_groups.append(parsed_id)
 
-    make_global = (not resolved_groups and is_admin)
+    # Defer the global/audience decision for an empty draft.  A 0-slide
+    # slideshow has no sources, so there is no audience to enforce yet — and
+    # minting it global (the admin default for empty groups) would lock the
+    # audience to "global" before any source is chosen, making it impossible
+    # for the assistant to then add the owner's non-global sources (the
+    # global-source ACL would 400).  The audience is finalized later via the
+    # builder's group/global picker (set_global action), which re-validates
+    # the invariant against the now-known sources.
+    make_global = (not resolved_groups and is_admin and bool(slides))
 
     _validate_slideshow_acl(
         set(resolved_groups), make_global, sources_by_id, source_groups

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -20,6 +20,13 @@ MAX_SLIDESHOW_SLIDES = 50
 # reasonable slide length and prevents a single slide starving a schedule.
 MIN_SLIDE_DURATION_MS = 500
 MAX_SLIDE_DURATION_MS = 60 * 60 * 1000
+# Default per-slide duration when a client omits ``duration_ms``.  The
+# manual builder UI always sends an explicit value, but the AI assistant
+# (and the MCP ``set_slideshow_slides`` tool doc + assistant prompt) both
+# advertise this field as optional with a 7000 ms default.  Keeping the
+# schema default in sync with that contract means an assistant-built slide
+# that omits the field no longer 400s.
+DEFAULT_SLIDE_DURATION_MS = 7000
 
 # Per-slide transition controls (Phase 1a of agora#226, expanded in 0029).
 # ``cut`` is an instant swap (no transition) and is the only mode the
@@ -160,7 +167,9 @@ class SlideIn(BaseModel):
     """One slide in a create/replace slideshow request body."""
 
     source_asset_id: uuid.UUID
-    duration_ms: int = Field(..., ge=MIN_SLIDE_DURATION_MS, le=MAX_SLIDE_DURATION_MS)
+    duration_ms: int = Field(
+        DEFAULT_SLIDE_DURATION_MS, ge=MIN_SLIDE_DURATION_MS, le=MAX_SLIDE_DURATION_MS
+    )
     play_to_end: bool = False
     # Per-slide transition that runs BEFORE the slide appears (i.e. attached
     # to the slide on the right of a gap).  Optional on the wire — old UI

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -131,8 +131,22 @@ async def _call_api(method_name: str, *args, **kwargs):
     try:
         return await getattr(client, method_name)(*args, **kwargs)
     except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 401:
-            raise
+        status = exc.response.status_code
+        if status != 401:
+            # Surface the CMS-provided ``detail`` (e.g. an ACL message like
+            # "A global slideshow can only reference global source assets …
+            # Mark these global first.") instead of a bare "400 Bad Request".
+            # Without this the LLM only ever sees the generic status line and
+            # can't relay the actionable reason to the user.
+            detail: str
+            try:
+                body = exc.response.json()
+                detail = body.get("detail") if isinstance(body, dict) else None
+            except Exception:
+                detail = None
+            if not detail:
+                detail = (exc.response.text or "").strip() or exc.response.reason_phrase
+            raise RuntimeError(f"CMS API error {status}: {detail}") from exc
         logger.warning("CMS returned 401 — reloading service key and retrying")
         await _reload_service_key()
         client = _get_client()

--- a/tests/test_mcp_auto_rotate.py
+++ b/tests/test_mcp_auto_rotate.py
@@ -230,9 +230,16 @@ class TestCallApiFallback:
 
     @pytest.mark.asyncio
     async def test_call_api_propagates_non_401(self, mcp_module):
-        """_call_api does NOT retry on non-401 errors."""
+        """_call_api does NOT retry on non-401 errors.
+
+        On a non-401 it re-raises as a RuntimeError carrying the CMS
+        ``detail`` (so the LLM sees the actionable reason instead of a bare
+        status line), with the original HTTPStatusError preserved as the
+        cause. It must NOT reload the service key.
+        """
         mock_response = MagicMock()
         mock_response.status_code = 500
+        mock_response.json.return_value = {"detail": "boom"}
 
         async def mock_method(*args, **kwargs):
             raise httpx.HTTPStatusError(
@@ -247,9 +254,12 @@ class TestCallApiFallback:
             patch.object(mcp_module, "_get_client", return_value=mock_client),
             patch.object(mcp_module, "_reload_service_key", mock_reload),
         ):
-            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            with pytest.raises(RuntimeError) as exc_info:
                 await mcp_module._call_api("list_devices")
-            assert exc_info.value.response.status_code == 500
+            assert "500" in str(exc_info.value)
+            assert "boom" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+            assert exc_info.value.__cause__.response.status_code == 500
             mock_reload.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_mcp_call_api_errors.py
+++ b/tests/test_mcp_call_api_errors.py
@@ -1,0 +1,119 @@
+"""Regression tests for ``_call_api`` error surfacing in mcp/server.py.
+
+Before this fix a non-401 ``HTTPStatusError`` propagated as a bare
+``"400 Bad Request"`` and the assistant LLM (and therefore the user)
+never saw the CMS-provided ``detail`` (e.g. the slideshow ACL message
+"A global slideshow can only reference global source assets …").
+These tests pin that the JSON ``detail`` is now re-raised verbatim,
+with sensible fallbacks, while the 401 reload-and-retry path is
+preserved.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def mcp_server_module():
+    """Import mcp/server.py as a standalone module with mocked MCP SDK."""
+    saved_modules = {}
+    for mod_name in [
+        "mcp",
+        "mcp.server",
+        "mcp.server.fastmcp",
+        "mcp.server.transport_security",
+        "cms_client",
+    ]:
+        saved_modules[mod_name] = sys.modules.get(mod_name)
+        mock_mod = types.ModuleType(mod_name)
+        if mod_name == "mcp.server.fastmcp":
+            mock_mod.FastMCP = MagicMock()
+        if mod_name == "mcp.server.transport_security":
+            mock_mod.TransportSecuritySettings = MagicMock()
+        if mod_name == "cms_client":
+            mock_mod.CMSClient = MagicMock()
+        sys.modules[mod_name] = mock_mod
+
+    server_path = Path(__file__).resolve().parent.parent / "mcp" / "server.py"
+    spec = importlib.util.spec_from_file_location("mcp_server_mod", server_path)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        for mod_name, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = original
+
+
+def _status_error(status: int, *, json_body=None, text: str = "") -> httpx.HTTPStatusError:
+    request = httpx.Request("PUT", "http://cms/api/assets/x/slides")
+    if json_body is not None:
+        response = httpx.Response(status, json=json_body, request=request)
+    else:
+        response = httpx.Response(status, text=text, request=request)
+    return httpx.HTTPStatusError("err", request=request, response=response)
+
+
+def _client_raising(exc: Exception) -> MagicMock:
+    client = MagicMock()
+    client.set_slideshow_slides = AsyncMock(side_effect=exc)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_call_api_surfaces_400_detail(mcp_server_module, monkeypatch):
+    mod = mcp_server_module
+    msg = (
+        "A global slideshow can only reference global source assets. "
+        "Not global: mine.png. Mark these global first."
+    )
+    client = _client_raising(_status_error(400, json_body={"detail": msg}))
+    monkeypatch.setattr(mod, "_get_client", lambda: client)
+
+    with pytest.raises(RuntimeError) as ei:
+        await mod._call_api("set_slideshow_slides", "asset-id", [])
+    assert msg in str(ei.value)
+    assert "400" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_call_api_falls_back_to_text_when_no_detail(
+    mcp_server_module, monkeypatch
+):
+    mod = mcp_server_module
+    client = _client_raising(_status_error(422, text="Unprocessable thing"))
+    monkeypatch.setattr(mod, "_get_client", lambda: client)
+
+    with pytest.raises(RuntimeError) as ei:
+        await mod._call_api("set_slideshow_slides", "asset-id", [])
+    assert "Unprocessable thing" in str(ei.value)
+    assert "422" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_call_api_401_reloads_key_and_retries(mcp_server_module, monkeypatch):
+    mod = mcp_server_module
+
+    # First client raises 401; second (post-reload) client succeeds.
+    bad = _client_raising(_status_error(401, json_body={"detail": "stale key"}))
+    good = MagicMock()
+    good.set_slideshow_slides = AsyncMock(return_value={"ok": True})
+    clients = iter([bad, good])
+    monkeypatch.setattr(mod, "_get_client", lambda: next(clients))
+    monkeypatch.setattr(mod, "_reload_service_key", AsyncMock())
+
+    result = await mod._call_api("set_slideshow_slides", "asset-id", [])
+    assert result == {"ok": True}
+    mod._reload_service_key.assert_awaited_once()

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -428,6 +428,54 @@ class TestSlideshowSlidesEndpoints:
         await db_session.refresh(ss)
         assert ss.duration_seconds == pytest.approx(5.5)
 
+    async def test_replace_slides_defaults_duration_when_omitted(
+        self, client, db_session
+    ):
+        # The MCP set_slideshow_slides tool + AI assistant prompt advertise
+        # duration_ms as optional (default 7000). A slide that omits it must
+        # NOT 400 — it lands on the schema default.
+        img = await _seed_image(db_session, filename="nodur.png", is_global=True)
+        create = await client.post(
+            "/api/assets/slideshow", json={"name": "nodur", "slides": []}
+        )
+        assert create.status_code == 201
+        sid = create.json()["id"]
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{"source_asset_id": str(img.id)}]},
+        )
+        assert put.status_code == 200, put.text
+        assert put.json()["slide_count"] == 1
+        # 7000 ms default → 7.0 s
+        assert put.json()["duration_seconds"] == pytest.approx(7.0)
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["duration_ms"] == 7000
+
+    async def test_empty_draft_not_global_allows_non_global_sources(
+        self, client, db_session
+    ):
+        # An admin minting an empty draft (no groups) must NOT lock it global.
+        # Otherwise the AI assistant can't then add the owner's non-global
+        # sources (the global-source ACL would 400). Mirrors the real
+        # assistant create flow: create empty draft → PUT non-global slides.
+        create = await client.post(
+            "/api/assets/slideshow", json={"name": "owner draft", "slides": []}
+        )
+        assert create.status_code == 201, create.text
+        sid = create.json()["id"]
+        ss = await db_session.get(Asset, uuid.UUID(sid))
+        assert ss.is_global is False
+
+        non_global = await _seed_image(
+            db_session, filename="mine.png", is_global=False
+        )
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{"source_asset_id": str(non_global.id)}]},
+        )
+        assert put.status_code == 200, put.text
+        assert put.json()["slide_count"] == 1
+
 
 @pytest.mark.asyncio
 class TestSlideTransitions:


### PR DESCRIPTION
## Problem

The slideshow AI assistant failed to create a slideshow: the tool trace showed list_assets ✓ → get_slideshow ✓ → set_slideshow_slides ✓ then \I encountered an error… 400 Bad Request\, with **no message at the top of the page**.

## Root cause — three combined bugs

1. **\SlideIn.duration_ms\ was required** despite the MCP \set_slideshow_slides\ tool doc + assistant prompt advertising it as optional (default 7000). A slide omitting it 400'd on schema validation. → now defaults to \DEFAULT_SLIDE_DURATION_MS = 7000\.
2. **Admin empty-draft locked global.** An admin minting a 0-slide draft (no groups) got \is_global=True\ (admin default), so the assistant couldn't then add the owner's **non-global** sources — the global-source ACL 400'd. → \make_global\ now also requires \ool(slides)\; empty drafts defer the audience decision (finalized later via the builder's \set_global\ action, which re-validates).
3. **\_call_api\ swallowed the CMS \detail\.** On non-401 errors it re-raised a bare status line, so the LLM never saw the actionable reason. → now extracts JSON \detail\ (fallback to text / reason phrase) and raises \RuntimeError\ with it; 401 reload-and-retry preserved.

Bug #1 (schema validation) masked bug #2 (ACL); they must ship together.

## Tests
- PUT \/slides\ without \duration_ms\ → 200, stored 7000.
- Admin empty-draft → \is_global=False\; PUT non-global source → 200 (no ACL 400).
- \_call_api\ surfaces the 400 \detail\ / falls back to text / still retries on 401.

43 targeted tests green locally (\	est_slideshow_assets.py\ + new \	est_mcp_call_api_errors.py\).