### PR TITLE
ci: allowlist MCP test fixtures in gitleaks scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,6 +19,16 @@ paths = [
     '''tests/nightly/\.env\.nightly''',
     '''docs/security/.*''',
     '''alembic/versions/.*''',  # schema migrations reference column names like api_key_hash
+    # MCP auth/key unit-test fixtures use fake high-entropy keys (e.g.
+    # "agora_mcp_test_key_...") that the generic-api-key rule flags. These
+    # files exist specifically to exercise secret handling with dummy values.
+    # Path-allowlisting them is durable across history; per-commit
+    # .gitleaksignore fingerprints are not (they break as new fixtures land).
+    '''tests/test_mcp_auth\.py''',
+    '''tests/test_mcp_keyvault\.py''',
+    '''tests/test_mcp_reload_key\.py''',
+    '''tests/nightly/conftest\.py''',
+    '''tests/nightly/test_09_device_commands\.py''',
 ]
 
 # Specific literal values that look secret-shaped but are either


### PR DESCRIPTION
## Problem

The weekly **Secrets Scan** scheduled run (cron `37 6 * * 1`, Mondays) fails on **every** run, while push/PR runs all pass.

## Root cause

`gitleaks/gitleaks-action@v2` scans differently by event:
- **push / pull_request** -> scans only the commits in that event range -> never reintroduces old secrets -> passes.
- **schedule / workflow_dispatch** -> scans the **entire git history** -> trips on fake test keys committed back in April -> `leaks found: 11` -> job fails.

All 11 findings are `generic-api-key` false positives in MCP secret-handling **test fixtures** (e.g. `raw_key="agora_mcp_test_key_1234567890abcdef"`) across:
- `tests/test_mcp_auth.py`
- `tests/test_mcp_keyvault.py`
- `tests/test_mcp_reload_key.py`
- `tests/nightly/conftest.py`
- `tests/nightly/test_09_device_commands.py`

The existing `.gitleaksignore` uses per-commit **fingerprints**, which never covered these and break whenever new fixtures land.

## Fix

Add those dedicated test files to `.gitleaks.toml` `[allowlist].paths`. Path-based allowlisting is durable across all history.

## Validation

Full-history scan locally (`gitleaks detect --config .gitleaks.toml --log-opts=--all`, **1624 commits**) -> **no leaks found**.
