### PR TITLE
fix(slideshow): persist per-slide fit and effect on reload

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1931,6 +1931,8 @@ async def list_slideshow_slides(
                 "play_to_end": slide.play_to_end,
                 "transition": slide.transition,
                 "transition_ms": slide.transition_ms,
+                "fit": slide.fit,
+                "effect": slide.effect,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.filename,
                 "source_asset_type": src.asset_type.value,

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1725,6 +1725,8 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                 "play_to_end": slide.play_to_end,
                 "transition": slide.transition,
                 "transition_ms": slide.transition_ms,
+                "fit": slide.fit,
+                "effect": slide.effect,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.display_name or src.original_filename or src.filename,
                 "source_asset_type": src.asset_type.value,

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -669,6 +669,110 @@ class TestSlideTransitions:
         assert ss.checksum != original_hash
 
 
+# ── Per-slide fit / effect (agora#7xx) ──
+
+
+@pytest.mark.asyncio
+class TestSlideFitEffect:
+    """Regression for the save -> reopen persistence bug: per-slide
+    ``fit`` and ``effect`` must round-trip through GET /slides. They were
+    persisted correctly but dropped from the serialized load payload, so
+    the editor silently reverted them to defaults (cover/none) on reload.
+    """
+
+    async def test_create_defaults_fit_cover_effect_none(self, client, db_session):
+        img = await _seed_image(db_session, filename="fx0.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fx0",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 1000}],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["fit"] == "cover"
+        assert slides[0]["effect"] == "none"
+
+    async def test_create_round_trips_explicit_fit_and_effect(
+        self, client, db_session
+    ):
+        img = await _seed_image(db_session, filename="fx1.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fx1",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "fit": "contain",
+                    "effect": "ken_burns",
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["fit"] == "contain"
+        assert slides[0]["effect"] == "ken_burns"
+
+    async def test_replace_round_trips_explicit_fit_and_effect(
+        self, client, db_session
+    ):
+        img = await _seed_image(db_session, filename="fx2.png", is_global=True)
+        sid = (await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fx2",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 1000}],
+            },
+        )).json()["id"]
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{
+                "source_asset_id": str(img.id),
+                "duration_ms": 1000,
+                "fit": "contain",
+                "effect": "ken_burns",
+            }]},
+        )
+        assert put.status_code == 200, put.text
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["fit"] == "contain"
+        assert slides[0]["effect"] == "ken_burns"
+
+    async def test_rejects_unknown_fit(self, client, db_session):
+        img = await _seed_image(db_session, filename="fx3.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fx3",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "fit": "squish",
+                }],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.text
+
+    async def test_rejects_unknown_effect(self, client, db_session):
+        img = await _seed_image(db_session, filename="fx4.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fx4",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "effect": "explode",
+                }],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.text
+
+
 # ── Source-delete guard ──
 
 

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -14,7 +14,10 @@ from cms.models.user import User
 pytestmark = pytest.mark.asyncio
 
 
-async def _seed_slideshow(db_session, *, name="My Show", is_global=True, slides=0):
+async def _seed_slideshow(
+    db_session, *, name="My Show", is_global=True, slides=0,
+    slide_fit="cover", slide_effect="none",
+):
     asset = Asset(
         filename=name,
         asset_type=AssetType.SLIDESHOW,
@@ -42,6 +45,8 @@ async def _seed_slideshow(db_session, *, name="My Show", is_global=True, slides=
                 position=i,
                 duration_ms=5000,
                 play_to_end=False,
+                fit=slide_fit,
+                effect=slide_effect,
             ))
     await db_session.commit()
     return asset
@@ -105,6 +110,21 @@ class TestSlideshowBuilderRoutes:
         assert "Editable" in body
         # Ensure the seeded slides are in the JSON island the page uses for state
         assert '"position": 0' in body or '"position":0' in body
+
+    async def test_edit_page_hydrates_fit_and_effect(self, client, db_session):
+        """Regression: per-slide fit/effect must survive the save -> reopen
+        round-trip. The edit-page JSON island (ss-initial-slides) is the
+        hydration source; if fit/effect are dropped here the editor silently
+        reverts them to defaults (cover/none) on reload."""
+        asset = await _seed_slideshow(
+            db_session, name="FitFx", slides=1,
+            slide_fit="contain", slide_effect="ken_burns",
+        )
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert '"fit": "contain"' in body or '"fit":"contain"' in body
+        assert '"effect": "ken_burns"' in body or '"effect":"ken_burns"' in body
 
     async def test_edit_page_wires_in_editor_rename(self, client, db_session):
         """Edit mode must persist a renamed slideshow in-editor. The /slides


### PR DESCRIPTION
Per-slide **Fit** and **Ken Burns** (effect) settings reverted to defaults (cover/none) after saving a slideshow and reopening it from the library.

## Root cause
Load-side serialization gap. The DB stored both columns correctly and both write endpoints persisted them, but two server-side slide serializers built raw dicts that omitted fit/effect:
- cms/ui.py edit-mode hydration (the reopen path rendered into the ss-initial-slides island)
- cms/routers/assets.py GET /api/assets/{id}/slides (assistant refresh path)

The editor JS then fell back to its <select> defaults, masking the loss.

## Fix
Add the two missing keys (it, ffect) to both serialized dicts.

## Tests
PR #788 shipped with no fit/effect round-trip test — that's why this slipped. Adds:
- API round-trip (create + replace) for explicit fit/effect, plus defaults and unknown-value rejection (	ests/test_slideshow_assets.py::TestSlideFitEffect)
- edit-page hydration assertion (	ests/test_slideshow_builder_ui.py::test_edit_page_hydrates_fit_and_effect)

20 targeted tests green locally. Goodwill dev only.