### PR TITLE
fix: render contain_blur blur-fill in slideshow preview

### DIFF
--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -364,7 +364,22 @@ class MediaWidget(Widget):
             # overrides the widget-wide ``config.object_fit`` default;
             # ``ken_burns`` adds a slow zoom keyframe that runs while the
             # slide is active (see ``css_out`` below).
-            fit = plan.fit if plan.fit in ("cover", "contain") else "cover"
+            #
+            # ``contain_blur`` is NOT a plain object-fit value — it renders
+            # the image contained over a blurred, zoomed copy of itself
+            # (filling the letterbox bars).  Mirrors the device firmware
+            # (agora/player/shell/player.js + player.css ``fit-blur-*``):
+            # for images we emit a wrapper (backdrop + foreground); video
+            # never gets a blurred backdrop in v1 and degrades to plain
+            # ``contain``.
+            blur_fill = plan.fit == "contain_blur"
+            if plan.fit in ("cover", "contain"):
+                fit = plan.fit
+            elif blur_fill:
+                # Foreground / video fallback object-fit.
+                fit = "contain"
+            else:
+                fit = "cover"
             fit_style = f"object-fit:{fit}"
             kb = plan.effect == "ken_burns"
             # Per-slide resting default for the transition-duration custom
@@ -401,11 +416,27 @@ class MediaWidget(Widget):
                     )
                 b64 = base64.b64encode(blob).decode("ascii")
                 data_uri = f"data:{mime};base64,{b64}"
-                inner = (
-                    f'<img src="{data_uri}" '
-                    f'style="{fit_style}" '
-                    f'alt="{alt_escaped}" draggable="false" />'
-                )
+                if blur_fill:
+                    # Blur-fill: a blurred, zoomed backdrop copy fills the
+                    # letterbox bars while the foreground stays contained.
+                    # Backdrop/foreground object-fit comes from the
+                    # ``cw-ss-blur-*`` classes (see ``css_out``); the
+                    # backdrop is hidden from a11y and excluded from Ken
+                    # Burns so the static scale never gets overridden.
+                    inner = (
+                        '<div class="cw-ss-blur-wrap">'
+                        f'<img src="{data_uri}" class="cw-ss-blur-bg" '
+                        f'aria-hidden="true" draggable="false" />'
+                        f'<img src="{data_uri}" class="cw-ss-blur-fg" '
+                        f'alt="{alt_escaped}" draggable="false" />'
+                        "</div>"
+                    )
+                else:
+                    inner = (
+                        f'<img src="{data_uri}" '
+                        f'style="{fit_style}" '
+                        f'alt="{alt_escaped}" draggable="false" />'
+                    )
             else:
                 # Same contract violation as the standalone else branch:
                 # the build layer must route every per-slide source into
@@ -448,6 +479,33 @@ class MediaWidget(Widget):
             f"  object-position: center;\n"
             f"  user-select: none;\n"
             f"}}\n"
+            # Blur-fill (per-slide fit='contain_blur', image slides only).
+            # The foreground image is contained; a second copy is blown up
+            # and blurred behind it to fill the letterbox bars, mirroring
+            # the device firmware's ``fit-blur-*`` rules.  Two-class
+            # selectors outrank the base ``object-fit`` above.  scale(1.12)
+            # hides the blur halo's transparent edge.
+            f".{css_class} .cw-ss-blur-wrap {{\n"
+            f"  position: absolute;\n"
+            f"  inset: 0;\n"
+            f"  width: 100%;\n"
+            f"  height: 100%;\n"
+            f"  overflow: hidden;\n"
+            f"}}\n"
+            f".{css_class} img.cw-ss-blur-bg,\n"
+            f".{css_class} img.cw-ss-blur-fg {{\n"
+            f"  position: absolute;\n"
+            f"  top: 0;\n"
+            f"  left: 0;\n"
+            f"}}\n"
+            f".{css_class} img.cw-ss-blur-bg {{\n"
+            f"  object-fit: cover;\n"
+            f"  transform: scale(1.12);\n"
+            f"  filter: blur(24px);\n"
+            f"}}\n"
+            f".{css_class} img.cw-ss-blur-fg {{\n"
+            f"  object-fit: contain;\n"
+            f"}}\n"
             # Ken Burns (manifest schema 1.3, per-slide effect='ken_burns').
             # A slow zoom that spans the slide's display time, applied only
             # while the slide is active so it restarts each time the slide
@@ -457,7 +515,8 @@ class MediaWidget(Widget):
             # byte-identically to the pre-1.3 output.  The KB transform is
             # on the media element while transitions animate the slide
             # ``<div>``, so the two never fight over the same property.
-            f".{css_class} .cw-ss-slide.cw-ss-kb.cw-ss-active img,\n"
+            f".{css_class} .cw-ss-slide.cw-ss-kb.cw-ss-active "
+            f"img:not(.cw-ss-blur-bg),\n"
             f".{css_class} .cw-ss-slide.cw-ss-kb.cw-ss-active video {{\n"
             f"  animation: cw-kb-{instance_id} var(--cw-ss-kb-ms, 10000ms)"
             f" ease-out forwards;\n"

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -499,8 +499,86 @@ class TestMediaWidgetSlideshowBranch:
         # Shared transition CSS is always emitted (base slide mechanics).
         assert [a for a in r.static_assets if a.kind == "css"]
 
