### PR TITLE
feat(slideshow): per-slide Fit (cover/contain) + Ken Burns effect

### DIFF
--- a/alembic/versions/0041_slideshow_slide_fit_effect.py
+++ b/alembic/versions/0041_slideshow_slide_fit_effect.py
@@ -1,0 +1,69 @@
+"""slideshow_slides: per-slide fit + effect columns
+
+Phase 5 slideshow feature (per-slide display effects, manifest schema
+1.3).  Adds two new columns to ``slideshow_slides``:
+
+* ``fit VARCHAR(16) NOT NULL DEFAULT 'cover'`` — how the slide's media
+  is fitted into the frame.  ``cover`` (fill, may crop) or ``contain``
+  (letterbox, no crop).  Enforced by the Pydantic input schema
+  (``cms.schemas.asset.SLIDE_FITS``) and a DB-level CHECK constraint.
+* ``effect VARCHAR(16) NOT NULL DEFAULT 'none'`` — an optional per-slide
+  display effect.  ``none`` (static) or ``ken_burns`` (slow zoom across
+  the slide's display time).  Enforced by
+  ``cms.schemas.asset.SLIDE_EFFECTS`` and a DB-level CHECK constraint.
+
+Mirrors 0028 (per-slide transitions).  The DEFAULTs ensure existing
+rows pick up the pre-1.3 behaviour (``cover`` / ``none`` — byte-
+identical rendering).  The manifest content hash folds fit/effect, so
+the hash rolls over once at deploy time (every row picks up the same
+defaults) and then only on actual edits.
+
+Revision ID: 0041
+Revises: 0040
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0041"
+down_revision = "0040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "fit",
+            sa.String(length=16),
+            nullable=False,
+            server_default="cover",
+        ),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "effect",
+            sa.String(length=16),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_fit_known",
+        "slideshow_slides",
+        "fit IN ('cover','contain')",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_effect_known",
+        "slideshow_slides",
+        "effect IN ('none','ken_burns')",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0041 is not supported")

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -252,6 +252,8 @@ async def publish_composed_slide(
                                 slide.transition
                             ),
                             transition_ms=int(slide.transition_ms),
+                            fit=slide.fit,
+                            effect=slide.effect,
                         )
                     )
                 slideshow_plans[aid] = plan

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -46,13 +46,19 @@ class SlideshowSlidePlan:
     media cell renders the full slideshow set as self-contained CSS/JS
     (``cut`` / ``fade`` / ``fade_black`` / ``dissolve`` / ``push`` /
     ``wipe`` / ``zoom``).  ``transition_ms`` is the transition duration
-    (ignored for ``"cut"``).
+    (ignored for ``"cut"``).  ``fit`` is the per-slide CSS object-fit
+    (``cover`` / ``contain``); ``effect`` is the per-slide motion effect
+    (``none`` / ``ken_burns``) — both mirror the on-device manifest
+    schema 1.3 fields so an embedded slideshow reads the same as the
+    standalone one.
     """
 
     source_asset_id: uuid.UUID
     duration_ms: int
     transition: str = "cut"
     transition_ms: int = 0
+    fit: str = "cover"
+    effect: str = "none"
 
 
 @dataclass

--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -460,6 +460,8 @@ async def _render_layout_to_html(
                                 slide.transition
                             ),
                             transition_ms=int(slide.transition_ms),
+                            fit=slide.fit,
+                            effect=slide.effect,
                         )
                     )
                 slideshow_plans[aid] = plan

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -359,17 +359,31 @@ class MediaWidget(Widget):
             trans_ms = 0 if transition == "cut" else int(plan.transition_ms)
             trans_codes.append(_SS_TRANSITIONS.index(transition))
             trans_durations.append(trans_ms)
+            # Per-slide display effect (manifest schema 1.3).  ``fit`` is
+            # the CSS object-fit applied inline to this slide's media so it
+            # overrides the widget-wide ``config.object_fit`` default;
+            # ``ken_burns`` adds a slow zoom keyframe that runs while the
+            # slide is active (see ``css_out`` below).
+            fit = plan.fit if plan.fit in ("cover", "contain") else "cover"
+            fit_style = f"object-fit:{fit}"
+            kb = plan.effect == "ken_burns"
             # Per-slide resting default for the transition-duration custom
             # property the shared CSS reads.  The cycling JS overrides it
             # per-swap (and halves it for fade_black); this inline value is
