### PR TITLE
feat(slideshow): per-slide Ken Burns direction + deck shuffle (manifest 1.4)

### DIFF
--- a/alembic/versions/0043_slideshow_effect_direction_shuffle.py
+++ b/alembic/versions/0043_slideshow_effect_direction_shuffle.py
@@ -1,0 +1,70 @@
+"""slideshow: per-slide Ken Burns direction + deck-level shuffle
+
+Slideshow feature roadmap (agora#261), milestone 1.  Two additive
+slideshow features that share one manifest schema bump (1.3 -> 1.4):
+
+* ``slideshow_slides.effect_direction VARCHAR(16) NOT NULL DEFAULT
+  'in'`` — the Ken Burns pan/zoom direction for a slide.  Only
+  meaningful when ``effect == 'ken_burns'``.  ``in`` (default)
+  reproduces the original zoom-in animation; the other presets are
+  ``out`` / ``left`` / ``right`` / ``up`` / ``down``.  Enforced by
+  ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` and a DB-level CHECK
+  constraint, mirrored by the JS shell's allow-list in
+  ``agora/player/shell/player.js``.
+* ``assets.shuffle BOOLEAN NOT NULL DEFAULT false`` — deck-level
+  flag for SLIDESHOW assets.  When true the device plays the slide
+  order in a deterministic per-cycle shuffle.  Slideshow-only meaning
+  (like ``duration_seconds``); default false for all other asset
+  types.
+
+Both DEFAULTs preserve pre-1.4 behaviour byte-for-byte (every row
+picks up ``in`` / ``false``).  Neither column is folded into the
+structural ``Asset.checksum`` content hash; the *resolved* per-device
+manifest checksum folds ``effect_direction`` and ``shuffle`` (mirroring
+how fit/effect are handled), so the hash rolls over only on actual
+edits.
+
+Revision ID: 0043
+Revises: 0042
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0043"
+down_revision = "0042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "effect_direction",
+            sa.String(length=16),
+            nullable=False,
+            server_default="in",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_effect_direction_known",
+        "slideshow_slides",
+        "effect_direction IN ('in','out','left','right','up','down')",
+    )
+    op.add_column(
+        "assets",
+        sa.Column(
+            "shuffle",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0043 is not supported")

--- a/cms/composed/publish.py
+++ b/cms/composed/publish.py
@@ -254,6 +254,7 @@ async def publish_composed_slide(
                             transition_ms=int(slide.transition_ms),
                             fit=slide.fit,
                             effect=slide.effect,
+                            effect_direction=slide.effect_direction,
                         )
                     )
                 slideshow_plans[aid] = plan

--- a/cms/composed/registry.py
+++ b/cms/composed/registry.py
@@ -59,6 +59,7 @@ class SlideshowSlidePlan:
     transition_ms: int = 0
     fit: str = "cover"
     effect: str = "none"
+    effect_direction: str = "in"
 
 
 @dataclass

--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -462,6 +462,7 @@ async def _render_layout_to_html(
                             transition_ms=int(slide.transition_ms),
                             fit=slide.fit,
                             effect=slide.effect,
+                            effect_direction=slide.effect_direction,
                         )
                     )
                 slideshow_plans[aid] = plan

--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -75,6 +75,52 @@ _SS_TRANSITIONS: tuple[str, ...] = (
     "wipe",
     "zoom",
 )
+
+# Per-slide Ken Burns directions (manifest schema 1.4).  ``in`` is the
+# legacy zoom-in default rendered by the base ``cw-kb-{instance_id}``
+# keyframe; the other five pan in a constant-zoom direction.  Kept in
+# lockstep with ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` and the device
+# shell's directional keyframes (agora ``player.js`` / ``player.css``).
+_KB_DIRECTIONS: tuple[str, ...] = ("in", "out", "left", "right", "up", "down")
+
+# from/to transforms for each non-``in`` direction.  ``out`` reverses the
+# zoom; the pan directions hold the zoom constant and slide the framing.
+_KB_DIRECTION_TRANSFORMS: dict[str, tuple[str, str]] = {
+    "out": ("scale(1.08)", "scale(1.0001)"),
+    "left": ("scale(1.08) translate(2%, 0)", "scale(1.08) translate(-2%, 0)"),
+    "right": ("scale(1.08) translate(-2%, 0)", "scale(1.08) translate(2%, 0)"),
+    "up": ("scale(1.08) translate(0, 2%)", "scale(1.08) translate(0, -2%)"),
+    "down": ("scale(1.08) translate(0, -2%)", "scale(1.08) translate(0, 2%)"),
+}
+
+
+def _kb_direction_css(css_class: str, instance_id: str, dirs_used: set[str]) -> str:
+    """Override rules + keyframes for non-``in`` Ken Burns directions.
+
+    Emitted only for directions actually present on a slide so an
+    all-``in`` deck's CSS is byte-identical to the pre-1.4 output.  Each
+    direction swaps the ``animation-name`` on its slides' active media to
+    a direction-specific instance-scoped keyframe.
+    """
+    parts: list[str] = []
+    for direction in _KB_DIRECTIONS:
+        if direction == "in" or direction not in dirs_used:
+            continue
+        frm, to = _KB_DIRECTION_TRANSFORMS[direction]
+        kf = f"cw-kb-{direction}-{instance_id}"
+        parts.append(
+            f"\n.{css_class} .cw-ss-slide.cw-ss-kb-{direction}.cw-ss-active "
+            f"img:not(.cw-ss-blur-bg),\n"
+            f".{css_class} .cw-ss-slide.cw-ss-kb-{direction}.cw-ss-active video {{\n"
+            f"  animation-name: {kf};\n"
+            f"}}\n"
+            f"@keyframes {kf} {{\n"
+            f"  from {{ transform: {frm}; }}\n"
+            f"  to {{ transform: {to}; }}\n"
+            f"}}"
+        )
+    return "".join(parts)
+
 # The composed media cell renders slideshow transitions by PORTING the
 # device player shell's real transition mechanism — two crossfading
 # layers plus per-mode ``tx-*`` classes flipped by JS — rather than
@@ -343,6 +389,11 @@ class MediaWidget(Widget):
         durations: list[int] = []
         trans_codes: list[int] = []
         trans_durations: list[int] = []
+        # Per-slide Ken Burns directions (schema 1.4) actually used by KB
+        # slides, other than the default ``in``.  We only emit the extra
+        # directional keyframes/rules for directions that appear, so an
+        # all-``in`` deck stays byte-identical to the pre-1.4 output.
+        kb_dirs_used: set[str] = set()
 
         for idx, plan in enumerate(plans):
             source = plan.source_asset_id
@@ -448,6 +499,11 @@ class MediaWidget(Widget):
                 )
 
             kb_class = " cw-ss-kb" if kb else ""
+            if kb and plan.effect_direction in _KB_DIRECTIONS and (
+                plan.effect_direction != "in"
+            ):
+                kb_class += f" cw-ss-kb-{plan.effect_direction}"
+                kb_dirs_used.add(plan.effect_direction)
             slide_classes = f"cw-ss-slide{active} cw-ss-t-{transition}{kb_class}"
             slide_html.append(
                 f'<div class="{slide_classes}" style="{slide_style}">'
@@ -527,6 +583,15 @@ class MediaWidget(Widget):
             f"  to {{ transform: scale(1.08); }}\n"
             f"}}"
         )
+
+        # Schema 1.4 directional Ken Burns.  The base rule above bakes the
+        # default ``in`` (zoom-in) keyframe so an all-``in`` deck renders
+        # byte-identically.  For any non-``in`` direction actually used we
+        # append an override that swaps the animation-name to a
+        # direction-specific keyframe.  Kept in lockstep with the device
+        # shell's directional keyframes (agora player.js).
+        if kb_dirs_used:
+            css_out += _kb_direction_css(css_class, instance_id, kb_dirs_used)
 
         # Bake ONLY integer arrays into the runtime — never interpolate
         # raw config strings into JS.  ``types`` are indices into the JS

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1842,6 +1842,7 @@ async def create_slideshow_asset(
         url=None,
         duration_seconds=duration_seconds,
         is_global=make_global,
+        shuffle=bool(body.get("shuffle", False)),
         uploaded_by_user_id=user.id,
     )
     db.add(asset)
@@ -1933,6 +1934,7 @@ async def list_slideshow_slides(
                 "transition_ms": slide.transition_ms,
                 "fit": slide.fit,
                 "effect": slide.effect,
+                "effect_direction": slide.effect_direction,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.filename,
                 "source_asset_type": src.asset_type.value,
@@ -1940,7 +1942,11 @@ async def list_slideshow_slides(
                 "thumbnail_url": src_thumb_map.get(src.id),
             }
         )
-    payload: dict = {"slideshow_id": str(asset_id), "slides": slides_out}
+    payload: dict = {
+        "slideshow_id": str(asset_id),
+        "slides": slides_out,
+        "shuffle": bool(asset.shuffle),
+    }
     if profile_id is not None:
         from cms.services.slideshow_resolver import slideshow_readiness
         payload["readiness"] = await slideshow_readiness(asset, profile_id, db)
@@ -1982,6 +1988,12 @@ async def replace_slideshow_slides(
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid slide payload: {e}")
 
+    # Deck-level shuffle (slideshow roadmap, agora#261).  Optional on the
+    # wire — absent body key leaves the current value untouched so older UI
+    # clients that only PUT ``slides`` don't clobber it.
+    if "shuffle" in body:
+        asset.shuffle = bool(body.get("shuffle"))
+
     visible = await _visible_asset_ids(user, db)
     sources_by_id, source_groups = await _load_and_validate_slide_sources(
         slides, db, visible_ids=visible
@@ -2017,6 +2029,7 @@ async def replace_slideshow_slides(
                 transition_ms=s.transition_ms,
                 fit=s.fit,
                 effect=s.effect,
+                effect_direction=s.effect_direction,
             )
         )
     asset.duration_seconds = duration_seconds

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -66,6 +66,15 @@ DEFAULT_SLIDE_FIT = "cover"
 SLIDE_EFFECTS = ("none", "ken_burns")
 DEFAULT_SLIDE_EFFECT = "none"
 
+# Per-slide Ken Burns pan/zoom direction (slideshow roadmap, agora#261).
+# Only meaningful when ``effect == "ken_burns"``; ignored otherwise.  The
+# default ``in`` reproduces the original ``fx-ken-burns`` keyframe exactly
+# (zoom-in + pan toward the top-left), so every pre-existing ken_burns slide
+# stays byte-identical.  Additive: a device that doesn't recognise the field
+# falls back to the default ``in`` animation (graceful).
+KEN_BURNS_DIRECTIONS = ("in", "out", "left", "right", "up", "down")
+DEFAULT_KEN_BURNS_DIRECTION = "in"
+
 
 class AssetVariantOut(BaseModel):
     model_config = {"from_attributes": True}
@@ -202,6 +211,10 @@ class SlideIn(BaseModel):
     # pre-effects behaviour.
     fit: str = Field(DEFAULT_SLIDE_FIT)
     effect: str = Field(DEFAULT_SLIDE_EFFECT)
+    # Ken Burns pan/zoom direction.  Only consulted when ``effect`` is
+    # ``ken_burns``; harmless otherwise.  Default ``in`` == the original
+    # zoom-in animation, so existing slides don't change.
+    effect_direction: str = Field(DEFAULT_KEN_BURNS_DIRECTION)
 
     @field_validator("transition")
     @classmethod
@@ -226,6 +239,15 @@ class SlideIn(BaseModel):
             raise ValueError(f"effect must be one of {SLIDE_EFFECTS}, got {v!r}")
         return v
 
+    @field_validator("effect_direction")
+    @classmethod
+    def _validate_effect_direction(cls, v: str) -> str:
+        if v not in KEN_BURNS_DIRECTIONS:
+            raise ValueError(
+                f"effect_direction must be one of {KEN_BURNS_DIRECTIONS}, got {v!r}"
+            )
+        return v
+
 
 class SlideOut(BaseModel):
     """One slide in a GET /slides response.
