### PR TITLE
feat(slideshow): blur-fill backdrop fit (contain_blur) — agora#261 milestone 1

### DIFF
--- a/alembic/versions/0042_slideshow_fit_contain_blur.py
+++ b/alembic/versions/0042_slideshow_fit_contain_blur.py
@@ -1,0 +1,45 @@
+"""slideshow_slides: allow 'contain_blur' fit
+
+Slideshow feature roadmap (agora#261), milestone 1.  Widens the
+``ck_slideshow_slide_fit_known`` CHECK constraint to accept a new
+per-slide fit value ``contain_blur`` in addition to ``cover`` /
+``contain``.
+
+``contain_blur`` renders the image contained (whole frame visible)
+over a blurred, zoomed ``cover`` backdrop of the same image so the
+letterbox bars are filled rather than black.  It is additive: existing
+rows keep ``cover`` and a pre-blur device parser that doesn't recognise
+the value degrades gracefully to plain ``contain``.
+
+Mirrors the allow-list in ``cms.schemas.asset.SLIDE_FITS`` and the JS
+shell's ``KNOWN_FITS`` in ``agora/player/shell/player.js``.
+
+Revision ID: 0042
+Revises: 0041
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0042"
+down_revision = "0041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_slideshow_slide_fit_known",
+        "slideshow_slides",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_fit_known",
+        "slideshow_slides",
+        "fit IN ('cover','contain','contain_blur')",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0042 is not supported")

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -50,14 +50,18 @@ MIN_SLIDE_TRANSITION_MS = 0
 MAX_SLIDE_TRANSITION_MS = 5000
 DEFAULT_SLIDE_TRANSITION_MS = 600
 
-# Per-slide display effects (agora#7xx).  ``fit`` maps to CSS object-fit:
-# ``cover`` fills the cell and crops overflow, ``contain`` letterboxes to
-# show the whole frame.  ``effect`` is an optional animated treatment:
-# ``none`` is a static frame, ``ken_burns`` is a slow pan/zoom.  Both are
-# rendered by the chromium player and the composed-bundle slideshow
-# renderer.  Wire IDs are short snake_case so they round-trip through DB
-# CHECK + JSON cleanly.
-SLIDE_FITS = ("cover", "contain")
+# Per-slide display effects (agora#7xx, #261).  ``fit`` maps to CSS
+# object-fit: ``cover`` fills the cell and crops overflow, ``contain``
+# letterboxes to show the whole frame.  ``contain_blur`` is a contained
+# foreground over a blurred, zoomed cover backdrop of the same image so
+# the letterbox bars are filled rather than black.  ``effect`` is an
+# optional animated treatment: ``none`` is a static frame, ``ken_burns``
+# is a slow pan/zoom.  Both are rendered by the chromium player and the
+# composed-bundle slideshow renderer.  Wire IDs are short snake_case so
+# they round-trip through DB CHECK + JSON cleanly.  ``contain_blur`` is
+# additive — a pre-blur device parser that doesn't recognise it falls
+# back to plain ``contain`` (black bars), which is a graceful downgrade.
+SLIDE_FITS = ("cover", "contain", "contain_blur")
 DEFAULT_SLIDE_FIT = "cover"
 SLIDE_EFFECTS = ("none", "ken_burns")
 DEFAULT_SLIDE_EFFECT = "none"

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -728,7 +728,9 @@ function makeSlot(s, i) {
     slot.dataset.slotIndex = String(i);
 
     const isVideo = s.source_asset_type === 'video';
-    const fit = (s.fit === 'contain') ? 'contain' : 'cover';
+    // The small slot thumbnail can't render the blurred backdrop, so
+    // ``contain_blur`` previews as a plain contained image here.
+    const fit = (s.fit === 'contain' || s.fit === 'contain_blur') ? 'contain' : 'cover';
     const fitStyle = `object-fit:${fit};`;
     // Prefer the small thumbnail-variant if available; only fall back to
     // the full-res preview while a fresh upload's thumbnail is still
@@ -754,7 +756,7 @@ function makeSlot(s, i) {
             </label>`
         : '';
 
-    const fitVal = (s.fit === 'contain') ? 'contain' : 'cover';
+    const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
     const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
     const fitEffectCtl = `
             <div class="ssb-slot-fx">
@@ -763,6 +765,7 @@ function makeSlot(s, i) {
                     <select class="ssb-slot-fit" aria-label="Fit">
                         <option value="cover" ${fitVal === 'cover' ? 'selected' : ''}>Fill (cover)</option>
                         <option value="contain" ${fitVal === 'contain' ? 'selected' : ''}>Fit (contain)</option>
+                        <option value="contain_blur" ${fitVal === 'contain_blur' ? 'selected' : ''}>Fit + blur fill</option>
                     </select>
                 </label>
                 <label class="ssb-slot-fx-item" title="Motion effect while the slide is shown">
@@ -1015,7 +1018,7 @@ function updateSlidePlayToEnd(i, checked) {
 }
 
 function updateSlideFit(i, value) {
-    slides[i].fit = (value === 'contain') ? 'contain' : 'cover';
+    slides[i].fit = (value === 'contain' || value === 'contain_blur') ? value : 'cover';
     markDirty();
     renderTimeline();
 }

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -55,7 +55,7 @@ class SlideshowSlide(Base):
         # validated in the Pydantic schema and re-asserted here as a guard
         # against out-of-band INSERTs.
         CheckConstraint(
-            "fit IN ('cover','contain')",
+            "fit IN ('cover','contain','contain_blur')",
             name="ck_slideshow_slide_fit_known",
         ),
         CheckConstraint(

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -742,6 +742,24 @@ class TestSlideFitEffect:
         assert slides[0]["fit"] == "contain"
         assert slides[0]["effect"] == "ken_burns"
 
+    async def test_create_round_trips_contain_blur_fit(self, client, db_session):
+        img = await _seed_image(db_session, filename="fxblur.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fxblur",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "fit": "contain_blur",
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["fit"] == "contain_blur"
+
     async def test_rejects_unknown_fit(self, client, db_session):
         img = await _seed_image(db_session, filename="fx3.png", is_global=True)
         resp = await client.post(

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -71,6 +71,12 @@ class TestSlideshowBuilderRoutes:
         # Library filter + fetch pull composed assets alongside image/video.
         assert "'image', 'video', 'composed'" in body
 
+    async def test_new_page_offers_blur_fill_fit_option(self, client):
+        """Blur-fill fit (agora#261) must be selectable in the builder."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        assert 'value="contain_blur"' in resp.text
+
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""
         from tests.test_ui_overhaul import _create_user, _login_as


### PR DESCRIPTION
## What

First milestone of the slideshow roadmap (sslivins/agora#261): a **blur-fill backdrop** fit mode for slideshow slides.

Adds a new per-slide `fit` value `contain_blur`. The image renders *contained* (whole frame visible) over a blurred, zoomed `cover` backdrop of the same image, so letterbox bars are filled with a soft blur instead of black.

## Why additive / safe

`contain_blur` is a **new enum value on the existing `fit` field**, not a new wire field:
- No manifest schema version bump (contract test unchanged).
- `fit` is generic passthrough on firmware; a pre-blur device parser that doesn't recognise the value degrades gracefully to plain `contain` (black bars) — no hard capability gate needed.

## Changes (CMS half)

- `cms/schemas/asset.py` — `SLIDE_FITS` allow-list gains `contain_blur`. `cms/schemas/protocol.py` imports the constant, so its validation updates automatically.
- `shared/models/slideshow_slide.py` + `alembic/versions/0042_slideshow_fit_contain_blur.py` — widen the `ck_slideshow_slide_fit_known` CHECK constraint.
- `cms/templates/slideshow_builder.html` — new **"Fit + blur fill"** option; thumbnail + `fitVal` normalizers pass the value through; `updateSlideFit` accepts it.
- Tests: round-trip (`test_slideshow_assets.py`) + builder-UI option assertion (`test_slideshow_builder_ui.py`).

## Follow-up (separate PR)

Firmware render — `agora` `player/shell/player.js` (`KNOWN_FITS` + backdrop wrapper) and `player.css` (blur-fill styling) — ships next, then an agora-os image + Pi100 validation.

🤖 Generated with GitHub Copilot CLI