-            # just a sensible default for a static t=0 snapshot.
-            slide_style = f"--cw-ss-ms:{trans_ms}ms"
+            # just a sensible default for a static t=0 snapshot.  The
+            # ``--cw-ss-kb-ms`` property spans the Ken Burns zoom across the
+            # slide's display time.
+            slide_style = (
+                f"--cw-ss-ms:{trans_ms}ms;"
+                f"--cw-ss-kb-ms:{int(plan.duration_ms)}ms"
+            )
 
             if source in ctx.sibling_asset_urls:
                 src = ctx.sibling_asset_urls[source]
                 src_escaped = _html.escape(src, quote=True)
                 inner = (
                     f'<video src="{src_escaped}" '
+                    f'style="{fit_style}" '
                     f"muted loop playsinline "
                     f'aria-label="{alt_escaped}"></video>'
                 )
@@ -389,6 +403,7 @@ class MediaWidget(Widget):
                 data_uri = f"data:{mime};base64,{b64}"
                 inner = (
                     f'<img src="{data_uri}" '
+                    f'style="{fit_style}" '
                     f'alt="{alt_escaped}" draggable="false" />'
                 )
             else:
@@ -401,7 +416,8 @@ class MediaWidget(Widget):
                     "asset_bytes nor sibling_asset_urls)"
                 )
 
-            slide_classes = f"cw-ss-slide{active} cw-ss-t-{transition}"
+            kb_class = " cw-ss-kb" if kb else ""
+            slide_classes = f"cw-ss-slide{active} cw-ss-t-{transition}{kb_class}"
             slide_html.append(
                 f'<div class="{slide_classes}" style="{slide_style}">'
                 f"{inner}</div>"
@@ -409,8 +425,10 @@ class MediaWidget(Widget):
 
         html_out = f'<div class="{css_class}">' + "".join(slide_html) + "</div>"
 
-        # Instance-scoped CSS holds only the container framing + media
-        # sizing (object-fit is per-config).  The slide-transition
+        # Instance-scoped CSS holds the container framing + media sizing.
+        # The widget-wide ``object-fit`` rule below is the default; each
+        # slideshow slide carries an inline ``object-fit`` (per-slide
+        # ``fit``, schema 1.3) that overrides it.  The slide-transition
         # mechanics live in the shared, global ``_SS_TRANSITION_CSS``
         # asset emitted below.
         css_out = (
@@ -429,6 +447,25 @@ class MediaWidget(Widget):
             f"  object-fit: {config.object_fit};\n"
             f"  object-position: center;\n"
             f"  user-select: none;\n"
+            f"}}\n"
+            # Ken Burns (manifest schema 1.3, per-slide effect='ken_burns').
+            # A slow zoom that spans the slide's display time, applied only
+            # while the slide is active so it restarts each time the slide
+            # comes back around.  The keyframe is instance-scoped so two
+            # cells on the same canvas don't share animation state.  Slides
+            # without the effect carry no ``cw-ss-kb`` class and render
+            # byte-identically to the pre-1.3 output.  The KB transform is
+            # on the media element while transitions animate the slide
+            # ``<div>``, so the two never fight over the same property.
+            f".{css_class} .cw-ss-slide.cw-ss-kb.cw-ss-active img,\n"
+            f".{css_class} .cw-ss-slide.cw-ss-kb.cw-ss-active video {{\n"
+            f"  animation: cw-kb-{instance_id} var(--cw-ss-kb-ms, 10000ms)"
+            f" ease-out forwards;\n"
+            f"  transform-origin: center center;\n"
+            f"}}\n"
+            f"@keyframes cw-kb-{instance_id} {{\n"
+            f"  from {{ transform: scale(1.0001); }}\n"
+            f"  to {{ transform: scale(1.08); }}\n"
             f"}}"
         )
 

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1860,6 +1860,8 @@ async def create_slideshow_asset(
                 play_to_end=s.play_to_end,
                 transition=s.transition,
                 transition_ms=s.transition_ms,
+                fit=s.fit,
+                effect=s.effect,
             )
         )
 
@@ -2011,6 +2013,8 @@ async def replace_slideshow_slides(
                 play_to_end=s.play_to_end,
                 transition=s.transition,
                 transition_ms=s.transition_ms,
+                fit=s.fit,
+                effect=s.effect,
             )
         )
     asset.duration_seconds = duration_seconds

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -50,6 +50,18 @@ MIN_SLIDE_TRANSITION_MS = 0
 MAX_SLIDE_TRANSITION_MS = 5000
 DEFAULT_SLIDE_TRANSITION_MS = 600
 