@@ -244,6 +266,7 @@ class SlideOut(BaseModel):
     transition_ms: int = DEFAULT_SLIDE_TRANSITION_MS
     fit: str = DEFAULT_SLIDE_FIT
     effect: str = DEFAULT_SLIDE_EFFECT
+    effect_direction: str = DEFAULT_KEN_BURNS_DIRECTION
     source_asset_id: uuid.UUID
     source_filename: str
     source_asset_type: AssetType

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -92,11 +92,22 @@ CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
 #           pan/zoom (Ken Burns) animation.  Devices that don't
 #           understand 1.3 ignore the extras and fall back to the
 #           previous cover/no-animation behaviour.
+#   "1.4" — adds optional per-slide ``effect_direction``
+#           ("in"/"out"/"left"/"right"/"up"/"down") on
+#           ``SlideDescriptor`` (the Ken Burns pan/zoom direction;
+#           only meaningful when ``effect == "ken_burns"``; default
+#           "in" reproduces the 1.3 zoom-in), plus deck-level
+#           ``shuffle`` (bool) + ``shuffle_seed`` (stable int) on
+#           ``FetchAssetMessage``.  When ``shuffle`` is set the device
+#           plays a deterministic per-cycle shuffle of the slide order
+#           seeded by ``(shuffle_seed, cycle_index)``.  Devices that
+#           don't understand 1.4 ignore both and play the authored
+#           order with the default zoom-in.
 #
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.3"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.4"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -328,6 +339,20 @@ class FetchAssetMessage(BaseMessage):
     # / None means "no siblings declared" (e.g. a composed slide that is
     # all text + clock widgets, or a draft with no referenced assets).
     siblings: Optional[list["Sibling"]] = None
