### PR TITLE
fix(slideshow-assistant): persist editor renames and clarify ambiguous fade

### DIFF
--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -140,11 +140,24 @@ Per-slide fields:
   true.
 * ``play_to_end``: for VIDEO slides only, play the whole clip instead
   of using ``duration_ms`` (default false).
-* ``transition``: how the slide enters — one of ``cut``, ``fade``,
-  ``fade_black``, ``dissolve``, ``push``, ``wipe``, ``zoom``
-  (default ``cut``).  The **first** slide's ``transition`` is special:
-  because the show loops continuously, it is applied every time the
-  show wraps from the last slide back to the first — i.e. it is the
+* ``transition``: how the slide enters — one of:
+    - ``cut`` — no transition, the slide appears instantly (default).
+    - ``fade`` — crossfade: the outgoing and incoming slides blend
+      directly into each other.
+    - ``fade_black`` — fade through black: the outgoing slide fades to
+      black, then the incoming slide fades up from black.
+    - ``dissolve`` — a soft, grainy crossfade variant.
+    - ``push`` — the incoming slide slides in, pushing the old one out.
+    - ``wipe`` — the incoming slide is revealed edge-to-edge over the
+      old one.
+    - ``zoom`` — the incoming slide scales up into place.
+  Because there are several fade-style options, if the operator asks
+  for "a fade" (or otherwise names a transition ambiguously that could
+  map to more than one of ``fade`` / ``fade_black`` / ``dissolve``),
+  ask them which one they want before applying it instead of guessing.
+  The **first** slide's ``transition`` is special: because the show
+  loops continuously, it is applied every time the show wraps from the
+  last slide back to the first — i.e. it is the
   **loop (last → first) transition**.  Set it when the operator wants
   the wrap-around to fade/dissolve instead of cutting.
 * ``transition_ms``: transition length, 0–5000 ms (default 600).

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -1179,6 +1179,8 @@ async function maybeRenameSlideshow(name) {
     }
     SS_ORIG_NAME = trimmed;
 }
+
+function openGroupPopup(id) {
     const el = document.getElementById(id);
     if (el && el.showPopover) el.showPopover();
 }

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -490,7 +490,7 @@
         </div>
         {% if edit_mode %}
         <p class="text-muted" style="font-size:0.85rem; margin-top:0.5rem;">
-            Group assignments and rename are managed via the Assets page actions.
+            Group assignments are managed via the Assets page actions.
         </p>
         {% endif %}
 
@@ -565,6 +565,12 @@
 <script>
 let SS_EDIT_MODE = {{ 'true' if edit_mode else 'false' }};
 let SS_ASSET_ID = {{ asset_id | tojson if asset_id else 'null' }};
+// Baseline name for edit-mode rename detection. The edit-mode Save path
+// PUTs only the slides (the /slides endpoint can't rename), so a changed
+// name is persisted via a separate PATCH /api/assets/{id} {display_name}
+// — the same endpoint the Assets-page rename uses. Mirrors the composed
+// editor's COMPOSED_ORIG_NAME / maybeRenameSlide() pattern.
+let SS_ORIG_NAME = {% if edit_mode %}{{ asset_name | tojson }}{% else %}""{% endif %};
 const SS_MAX_SLIDES = 50;
 
 let slides = JSON.parse(document.getElementById('ss-initial-slides').textContent || '[]');
@@ -1110,6 +1116,7 @@ async function saveSlideshow(opts) {
                 const err = await r.json().catch(() => ({}));
                 throw new Error(err.detail || ('HTTP ' + r.status));
             }
+            await maybeRenameSlideshow(name);
             clearDirty();
             setStatus('Saved.');
             // Stay on the page after a normal Save; only redirect when the
@@ -1153,7 +1160,25 @@ async function saveSlideshow(opts) {
     }
 }
 