+# Per-slide display effects (agora#7xx).  ``fit`` maps to CSS object-fit:
+# ``cover`` fills the cell and crops overflow, ``contain`` letterboxes to
+# show the whole frame.  ``effect`` is an optional animated treatment:
+# ``none`` is a static frame, ``ken_burns`` is a slow pan/zoom.  Both are
+# rendered by the chromium player and the composed-bundle slideshow
+# renderer.  Wire IDs are short snake_case so they round-trip through DB
+# CHECK + JSON cleanly.
+SLIDE_FITS = ("cover", "contain")
+DEFAULT_SLIDE_FIT = "cover"
+SLIDE_EFFECTS = ("none", "ken_burns")
+DEFAULT_SLIDE_EFFECT = "none"
+
 
 class AssetVariantOut(BaseModel):
     model_config = {"from_attributes": True}
@@ -181,6 +193,11 @@ class SlideIn(BaseModel):
         ge=MIN_SLIDE_TRANSITION_MS,
         le=MAX_SLIDE_TRANSITION_MS,
     )
+    # Per-slide display effects.  Optional on the wire — old clients that
+    # don't send them land on ``cover`` / ``none`` which is the
+    # pre-effects behaviour.
+    fit: str = Field(DEFAULT_SLIDE_FIT)
+    effect: str = Field(DEFAULT_SLIDE_EFFECT)
 
     @field_validator("transition")
     @classmethod
@@ -189,6 +206,20 @@ class SlideIn(BaseModel):
             raise ValueError(
                 f"transition must be one of {SLIDE_TRANSITIONS}, got {v!r}"
             )
+        return v
+
+    @field_validator("fit")
+    @classmethod
+    def _validate_fit(cls, v: str) -> str:
+        if v not in SLIDE_FITS:
+            raise ValueError(f"fit must be one of {SLIDE_FITS}, got {v!r}")
+        return v
+
+    @field_validator("effect")
+    @classmethod
+    def _validate_effect(cls, v: str) -> str:
+        if v not in SLIDE_EFFECTS:
+            raise ValueError(f"effect must be one of {SLIDE_EFFECTS}, got {v!r}")
         return v
 
 
@@ -207,6 +238,8 @@ class SlideOut(BaseModel):
     play_to_end: bool
     transition: str = DEFAULT_SLIDE_TRANSITION
     transition_ms: int = DEFAULT_SLIDE_TRANSITION_MS
+    fit: str = DEFAULT_SLIDE_FIT
+    effect: str = DEFAULT_SLIDE_EFFECT
     source_asset_id: uuid.UUID
     source_filename: str
     source_asset_type: AssetType

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -86,11 +86,17 @@ CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
 #           ``slideshow_composed_v1`` capability — a slideshow containing
 #           composed members is only sent to devices that advertise it,
 #           so a 1.0/1.1 player never sees an unknown slide type.
+#   "1.3" — adds optional per-slide ``fit`` ("cover"/"contain") and
+#           ``effect`` ("none"/"ken_burns") on ``SlideDescriptor``.
+#           ``fit`` controls object-fit; ``effect`` enables a slow
+#           pan/zoom (Ken Burns) animation.  Devices that don't
+#           understand 1.3 ignore the extras and fall back to the
+#           previous cover/no-animation behaviour.
 #
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.2"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.3"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -340,6 +346,12 @@ class SlideDescriptor(BaseModel):
     # behaviour (``cut`` / 600 ms) matches the pre-versioning era.
     transition: str = "cut"
     transition_ms: int = 600
+    # Per-slide display effects (manifest schema 1.3).  Optional on the
+    # wire so v1.0–1.2 device parsers ignore them.  ``fit`` controls
+    # object-fit ("cover"/"contain"); ``effect`` enables a slow pan/zoom
+    # ("none"/"ken_burns").  Defaults match the pre-1.3 behaviour.
+    fit: str = "cover"
+    effect: str = "none"
     # Composed-slide sibling dependencies (manifest schema 1.2).  Only
     # present (non-None) when ``asset_type`` is ``"composed"``: the
     # resolved source assets (video / image / saved_stream) embedded in
