### PR TITLE
docs(slideshow): expose fit/effect in MCP tools + assistant prompt

### DIFF
--- a/alembic/versions/0042_slideshow_fit_contain_blur.py
+++ b/alembic/versions/0042_slideshow_fit_contain_blur.py
@@ -1,0 +1,45 @@
+"""slideshow_slides: allow 'contain_blur' fit
+
+Slideshow feature roadmap (agora#261), milestone 1.  Widens the
+``ck_slideshow_slide_fit_known`` CHECK constraint to accept a new
+per-slide fit value ``contain_blur`` in addition to ``cover`` /
+``contain``.
+
+``contain_blur`` renders the image contained (whole frame visible)
+over a blurred, zoomed ``cover`` backdrop of the same image so the
+letterbox bars are filled rather than black.  It is additive: existing
+rows keep ``cover`` and a pre-blur device parser that doesn't recognise
+the value degrades gracefully to plain ``contain``.
+
+Mirrors the allow-list in ``cms.schemas.asset.SLIDE_FITS`` and the JS
+shell's ``KNOWN_FITS`` in ``agora/player/shell/player.js``.
+
+Revision ID: 0042
+Revises: 0041
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0042"
+down_revision = "0041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_slideshow_slide_fit_known",
+        "slideshow_slides",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_fit_known",
+        "slideshow_slides",
+        "fit IN ('cover','contain','contain_blur')",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0042 is not supported")

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -50,14 +50,18 @@ MIN_SLIDE_TRANSITION_MS = 0
 MAX_SLIDE_TRANSITION_MS = 5000
 DEFAULT_SLIDE_TRANSITION_MS = 600
 
-# Per-slide display effects (agora#7xx).  ``fit`` maps to CSS object-fit:
-# ``cover`` fills the cell and crops overflow, ``contain`` letterboxes to
-# show the whole frame.  ``effect`` is an optional animated treatment:
-# ``none`` is a static frame, ``ken_burns`` is a slow pan/zoom.  Both are
-# rendered by the chromium player and the composed-bundle slideshow
-# renderer.  Wire IDs are short snake_case so they round-trip through DB
-# CHECK + JSON cleanly.
-SLIDE_FITS = ("cover", "contain")
+# Per-slide display effects (agora#7xx, #261).  ``fit`` maps to CSS
+# object-fit: ``cover`` fills the cell and crops overflow, ``contain``
+# letterboxes to show the whole frame.  ``contain_blur`` is a contained
+# foreground over a blurred, zoomed cover backdrop of the same image so
+# the letterbox bars are filled rather than black.  ``effect`` is an
+# optional animated treatment: ``none`` is a static frame, ``ken_burns``
+# is a slow pan/zoom.  Both are rendered by the chromium player and the
+# composed-bundle slideshow renderer.  Wire IDs are short snake_case so
+# they round-trip through DB CHECK + JSON cleanly.  ``contain_blur`` is
+# additive — a pre-blur device parser that doesn't recognise it falls
+# back to plain ``contain`` (black bars), which is a graceful downgrade.
+SLIDE_FITS = ("cover", "contain", "contain_blur")
 DEFAULT_SLIDE_FIT = "cover"
 SLIDE_EFFECTS = ("none", "ken_burns")
 DEFAULT_SLIDE_EFFECT = "none"

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -161,6 +161,21 @@ Per-slide fields:
   **loop (last → first) transition**.  Set it when the operator wants
   the wrap-around to fade/dissolve instead of cutting.
 * ``transition_ms``: transition length, 0–5000 ms (default 600).
+* ``fit``: how the image/video fills the screen — one of:
+    - ``cover`` — fill the whole screen, cropping any overflow so there
+      are no bars (default).
+    - ``contain`` — show the entire frame, letterboxing with black bars
+      where the aspect ratio doesn't match the screen.
+    - ``contain_blur`` — like ``contain``, but the letterbox bars are
+      filled with a blurred, zoomed copy of the same image instead of
+      black ("blur fill" backdrop).  Use this when the operator wants
+      to see the whole image without ugly black bars.
+* ``effect``: an optional motion treatment applied while the slide is
+  on screen — one of:
+    - ``none`` — a static frame (default).
+    - ``ken_burns`` — a slow, cinematic pan-and-zoom across the image.
+  Effects render on images (and composed slides); a video slide plays
+  its own motion, so ``ken_burns`` has no visible effect there.
 
 Facts (fixed):
 * A slideshow can hold at most 50 slides.

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -728,7 +728,9 @@ function makeSlot(s, i) {
     slot.dataset.slotIndex = String(i);
 
     const isVideo = s.source_asset_type === 'video';
-    const fit = (s.fit === 'contain') ? 'contain' : 'cover';
+    // The small slot thumbnail can't render the blurred backdrop, so
+    // ``contain_blur`` previews as a plain contained image here.
+    const fit = (s.fit === 'contain' || s.fit === 'contain_blur') ? 'contain' : 'cover';
     const fitStyle = `object-fit:${fit};`;
     // Prefer the small thumbnail-variant if available; only fall back to
     // the full-res preview while a fresh upload's thumbnail is still
@@ -754,7 +756,7 @@ function makeSlot(s, i) {
             </label>`
         : '';
 
-    const fitVal = (s.fit === 'contain') ? 'contain' : 'cover';
+    const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
     const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
     const fitEffectCtl = `
             <div class="ssb-slot-fx">
@@ -763,6 +765,7 @@ function makeSlot(s, i) {
                     <select class="ssb-slot-fit" aria-label="Fit">
                         <option value="cover" ${fitVal === 'cover' ? 'selected' : ''}>Fill (cover)</option>
                         <option value="contain" ${fitVal === 'contain' ? 'selected' : ''}>Fit (contain)</option>
+                        <option value="contain_blur" ${fitVal === 'contain_blur' ? 'selected' : ''}>Fit + blur fill</option>
                     </select>
                 </label>
                 <label class="ssb-slot-fx-item" title="Motion effect while the slide is shown">
@@ -1015,7 +1018,7 @@ function updateSlidePlayToEnd(i, checked) {
 }
 
 function updateSlideFit(i, value) {
-    slides[i].fit = (value === 'contain') ? 'contain' : 'cover';
+    slides[i].fit = (value === 'contain' || value === 'contain_blur') ? value : 'cover';
     markDirty();
     renderTimeline();
 }

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -490,8 +490,12 @@ async def get_slideshow(asset_id: str) -> str:
 
     Returns ``{slideshow_id, slides}`` where each slide is
     ``{id, position, duration_ms, play_to_end, transition,
-    transition_ms, source_asset_id, source_filename,
+    transition_ms, fit, effect, source_asset_id, source_filename,
     source_asset_type, source_duration_seconds, thumbnail_url}``.
+
+    ``fit`` is one of ``cover`` / ``contain`` / ``contain_blur`` and
+    ``effect`` is one of ``none`` / ``ken_burns`` (see
+    ``set_slideshow_slides`` for their meanings).
 
     ``source_asset_id`` is the IMAGE / VIDEO / COMPOSED asset shown for
     that slide — pass these back to ``set_slideshow_slides`` to keep the
@@ -517,7 +521,7 @@ async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
     step).
 
     Each slide is ``{source_asset_id, duration_ms?, play_to_end?,
-    transition?, transition_ms?}``:
+    transition?, transition_ms?, fit?, effect?}``:
       - ``source_asset_id``: UUID of an IMAGE / VIDEO / COMPOSED asset
         (from ``list_assets`` or an existing slide's ``source_asset_id``).
       - ``duration_ms``: how long the slide shows, 500–3,600,000
@@ -528,6 +532,13 @@ async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
         ``fade_black``, ``dissolve``, ``push``, ``wipe``, ``zoom``
         (default ``cut``).
       - ``transition_ms``: transition length in ms, 0–5000 (default 600).
+      - ``fit``: how the asset fills the screen — ``cover`` (fill and
+        crop, no bars; default), ``contain`` (whole frame with black
+        letterbox bars), or ``contain_blur`` (whole frame with the bars
+        filled by a blurred zoomed copy of the image instead of black).
+      - ``effect``: optional motion — ``none`` (static; default) or
+        ``ken_burns`` (slow pan-and-zoom). Applies to image / composed
+        slides; videos play their own motion.
 
     A slideshow can hold up to 50 slides. On invalid input the call
     returns structured errors — fix and retry.

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -55,7 +55,7 @@ class SlideshowSlide(Base):
         # validated in the Pydantic schema and re-asserted here as a guard
         # against out-of-band INSERTs.
         CheckConstraint(
-            "fit IN ('cover','contain')",
+            "fit IN ('cover','contain','contain_blur')",
             name="ck_slideshow_slide_fit_known",
         ),
         CheckConstraint(

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -742,6 +742,24 @@ class TestSlideFitEffect:
         assert slides[0]["fit"] == "contain"
         assert slides[0]["effect"] == "ken_burns"
 
+    async def test_create_round_trips_contain_blur_fit(self, client, db_session):
+        img = await _seed_image(db_session, filename="fxblur.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "fxblur",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "fit": "contain_blur",
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["fit"] == "contain_blur"
+
     async def test_rejects_unknown_fit(self, client, db_session):
         img = await _seed_image(db_session, filename="fx3.png", is_global=True)
         resp = await client.post(

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -71,6 +71,12 @@ class TestSlideshowBuilderRoutes:
         # Library filter + fetch pull composed assets alongside image/video.
         assert "'image', 'video', 'composed'" in body
 
+    async def test_new_page_offers_blur_fill_fit_option(self, client):
+        """Blur-fill fit (agora#261) must be selectable in the builder."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        assert 'value="contain_blur"' in resp.text
+
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""
         from tests.test_ui_overhaul import _create_user, _login_as

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -227,6 +227,21 @@ class TestBuildSystemPrompt:
         assert "crossfade" in prompt
         assert "ask them which one" in prompt
 
+    def test_editor_prompt_documents_fit_and_effect(self):
+        """The per-slide ``fit`` (incl. blur-fill) and ``effect`` (Ken
+        Burns) options must be advertised so the assistant can set them."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        # fit values + the blur-fill option are described.
+        assert "contain_blur" in prompt
+        assert "cover" in prompt
+        # effect values incl. Ken Burns are described.
+        assert "ken_burns" in prompt
+
     def test_slideshow_mode_without_id_falls_back_to_general(self):
         from cms.services.assistant.prompts import build_system_prompt
 


### PR DESCRIPTION
## What

The REST API (SlideIn/SlideOut) and the assets router already fully support the per-slide **it** (cover / contain / contain_blur) and **ffect** (none / ken_burns) fields, and the MCP tools forward the `slides` payload verbatim — so these worked functionally already. They simply weren't **advertised** anywhere the assistant LLM reads, so it never set them.

This is a documentation/contract fix only — no new plumbing.

## Changes

- **mcp/server.py** — set_slideshow_slides and get_slideshow docstrings now document it and ffect (allowed values, defaults, plain-language descriptions; updated the slide-shape lines).
- **cms/services/assistant/prompts.py** — added it + ffect bullets to the slideshow-editor system prompt's per-slide fields section.
- **tests/test_slideshow_editor_assistant.py** — new prompt-coverage regression test asserting \contain_blur\, \cover\, and \ken_burns\ appear in the editor prompt.

## Tests

\\\
tests/test_slideshow_editor_assistant.py  16 passed
tests/test_mcp_call_api_errors.py + tests/test_slideshow_assets.py  49 passed
\\\

Goodwill **dev** only.