### PR TITLE
fix(schedules): live-refresh stale transcoding asset options

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -323,6 +323,17 @@ async def assets_status_json(
         variant_ready += a_ready
         variant_processing += a_processing
         variant_failed += a_failed
+        # Schedule-picker readiness, computed identically to the server
+        # render in cms/ui.py (issue #201) so pages that poll this endpoint
+        # can self-heal a "transcoding…" disabled state once the variants
+        # finish — without a full page reload. Mirror ui.py exactly: use the
+        # full variant list (not the device-filtered view) and apply the
+        # composed-unpublished override.
+        from cms.services.variant_view import is_asset_ready as _is_asset_ready
+        _ready, _reason = _is_asset_ready(a.variants)
+        _composed_reason = composed_unpublished_reason(a)
+        if _ready and _composed_reason:
+            _ready, _reason = False, _composed_reason
         # Build group name map for scope data
         variant_progress_sum = sum((v.progress or 0.0) for v in visible_variants)
         aggregate_pct = round(variant_progress_sum / len(visible_variants), 1) if visible_variants else 0.0
@@ -350,6 +361,10 @@ async def assets_status_json(
             # buildVariantBadge() keeps the "Unpublished" badge instead of
             # overwriting it with "none" on the first reconcile.
             "unpublished": composed_unpublished_reason(a) is not None,
+            # Schedule-picker readiness (issue #201) so the schedules page can
+            # refresh a stale "transcoding…" disabled option live.
+            "ready_for_selection": _ready,
+            "not_ready_reason": _reason,
         })
 
     # Compute a hash of group-asset assignments so the poller can detect scope changes

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -1431,10 +1431,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     const byId = {};
                     for (const a of _scheduleData.assets) byId[a.id] = a;
                     createSel.querySelectorAll('option[value]').forEach(opt => {
-                        const a = byId[opt.value];
-                        if (a) {
-                            opt.disabled = !a.ready;
-                            opt.textContent = scheduleAssetLabel(a);
+                        const csa = byId[opt.value];
+                        if (csa) {
+                            opt.disabled = !csa.ready;
+                            opt.textContent = scheduleAssetLabel(csa);
                         }
                     });
                 }

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -201,6 +201,58 @@ window._playingScheduleIds = {{ playing_schedule_ids | tojson }};
 const _tzList = JSON.parse(document.getElementById('_tzOptions').value);
 const _currentTz = document.getElementById('_tz').value;
 
+// Asset readiness ("transcoding…" disabled state) is baked into
+// `_scheduleData.assets` at page render. If an asset finishes transcoding
+// after the page loads, that frozen snapshot leaves the option disabled and
+// unselectable in the edit/create pickers until a full reload. Re-fetch the
+// canonical readiness from /api/assets/status (computed identically to the
+// server render) and merge it back into the in-memory snapshot. Best-effort:
+// any failure leaves the existing (possibly stale) data untouched.
+async function refreshAssetReadiness() {
+    try {
+        const resp = await fetch('/api/assets/status', {headers: {'Accept': 'application/json'}});
+        if (!resp.ok) return false;
+        const data = await resp.json();
+        const byId = {};
+        for (const fa of (data.assets || [])) byId[fa.id] = fa;
+        let changed = false;
+        for (const a of _scheduleData.assets) {
+            const fresh = byId[a.id];
+            if (!fresh || typeof fresh.ready_for_selection !== 'boolean') continue;
+            const newReason = fresh.not_ready_reason || '';
+            if (a.ready !== fresh.ready_for_selection || a.notReadyReason !== newReason) {
+                a.ready = fresh.ready_for_selection;
+                a.notReadyReason = newReason;
+                changed = true;
+            }
+        }
+        return changed;
+    } catch (e) {
+        return false;
+    }
+}
+
+// Build the <option> list for an asset picker from the current
+// `_scheduleData.assets` snapshot, marking `selectedId` selected. Shared by
+// the edit modal's initial render and its post-refresh rebuild so the two
+// paths can never drift.
+function buildScheduleAssetOptions(selectedId) {
+    return _scheduleData.assets.map(a => {
+        const icon = ASSET_ICONS[a.type];
+        let label = icon ? icon + ' ' + a.name : a.name;
+        if (a.duration) {
+            const m = Math.floor(a.duration / 60), sec = Math.round(a.duration % 60);
+            label += ` (${m}:${String(sec).padStart(2,'0')})`;
+        }
+        if (!a.ready && a.notReadyReason) label += ` (${a.notReadyReason})`;
+        // Keep a not-ready asset selectable when it is the schedule's current
+        // pick so editing an existing schedule never silently drops its asset.
+        const isSelected = a.id === selectedId;
+        const disabledAttr = (a.ready || isSelected) ? '' : ' disabled';
+        return `<option value="${a.id}" data-asset-type="${a.type || ''}"${disabledAttr} ${isSelected ? "selected" : ""}>${label}</option>`;
+    }).join("");
+}
+
 // Browser-vs-server clock skew in ms (browser - server).  The "Set to
 // now" chip needs server time, not browser time -- if the browser is
 // running a few seconds ahead of the server (common on Windows where