@@ -380,6 +392,19 @@ class SlideDescriptor(BaseModel):
             raise ValueError(
                 f"SlideDescriptor.transition_ms must be in [0, 5000], "
                 f"got {self.transition_ms}"
+            )
+        # Keep these allow-lists in sync with cms.schemas.asset.SLIDE_FITS /
+        # SLIDE_EFFECTS and the JS shell's player allow-lists.
+        from cms.schemas.asset import SLIDE_EFFECTS, SLIDE_FITS
+        if self.fit not in SLIDE_FITS:
+            raise ValueError(
+                f"SlideDescriptor.fit must be one of {SLIDE_FITS}, "
+                f"got {self.fit!r}"
+            )
+        if self.effect not in SLIDE_EFFECTS:
+            raise ValueError(
+                f"SlideDescriptor.effect must be one of {SLIDE_EFFECTS}, "
+                f"got {self.effect!r}"
             )
         return self
 

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -95,6 +95,10 @@ class _SlidePlan:
     # column existed.
     transition: str = "cut"
     transition_ms: int = 600
+    # Per-slide display effects.  Default ``cover`` / ``none`` matches the
+    # pre-effects behaviour for slides created before the columns existed.
+    fit: str = "cover"
+    effect: str = "none"
     # Populated for ready slides only:
     download_path: Optional[str] = None  # storage path for get_device_download_url
     api_url_path: Optional[str] = None  # CMS-relative API URL for fallback
@@ -354,6 +358,8 @@ async def plan_slideshow(
             play_to_end=slide_row.play_to_end,
             transition=slide_row.transition,
             transition_ms=slide_row.transition_ms,
+            fit=slide_row.fit,
+            effect=slide_row.effect,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -450,7 +456,8 @@ def _compute_resolved_manifest_checksum(
     for s in slides:
         h.update(
             f"|{s.position}|{s.source_asset_id}|{s.checksum or ''}|"
-            f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}".encode()
+            f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}|"
+            f"{s.fit}|{s.effect}".encode()
         )
         # Fold each composed sibling's checksum so a re-transcoded sibling
         # video flips the resolved hash and prompts a device refetch.
@@ -536,6 +543,8 @@ async def build_fetch_for_slideshow(
                 play_to_end=sp.play_to_end,
                 transition=sp.transition,
                 transition_ms=sp.transition_ms,
+                fit=sp.fit,
+                effect=sp.effect,
                 siblings=wire_siblings,
             )
         )

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -223,6 +223,29 @@
     font-size: 0.72rem;
     color: #aaa;
 }
