### PR TITLE
infra: derive Postgres max_connections from replica count (dev only)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -95,6 +95,13 @@ param cmsCpu string = '1.0'
 @description('CMS container memory (must be 2× CPU, e.g. 0.5→1Gi, 1.0→2Gi, 2.0→4Gi)')
 param cmsMemory string = '2Gi'
 
+@description('Maximum number of CMS container-app replicas. Sets the autoscale ceiling AND drives the Postgres max_connections formula (postgres.bicep). Pinned to 2 today.')
+@minValue(1)
+param cmsMaxReplicas int = 2
+
+@description('When true, Bicep manages Postgres max_connections via the replica-count formula (base + perReplica*cmsMaxReplicas). When false (default, all envs except dev), max_connections stays at the B1ms default (50). Enable per-env in its .bicepparam.')
+param manageMaxConnections bool = false
+
 @description('Object ID of the Azure AD user/principal for Key Vault admin access')
 param adminPrincipalId string
 
@@ -159,6 +166,9 @@ module postgres 'modules/postgres.bicep' = {
     postgresSubnetId: networking.outputs.postgresSubnetId
     privateDnsZoneId: networking.outputs.privateDnsZoneId
     tags: tags
+    // max_connections replica-count formula (no-op unless manageMaxConnections=true).
+    manageMaxConnections: manageMaxConnections
+    cmsMaxReplicas: cmsMaxReplicas
   }
 }
 
@@ -236,6 +246,7 @@ module containerApps 'modules/containerApps.bicep' = {
     cmsImage: cmsImage
     cmsCpu: cmsCpu
     cmsMemory: cmsMemory
+    cmsMaxReplicas: cmsMaxReplicas
     cmsDatabaseUrl: databaseUrl
     cmsSecretKey: cmsSecretKey
     cmsAdminUsername: cmsAdminUsername

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -14,6 +14,9 @@ param cmsAppName string
 param cmsImage string
 param cmsCpu string = '1.0'
 param cmsMemory string = '2Gi'
+@description('Maximum number of CMS container-app replicas. Drives autoscale ceiling AND the Postgres max_connections formula in postgres.bicep (10 SQLAlchemy conns/replica). Pinned to 2 today; raise to scale out.')
+@minValue(1)
+param cmsMaxReplicas int = 2
 @secure()
 param cmsSecretKey string
 @secure()
@@ -362,7 +365,7 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 2
+        minReplicas: min(2, cmsMaxReplicas)
         // Multi-replica safe as of issue #344 completion (April 2026).
         // All singleton state has been moved to DB-backed or leader-gated
         // paths: device presence, confirmed-playing, missed-schedule state,
@@ -370,9 +373,11 @@ resource cmsApp 'Microsoft.App/containerApps@2024-03-01' = {
         // transport fan-out.  Pinned to N=2 rather than letting autoscale
         // decide so the multi-replica paths are always exercised and we
         // learn about regressions before they surface at higher scale.
-        // Next step (post-stability): lift maxReplicas and gate scaling
-        // on CPU/HTTP metrics.
-        maxReplicas: 2
+        // Next step (post-stability): lift cmsMaxReplicas and gate scaling
+        // on CPU/HTTP metrics.  The Postgres max_connections ceiling tracks
+        // this value automatically (see postgres.bicep formula), so scaling
+        // out no longer requires hand-tuning the DB.
+        maxReplicas: cmsMaxReplicas
       }
     }
   }

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -12,6 +12,25 @@ param postgresSubnetId string
 param privateDnsZoneId string
 param tags object = {}
 
+// ── max_connections management (replica-count formula) ──
+@description('When true, Bicep manages max_connections via the replica-count formula below. When false (default), max_connections is left at the B1ms default (50) and hand-tuned out of band — the historical behavior for all envs.')
+param manageMaxConnections bool = false
+@description('Maximum CMS container-app replicas (mirrors containerApps cmsMaxReplicas). Each CMS replica runs a single uvicorn process with a SQLAlchemy pool capped at pool_size+max_overflow = 10 connections.')
+@minValue(1)
+param cmsMaxReplicas int = 2
+@description('Connection budget per CMS replica used by the max_connections formula. Sized for ~10 steady pool conns/replica plus rolling-deploy overlap (old+new revision briefly co-resident), migration transients, and monitoring headroom.')
+@minValue(10)
+param connectionsPerReplica int = 35
+@description('Fixed connection reserve in the max_connections formula for the MCP app, the worker job, admin/migration sessions, and monitoring — independent of CMS replica count.')
+@minValue(0)
+param baseConnections int = 30
+
+// max_connections = baseConnections + connectionsPerReplica * cmsMaxReplicas.
+// At the current N=2 this evaluates to 30 + 35*2 = 100, matching the value
+// dev was hand-bumped to. Scaling cmsMaxReplicas auto-raises the ceiling so
+// the DB never has to be hand-tuned per replica-count change again.
+var computedMaxConnections = baseConnections + (connectionsPerReplica * cmsMaxReplicas)
+
 resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: serverName
   location: location
@@ -89,13 +108,40 @@ resource extensionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurati
   ]
 }
 