+    # Deck-level shuffle (manifest schema 1.4).  Only present (non-None)
+    # when ``asset_type`` is ``slideshow``.  When ``shuffle`` is true the
+    # device plays a deterministic per-cycle shuffle of the authored slide
+    # order: for cycle index N (``elapsed_ms // cycle_duration_ms``) it
+    # derives a permutation seeded by ``(shuffle_seed, N)``, so every
+    # device in the fleet shows the same order for the same cycle and a
+    # reboot resyncs mid-cycle.  ``shuffle_seed`` is a stable integer
+    # derived from the asset id (identical across re-fetches) so it does
+    # NOT perturb the resolved manifest checksum; only the ``shuffle`` bool
+    # is folded into the checksum so toggling it re-pushes.  Optional /
+    # additive — devices that don't understand 1.4 ignore both and play
+    # the authored order.
+    shuffle: Optional[bool] = None
+    shuffle_seed: Optional[int] = None
 
 
 class SlideDescriptor(BaseModel):
@@ -352,6 +377,10 @@ class SlideDescriptor(BaseModel):
     # ("none"/"ken_burns").  Defaults match the pre-1.3 behaviour.
     fit: str = "cover"
     effect: str = "none"
+    # Ken Burns pan/zoom direction (manifest schema 1.4).  Optional on the
+    # wire so v1.0–1.3 device parsers ignore it.  Only meaningful when
+    # ``effect == "ken_burns"``; default "in" reproduces the 1.3 zoom-in.
+    effect_direction: str = "in"
     # Composed-slide sibling dependencies (manifest schema 1.2).  Only
     # present (non-None) when ``asset_type`` is ``"composed"``: the
     # resolved source assets (video / image / saved_stream) embedded in
