### PR TITLE
feat(slideshow): diagonal Ken Burns + compass authoring popover (CMS)

### DIFF
--- a/cms/composed/widgets/media.py
+++ b/cms/composed/widgets/media.py
@@ -76,42 +76,114 @@ _SS_TRANSITIONS: tuple[str, ...] = (
     "zoom",
 )
 
-# Per-slide Ken Burns directions (manifest schema 1.4).  ``in`` is the
-# legacy zoom-in default rendered by the base ``cw-kb-{instance_id}``
-# keyframe; the other five pan in a constant-zoom direction.  Kept in
+# Per-slide Ken Burns motion (manifest schema 1.4 ``effect_direction``).
+# The token encodes two orthogonal tracks: a ZOOM (``in`` | ``out``) and an
+# optional PAN (one of 8 compass directions, incl. diagonals).  ``in``
+# (pure zoom-in) is the legacy default rendered by the base
+# ``cw-kb-{instance_id}`` keyframe; every other combo gets an
+# instance-scoped override keyframe emitted only when used.  Kept in
 # lockstep with ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` and the device
-# shell's directional keyframes (agora ``player.js`` / ``player.css``).
-_KB_DIRECTIONS: tuple[str, ...] = ("in", "out", "left", "right", "up", "down")
+# shell's ``fx-kb-*`` keyframes (agora ``player.js`` / ``player.css``).
+_KB_PANS: tuple[str, ...] = (
+    "left",
+    "right",
+    "up",
+    "down",
+    "up_left",
+    "up_right",
+    "down_left",
+    "down_right",
+)
 