-// max_connections is intentionally left at the B1ms default (50). The
-// 2026-05-06T13-14Z Sev2 was caused by stacked active Container App
-// revisions (each pinned to minReplicas=2) blowing past the 50-slot
-// ceiling, not by genuine load. The structural fix is in publish-image.yml
-// (auto-deactivate stale revisions after promote) plus the 5+5 SQLAlchemy
-// pool cap in shared/database.py — together they bound steady-state at
-// ~30 connections.
+// max_connections management.
+//
+// Historically (and still, for any env where manageMaxConnections=false)
+// this was left at the B1ms default (50). The 2026-05-06T13-14Z Sev2 was
+// caused by stacked active Container App revisions (each pinned to
+// minReplicas=2) blowing past the 50-slot ceiling, not by genuine load.
+// The structural fix is in publish-image.yml (auto-deactivate stale
+// revisions after promote) plus the 5+5 SQLAlchemy pool cap in
+// shared/database.py — together they bound steady-state at ~30 conns.
+//
+// When manageMaxConnections=true (dev), Bicep instead pins max_connections
+// to a replica-count formula (see computedMaxConnections above) so the DB
+// ceiling tracks cmsMaxReplicas automatically and never needs hand-tuning
+// when we scale out. At the current N=2 the formula yields 100 — the value
+// dev was already bumped to — so the first managed deploy is a no-op write
+// and does NOT trigger a server restart. Note: max_connections is a STATIC
+// Postgres parameter, so any FUTURE change to the computed value (e.g.
+// raising cmsMaxReplicas) WILL require a server restart on that deploy.
+//
+// dependsOn extensionsConfig is load-bearing for the same reason sslConfig
+// chains into extensionsConfig: Azure Postgres Flexible Server serialises
+// all `configurations` writes on the server. A parallel apply loses with
+// `ServerIsBusy`. The explicit chain forces sequential apply.
+resource maxConnectionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if (manageMaxConnections) {
+  parent: postgresServer
+  name: 'max_connections'
+  properties: {
+    value: string(computedMaxConnections)
+    source: 'user-override'
+  }
+  dependsOn: [
+    extensionsConfig
+  ]
+}
 
 output serverFqdn string = postgresServer.properties.fullyQualifiedDomainName
 output serverName string = postgresServer.name

--- a/infra/parameters/goodwill-dev.bicepparam
+++ b/infra/parameters/goodwill-dev.bicepparam
@@ -57,6 +57,15 @@ param workerMemory = '2Gi'
 // here we'll flip the default for the other envs too.
 param useSyntheticHeartbeat = true
 
+// Postgres max_connections is Bicep-managed in dev via the replica-count
+// formula in postgres.bicep: max_connections = 30 + 35*cmsMaxReplicas.
+// At the current cmsMaxReplicas=2 this is 100 — exactly the value dev was
+// hand-bumped to — so enabling this is a no-op write today (no PG restart).
+// Scaling cmsMaxReplicas later auto-raises the ceiling (that deploy WILL
+// restart PG, since max_connections is a static parameter). Prod and all
+// other envs leave manageMaxConnections=false (default 50) until reviewed.
+param manageMaxConnections = true
+
 // Opt this environment into the Assistant feature backend.
 // Phase 1: dev only. Prod opts in after the dev pilot validates the
 // budget caps + approval UX.


### PR DESCRIPTION
## What

Make Postgres `max_connections` a deterministic, replica-count-driven bicep formula in **Goodwill dev only**, so we stop hand-tuning the DB ceiling every time the CMS replica count changes.

Formula (postgres.bicep):
```
max_connections = baseConnections + connectionsPerReplica * cmsMaxReplicas
                = 30 + 35 * cmsMaxReplicas
```
At the current `cmsMaxReplicas = 2` -> **100**, which is exactly the value dev was hand-bumped to during the recent connection-exhaustion incident.

## Why `connectionsPerReplica = 35` (not just the 10-conn pool)

Each CMS replica runs a single uvicorn process with a SQLAlchemy pool capped at `pool_size + max_overflow = 10`. 35/replica leaves headroom for rolling-deploy overlap (old + new revision both at maxReplicas briefly), the MCP app, the worker job, and admin/migration/monitoring sessions sharing the server.

## Restart behavior (important)

`max_connections` is a **static** Postgres parameter, so changing its *value* requires a server restart. Because the formula yields **100 at N=2 — the current live value — the first managed deploy is a no-op write and triggers NO restart.** Any **future** increase (e.g. raising `cmsMaxReplicas`) WILL restart PG on that deploy.

## Scope: dev only

All new config is gated behind `manageMaxConnections` (**default `false`**). Set `true` only in `goodwill-dev.bicepparam`. **Prod and every other env are unchanged** — they stay at the B1ms default (50), hand-tuned out of band. Raising prod's ceiling needs a reviewer-approved restart window and is intentionally out of scope.

## Changes

- `infra/modules/postgres.bicep` — 4 new params + `computedMaxConnections` var + conditional `max_connections` configuration resource, chained `dependsOn: [extensionsConfig]` (Azure serialises `configurations` writes; parallel apply loses with `ServerIsBusy`).
- `infra/modules/containerApps.bicep` — `cmsMaxReplicas` param drives the CMS scale block (`minReplicas: min(2, cmsMaxReplicas)` / `maxReplicas: cmsMaxReplicas`).
- `infra/main.bicep` — wire `cmsMaxReplicas` + `manageMaxConnections` into the postgres and containerApps module calls.
- `infra/parameters/goodwill-dev.bicepparam` — `manageMaxConnections = true`.

## Validation

- `az bicep build --file infra/main.bicep` -> exit 0 (only pre-existing BCP318 / storage-listKeys warnings; none from this change).
- Infra-only change; no app code or tests touched.