@@ -405,6 +434,15 @@ class SlideDescriptor(BaseModel):
             raise ValueError(
                 f"SlideDescriptor.effect must be one of {SLIDE_EFFECTS}, "
                 f"got {self.effect!r}"
+            )
+        # Keep this allow-list in sync with
+        # cms.schemas.asset.KEN_BURNS_DIRECTIONS and the JS shell's player
+        # allow-list.
+        from cms.schemas.asset import KEN_BURNS_DIRECTIONS
+        if self.effect_direction not in KEN_BURNS_DIRECTIONS:
+            raise ValueError(
+                f"SlideDescriptor.effect_direction must be one of "
+                f"{KEN_BURNS_DIRECTIONS}, got {self.effect_direction!r}"
             )
         return self
 

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -99,6 +99,9 @@ class _SlidePlan:
     # pre-effects behaviour for slides created before the columns existed.
     fit: str = "cover"
     effect: str = "none"
+    # Ken Burns pan/zoom direction.  Default ``in`` matches the pre-1.4
+    # zoom-in behaviour for slides created before the column existed.
+    effect_direction: str = "in"
     # Populated for ready slides only:
     download_path: Optional[str] = None  # storage path for get_device_download_url
     api_url_path: Optional[str] = None  # CMS-relative API URL for fallback