+.ssb-slot-fx {
+    display: flex;
+    gap: 0.4rem;
+    margin-top: 0.2rem;
+}
+.ssb-slot-fx-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    font-size: 0.66rem;
+    color: #888;
+    flex: 1 1 0;
+    min-width: 0;
+}
+.ssb-slot-fx-item select {
+    background: #2a2a2a;
+    color: #ddd;
+    border: 1px solid #444;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.2rem;
+    width: 100%;
+}
 
 /* Transition gap between slots */
 .ssb-gap {
@@ -690,17 +713,19 @@ function makeSlot(s, i) {
     slot.dataset.slotIndex = String(i);
 
     const isVideo = s.source_asset_type === 'video';
+    const fit = (s.fit === 'contain') ? 'contain' : 'cover';
+    const fitStyle = `object-fit:${fit};`;
     // Prefer the small thumbnail-variant if available; only fall back to
     // the full-res preview while a fresh upload's thumbnail is still
     // transcoding.
     let thumb;
     if (s.thumbnail_url) {
-        thumb = `<img class="ssb-slot-thumb" src="${s.thumbnail_url}" alt="" loading="lazy">`;
+        thumb = `<img class="ssb-slot-thumb" style="${fitStyle}" src="${s.thumbnail_url}" alt="" loading="lazy">`;
     } else {
         const previewUrl = `/api/assets/${s.source_asset_id}/preview`;
         thumb = isVideo
-            ? `<video class="ssb-slot-thumb" src="${previewUrl}" preload="metadata" muted playsinline></video>`
-            : `<img class="ssb-slot-thumb" src="${previewUrl}" alt="" loading="lazy">`;
+            ? `<video class="ssb-slot-thumb" style="${fitStyle}" src="${previewUrl}" preload="metadata" muted playsinline></video>`
+            : `<img class="ssb-slot-thumb" style="${fitStyle}" src="${previewUrl}" alt="" loading="lazy">`;
     }
     const effectiveSec = s.play_to_end && isVideo && s.source_duration_seconds
         ? s.source_duration_seconds
@@ -713,6 +738,26 @@ function makeSlot(s, i) {
                 <span>play to end</span>
             </label>`
         : '';
+
+    const fitVal = (s.fit === 'contain') ? 'contain' : 'cover';
+    const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
+    const fitEffectCtl = `
+            <div class="ssb-slot-fx">
+                <label class="ssb-slot-fx-item" title="How the slide fills the screen">
+                    <span>Fit</span>
+                    <select class="ssb-slot-fit" aria-label="Fit">
+                        <option value="cover" ${fitVal === 'cover' ? 'selected' : ''}>Fill (cover)</option>
+                        <option value="contain" ${fitVal === 'contain' ? 'selected' : ''}>Fit (contain)</option>
+                    </select>
+                </label>
+                <label class="ssb-slot-fx-item" title="Motion effect while the slide is shown">
+                    <span>Motion</span>
+                    <select class="ssb-slot-effect" aria-label="Motion effect">
+                        <option value="none" ${effectVal === 'none' ? 'selected' : ''}>None</option>
+                        <option value="ken_burns" ${effectVal === 'ken_burns' ? 'selected' : ''}>Ken Burns</option>
+                    </select>
+                </label>
+            </div>`;
 
     slot.innerHTML = `
         <div class="ssb-slot-thumb-wrap">
@@ -732,6 +777,7 @@ function makeSlot(s, i) {
                 <span style="color:#888;">s</span>
             </div>
             ${playToEndCtl}
+            ${fitEffectCtl}
         </div>`;
 
     slot.querySelector('.ssb-slot-remove').addEventListener('click', (e) => {
@@ -749,6 +795,10 @@ function makeSlot(s, i) {
     slot.querySelector('input[type=number]').addEventListener('change', (e) => updateSlideDuration(i, e.target.value));
     const pte = slot.querySelector('input[type=checkbox]');
     if (pte) pte.addEventListener('change', (e) => updateSlidePlayToEnd(i, e.target.checked));
+    const fitSel = slot.querySelector('.ssb-slot-fit');
+    if (fitSel) fitSel.addEventListener('change', (e) => updateSlideFit(i, e.target.value));
+    const effectSel = slot.querySelector('.ssb-slot-effect');
+    if (effectSel) effectSel.addEventListener('change', (e) => updateSlideEffect(i, e.target.value));
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -949,6 +999,17 @@ function updateSlidePlayToEnd(i, checked) {
     renderTimeline();
 }
 
+function updateSlideFit(i, value) {
+    slides[i].fit = (value === 'contain') ? 'contain' : 'cover';
+    markDirty();
+    renderTimeline();
+}
+
+function updateSlideEffect(i, value) {
+    slides[i].effect = (value === 'ken_burns') ? 'ken_burns' : 'none';
+    markDirty();
+}
+
 function removeSlide(i) {
     slides.splice(i, 1);
     markDirty();
@@ -976,6 +1037,10 @@ function addSlideFromAsset(assetId, atIndex) {
         // Phase 1a of agora#226 makes these editable per slide.
         transition: 'cut',
         transition_ms: 600,
+        // Per-slide display effects (manifest schema 1.3).  Default
+        // cover / none matches the pre-effects behaviour.
+        fit: 'cover',
+        effect: 'none',
         source_filename: a.display_name || a.original_filename || a.filename,
         source_asset_type: a.asset_type,
         source_duration_seconds: a.duration_seconds,
@@ -1105,6 +1170,8 @@ async function saveSlideshow(opts) {
             play_to_end: !!s.play_to_end,
             transition: s.transition || 'cut',
             transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
+            fit: s.fit || 'cover',
+            effect: s.effect || 'none',
         }));
         if (SS_EDIT_MODE) {
             const r = await fetch(`/api/assets/${SS_ASSET_ID}/slides`, {
@@ -1394,6 +1461,8 @@ window.slideshowMintDraft = async function () {
         play_to_end: !!s.play_to_end,
         transition: s.transition || 'cut',
         transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
+        fit: s.fit || 'cover',
+        effect: s.effect || 'none',
     }));
     try {
         const r = await fetch('/api/assets/slideshow', {

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -49,6 +49,19 @@ class SlideshowSlide(Base):
             "transition_ms >= 0 AND transition_ms <= 5000",
             name="ck_slideshow_slide_transition_ms_range",
         ),
+        # Per-slide display effects (agora#7xx).  ``fit`` controls how the
+        # media is scaled into the cell (object-fit); ``effect`` is an
+        # optional animated treatment (Ken Burns slow pan/zoom).  Both are
+        # validated in the Pydantic schema and re-asserted here as a guard
+        # against out-of-band INSERTs.
+        CheckConstraint(
+            "fit IN ('cover','contain')",
+            name="ck_slideshow_slide_fit_known",
+        ),
+        CheckConstraint(
+            "effect IN ('none','ken_burns')",
+            name="ck_slideshow_slide_effect_known",
+        ),
         # FK columns are not auto-indexed in Postgres; the source-delete guard
         # and ACL re-check queries scan by source_asset_id.
         Index("ix_slideshow_slides_source_asset_id", "source_asset_id"),
@@ -84,6 +97,19 @@ class SlideshowSlide(Base):
     )
     transition_ms: Mapped[int] = mapped_column(
         Integer, nullable=False, default=600, server_default="600"
+    )
+    # How the media scales into the slide cell.  ``cover`` (default) fills
+    # the frame and crops overflow; ``contain`` letterboxes to show the
+    # whole image.  Mirrors CSS object-fit.
+    fit: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="cover", server_default="cover"
+    )
+    # Optional animated treatment applied while the slide is shown.
+    # ``none`` (default) is a static frame; ``ken_burns`` is a slow
+    # pan/zoom.  Rendered by the chromium player and the composed-bundle
+    # slideshow renderer.
+    effect: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="none", server_default="none"
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -424,7 +424,7 @@ class TestSlideshowResolver:
             ss, device, "https://cms.example", db_session,
         )
         assert fetch is not None
-        assert fetch.manifest_schema_version == "1.2"
+        assert fetch.manifest_schema_version == "1.3"
         assert fetch.cycle_duration_ms == 7500
         assert fetch.started_at is not None
         assert fetch.started_at.endswith("Z")

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -149,10 +149,11 @@ class TestSlideshowV10Contract:
         """
         assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT == "1.0"
         # Phase 1b bumped LATEST to "1.1" (wall-clock fields); Phase 5
-        # composed-in-slideshow bumps it to "1.2" (composed slide
-        # descriptors + per-slide siblings).  DEFAULT stays at "1.0" —
-        # that's the "no version on the wire" fallback.
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.2"
+        # composed-in-slideshow bumped it to "1.2" (composed slide
+        # descriptors + per-slide siblings); per-slide fit/effect bumps
+        # it to "1.3".  DEFAULT stays at "1.0" — that's the "no version
+        # on the wire" fallback.
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.3"
 
     def test_forward_wall_clock_fields_are_ignored(self):
         """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to


### PR DESCRIPTION
## Slideshow feature 2/2: per-slide Fit + Ken Burns

Second of two PRs from the "top 3 slideshow features" request. (PR 1 = bulk-add + apply-duration-to-all, shipped as #787.)

Adds two new **per-slide** options to the slideshow builder:

- **Fit**: `cover` (default) or `contain` (letterbox on black)
- **Effect**: `none` (default) or `ken_burns` (slow zoom spanning the slide's display time)

### Hard requirement honored
Both effects render in the **composed-bundle** slideshow paths (composed-in-slideshow #734 and slideshow-in-media-widget #767), not just the on-device manifest. Default (`cover`/`none`) slides remain **byte-identical** to pre-1.3 output.

### Layers touched (mirrors transition/transition_ms exactly)
- Model + migration `0041` (two columns + CHECK constraints)
- Schemas (`SlideIn`/`SlideOut` + validators), persistence, resolver
- Protocol: manifest schema **1.3**; fit/effect folded into resolved checksum so devices refetch on change
- Builder UI (`slideshow_builder.html`): per-slot Fit/Effect selects
- Composed-bundle: registry/publish/render plan plumbing + `media.py` `_render_slideshow` (per-slide inline `object-fit` + instance-scoped Ken Burns `@keyframes`)

### Security
No raw config strings interpolated into baked JS — Fit via per-slide inline `object-fit` style; Ken Burns via per-slide CSS class + instance-scoped keyframes only.

### Tests
245 targeted tests green locally (resolver, schema-contract, media widget, publish, preview, builder UI, inline-JS syntax). Manifest contract pinned to 1.3.

### Follow-up
On-device **standalone** player rendering (`sslivins/agora` `player.js`) is a deferred firmware PR, matching how transitions shipped (CMS-first).

Goodwill **dev** only.
