### PR TITLE
feat(composed): drag to create widgets on the editor grid

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -246,6 +246,16 @@
         outline-offset: -2px;
     }
     .placed-widget.dragging { opacity: 0.7; }
+    /* Marquee shown while click-dragging on empty cells to size a new
+       widget before it is placed. pointer-events:none so the drag math
+       (window-level pointermove + cellFromPoint) is never intercepted. */
+    .place-marquee {
+        background: rgba(34,197,94,0.22);
+        border: 1px dashed #22c55e;
+        border-radius: 2px;
+        pointer-events: none;
+        z-index: 50;
+    }
     /* When a widget shows a live content preview, drop the generic blue
        placeholder fill so the real content reads clearly; keep a faint
        border for bounds. Selection still adds the green outline below. */
@@ -2020,7 +2030,7 @@ function renderCanvas() {
             cell.style.gridRow = r;
             cell.dataset.row = r;
             cell.dataset.col = c;
-            cell.onclick = () => placeAt(r, c);
+            cell.addEventListener("pointerdown", (e) => beginPlaceDrag(e, r, c));
             canvas.appendChild(cell);
         }
     }
@@ -2472,7 +2482,7 @@ function summarize(w) {
     return d && d.summary ? d.summary(w) : "";
 }
 
-function placeAt(row, col) {
+function placeWidgetAt(row, col, rowspan, colspan) {
     if (!selectedPaletteType) {
         flash("Pick a widget type from the palette first.", false);
         return;
@@ -2484,7 +2494,7 @@ function placeAt(row, col) {
     LAYOUT.widgets.push({
         id,
         type: selectedPaletteType,
-        cell: {row, col, rowspan: 1, colspan: 1},
+        cell: {row, col, rowspan: rowspan || 1, colspan: colspan || 1},
         config: cfg,
         config_version: 1,
     });
@@ -2496,6 +2506,61 @@ function placeAt(row, col) {
     markDirty();
     renderCanvas();
     renderSettings();
+}
+
+// Single-cell drop (click without dragging). Kept as a thin wrapper so the
+// "pick a tool first" hint path is identical to the drag path.
+function placeAt(row, col) {
+    placeWidgetAt(row, col, 1, 1);
+}
+
+// Click-and-drag on empty cells to size a new widget as you draw it.
+// A plain click (no movement) drops the usual 1x1 block; dragging across
+// cells drops a widget spanning the marquee. Resizing an existing widget
+// via its edge/corner handles (beginDrag) is unaffected.
+function beginPlaceDrag(ev, startRow, startCol) {
+    if (ev.button !== 0) return; // left button only
+    // Without a selected palette tool, preserve the click-to-get-hint UX.
+    if (!selectedPaletteType) {
+        placeAt(startRow, startCol);
+        return;
+    }
+    ev.preventDefault();
+    const canvas = document.getElementById("canvas");
+    const rect = canvas.getBoundingClientRect();
+    const cellW = rect.width / 12;
+    const cellH = rect.height / 8;
+    const cellFromPoint = (x, y) => ({
+        row: clampInt(Math.floor((y - rect.top) / cellH) + 1, 1, 8),
+        col: clampInt(Math.floor((x - rect.left) / cellW) + 1, 1, 12),
+    });
+    let cur = {row: startRow, col: startCol};
+
+    const marquee = document.createElement("div");
+    marquee.className = "place-marquee";
+    canvas.appendChild(marquee);
+    const paint = () => {
+        const r1 = Math.min(startRow, cur.row), r2 = Math.max(startRow, cur.row);
+        const c1 = Math.min(startCol, cur.col), c2 = Math.max(startCol, cur.col);
+        marquee.style.gridRow = r1 + " / span " + (r2 - r1 + 1);
+        marquee.style.gridColumn = c1 + " / span " + (c2 - c1 + 1);
+    };
+    paint();
+
+    const onMove = (e) => {
+        const p = cellFromPoint(e.clientX, e.clientY);
+        if (p.row !== cur.row || p.col !== cur.col) { cur = p; paint(); }
+    };
+    const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        marquee.remove();
+        const r1 = Math.min(startRow, cur.row), r2 = Math.max(startRow, cur.row);
+        const c1 = Math.min(startCol, cur.col), c2 = Math.max(startCol, cur.col);
+        placeWidgetAt(r1, c1, r2 - r1 + 1, c2 - c1 + 1);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
 }
 
 function selectWidget(id) {


### PR DESCRIPTION
## What

Adds **drag-to-create** widget placement to the composed-slide editor.

- Pointer-down on an empty grid cell starts a green marquee you can drag to size a new widget in a single gesture; releasing places the widget spanning the drawn area.
- A plain click (no drag movement) still drops the usual 1x1 widget — existing behavior preserved.
- Edge/corner resize handles on already-placed widgets ( + "eginDrag" + ) are untouched.

## How

- Refactored  + "placeAt" +  into a span-aware  + "placeWidgetAt(row, col, rowspan, colspan)" + ;  + "placeAt" +  is now a thin 1x1 wrapper so the "pick a tool first" hint path is identical for click and drag.
- Replaced the per-cell  + "onclick" +  with a  + "pointerdown -> beginPlaceDrag" +  handler (removing the onclick avoids a synthetic-click double-place).
-  + "eginPlaceDrag" +  reuses the existing cell math ( + "cellW=width/12, cellH=height/8, clampInt" + ) and window-level pointer listeners; left-button only; no selected palette tool falls back to the click-to-hint flash.
- New  + ".place-marquee" +  CSS (pointer-events:none, dashed green).

## Tests

 + "	ests/test_template_inline_js_syntax.py" +  green (17 passed) — inline JS parses.

Dev-only.