-function openGroupPopup(id) {
+// Persist an edit-mode rename. The /slides PUT can't carry a name, so a
+// changed name is PATCHed to /api/assets/{id} {display_name} (the same
+// endpoint the Assets-page rename uses). No-op in create mode or when the
+// name is unchanged. Mirrors composed_editor.html's maybeRenameSlide().
+async function maybeRenameSlideshow(name) {
+    if (!SS_EDIT_MODE || !SS_ASSET_ID) return;
+    const trimmed = (name || '').trim();
+    if (!trimmed || trimmed === (SS_ORIG_NAME || '').trim()) return;
+    const r = await fetch(`/api/assets/${SS_ASSET_ID}`, {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({display_name: trimmed}),
+    });
+    if (!r.ok) {
+        const err = await r.json().catch(() => ({}));
+        throw new Error(err.detail || ('HTTP ' + r.status));
+    }
+    SS_ORIG_NAME = trimmed;
+}
     const el = document.getElementById(id);
     if (el && el.showPopover) el.showPopover();
 }
@@ -1384,6 +1409,7 @@ window.slideshowMintDraft = async function () {
         if (!newId) { setStatus('Create failed', true); return false; }
         SS_ASSET_ID = newId;
         SS_EDIT_MODE = true;
+        SS_ORIG_NAME = name;
         clearDirty();
         setStatus('Created.');
         try {

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -106,6 +106,32 @@ class TestSlideshowBuilderRoutes:
         # Ensure the seeded slides are in the JSON island the page uses for state
         assert '"position": 0' in body or '"position":0' in body
 
+    async def test_edit_page_wires_in_editor_rename(self, client, db_session):
+        """Edit mode must persist a renamed slideshow in-editor. The /slides
+        PUT can't carry a name, so a changed name is PATCHed to
+        /api/assets/{id} {display_name}. Regression for the silent
+        edit-mode rename drop."""
+        asset = await _seed_slideshow(db_session, name="Renameable", slides=2)
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Rename baseline + helper are baked into the edit page.
+        assert "SS_ORIG_NAME" in body
+        assert "maybeRenameSlideshow" in body
+        # Baseline is seeded with the current name so an unchanged name is a no-op.
+        assert "Renameable" in body
+        # The old "rename is managed via the Assets page" note must be gone.
+        assert "and rename are managed" not in body
+
+    async def test_new_page_omits_editor_rename_baseline(self, client):
+        """Create mode has no asset yet — the rename baseline is empty and
+        the helper is still defined (the mint flow flips into edit mode)."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert 'SS_ORIG_NAME = ""' in body
+        assert "maybeRenameSlideshow" in body
+
     async def test_edit_page_404s_for_non_slideshow(self, client, db_session):
         # Image, not slideshow: should redirect away
         img = Asset(

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -210,6 +210,23 @@ class TestBuildSystemPrompt:
         )
         assert "loop (last \u2192 first) transition" in prompt
 
+    def test_editor_prompt_clarifies_ambiguous_fade(self):
+        """Several transitions are fade-style (fade/fade_black/dissolve);
+        when the operator asks for "a fade" the assistant must ask which
+        one rather than guessing."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        # Each fade-family transition is described so the assistant can
+        # distinguish them, and it is told to ask when the request is
+        # ambiguous.
+        assert "fade through black" in prompt
+        assert "crossfade" in prompt
+        assert "ask them which one" in prompt
+
     def test_slideshow_mode_without_id_falls_back_to_general(self):
         from cms.services.assistant.prompts import build_system_prompt
 


### PR DESCRIPTION
Two slideshow-editor assistant polish fixes.

### 1. Edit-mode renames were silently dropped
saveSlideshow()'s edit branch PUT \/api/assets/{id}/slides\ with only \{slides}\ — the name was never sent. Renaming a slideshow in the editor (including one the AI assistant just named) appeared to save but reverted on reload.

**Fix:** add \maybeRenameSlideshow()\ that PATCHes \/api/assets/{id}\ \{display_name}\ when the name changed vs \SS_ORIG_NAME\, mirroring the composed editor. \SS_ORIG_NAME\ is seeded on load and after the AI mint flow so a subsequent rename is detected.

### 2. Ambiguous fade now asks which one
When a fade is requested ambiguously, the assistant asks which fade variant (\ade\ / \ade_black\ / \dissolve\) instead of silently picking. Rewrote the transition bullet in the editor system prompt to list all 7 transitions + the clarify rule.

### Tests
Regression tests added for both (29 passed locally, \-p no:timeout\).