@@ -360,6 +363,7 @@ async def plan_slideshow(
             transition_ms=slide_row.transition_ms,
             fit=slide_row.fit,
             effect=slide_row.effect,
+            effect_direction=slide_row.effect_direction,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -442,7 +446,7 @@ async def plan_slideshow(
 
 
 def _compute_resolved_manifest_checksum(
-    asset_checksum: str, slides: list[_SlidePlan]
+    asset_checksum: str, slides: list[_SlidePlan], shuffle: bool = False
 ) -> str:
     """Per-device-profile resolved checksum.
 
@@ -450,14 +454,20 @@ def _compute_resolved_manifest_checksum(
     selected variant checksum (or source checksum) so that re-transcoding
     a single source variant flips the manifest hash for any device on
     that profile, prompting a refetch.
+
+    The deck-level ``shuffle`` bool is folded in so toggling it re-pushes
+    the manifest.  The companion ``shuffle_seed`` is intentionally NOT
+    folded — it's a stable function of the asset id so a re-fetch keeps
+    the same per-cycle order without perturbing the checksum.
     """
     h = hashlib.sha256()
     h.update((asset_checksum or "").encode())
+    h.update(f"|shuffle={int(bool(shuffle))}".encode())
     for s in slides:
         h.update(
             f"|{s.position}|{s.source_asset_id}|{s.checksum or ''}|"
             f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}|"
-            f"{s.fit}|{s.effect}".encode()
+            f"{s.fit}|{s.effect}|{s.effect_direction}".encode()
         )
         # Fold each composed sibling's checksum so a re-transcoded sibling
         # video flips the resolved hash and prompts a device refetch.
@@ -480,7 +490,9 @@ async def resolved_slideshow_checksum(
     plan = await plan_slideshow(asset, profile_id, db)
     if not plan.ready:
         return None
-    return _compute_resolved_manifest_checksum(asset.checksum or "", plan.slides)
+    return _compute_resolved_manifest_checksum(
+        asset.checksum or "", plan.slides, bool(asset.shuffle)
+    )
 
 
 async def build_fetch_for_slideshow(
@@ -545,15 +557,24 @@ async def build_fetch_for_slideshow(
                 transition_ms=sp.transition_ms,
                 fit=sp.fit,
                 effect=sp.effect,
+                effect_direction=sp.effect_direction,
                 siblings=wire_siblings,
             )
         )
 
-    resolved = _compute_resolved_manifest_checksum(asset.checksum or "", plan.slides)
+    resolved = _compute_resolved_manifest_checksum(
+        asset.checksum or "", plan.slides, bool(asset.shuffle)
+    )
 
     # Phase 1b of agora#226 — wall-clock anchor support.
     cycle_duration_ms = sum(sp.duration_ms for sp in plan.slides)
     started_at = _compute_cycle_anchor(cycle_duration_ms)
+
+    # Deck-level shuffle (agora#261).  Emit the bool + a stable per-asset
+    # seed so every device derives the same per-cycle permutation and a
+    # re-fetch keeps the same order (seed does not perturb the checksum).
+    shuffle = bool(asset.shuffle)
+    shuffle_seed = _shuffle_seed_for_asset(asset.id) if shuffle else None
 
     return FetchAssetMessage(
         asset_name=asset.filename,
@@ -565,7 +586,22 @@ async def build_fetch_for_slideshow(
         manifest_schema_version=SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
         cycle_duration_ms=cycle_duration_ms,
         started_at=started_at,
+        shuffle=shuffle,
+        shuffle_seed=shuffle_seed,
     )
+
+
+def _shuffle_seed_for_asset(asset_id: uuid.UUID) -> int:
+    """Stable, process-independent shuffle seed derived from the asset id.
+
+    Uses SHA-256 (not Python's salted ``hash()``) so the value is
+    identical across CMS processes, restarts, and re-fetches — the device
+    needs the same seed every time to keep a consistent per-cycle order.
+    Truncated to a 31-bit non-negative int (fits a signed 32-bit / JS
+    safe integer range comfortably).
+    """
+    digest = hashlib.sha256(asset_id.bytes).digest()
+    return int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
 
 
 def _compute_cycle_anchor(cycle_duration_ms: int) -> Optional[str]:

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -517,6 +517,17 @@
         </p>
         {% endif %}
 
+        <div class="form-group" style="margin-top:0.75rem; margin-bottom:0;">
+            <label style="display:flex; align-items:center; gap:0.5rem; cursor:pointer;"
+                   title="Play slides in a random order. The order is reshuffled each time the slideshow loops, and all devices stay in sync.">
+                <input type="checkbox" id="ss-shuffle" {% if deck_shuffle %}checked{% endif %}>
+                <span>Shuffle slide order</span>
+            </label>
+            <p class="text-muted" style="margin:0.25rem 0 0 1.6rem; font-size:0.8rem;">
+                Reshuffles every loop; devices stay in sync.
+            </p>
+        </div>
+
         <div style="margin-top:1.25rem;">
             <h3 style="margin:0 0 0.5rem; font-size:1rem; display:flex; align-items:center; gap:0.5rem;">
                 Library
@@ -614,6 +625,7 @@ const SS_MAX_SLIDES = 50;
 let slides = JSON.parse(document.getElementById('ss-initial-slides').textContent || '[]');
 let availableAssets = [];
 let selectedGroupIds = [];
+let deckShuffle = {% if deck_shuffle %}true{% else %}false{% endif %};
 
 function escapeHtml(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -758,6 +770,24 @@ function makeSlot(s, i) {
 
     const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
     const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
+    const KB_DIRS = ['in', 'out', 'left', 'right', 'up', 'down'];
+    const KB_DIR_LABELS = {
+        in: 'Zoom in', out: 'Zoom out',
+        left: 'Pan left', right: 'Pan right',
+        up: 'Pan up', down: 'Pan down',
+    };
+    const dirVal = KB_DIRS.includes(s.effect_direction) ? s.effect_direction : 'in';
+    const dirOptions = KB_DIRS
+        .map((d) => `<option value="${d}" ${dirVal === d ? 'selected' : ''}>${KB_DIR_LABELS[d]}</option>`)
+        .join('');
+    const dirCtl = `
+                <label class="ssb-slot-fx-item ssb-slot-kbdir" title="Ken Burns direction"
+                       style="${effectVal === 'ken_burns' ? '' : 'display:none;'}">
+                    <span>Direction</span>
+                    <select class="ssb-slot-effect-direction" aria-label="Ken Burns direction">
+                        ${dirOptions}
+                    </select>
+                </label>`;
     const fitEffectCtl = `
             <div class="ssb-slot-fx">
                 <label class="ssb-slot-fx-item" title="How the slide fills the screen">
@@ -775,6 +805,7 @@ function makeSlot(s, i) {
                         <option value="ken_burns" ${effectVal === 'ken_burns' ? 'selected' : ''}>Ken Burns</option>
                     </select>
                 </label>
+                ${dirCtl}
             </div>`;
 
     slot.innerHTML = `
@@ -817,6 +848,8 @@ function makeSlot(s, i) {
     if (fitSel) fitSel.addEventListener('change', (e) => updateSlideFit(i, e.target.value));
     const effectSel = slot.querySelector('.ssb-slot-effect');
     if (effectSel) effectSel.addEventListener('change', (e) => updateSlideEffect(i, e.target.value));
+    const dirSel = slot.querySelector('.ssb-slot-effect-direction');
+    if (dirSel) dirSel.addEventListener('change', (e) => updateSlideEffectDirection(i, e.target.value));
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -1026,6 +1059,15 @@ function updateSlideFit(i, value) {
 function updateSlideEffect(i, value) {
     slides[i].effect = (value === 'ken_burns') ? 'ken_burns' : 'none';
     markDirty();
+    // Re-render so the per-slide Ken Burns direction control shows/hides
+    // in step with the Motion selector.
+    renderTimeline();
+}
+
+function updateSlideEffectDirection(i, value) {
+    const KB_DIRS = ['in', 'out', 'left', 'right', 'up', 'down'];
+    slides[i].effect_direction = KB_DIRS.includes(value) ? value : 'in';
+    markDirty();
 }
 
 function removeSlide(i) {
@@ -1059,6 +1101,7 @@ function addSlideFromAsset(assetId, atIndex) {
         // cover / none matches the pre-effects behaviour.
         fit: 'cover',
         effect: 'none',
+        effect_direction: 'in',
         source_filename: a.display_name || a.original_filename || a.filename,
         source_asset_type: a.asset_type,
         source_duration_seconds: a.duration_seconds,
@@ -1262,12 +1305,13 @@ async function saveSlideshow(opts) {
             transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
             fit: s.fit || 'cover',
             effect: s.effect || 'none',
+            effect_direction: s.effect_direction || 'in',
         }));
         if (SS_EDIT_MODE) {
             const r = await fetch(`/api/assets/${SS_ASSET_ID}/slides`, {
                 method: 'PUT',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({slides: slidePayload}),
+                body: JSON.stringify({slides: slidePayload, shuffle: !!deckShuffle}),
             });
             if (!r.ok) {
                 const err = await r.json().catch(() => ({}));
@@ -1287,6 +1331,7 @@ async function saveSlideshow(opts) {
                 name,
                 slides: slidePayload,
                 group_ids: selectedGroupIds,
+                shuffle: !!deckShuffle,
             };
             const r = await fetch('/api/assets/slideshow', {
                 method: 'POST',
@@ -1377,6 +1422,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     loadAvailableAssets();
     initDirtyTracking();
+    const shuffleEl = document.getElementById('ss-shuffle');
+    if (shuffleEl) {
+        shuffleEl.addEventListener('change', (e) => {
+            deckShuffle = !!e.target.checked;
+            markDirty();
+        });
+    }
     // Safety net: if a drag ends anywhere (released outside any drop
     // zone, Esc-cancelled, etc.), make sure no gap is left "opened".
     const _clearDropActive = () => {
@@ -1512,6 +1564,11 @@ window.slideshowEditorBridge = {
         const data = await r.json().catch(() => null);
         if (!data || !Array.isArray(data.slides)) return false;
         slides = data.slides;
+        if (typeof data.shuffle === 'boolean') {
+            deckShuffle = data.shuffle;
+            const shuffleEl = document.getElementById('ss-shuffle');
+            if (shuffleEl) shuffleEl.checked = deckShuffle;
+        }
         renderTimeline();
         clearDirty();
         return true;
@@ -1553,12 +1610,13 @@ window.slideshowMintDraft = async function () {
         transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
         fit: s.fit || 'cover',
         effect: s.effect || 'none',
+        effect_direction: s.effect_direction || 'in',
     }));
     try {
         const r = await fetch('/api/assets/slideshow', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({name, slides: slidePayload, group_ids: selectedGroupIds}),
+            body: JSON.stringify({name, slides: slidePayload, group_ids: selectedGroupIds, shuffle: !!deckShuffle}),
         });
         if (!r.ok) {
             const err = await r.json().catch(() => ({}));

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1693,6 +1693,7 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
         "slides": [],
         "asset_groups": [],
         "asset_is_global": False,
+        "deck_shuffle": False,
         "assistant_enabled": assistant_on,
     }
 
@@ -1727,6 +1728,7 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                 "transition_ms": slide.transition_ms,
                 "fit": slide.fit,
                 "effect": slide.effect,
+                "effect_direction": getattr(slide, "effect_direction", "in") or "in",
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.display_name or src.original_filename or src.filename,
                 "source_asset_type": src.asset_type.value,
@@ -1744,6 +1746,7 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
             "slides": slides,
             "asset_groups": [str(g) for g in asset_group_rows],
             "asset_is_global": bool(asset.is_global),
+            "deck_shuffle": bool(getattr(asset, "shuffle", False)),
         })
     return ctx
 

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -68,6 +68,13 @@ class Asset(Base):
     # Max capture duration in seconds (for SAVED_STREAM of live sources)
     capture_duration: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Deck-level shuffle for SLIDESHOW assets (agora#261).  When true the
+    # device plays the slide order in a deterministic per-cycle shuffle.
+    # Slideshow-only meaning, like duration_seconds; default false for all
+    # other asset types.
+    shuffle: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     # Capture progress (SAVED_STREAM): 0.0-100.0 while ffmpeg runs, NULL when
     # not yet started.  Populated by worker during _capture_stream; cleared
     # on recapture.  Mirrors AssetVariant.progress so the UI can show a

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -62,6 +62,14 @@ class SlideshowSlide(Base):
             "effect IN ('none','ken_burns')",
             name="ck_slideshow_slide_effect_known",
         ),
+        # Ken Burns pan/zoom direction (agora#261).  Only meaningful when
+        # ``effect == 'ken_burns'``; the default ``in`` reproduces the
+        # original zoom-in animation.  Validated in the Pydantic schema and
+        # re-asserted here against out-of-band INSERTs.
+        CheckConstraint(
+            "effect_direction IN ('in','out','left','right','up','down')",
+            name="ck_slideshow_slide_effect_direction_known",
+        ),
         # FK columns are not auto-indexed in Postgres; the source-delete guard
         # and ACL re-check queries scan by source_asset_id.
         Index("ix_slideshow_slides_source_asset_id", "source_asset_id"),
@@ -110,6 +118,14 @@ class SlideshowSlide(Base):
     # slideshow renderer.
     effect: Mapped[str] = mapped_column(
         String(16), nullable=False, default="none", server_default="none"
+    )
+    # Ken Burns pan/zoom direction.  Only meaningful when ``effect`` is
+    # ``ken_burns``.  ``in`` (default) reproduces the original zoom-in
+    # animation; ``out``/``left``/``right``/``up``/``down`` are the other
+    # presets.  Rendered by the chromium player and the composed-bundle
+    # slideshow renderer.
+    effect_direction: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="in", server_default="in"
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -424,7 +424,7 @@ class TestSlideshowResolver:
             ss, device, "https://cms.example", db_session,
         )
         assert fetch is not None
-        assert fetch.manifest_schema_version == "1.3"
+        assert fetch.manifest_schema_version == "1.4"
         assert fetch.cycle_duration_ms == 7500
         assert fetch.started_at is not None
         assert fetch.started_at.endswith("Z")
@@ -876,3 +876,65 @@ class TestComposedCapabilityGate:
             },
         )
         assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: deck shuffle seed + resolved-checksum fold (agora#261)
+# ---------------------------------------------------------------------------
+
+class TestShuffleSeedAndChecksumFold:
+    """Unit coverage for the manifest 1.4 deck-shuffle + per-slide
+    effect_direction folding, exercised through the resolver's pure
+    helpers so we don't need the DB / variant pipeline.
+    """
+
+    def test_shuffle_seed_is_stable_and_js_safe(self) -> None:
+        from cms.services.slideshow_resolver import _shuffle_seed_for_asset
+
+        aid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        s1 = _shuffle_seed_for_asset(aid)
+        s2 = _shuffle_seed_for_asset(aid)
+        assert s1 == s2  # deterministic across calls / processes
+        assert 0 <= s1 <= 0x7FFFFFFF  # 31-bit, JS-safe non-negative int
+        # A different asset id yields a different seed (overwhelmingly likely).
+        other = _shuffle_seed_for_asset(uuid.uuid4())
+        assert isinstance(other, int)
+
+    def _plan(self, effect_direction: str = "in"):
+        from cms.services.slideshow_resolver import _SlidePlan
+
+        return _SlidePlan(
+            position=0,
+            source_asset_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+            source_filename="a.png",
+            source_asset_type=AssetType.IMAGE,
+            duration_ms=2000,
+            play_to_end=False,
+            fit="cover",
+            effect="ken_burns",
+            effect_direction=effect_direction,
+            checksum="sha-a",
+        )
+
+    def test_shuffle_bool_folds_into_checksum(self) -> None:
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum,
+        )
+
+        slides = [self._plan()]
+        off = _compute_resolved_manifest_checksum("asset-sha", slides, shuffle=False)
+        on = _compute_resolved_manifest_checksum("asset-sha", slides, shuffle=True)
+        assert off != on  # toggling shuffle re-pushes the manifest
+
+    def test_effect_direction_folds_into_checksum(self) -> None:
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum,
+        )
+
+        in_ck = _compute_resolved_manifest_checksum(
+            "asset-sha", [self._plan("in")], shuffle=False
+        )
+        left_ck = _compute_resolved_manifest_checksum(
+            "asset-sha", [self._plan("left")], shuffle=False
+        )
+        assert in_ck != left_ck  # changing KB direction invalidates the cache

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -151,9 +151,10 @@ class TestSlideshowV10Contract:
         # Phase 1b bumped LATEST to "1.1" (wall-clock fields); Phase 5
         # composed-in-slideshow bumped it to "1.2" (composed slide
         # descriptors + per-slide siblings); per-slide fit/effect bumps
-        # it to "1.3".  DEFAULT stays at "1.0" — that's the "no version
+        # it to "1.3"; per-slide effect_direction + deck shuffle bumps
+        # it to "1.4".  DEFAULT stays at "1.0" — that's the "no version
         # on the wire" fallback.
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.3"
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.4"
 
     def test_forward_wall_clock_fields_are_ignored(self):
         """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to
@@ -241,3 +242,102 @@ class TestSlideDescriptorTransitionAllowList:
                 transition="kaleidoscope",
                 transition_ms=600,
             )
+
+
+class TestSlideEffectDirectionAllowList:
+    """Schema 1.4: per-slide ``effect_direction`` (Ken Burns pan/zoom
+    direction).  The descriptor must accept every direction listed in
+    ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` and reject unknown ones,
+    mirroring the transition allow-list guard above.
+    """
+
+    @pytest.mark.parametrize(
+        "direction",
+        list(__import__("cms.schemas.asset", fromlist=["KEN_BURNS_DIRECTIONS"]).KEN_BURNS_DIRECTIONS),
+    )
+    def test_every_known_direction_accepted(self, direction: str) -> None:
+        sd = SlideDescriptor(
+            asset_name="slide.png",
+            asset_type="image",
+            download_url="/x",
+            checksum="a" * 64,
+            size_bytes=1024,
+            duration_ms=2000,
+            effect="ken_burns",
+            effect_direction=direction,
+        )
+        assert sd.effect_direction == direction
+
+    def test_unknown_direction_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            SlideDescriptor(
+                asset_name="slide.png",
+                asset_type="image",
+                download_url="/x",
+                checksum="a" * 64,
+                size_bytes=1024,
+                duration_ms=2000,
+                effect="ken_burns",
+                effect_direction="diagonal",
+            )
+
+    def test_effect_direction_defaults_to_in(self) -> None:
+        """An all-default slide serializes ``effect_direction="in"``, exactly
+        like the sibling ``fit``/``effect`` defaults (non-Optional scalars
+        that always appear on the wire since manifest 1.3).  Default ``in``
+        reproduces the pre-1.4 zoom-in keyframes byte-for-byte.
+        """
+        sd = SlideDescriptor(
+            asset_name="slide.png",
+            asset_type="image",
+            download_url="/x",
+            checksum="a" * 64,
+            size_bytes=1024,
+            duration_ms=2000,
+        )
+        assert sd.effect_direction == "in"
+        wire = json.loads(sd.model_dump_json(exclude_none=True))
+        assert wire["effect_direction"] == "in"
+
+    def test_v10_parser_ignores_effect_direction(self) -> None:
+        """A v1.0 device parser must silently drop ``effect_direction``."""
+        sd = SlideDescriptor(
+            asset_name="slide.png",
+            asset_type="image",
+            download_url="/x",
+            checksum="a" * 64,
+            size_bytes=1024,
+            duration_ms=2000,
+            effect="ken_burns",
+            effect_direction="left",
+        )
+        wire = json.loads(sd.model_dump_json())
+        assert wire["effect_direction"] == "left"
+        v10 = SlideDescriptorV10.model_validate(wire)
+        assert getattr(v10, "effect_direction", None) is None
+
+
+class TestSlideshowShuffleEnvelope:
+    """Schema 1.4: deck-level ``shuffle`` + stable ``shuffle_seed`` on the
+    slideshow ``FetchAssetMessage``.  Additive + forward-compatible.
+    """
+
+    def test_shuffle_fields_serialize_when_set(self) -> None:
+        msg = _build_cms_slideshow_msg(shuffle=True, shuffle_seed=12345)
+        wire = json.loads(msg.model_dump_json())
+        assert wire["shuffle"] is True
+        assert wire["shuffle_seed"] == 12345
+
+    def test_shuffle_fields_omitted_when_none(self) -> None:
+        msg = _build_cms_slideshow_msg()
+        wire = json.loads(msg.model_dump_json(exclude_none=True))
+        assert "shuffle" not in wire
+        assert "shuffle_seed" not in wire
+
+    def test_v10_parser_ignores_shuffle_fields(self) -> None:
+        msg = _build_cms_slideshow_msg(shuffle=True, shuffle_seed=777)
+        wire = json.loads(msg.model_dump_json())
+        v10 = FetchAssetMessageV10.model_validate(wire)
+        assert getattr(v10, "shuffle", None) is None
+        assert getattr(v10, "shuffle_seed", None) is None
+        assert v10.slides is not None and len(v10.slides) == 2


### PR DESCRIPTION
## What

Two additive slideshow features from the agora#261 roadmap (manifest schema **1.3 -> 1.4**). Both follow the established additive-schema pattern: new fields optional on the wire, allow-lists synced across CMS schema / protocol / firmware JS + DB CHECK + migration.

### 1. Per-slide Ken Burns direction
- 6 presets: `in` / `out` / `left` / `right` / `up` / `down`.
- Default `in` reproduces today's zoom-in keyframes **byte-for-byte**.
- Only meaningful when `effect == ken_burns`.
- `KEN_BURNS_DIRECTIONS` allow-list in `cms/schemas/asset.py`; `SlideDescriptor.effect_direction` validator; directional keyframe emission in `cms/composed/widgets/media.py`.

### 2. Deck-level shuffle
- Device-side **deterministic per-cycle** shuffle (devices stay in sync; reboots resync mid-cycle).
- `Asset.shuffle` bool. Resolver emits manifest `shuffle` + a **stable** `shuffle_seed` (sha256 of asset id, JS-safe 31-bit) that does **not** perturb the resolved checksum; the `shuffle` bool **is** folded into the checksum so toggling re-pushes.

## Wire / compat
- `SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST` -> `"1.4"`; default-on-wire stays `"1.0"`.
- New fields are optional/additive; v1.0-1.3 device parsers ignore them. `effect_direction` mirrors the existing non-Optional `fit`/`effect` default behaviour (always serialized, default `in`).

## Tests
- Contract suite bumped to 1.4 + new `effect_direction` allow-list + `shuffle` envelope tests.
- Resolver shuffle-seed stability (deterministic, 31-bit) + checksum-fold (shuffle bool, effect_direction) unit tests.
- Targeted suites green locally: schema contract (27), resolver (28), assets, builder UI.

## Follow-up (separate PR, needs explicit approval)
Firmware (`sslivins/agora`): mirror the 6 directional keyframes + dispatch, `show_image` direction param, deterministic per-cycle shuffle engine, manifest shuffle/shuffle_seed reading, version bump.
