### PR TITLE
fix(assets): friendly names in delete confirm and transcode queue

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -2020,11 +2020,11 @@ async def replace_slideshow_slides(
         db, user=user, action="asset.replace_slides", resource_type="asset",
         resource_id=str(asset_id),
         description=(
-            f"Replaced slides on slideshow '{asset.filename}' "
+            f"Replaced slides on slideshow '{asset.display_name or asset.original_filename or asset.filename}' "
             f"({len(slides)} slide(s))"
         ),
         details={
-            "filename": asset.filename,
+            "filename": asset.display_name or asset.original_filename or asset.filename,
             "slide_count": len(slides),
             "duration_seconds": duration_seconds,
         },
@@ -2170,7 +2170,7 @@ async def update_asset(
         await audit_log(
             db, user=user, action="asset.update", resource_type="asset",
             resource_id=str(asset_id),
-            description=f"Modified asset '{asset.filename}'",
+            description=f"Modified asset '{asset.display_name or asset.original_filename or asset.filename}'",
             details={"changes": changes},
             request=request,
         )
@@ -2260,7 +2260,7 @@ async def recapture_stream(
     await audit_log(
         db, user=user, action="asset.recapture", resource_type="asset",
         resource_id=str(asset_id),
-        description=f"Recaptured saved-stream asset '{asset.filename}'",
+        description=f"Recaptured saved-stream asset '{asset.display_name or asset.original_filename or asset.filename}'",
         details={"variants_reset": reset_count},
         request=request,
     )
@@ -2566,6 +2566,11 @@ async def delete_asset(
         await db.execute(delete(Schedule).where(Schedule.asset_id == asset_id))
 
     asset_filename = asset.filename
+    # Friendly, user-facing name for the audit log (the raw filename is a
+    # GUID storage name, e.g. composed-<uuid>-<hash>.html).
+    asset_display_name = (
+        asset.display_name or asset.original_filename or asset.filename
+    )
 
     # Mark as soft-deleted
     asset.deleted_at = datetime.now(timezone.utc)
@@ -2607,8 +2612,8 @@ async def delete_asset(
     await audit_log(
         db, user=user, action="asset.delete", resource_type="asset",
         resource_id=str(asset_id),
-        description=f"Soft-deleted asset '{asset_filename}'",
-        details={"filename": asset_filename, "asset_type": asset.asset_type.value},
+        description=f"Soft-deleted asset '{asset_display_name}'",
+        details={"filename": asset_display_name, "asset_type": asset.asset_type.value},
         request=request,
     )
     await db.commit()
@@ -2673,9 +2678,9 @@ async def share_asset(
     await audit_log(
         db, user=user, action="asset.share", resource_type="asset",
         resource_id=str(asset_id),
-        description=f"Shared asset '{asset.filename}' with group '{group.name}'",
+        description=f"Shared asset '{asset.display_name or asset.original_filename or asset.filename}' with group '{group.name}'",
         details={
-            "asset_filename": asset.filename,
+            "asset_filename": asset.display_name or asset.original_filename or asset.filename,
             "group_id": str(group_id),
             "group_name": group.name,
             "uploaded_by_user_id": (
@@ -2750,7 +2755,10 @@ async def unshare_asset(
     group_row = (await db.execute(
         select(DeviceGroup).where(DeviceGroup.id == group_id)
     )).scalar_one_or_none()
-    asset_filename = asset_row.filename if asset_row is not None else None
+    asset_filename = (
+        (asset_row.display_name or asset_row.original_filename or asset_row.filename)
+        if asset_row is not None else None
+    )
     group_name = group_row.name if group_row is not None else None
     uploader_email: str | None = None
     uploader_id = asset_row.uploaded_by_user_id if asset_row is not None else None
@@ -2846,7 +2854,7 @@ async def toggle_asset_global(
         db, user=getattr(request.state, "user", None),
         action="asset.toggle_global", resource_type="asset",
         resource_id=str(asset_id),
-        description=f"{'Marked' if asset.is_global else 'Unmarked'} asset '{asset.filename}' as global",
+        description=f"{'Marked' if asset.is_global else 'Unmarked'} asset '{asset.display_name or asset.original_filename or asset.filename}' as global",
         details={"is_global": asset.is_global},
         request=request,
     )

--- a/cms/routers/composed.py
+++ b/cms/routers/composed.py
@@ -471,7 +471,7 @@ async def _validate_persist_layout(
         action=action,
         resource_type="asset",
         resource_id=str(asset.id),
-        description=f"Updated composed-slide layout for '{asset.filename}'",
+        description=f"Updated composed-slide layout for '{asset.display_name or asset.original_filename or asset.filename}'",
         details={"widget_count": len(layout.widgets)},
         request=request,
     )
@@ -711,9 +711,9 @@ async def create_composed_slide(
         action="asset.create_composed",
         resource_type="asset",
         resource_id=str(asset.id),
-        description=f"Created composed slide '{filename}'",
+        description=f"Created composed slide '{asset.display_name or asset.original_filename or asset.filename}'",
         details={
-            "filename": filename,
+            "filename": asset.display_name or asset.original_filename or asset.filename,
             "group_ids": [str(g) for g in resolved_groups],
             "is_global": make_global,
         },
@@ -827,9 +827,9 @@ async def publish_composed_endpoint(
         action="asset.publish_composed",
         resource_type="asset",
         resource_id=str(asset.id),
-        description=f"Published composed slide '{asset.filename}'",
+        description=f"Published composed slide '{asset.display_name or asset.original_filename or asset.filename}'",
         details={
-            "filename": result.filename,
+            "filename": asset.display_name or asset.original_filename or asset.filename,
             "size_bytes": result.size_bytes,
             "checksum": result.checksum,
         },

--- a/cms/routers/profiles.py
+++ b/cms/routers/profiles.py
@@ -934,7 +934,10 @@ async def profiles_status_json(
         await db.refresh(v, ["source_asset", "profile"])
         queue_out.append({
             "id": str(v.id),
-            "source_filename": v.source_asset.filename if v.source_asset else "?",
+            "source_filename": (
+                (v.source_asset.display_name or v.source_asset.original_filename or v.source_asset.filename)
+                if v.source_asset else "?"
+            ),
             "profile_name": v.profile.name if v.profile else "?",
             "status": v.status.value,
             "progress": v.progress,

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -307,7 +307,7 @@
                         {% if a.schedule_count > 0 %}
                         <button type="button" role="menuitem" class="kebab-item-danger" disabled title="Used by {{ a.schedule_count }} schedule{{ 's' if a.schedule_count != 1 }}. Remove from all schedules before deleting.">Delete</button>
                         {% else %}
-                        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset('{{ a.id }}', {{ a.filename | tojson | forceescape }})">Delete</button>
+                        <button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset('{{ a.id }}', {{ (a.display_name or a.original_filename or a.filename) | tojson | forceescape }})">Delete</button>
                         {% endif %}
                     {% endif %}
                     {% endcall %}

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -1320,7 +1320,7 @@ function fallbackCopy(text, onSuccess) {
             if (sched > 0) {
                 items.push('<button type="button" role="menuitem" class="kebab-item-danger" disabled title="Used by ' + sched + ' schedule' + (sched !== 1 ? 's' : '') + '. Remove from all schedules before deleting.">Delete</button>');
             } else {
-                items.push('<button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset(' + _kebabArg(a.id) + ', ' + _kebabArg(a.filename) + ')">Delete</button>');
+                items.push('<button type="button" role="menuitem" class="kebab-item-danger" onclick="deleteAsset(' + _kebabArg(a.id) + ', ' + _kebabArg(name) + ')">Delete</button>');
             }
         }
 


### PR DESCRIPTION
## Problem

Deleting a composed slide showed `Delete "composed-<uuid>-<hash>.html"?` (the GUID storage filename), and the transcoding-queue panel listed the same GUID. Users see friendly names everywhere else.

## Fix

- **Grid kebab delete** (`assets.html`): pass the already-computed friendly `name` to `deleteAsset` instead of `a.filename`.
- **List-view kebab delete** (`_macros.html`): pass `display_name or original_filename or filename`.
- **Transcode queue** (`/api/profiles/status` in `profiles.py`): `source_filename` now uses the same friendly-name fallback.

## Tests

- `test_inline_script_is_valid_js` (16 passed)
- `test_profile_row_endpoint` + `test_profile_clear_errors` (11 passed)

Dev only.