+    def test_contain_blur_image_emits_layered_blur_fill(self):
+        # Per-slide fit='contain_blur' on an IMAGE slide must render a
+        # blurred backdrop + a contained foreground (NOT a cropping
+        # object-fit:cover img), mirroring the device firmware.
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 3000, "transition": "cut",
+                   "fit": "contain_blur"}, "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssBlur", ctx=ctx)
+        # Layered wrap: a backdrop and a foreground copy of the image.
+        assert "cw-ss-blur-wrap" in r.html
+        assert 'class="cw-ss-blur-bg"' in r.html
+        assert 'class="cw-ss-blur-fg"' in r.html
+        assert 'aria-hidden="true"' in r.html
+        # The bug we are fixing: contain_blur must NOT silently crop via
+        # an inline object-fit:cover on the slide image.
+        assert "object-fit:cover" not in r.html
+        # CSS gives the backdrop cover+blur and the foreground contain.
+        assert "img.cw-ss-blur-bg" in r.css
+        assert "filter: blur(24px)" in r.css
+        assert "transform: scale(1.12)" in r.css
+        assert "img.cw-ss-blur-fg" in r.css
 
-class TestComposedCellTransitionMapper:
+    def test_contain_blur_backdrop_excluded_from_ken_burns(self):
+        # Ken Burns must zoom only the foreground; the blurred backdrop's
+        # static scale(1.12) must not be overridden by the KB keyframe
+        # (which would reveal the black wrapper edges).
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 8000, "transition": "cut",
+                   "fit": "contain_blur", "effect": "ken_burns"},
+              "img", (_TINY_PNG, "image/png"))],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssKB", ctx=ctx)
+        assert "cw-ss-kb" in r.html
+        # KB animation selector excludes the blurred backdrop image.
+        assert "img:not(.cw-ss-blur-bg)" in r.css
+
+    def test_contain_blur_video_degrades_to_plain_contain(self):
+        # Video never gets a blurred backdrop in v1 — contain_blur on a
+        # video slide must fall through to a plain object-fit:contain
+        # <video>, with no blur-fill wrapper.
+        container = uuid.uuid4()
+        s1 = uuid.uuid4()
+        cfg = MediaWidgetConfig(asset_id=container)
+        ctx = self._ss_ctx(
+            container,
+            [(s1, {"duration_ms": 4000, "transition": "cut",
+                   "fit": "contain_blur"}, "vid",
+              "/assets/videos/clip.mp4")],
+        )
+        r = MediaWidget().render_html(cfg, _cell(), "ssBV", ctx=ctx)
+        assert "<video" in r.html
+        assert "object-fit:contain" in r.html
+        assert "cw-ss-blur-wrap" not in r.html
+
+    def test_plain_fits_unchanged_no_blur_markup(self):
+        # cover/contain slides must render byte-identically to before:
+        # a single inline-object-fit img, no blur-fill classes.
+        for fit in ("cover", "contain"):
+            container = uuid.uuid4()
+            s1 = uuid.uuid4()
+            cfg = MediaWidgetConfig(asset_id=container)
+            ctx = self._ss_ctx(
+                container,
+                [(s1, {"duration_ms": 3000, "transition": "cut",
+                       "fit": fit}, "img", (_TINY_PNG, "image/png"))],
+            )
+            r = MediaWidget().render_html(cfg, _cell(), "ssPlain", ctx=ctx)
+            assert f"object-fit:{fit}" in r.html
+            assert "cw-ss-blur-wrap" not in r.html
+
+
     """``composed_cell_transition`` now passes the full validated
     repertoire through (was: collapse everything but cut -> fade)."""
 


### PR DESCRIPTION
## Problem
The slideshow `contain_blur` fit (blur-fill the letterbox bars on 16:9 images) **crops** the image in the **CMS preview player** instead of showing the image contained over a blurred backdrop.

## Root cause
The preview player is **server-rendered** via the composed pipeline, not client JS. The composed media widget slideshow render loop mapped `contain_blur` -> `cover`, so the image was cropped to fill.

## Fix
- Image `contain_blur` slides now render a layered structure: a blurred `cover` backdrop (`scale(1.12)` + `blur(24px)`) behind a `contain` foreground, mirroring the firmware `player.js`/`player.css` reference.
- Ken Burns selector excludes the backdrop (`img:not(.cw-ss-blur-bg)`) so the static-scaled backdrop never gets revealed.
- Video `contain_blur` degrades to plain `object-fit:contain` (matches firmware; no blur-fill for video in v1).
- `cover`/`contain` paths unchanged (byte-identical markup).

## Scope
**Preview-parity fix only.** The device firmware already renders `contain_blur` correctly. Slideshow per-slide rendering only; the standalone media widget config doesn't expose `contain_blur`.

## Tests
4 new tests in `tests/test_composed_media_widget.py` (layered markup, KB backdrop exclusion, video degrade, plain-fit unchanged). Full file: 47 passed.
