### PR TITLE
feat(assets): clearer copy on the Build a new asset page

### DIFF
--- a/cms/templates/assets_new.html
+++ b/cms/templates/assets_new.html
@@ -11,9 +11,8 @@
 <div class="card">
     <h2 style="margin-top:0;">Build a new asset</h2>
     <p class="text-muted" style="margin-top:0;">
-        Builders compose a new asset from existing content in your library.
-        For straightforward uploads or live streams, head to the
-        <a href="/assets">Library</a> tab.
+        Create a richer asset by combining your media and live content
+        into a single, schedulable format. Pick a type below to get started.
     </p>
 
     <div class="builder-tiles">


### PR DESCRIPTION
## What

Revamps the description on the **Build a new asset** page ( + "ssets_new.html" + ).

**Before:** "Builders compose a new asset from existing content in your library. For straightforward uploads or live streams, head to the Library tab."

**After:** "Create a richer asset by combining your media and live content into a single, schedulable format. Pick a type below to get started."

## Why

- "Builders" is the internal name for the tile creators, not a user-facing term — it read oddly.
- The old copy over-emphasized reusing existing library content, which is misleading: a composed slide can be entirely live widgets (weather, RSS, clocks) with no library media at all.
- Dropped the redundant "head to the Library tab for uploads" line — most users already know this.
- New copy is format-agnostic so additional builder types added later still fit.

Copy-only change. Dev-only.