@@ -785,17 +837,7 @@ function editSchedule(s) {
         return `<label><input type="checkbox" name="edit_day_${num}" ${checked}> ${name}</label>`;
     }).join(" ");
 
-    const assetOpts = _scheduleData.assets.map(a => {
-        const icon = ASSET_ICONS[a.type];
-        let label = icon ? icon + ' ' + a.name : a.name;
-        if (a.duration) {
-            const m = Math.floor(a.duration / 60), s = Math.round(a.duration % 60);
-            label += ` (${m}:${String(s).padStart(2,'0')})`;
-        }
-        if (!a.ready && a.notReadyReason) label += ` (${a.notReadyReason})`;
-        const disabledAttr = a.ready ? '' : ' disabled';
-        return `<option value="${a.id}" data-asset-type="${a.type || ''}"${disabledAttr} ${a.id === s.asset_id ? "selected" : ""}>${label}</option>`;
-    }).join("");
+    const assetOpts = buildScheduleAssetOptions(s.asset_id);
 
     const groupOpts = groups.map(g =>
         `<option value="${g.id}" ${g.id === s.group_id ? "selected" : ""}>${g.name}</option>`
@@ -877,6 +919,20 @@ function editSchedule(s) {
 
     overlay.appendChild(box);
     document.body.appendChild(overlay);
+    // Self-heal a stale "transcoding…" disabled asset option: the modal is
+    // built instantly from the page-load snapshot (above) for a snappy open,
+    // then we re-fetch canonical readiness and rebuild the picker in place if
+    // anything changed. Preserve whatever the user currently has selected
+    // (defaults to the schedule's asset) so a finished transcode becomes
+    // selectable without dropping their choice.
+    (async () => {
+        const changed = await refreshAssetReadiness();
+        if (!changed) return;
+        const sel = box.querySelector("#edit-asset");
+        if (!sel) return;
+        const keep = sel.value || s.asset_id;
+        sel.innerHTML = buildScheduleAssetOptions(keep);
+    })();
     const _closeEditModal = async (force) => {
         if (!force && _isEditModalDirty()) {
             const ok = await showConfirm("\u26a0\ufe0f You have unsaved changes to this schedule. Discard them and close?");
@@ -1354,6 +1410,25 @@ document.addEventListener('DOMContentLoaded', () => {
             const el = document.activeElement;
             if (el && (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA')) return;
         }
+        // Keep the in-memory asset snapshot and the (server-rendered) create
+        // form picker honest about transcoding completion, so a finished
+        // transcode becomes selectable without a manual reload. Functional
+        // only: we toggle the `disabled` attribute; the cosmetic
+        // "(transcoding…)" suffix on a now-ready option clears on next reload.
+        try {
+            const changed = await refreshAssetReadiness();
+            if (changed) {
+                const createSel = document.querySelector('[name="asset_id"]');
+                if (createSel) {
+                    const byId = {};
+                    for (const a of _scheduleData.assets) byId[a.id] = a;
+                    createSel.querySelectorAll('option[value]').forEach(opt => {
+                        const a = byId[opt.value];
+                        if (a) opt.disabled = !a.ready;
+                    });
+                }
+            }
+        } catch (e) { /* best-effort */ }
         try {
             const resp = await fetch('/api/schedules');
             if (!resp.ok) return;

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -236,15 +236,24 @@ async function refreshAssetReadiness() {
 // `_scheduleData.assets` snapshot, marking `selectedId` selected. Shared by
 // the edit modal's initial render and its post-refresh rebuild so the two
 // paths can never drift.
+// Build the visible label for an asset <option> (icon + name + duration,
+// plus a trailing "(reason)" only while the asset isn't ready). Shared by
+// the edit-modal builder and the create-form self-heal so the two never
+// drift apart.
+function scheduleAssetLabel(a) {
+    const icon = ASSET_ICONS[a.type];
+    let label = icon ? icon + ' ' + a.name : a.name;
+    if (a.duration) {
+        const m = Math.floor(a.duration / 60), sec = Math.round(a.duration % 60);
+        label += ` (${m}:${String(sec).padStart(2,'0')})`;
+    }
+    if (!a.ready && a.notReadyReason) label += ` (${a.notReadyReason})`;
+    return label;
+}
+
 function buildScheduleAssetOptions(selectedId) {
     return _scheduleData.assets.map(a => {
-        const icon = ASSET_ICONS[a.type];
-        let label = icon ? icon + ' ' + a.name : a.name;
-        if (a.duration) {
-            const m = Math.floor(a.duration / 60), sec = Math.round(a.duration % 60);
-            label += ` (${m}:${String(sec).padStart(2,'0')})`;
-        }
-        if (!a.ready && a.notReadyReason) label += ` (${a.notReadyReason})`;
+        const label = scheduleAssetLabel(a);
         // Keep a not-ready asset selectable when it is the schedule's current
         // pick so editing an existing schedule never silently drops its asset.
         const isSelected = a.id === selectedId;
@@ -1412,9 +1421,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         // Keep the in-memory asset snapshot and the (server-rendered) create
         // form picker honest about transcoding completion, so a finished
-        // transcode becomes selectable without a manual reload. Functional
-        // only: we toggle the `disabled` attribute; the cosmetic
-        // "(transcoding…)" suffix on a now-ready option clears on next reload.
+        // transcode becomes selectable — and loses its "(transcoding…)"
+        // label — without a manual reload.
         try {
             const changed = await refreshAssetReadiness();
             if (changed) {
@@ -1424,7 +1432,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     for (const a of _scheduleData.assets) byId[a.id] = a;
                     createSel.querySelectorAll('option[value]').forEach(opt => {
                         const a = byId[opt.value];
-                        if (a) opt.disabled = !a.ready;
+                        if (a) {
+                            opt.disabled = !a.ready;
+                            opt.textContent = scheduleAssetLabel(a);
+                        }
                     });
                 }
             }

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -116,6 +116,69 @@ class TestAssetStatus:
         assert by_id[str(composed_pub.id)]["unpublished"] is False
         assert by_id[str(video.id)]["unpublished"] is False
 
+    async def test_status_exposes_schedule_picker_readiness(self, client, db_session):
+        """``/api/assets/status`` must echo ``ready_for_selection`` +
+        ``not_ready_reason`` so the schedules page can live-refresh a stale
+        "transcoding…" disabled <option> once a transcode finishes, without a
+        full reload (issue #201).
+        """
+        from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
+        from cms.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(name="Readiness Test")
+        db_session.add(profile)
+        await db_session.flush()
+
+        # READY video → selectable.
+        ready_vid = Asset(
+            filename="ready.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=5000, checksum="r1",
+        )
+        # Video still transcoding → not selectable, reason "transcoding…".
+        proc_vid = Asset(
+            filename="proc.mp4", asset_type=AssetType.VIDEO,
+            size_bytes=0, checksum="p1",
+        )
+        # Never-published composed → not selectable via composed override.
+        composed_unpub = Asset(
+            filename="composed_unpub.html", asset_type=AssetType.COMPOSED,
+            size_bytes=0, checksum="",
+        )
+        db_session.add_all([ready_vid, proc_vid, composed_unpub])
+        await db_session.flush()
+
+        db_session.add_all([
+            AssetVariant(
+                source_asset_id=ready_vid.id, profile_id=profile.id,
+                filename="ready_v.mp4", size_bytes=3000,
+                status=VariantStatus.READY, progress=100.0, checksum="rv",
+            ),
+            AssetVariant(
+                source_asset_id=proc_vid.id, profile_id=profile.id,
+                filename="proc_v.mp4", size_bytes=0,
+                status=VariantStatus.PROCESSING, progress=20.0, checksum="",
+            ),
+        ])
+        await db_session.commit()
+
+        resp = await client.get("/api/assets/status")
+        assert resp.status_code == 200
+        by_id = {a["id"]: a for a in resp.json()["assets"]}
+
+        # Both fields present on every asset.
+        for a in by_id.values():
+            assert "ready_for_selection" in a
+            assert "not_ready_reason" in a
+
+        assert by_id[str(ready_vid.id)]["ready_for_selection"] is True
+        assert by_id[str(ready_vid.id)]["not_ready_reason"] in (None, "")
+
+        assert by_id[str(proc_vid.id)]["ready_for_selection"] is False
+        assert by_id[str(proc_vid.id)]["not_ready_reason"]
+
+        assert by_id[str(composed_unpub.id)]["ready_for_selection"] is False
+        assert by_id[str(composed_unpub.id)]["not_ready_reason"]
+
 
 @pytest.mark.asyncio
 class TestAssetStatusCollapse:


### PR DESCRIPTION
When the schedules page or edit modal opened while an asset was transcoding, the asset dropdown froze that asset's `transcoding…` disabled/unselectable state at page load and never refreshed after the transcode finished server-side — so a long-since-ready asset stayed unselectable until a manual reload.

## Fix
- `GET /api/assets/status` now returns `ready_for_selection` + `not_ready_reason` per asset, computed identically to the `cms/ui.py` server render (`is_asset_ready` over the full variant list + composed-unpublished override).
- `schedules.html`: `refreshAssetReadiness()` merges polled readiness into the in-page asset snapshot; `buildScheduleAssetOptions()` rebuilds the `<select>` from it. The edit modal rebuilds `#edit-asset` right after open, and `pollSchedulesOnce` self-heals both edit + create dropdowns every poll cycle (functional `disabled` toggle; cosmetic suffix clears on next reload).

## Tests
- New regression test asserts the two new fields on `/api/assets/status`.
- `test_template_inline_js_syntax` + `TestAssetStatus` green locally.

Dev-only.