-# from/to transforms for each non-``in`` direction.  ``out`` reverses the
-# zoom; the pan directions hold the zoom constant and slide the framing.
-_KB_DIRECTION_TRANSFORMS: dict[str, tuple[str, str]] = {
-    "out": ("scale(1.08)", "scale(1.0001)"),
-    "left": ("scale(1.08) translate(2%, 0)", "scale(1.08) translate(-2%, 0)"),
-    "right": ("scale(1.08) translate(-2%, 0)", "scale(1.08) translate(2%, 0)"),
-    "up": ("scale(1.08) translate(0, 2%)", "scale(1.08) translate(0, -2%)"),
-    "down": ("scale(1.08) translate(0, -2%)", "scale(1.08) translate(0, 2%)"),
+# Per-pan translate offsets ((from_x, from_y), (to_x, to_y)) in percent.
+# The image drifts TOWARD the named direction, so it animates from the
+# opposite corner to the named one.  Composed with the zoom track below.
+# Matches agora ``player.css`` exactly (incl. the ``%`` on both axes).
+_KB_PAN_OFFSETS: dict[str, tuple[tuple[int, int], tuple[int, int]]] = {
+    "left": ((2, 0), (-2, 0)),
+    "right": ((-2, 0), (2, 0)),
+    "up": ((0, 2), (0, -2)),
+    "down": ((0, -2), (0, 2)),
+    "up_left": ((2, 2), (-2, -2)),
+    "up_right": ((-2, 2), (2, -2)),
+    "down_left": ((2, -2), (-2, 2)),
+    "down_right": ((-2, -2), (2, 2)),
 }
 
 
-def _kb_direction_css(css_class: str, instance_id: str, dirs_used: set[str]) -> str:
-    """Override rules + keyframes for non-``in`` Ken Burns directions.
+def _kb_normalize(token: str) -> tuple[str, str | None]:
+    """Parse an ``effect_direction`` token into a (zoom, pan) pair.
 
-    Emitted only for directions actually present on a slide so an
-    all-``in`` deck's CSS is byte-identical to the pre-1.4 output.  Each
-    direction swaps the ``animation-name`` on its slides' active media to
-    a direction-specific instance-scoped keyframe.
+    Mirrors the device shell's ``kbDirectionClass`` parser.  Grammar:
+    ``in``/``out`` (pure zoom), ``in_<pan>``/``out_<pan>`` (zoom + pan),
+    bare ``<pan>`` (legacy 1.4 alias -> zoom-in pan).  Anything unknown or
+    absent degrades to ``("in", None)`` -- the safe pure-zoom-in default.
+    """
+    t = (token or "").strip().lower()
+    if t in ("", "in"):
+        return ("in", None)
+    if t == "out":
+        return ("out", None)
+    zoom, pan = "in", t
+    if t.startswith("in_"):
+        zoom, pan = "in", t[3:]
+    elif t.startswith("out_"):
+        zoom, pan = "out", t[4:]
+    if pan in _KB_PANS:
+        return (zoom, pan)
+    return ("in", None)
+
+
+def _kb_css_suffix(zoom: str, pan: str | None) -> str | None:
+    """CSS class/keyframe suffix for a (zoom, pan) combo.
+
+    Returns ``None`` for the base ``in`` (pure zoom-in), which uses the
+    base ``cw-kb-{instance_id}`` keyframe.  Wire tokens use underscores
+    (``out_up_right``); CSS identifiers use hyphens to mirror the device
+    shell (``cw-ss-kb-out-up-right``).
+    """
+    if zoom == "in" and pan is None:
+        return None
+    if pan is None:
+        return zoom
+    return f"{zoom}-{pan.replace('_', '-')}"
+
+
+def _kb_transform(zoom: str, pan: str | None) -> tuple[str, str]:
+    """from/to ``transform`` values for a (zoom, pan) combo."""
+    s_from, s_to = ("1.0001", "1.08") if zoom == "in" else ("1.08", "1.0001")
+    if pan is None:
+        return (f"scale({s_from})", f"scale({s_to})")
+    (fx, fy), (tx, ty) = _KB_PAN_OFFSETS[pan]
+    return (
+        f"scale({s_from}) translate({fx}%, {fy}%)",
+        f"scale({s_to}) translate({tx}%, {ty}%)",
+    )
+
+
+def _kb_direction_css(
+    css_class: str,
+    instance_id: str,
+    combos_used: set[tuple[str, str | None]],
+) -> str:
+    """Override rules + keyframes for non-base Ken Burns combos.
+
+    Emitted only for combos actually present on a slide so an all-``in``
+    deck's CSS is byte-identical to the pre-1.4 output.  Each combo swaps
+    the ``animation-name`` on its slides' active media to an
+    instance-scoped, combo-specific keyframe.
     """
     parts: list[str] = []
-    for direction in _KB_DIRECTIONS:
-        if direction == "in" or direction not in dirs_used:
+    for zoom, pan in sorted(combos_used, key=lambda c: (c[0], c[1] or "")):
+        suffix = _kb_css_suffix(zoom, pan)
+        if suffix is None:  # base ``in`` -- handled by the base rule
             continue
-        frm, to = _KB_DIRECTION_TRANSFORMS[direction]
-        kf = f"cw-kb-{direction}-{instance_id}"
+        frm, to = _kb_transform(zoom, pan)
+        kf = f"cw-kb-{suffix}-{instance_id}"
         parts.append(
-            f"\n.{css_class} .cw-ss-slide.cw-ss-kb-{direction}.cw-ss-active "
+            f"\n.{css_class} .cw-ss-slide.cw-ss-kb-{suffix}.cw-ss-active "
             f"img:not(.cw-ss-blur-bg),\n"
-            f".{css_class} .cw-ss-slide.cw-ss-kb-{direction}.cw-ss-active video {{\n"
+            f".{css_class} .cw-ss-slide.cw-ss-kb-{suffix}.cw-ss-active video {{\n"
             f"  animation-name: {kf};\n"
             f"}}\n"
             f"@keyframes {kf} {{\n"
@@ -393,7 +465,7 @@ class MediaWidget(Widget):
         # slides, other than the default ``in``.  We only emit the extra
         # directional keyframes/rules for directions that appear, so an
         # all-``in`` deck stays byte-identical to the pre-1.4 output.
-        kb_dirs_used: set[str] = set()
+        kb_combos_used: set[tuple[str, str | None]] = set()
 
         for idx, plan in enumerate(plans):
             source = plan.source_asset_id
@@ -499,11 +571,12 @@ class MediaWidget(Widget):
                 )
 
             kb_class = " cw-ss-kb" if kb else ""
-            if kb and plan.effect_direction in _KB_DIRECTIONS and (
-                plan.effect_direction != "in"
-            ):
-                kb_class += f" cw-ss-kb-{plan.effect_direction}"
-                kb_dirs_used.add(plan.effect_direction)
+            if kb:
+                zoom, pan = _kb_normalize(plan.effect_direction)
+                suffix = _kb_css_suffix(zoom, pan)
+                if suffix is not None:
+                    kb_class += f" cw-ss-kb-{suffix}"
+                    kb_combos_used.add((zoom, pan))
             slide_classes = f"cw-ss-slide{active} cw-ss-t-{transition}{kb_class}"
             slide_html.append(
                 f'<div class="{slide_classes}" style="{slide_style}">'
@@ -590,8 +663,8 @@ class MediaWidget(Widget):
         # append an override that swaps the animation-name to a
         # direction-specific keyframe.  Kept in lockstep with the device
         # shell's directional keyframes (agora player.js).
-        if kb_dirs_used:
-            css_out += _kb_direction_css(css_class, instance_id, kb_dirs_used)
+        if kb_combos_used:
+            css_out += _kb_direction_css(css_class, instance_id, kb_combos_used)
 
         # Bake ONLY integer arrays into the runtime — never interpolate
         # raw config strings into JS.  ``types`` are indices into the JS

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -68,11 +68,33 @@ DEFAULT_SLIDE_EFFECT = "none"
 
 # Per-slide Ken Burns pan/zoom direction (slideshow roadmap, agora#261).
 # Only meaningful when ``effect == "ken_burns"``; ignored otherwise.  The
-# default ``in`` reproduces the original ``fx-ken-burns`` keyframe exactly
-# (zoom-in + pan toward the top-left), so every pre-existing ken_burns slide
-# stays byte-identical.  Additive: a device that doesn't recognise the field
-# falls back to the default ``in`` animation (graceful).
-KEN_BURNS_DIRECTIONS = ("in", "out", "left", "right", "up", "down")
+# direction token encodes two orthogonal tracks: a ZOOM (``in`` | ``out``)
+# and an optional PAN (one of 8 compass directions, incl. diagonals).  The
+# default ``in`` is pure zoom-in and reproduces the original keyframe
+# exactly, so every pre-existing ken_burns slide stays byte-identical.
+# Wire grammar: ``in``/``out`` (pure zoom), ``in_<pan>``/``out_<pan>``
+# (zoom + pan), and legacy bare-pan aliases (``left`` ... render as
+# zoom-in pans, matching the device shell's ``kbDirectionClass`` parser).
+# Additive: a device that doesn't recognise the field falls back to the
+# default ``in`` animation (graceful).  Kept in lockstep with the composed
+# media widget (``cms.composed.widgets.media``) + agora player.js/css.
+_KEN_BURNS_PANS = (
+    "left",
+    "right",
+    "up",
+    "down",
+    "up_left",
+    "up_right",
+    "down_left",
+    "down_right",
+)
+KEN_BURNS_DIRECTIONS = (
+    "in",
+    "out",
+    *(f"in_{_p}" for _p in _KEN_BURNS_PANS),
+    *(f"out_{_p}" for _p in _KEN_BURNS_PANS),
+    *_KEN_BURNS_PANS,
+)
 DEFAULT_KEN_BURNS_DIRECTION = "in"
 
 

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -390,6 +390,114 @@
 }
 .ssb-trans-dur-unit { color: #888; }
 
+/* Ken Burns customize button + popover (compass + zoom + live preview) */
+.ssb-slot-kbbtn {
+    background: #2a2a2a;
+    color: #ddd;
+    border: 1px solid #444;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    padding: 0.2rem 0.4rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.3rem;
+    width: 100%;
+}
+.ssb-slot-kbbtn:hover { border-color: #1abc9c; }
+.ssb-slot-kbbtn .ssb-kbbtn-arrow { color: #1abc9c; font-size: 0.9rem; line-height: 1; }
+.ssb-kb-menu {
+    position: fixed;
+    margin: 0;
+    inset: auto;
+    background: #1f1f1f;
+    border: 1px solid #444;
+    border-radius: 0.4rem;
+    padding: 0.6rem;
+    width: 210px;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.6);
+    color: #ddd;
+}
+.ssb-kb-menu:not(:popover-open) { display: none; }
+.ssb-kb-zoom {
+    display: flex;
+    gap: 0.3rem;
+    margin-bottom: 0.55rem;
+}
+.ssb-kb-zoom button {
+    flex: 1 1 0;
+    background: #2a2a2a;
+    color: #ccc;
+    border: 1px solid #444;
+    border-radius: 0.3rem;
+    padding: 0.3rem 0;
+    font-size: 0.72rem;
+    cursor: pointer;
+}
+.ssb-kb-zoom button.sel {
+    background: rgba(22,160,133,0.28);
+    border-color: #1abc9c;
+    color: #fff;
+    font-weight: 600;
+}
+.ssb-kb-body { display: flex; gap: 0.6rem; align-items: center; }
+.ssb-kb-compass {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    gap: 3px;
+    flex: 0 0 auto;
+}
+.ssb-kb-compass button {
+    width: 26px;
+    height: 26px;
+    background: #2a2a2a;
+    color: #aaa;
+    border: 1px solid #444;
+    border-radius: 0.25rem;
+    font-size: 0.85rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.ssb-kb-compass button:hover { border-color: #1abc9c; color: #fff; }
+.ssb-kb-compass button.sel {
+    background: rgba(22,160,133,0.3);
+    border-color: #1abc9c;
+    color: #fff;
+}
+.ssb-kb-preview {
+    flex: 1 1 auto;
+    height: 84px;
+    border: 1px solid #333;
+    border-radius: 0.3rem;
+    overflow: hidden;
+    background: #000;
+    position: relative;
+}
+.ssb-kb-preview img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    will-change: transform;
+}
+.ssb-kb-preview-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #666;
+    font-size: 0.65rem;
+    text-align: center;
+    padding: 0.2rem;
+}
+
 /* Drop zone at end of timeline / when empty */
 .ssb-end {
     flex: 0 0 180px;
@@ -631,6 +739,67 @@ function escapeHtml(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 }
 
+// --- Ken Burns grammar (mirrors cms/composed/widgets/media.py) -------------
+// Orthogonal model: a zoom track (in/out) composed with an optional pan
+// (8 compass directions). Wire tokens: 'in', 'out', 'in_<pan>', 'out_<pan>',
+// and bare legacy '<pan>' (== zoom-in pan). Anything else -> 'in'.
+const KB_PANS = ['left', 'right', 'up', 'down', 'up_left', 'up_right', 'down_left', 'down_right'];
+// Per-pan offsets as [fromX, fromY, toX, toY] in percent. MUST match
+// _KB_PAN_OFFSETS in media.py / the firmware player.css keyframes.
+const KB_PAN_OFFSETS = {
+    left:       [2, 0, -2, 0],
+    right:      [-2, 0, 2, 0],
+    up:         [0, 2, 0, -2],
+    down:       [0, -2, 0, 2],
+    up_left:    [2, 2, -2, -2],
+    up_right:   [-2, 2, 2, -2],
+    down_left:  [2, -2, -2, 2],
+    down_right: [-2, -2, 2, 2],
+};
+const KB_ZOOM_SCALE = { 'in': [1.0001, 1.08], 'out': [1.08, 1.0001] };
+const KB_ARROWS = {
+    left: '←', right: '→', up: '↑', down: '↓',
+    up_left: '↖', up_right: '↗', down_left: '↙', down_right: '↘',
+};
+
+// token -> { zoom: 'in'|'out', pan: <pan>|null }
+function kbParse(token) {
+    const t = (token == null ? '' : String(token)).trim().toLowerCase();
+    if (t === 'in' || t === '') return { zoom: 'in', pan: null };
+    if (t === 'out') return { zoom: 'out', pan: null };
+    if (KB_PANS.includes(t)) return { zoom: 'in', pan: t };       // legacy bare pan
+    if (t.startsWith('out_') && KB_PANS.includes(t.slice(4))) return { zoom: 'out', pan: t.slice(4) };
+    if (t.startsWith('in_') && KB_PANS.includes(t.slice(3))) return { zoom: 'in', pan: t.slice(3) };
+    return { zoom: 'in', pan: null };
+}
+
+// { zoom, pan } -> canonical wire token
+function kbCompose(zoom, pan) {
+    const z = (zoom === 'out') ? 'out' : 'in';
+    if (!pan) return z;
+    return `${z}_${pan}`;
+}
+
+// Human summary label, e.g. "Zoom out ↗"
+function kbLabel(token) {
+    const { zoom, pan } = kbParse(token);
+    const z = zoom === 'out' ? 'Zoom out' : 'Zoom in';
+    return pan ? `${z} ${KB_ARROWS[pan]}` : z;
+}
+
+// CSS transform pair [from, to] for a token. scale() FIRST, then translate()
+// with explicit % on both axes — byte-identical to media.py / player.css.
+function kbTransforms(token) {
+    const { zoom, pan } = kbParse(token);
+    const [sFrom, sTo] = KB_ZOOM_SCALE[zoom];
+    let fx = 0, fy = 0, tx = 0, ty = 0;
+    if (pan) [fx, fy, tx, ty] = KB_PAN_OFFSETS[pan];
+    return [
+        `scale(${sFrom}) translate(${fx}%, ${fy}%)`,
+        `scale(${sTo}) translate(${tx}%, ${ty}%)`,
+    ];
+}
+
 function fmtDur(s) {
     if (!s && s !== 0) return '—';
     if (s < 60) return s.toFixed(1) + 's';
@@ -770,24 +939,19 @@ function makeSlot(s, i) {
 
     const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
     const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
-    const KB_DIRS = ['in', 'out', 'left', 'right', 'up', 'down'];
-    const KB_DIR_LABELS = {
-        in: 'Zoom in', out: 'Zoom out',
-        left: 'Pan left', right: 'Pan right',
-        up: 'Pan up', down: 'Pan down',
-    };
-    const dirVal = KB_DIRS.includes(s.effect_direction) ? s.effect_direction : 'in';
-    const dirOptions = KB_DIRS
-        .map((d) => `<option value="${d}" ${dirVal === d ? 'selected' : ''}>${KB_DIR_LABELS[d]}</option>`)
-        .join('');
+    const dirToken = (function () { const p = kbParse(s.effect_direction); return kbCompose(p.zoom, p.pan); })();
+    const kbMenuId = `ssb-kb-menu-${i}`;
     const dirCtl = `
-                <label class="ssb-slot-fx-item ssb-slot-kbdir" title="Ken Burns direction"
+                <label class="ssb-slot-fx-item ssb-slot-kbdir" title="Ken Burns motion"
                        style="${effectVal === 'ken_burns' ? '' : 'display:none;'}">
-                    <span>Direction</span>
-                    <select class="ssb-slot-effect-direction" aria-label="Ken Burns direction">
-                        ${dirOptions}
-                    </select>
-                </label>`;
+                    <span>Motion path</span>
+                    <button type="button" class="ssb-slot-kbbtn"
+                            aria-label="Customize Ken Burns motion">
+                        <span class="ssb-kbbtn-label">${escapeHtml(kbLabel(dirToken))}</span>
+                        <span class="ssb-kbbtn-arrow" aria-hidden="true">⚙</span>
+                    </button>
+                </label>
+                <div id="${kbMenuId}" class="ssb-kb-menu" popover="auto"></div>`;
     const fitEffectCtl = `
             <div class="ssb-slot-fx">
                 <label class="ssb-slot-fx-item" title="How the slide fills the screen">
@@ -848,8 +1012,13 @@ function makeSlot(s, i) {
     if (fitSel) fitSel.addEventListener('change', (e) => updateSlideFit(i, e.target.value));
     const effectSel = slot.querySelector('.ssb-slot-effect');
     if (effectSel) effectSel.addEventListener('change', (e) => updateSlideEffect(i, e.target.value));
-    const dirSel = slot.querySelector('.ssb-slot-effect-direction');
-    if (dirSel) dirSel.addEventListener('change', (e) => updateSlideEffectDirection(i, e.target.value));
+    const kbBtn = slot.querySelector('.ssb-slot-kbbtn');
+    if (kbBtn) {
+        kbBtn.addEventListener('click', () => {
+            const menu = slot.querySelector('.ssb-kb-menu');
+            if (menu) buildKbMenu(menu, kbBtn, i);
+        });
+    }
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -999,6 +1168,123 @@ function buildTransitionGap(gap, slideIdx, isLoop) {
         });
 }
 
+// Builds the Ken Burns motion popover (zoom toggle + 3x3 compass + a live
+// looping mini-preview) into ``menu`` bound to ``slides[i]``, then positions
+// and toggles it under ``btn``. The mini-preview uses the Web Animations API
+// with the EXACT same transform pair the device/composed pipeline emits
+// (kbTransforms ↔ media.py ↔ player.css) so authoring is true WYSIWYG.
+function buildKbMenu(menu, btn, i) {
+    const s = slides[i];
+    if (!s) return;
+
+    // Close any other open popover; if this one is already open, just close it.
+    const wasOpen = menu.matches(':popover-open');
+    document.querySelectorAll('.ssb-kb-menu, .ssb-trans-menu').forEach((m) => {
+        if (m !== menu) { try { m.hidePopover(); } catch {} }
+    });
+    if (wasOpen) { try { menu.hidePopover(); } catch {} return; }
+
+    const parsed = kbParse(s.effect_direction);
+    let zoom = parsed.zoom;   // 'in' | 'out'
+    let pan = parsed.pan;     // pan token | null
+
+    const thumbUrl = s.thumbnail_url
+        || (s.source_asset_id ? `/api/assets/${s.source_asset_id}/preview` : '');
+
+    // 3x3 compass; center (null) = no pan (zoom only).
+    const COMPASS = [
+        ['up_left', 'up', 'up_right'],
+        ['left', null, 'right'],
+        ['down_left', 'down', 'down_right'],
+    ];
+
+    menu.innerHTML = `
+        <div class="ssb-kb-zoom" role="group" aria-label="Zoom">
+            <button type="button" data-zoom="in">Zoom in</button>
+            <button type="button" data-zoom="out">Zoom out</button>
+        </div>
+        <div class="ssb-kb-body">
+            <div class="ssb-kb-compass" role="group" aria-label="Pan direction"></div>
+            <div class="ssb-kb-preview">${
+                thumbUrl
+                    ? `<img alt="" src="${escapeHtml(thumbUrl)}">`
+                    : '<div class="ssb-kb-preview-empty">No preview</div>'
+            }</div>
+        </div>`;
+
+    const compass = menu.querySelector('.ssb-kb-compass');
+    COMPASS.forEach((rowArr) => {
+        rowArr.forEach((p) => {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.dataset.pan = (p == null) ? '' : p;
+            b.textContent = (p == null) ? '•' : KB_ARROWS[p];
+            b.title = (p == null) ? 'No pan (zoom only)' : `Pan ${p.replace('_', '-')}`;
+            compass.appendChild(b);
+        });
+    });
+
+    const previewImg = menu.querySelector('.ssb-kb-preview img');
+    let previewAnim = null;
+
+    function refresh(persist) {
+        const token = kbCompose(zoom, pan);
+        menu.querySelectorAll('.ssb-kb-zoom button').forEach((zb) => {
+            zb.classList.toggle('sel', zb.dataset.zoom === zoom);
+        });
+        menu.querySelectorAll('.ssb-kb-compass button').forEach((cb) => {
+            cb.classList.toggle('sel', (cb.dataset.pan || null) === pan);
+        });
+        if (previewImg) {
+            if (previewAnim) { try { previewAnim.cancel(); } catch {} }
+            const [from, to] = kbTransforms(token);
+            try {
+                previewAnim = previewImg.animate(
+                    [{ transform: from }, { transform: to }],
+                    { duration: 3500, iterations: Infinity, easing: 'linear' }
+                );
+            } catch {}
+        }
+        const lbl = btn.querySelector('.ssb-kbbtn-label');
+        if (lbl) lbl.textContent = kbLabel(token);
+        if (persist && s.effect_direction !== token) {
+            s.effect_direction = token;
+            markDirty();
+        }
+    }
+
+    menu.querySelectorAll('.ssb-kb-zoom button').forEach((zb) => {
+        zb.addEventListener('click', (e) => {
+            e.stopPropagation();
+            zoom = (zb.dataset.zoom === 'out') ? 'out' : 'in';
+            refresh(true);
+        });
+    });
+    menu.querySelectorAll('.ssb-kb-compass button').forEach((cb) => {
+        cb.addEventListener('click', (e) => {
+            e.stopPropagation();
+            pan = cb.dataset.pan || null;
+            refresh(true);
+        });
+    });
+
+    // Stop the looping preview animation whenever the popover closes.
+    menu.addEventListener('toggle', (e) => {
+        if (e.newState === 'closed' && previewAnim) {
+            try { previewAnim.cancel(); } catch {}
+            previewAnim = null;
+        }
+    }, { once: true });
+
+    refresh(false);  // initialize selection + preview without persisting
+
+    const r = btn.getBoundingClientRect();
+    menu.style.top = (r.bottom + 6) + 'px';
+    menu.style.left = (r.left + r.width / 2) + 'px';
+    menu.style.transform = 'translateX(-50%)';
+    try { menu.showPopover(); } catch {}
+}
+
 function wireDropZone(el, dropIndex) {
     el.addEventListener('dragover', (e) => {
         if (!e.dataTransfer.types.includes('application/x-slideshow-source')) return;
@@ -1057,17 +1343,18 @@ function updateSlideFit(i, value) {
 }
 
 function updateSlideEffect(i, value) {
-    slides[i].effect = (value === 'ken_burns') ? 'ken_burns' : 'none';
+    const enabling = (value === 'ken_burns');
+    slides[i].effect = enabling ? 'ken_burns' : 'none';
+    // When a slide is newly switched to Ken Burns and still carries the
+    // bare default token, seed the nicer authoring default (zoom-out +
+    // up-right drift). Existing decks keep whatever token they stored.
+    if (enabling && (!slides[i].effect_direction || slides[i].effect_direction === 'in')) {
+        slides[i].effect_direction = 'out_up_right';
+    }
     markDirty();
     // Re-render so the per-slide Ken Burns direction control shows/hides
     // in step with the Motion selector.
     renderTimeline();
-}
-
-function updateSlideEffectDirection(i, value) {
-    const KB_DIRS = ['in', 'out', 'left', 'right', 'up', 'down'];
-    slides[i].effect_direction = KB_DIRS.includes(value) ? value : 'in';
-    markDirty();
 }
 
 function removeSlide(i) {

--- a/tests/test_composed_media_widget.py
+++ b/tests/test_composed_media_widget.py
@@ -597,3 +597,66 @@ class TestMediaWidgetSlideshowBranch:
         assert composed_cell_transition("bogus") == "fade"
         assert composed_cell_transition("") == "fade"
 
+
+class TestKenBurnsOrthogonalGrammar:
+    """Pins the orthogonal Ken Burns (zoom × pan) token grammar.
+
+    The CMS authoring popover (``slideshow_builder.html`` ``kbParse`` /
+    ``kbTransforms``) mirrors these helpers byte-for-byte so the live
+    mini-preview matches the device render. If these expectations move,
+    update the JS helpers in lockstep.
+    """
+
+    @pytest.mark.parametrize(
+        "token,expected",
+        [
+            ("", ("in", None)),
+            ("in", ("in", None)),
+            ("out", ("out", None)),
+            # legacy bare-pan aliases fold to a zoom-in pan
+            ("left", ("in", "left")),
+            ("down_right", ("in", "down_right")),
+            # composed tokens
+            ("in_up", ("in", "up")),
+            ("out_up_right", ("out", "up_right")),
+            ("out_down_left", ("out", "down_left")),
+            # garbage degrades to the safe pure-zoom-in default
+            ("diagonal", ("in", None)),
+            ("out_sideways", ("in", None)),
+        ],
+    )
+    def test_normalize(self, token, expected):
+        from cms.composed.widgets.media import _kb_normalize
+
+        assert _kb_normalize(token) == expected
+
+    def test_transform_pure_zoom(self):
+        from cms.composed.widgets.media import _kb_transform
+
+        assert _kb_transform("in", None) == ("scale(1.0001)", "scale(1.08)")
+        assert _kb_transform("out", None) == ("scale(1.08)", "scale(1.0001)")
+
+    def test_transform_zoom_out_up_right(self):
+        # The new authoring default: zoom-out drifting toward the
+        # up-right corner. Both axes carry an explicit ``%``.
+        from cms.composed.widgets.media import _kb_transform
+
+        assert _kb_transform("out", "up_right") == (
+            "scale(1.08) translate(-2%, 2%)",
+            "scale(1.0001) translate(2%, -2%)",
+        )
+
+    def test_transform_diagonals_are_corner_to_corner(self):
+        from cms.composed.widgets.media import _kb_transform
+
+        frm, to = _kb_transform("in", "down_left")
+        assert frm == "scale(1.0001) translate(2%, -2%)"
+        assert to == "scale(1.08) translate(-2%, 2%)"
+
+    def test_out_up_right_is_an_allowed_wire_token(self):
+        # The authoring default must survive schema validation.
+        from cms.schemas.asset import KEN_BURNS_DIRECTIONS
+
+        assert "out_up_right" in KEN_BURNS_DIRECTIONS
+
+


### PR DESCRIPTION
## What

CMS side of the diagonal Ken Burns + compass-popover slideshow feature.
The firmware half already shipped (agora PR #263 → APT firmware
1.11.108; agora-os v1.0.13). This makes the **CMS builder Preview and
the device render pixel-identically** for the new orthogonal KB model.

The model composes two orthogonal tracks:
- **zoom**: `in` | `out`
- **pan** (optional): 8 compass directions incl. diagonals
  (`up_right`, `down_left`, …) or none ("zoom only")

The old 6-token direction `<select>` is replaced by a **Customize**
button that opens a native popover: zoom in/out toggle + 3×3 compass +
a live WAAPI mini-preview driven by the exact transform pair the device
emits.

## Changes

- **`cms/schemas/asset.py`** — `KEN_BURNS_DIRECTIONS` expanded to **26
  tokens** (`in`/`out`, `in_<pan>`/`out_<pan>`, legacy bare-pan
  aliases). **Schema stays 1.4 — no version bump.**
- **`cms/composed/widgets/media.py`** — orthogonal `_kb_normalize` /
  `_kb_transform` canonical render. Transform order `scale()` then
  `translate()`; per-pan offsets mirror the agora player.css byte-for-byte.
- **`cms/templates/slideshow_builder.html`** — KB grammar JS helpers
  (`kbParse`/`kbCompose`/`kbLabel`/`kbTransforms`) mirroring `media.py`;
  Customize button + `buildKbMenu` popover; new-slide authoring default
  `out_up_right`; removed the dead direction `<select>` + 6-token list.
- **`tests/test_composed_media_widget.py`** — 14 new orthogonal-grammar
  tests (diagonals, legacy aliases, new default).

## Visual changes to review

1. Base `in` now renders **pure zoom-in** (was zoom-in + top-left pan).
2. Legacy 1.4 constant-zoom pans now re-render as **zoom-in pans**.
3. New authoring default is **`out_up_right`** (zoom-out + up-right
   drift) — applies to **new slides only**; existing decks keep their
   stored token; schema/firmware default stays `in`.

## Parity / safety

- JS preview helpers verified byte-identical to `media.py` offsets,
  scale values (1.0001 / 1.08), and transform order.
- Firmware parity: agora-os v1.0.13.
- Targeted suites green locally (media widget 61, schema contract,
  builder UI, + 14 new grammar tests).
