### PR TITLE
Fix Ken Burns save 500 + lenient effect_direction parsing

### DIFF
--- a/alembic/versions/0044_slideshow_effect_direction_full_grammar.py
+++ b/alembic/versions/0044_slideshow_effect_direction_full_grammar.py
@@ -1,0 +1,78 @@
+"""slideshow: widen Ken Burns effect_direction CHECK to full grammar
+
+The Ken Burns authoring UI (slideshow builder) emits the full direction
+grammar — a ZOOM (``in``/``out``) plus an optional PAN over 8 compass
+directions including diagonals, e.g. ``out_up_right`` (which is now the
+authoring default for a new ken_burns slide).  The Pydantic schema
+(``cms.schemas.asset.KEN_BURNS_DIRECTIONS``) and the JS player shell have
+allowed this full set since agora#261, but the DB CHECK constraint
+created in migration 0043 only permitted the original six tokens
+``('in','out','left','right','up','down')``.
+
+As a result, saving a slide with any diagonal or zoom+pan direction
+passed Pydantic validation but violated ``ck_slideshow_slide_effect_
+direction_known`` on INSERT/UPDATE, surfacing as an HTTP 500
+(IntegrityError) — i.e. *every* Ken Burns save failed once the UI shipped
+the new default.  This migration drops and recreates the constraint with
+the full 26-token grammar so the DB guard matches the schema.
+
+Additive / non-destructive: the new allowed set is a strict superset of
+the old one, so no existing row can violate it and no data migration is
+needed.  ``VARCHAR(16)`` already accommodates the longest token
+(``out_down_right`` = 14 chars).
+
+Revision ID: 0044
+Revises: 0043
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0044"
+down_revision = "0043"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "ck_slideshow_slide_effect_direction_known"
+
+# Canonical Ken Burns direction grammar.  Frozen copy of
+# ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` (and the matching tuple in
+# ``shared.models.slideshow_slide``) as of this revision — migrations must
+# be self-contained and must not import live app code, so the list is
+# materialised here rather than imported.
+_PANS = (
+    "left",
+    "right",
+    "up",
+    "down",
+    "up_left",
+    "up_right",
+    "down_left",
+    "down_right",
+)
+_DIRECTIONS = (
+    "in",
+    "out",
+    *(f"in_{_p}" for _p in _PANS),
+    *(f"out_{_p}" for _p in _PANS),
+    *_PANS,
+)
+_NEW_LIST = ",".join(f"'{_d}'" for _d in _DIRECTIONS)
+_OLD_LIST = "'in','out','left','right','up','down'"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, "slideshow_slides", type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        "slideshow_slides",
+        f"effect_direction IN ({_NEW_LIST})",
+    )
+
+
+def downgrade() -> None:
+    # Reverting would re-narrow the allowed set; any row written with a
+    # diagonal/zoom+pan direction while 0044 was applied would then violate
+    # the constraint.  Mirror 0043's stance and refuse to downgrade.
+    raise NotImplementedError("downgrade of 0044 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1863,6 +1863,7 @@ async def create_slideshow_asset(
                 transition_ms=s.transition_ms,
                 fit=s.fit,
                 effect=s.effect,
+                effect_direction=s.effect_direction,
             )
         )
 

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -98,6 +98,69 @@ KEN_BURNS_DIRECTIONS = (
 DEFAULT_KEN_BURNS_DIRECTION = "in"
 
 
+# Filler words that may appear when a human (or an LLM relaying a human
+# request) describes a direction, e.g. "zoom out going right-down".
+_KEN_BURNS_FILLER_WORDS = frozenset(
+    {"zoom", "pan", "and", "going", "go", "to", "the", "then", "motion", "drift"}
+)
+
+
+def normalize_effect_direction(value: str) -> str:
+    """Best-effort canonicalisation of a Ken Burns direction token.
+
+    The canonical grammar is ZOOM (``in``/``out``) + an optional PAN, with
+    diagonals written vertical-first (``out_down_right``).  Humans — and the
+    assistant relaying them — naturally write these in any order and with any
+    separator: ``"out-right-down"``, ``"zoom out right down"``,
+    ``"right_down"`` all mean ``out_down_right`` (or ``down_right``).
+
+    This collapses separators (``-``/space/``/``/``+`` → ``_``), drops filler
+    words, and reorders the pan components so order never matters.  If the
+    input can be mapped onto a canonical token it returns that token;
+    otherwise it returns ``value`` unchanged so the caller's membership check
+    raises the usual descriptive error.
+    """
+    if not isinstance(value, str):
+        return value
+    raw = value.strip().lower()
+    if raw in KEN_BURNS_DIRECTIONS:
+        return raw
+    for sep in ("-", " ", "/", "+", ","):
+        raw = raw.replace(sep, "_")
+    parts = [p for p in raw.split("_") if p and p not in _KEN_BURNS_FILLER_WORDS]
+
+    zoom: str | None = None
+    vert: list[str] = []
+    horiz: list[str] = []
+    for p in parts:
+        if p in ("in", "out"):
+            if zoom is not None and zoom != p:
+                return value  # contradictory zoom (e.g. "in_out")
+            zoom = p
+        elif p in ("up", "down"):
+            if p not in vert:
+                vert.append(p)
+        elif p in ("left", "right"):
+            if p not in horiz:
+                horiz.append(p)
+        else:
+            return value  # unknown token — let the validator reject it
+
+    if len(vert) > 1 or len(horiz) > 1:
+        return value  # e.g. "up_down" / "left_right" — not a valid pan
+    pan = "_".join(vert + horiz)  # vertical-first, matching the canonical set
+
+    if zoom and pan:
+        candidate = f"{zoom}_{pan}"
+    elif zoom:
+        candidate = zoom
+    elif pan:
+        candidate = pan  # legacy bare-pan alias (zoom-in pan)
+    else:
+        return value
+    return candidate if candidate in KEN_BURNS_DIRECTIONS else value
+
+
 class AssetVariantOut(BaseModel):
     model_config = {"from_attributes": True}
 
@@ -264,6 +327,7 @@ class SlideIn(BaseModel):
     @field_validator("effect_direction")
     @classmethod
     def _validate_effect_direction(cls, v: str) -> str:
+        v = normalize_effect_direction(v)
         if v not in KEN_BURNS_DIRECTIONS:
             raise ValueError(
                 f"effect_direction must be one of {KEN_BURNS_DIRECTIONS}, got {v!r}"

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -539,6 +539,15 @@ async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
       - ``effect``: optional motion — ``none`` (static; default) or
         ``ken_burns`` (slow pan-and-zoom). Applies to image / composed
         slides; videos play their own motion.
+      - ``effect_direction``: the Ken Burns motion path (only meaningful
+        when ``effect`` is ``ken_burns``). A zoom — ``in`` or ``out`` —
+        optionally combined with a pan direction: ``up``, ``down``,
+        ``left``, ``right``, or a diagonal (``up_left``, ``up_right``,
+        ``down_left``, ``down_right``). Examples: ``in`` (zoom in, no
+        pan), ``out_down_right`` (zoom out drifting toward the
+        bottom-right). Word order and separators DON'T matter —
+        ``"zoom out right down"`` and ``"out-right-down"`` are both
+        accepted and normalized to ``out_down_right``. Defaults to ``in``.
 
     A slideshow can hold up to 50 slides. On invalid input the call
     returns structured errors — fix and retry.

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -26,6 +26,35 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from shared.database import Base
 
 
+# Canonical Ken Burns direction grammar — kept in lockstep with
+# ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` (the Pydantic-layer source of
+# truth) and the JS shell allow-list in ``agora/player/shell/player.js``.
+# Defined locally (rather than imported from the cms app layer) so this
+# shared model has no upward dependency on ``cms`` and stays import-cycle
+# free.  ZOOM (``in``/``out``) × optional PAN (8 compass dirs), plus legacy
+# bare-pan aliases.  The DB CHECK constraint below is derived from this
+# tuple so the two can never drift (the original drift caused a 500 on
+# saving any diagonal/zoom+pan Ken Burns slide — see migration 0044).
+_KEN_BURNS_PANS = (
+    "left",
+    "right",
+    "up",
+    "down",
+    "up_left",
+    "up_right",
+    "down_left",
+    "down_right",
+)
+KEN_BURNS_DIRECTIONS = (
+    "in",
+    "out",
+    *(f"in_{_p}" for _p in _KEN_BURNS_PANS),
+    *(f"out_{_p}" for _p in _KEN_BURNS_PANS),
+    *_KEN_BURNS_PANS,
+)
+_KEN_BURNS_DIRECTION_SQL_LIST = ",".join(f"'{_d}'" for _d in KEN_BURNS_DIRECTIONS)
+
+
 class SlideshowSlide(Base):
     """One slide inside a slideshow asset."""
 
@@ -65,9 +94,15 @@ class SlideshowSlide(Base):
         # Ken Burns pan/zoom direction (agora#261).  Only meaningful when
         # ``effect == 'ken_burns'``; the default ``in`` reproduces the
         # original zoom-in animation.  Validated in the Pydantic schema and
-        # re-asserted here against out-of-band INSERTs.
+        # re-asserted here against out-of-band INSERTs.  The token grammar
+        # encodes a ZOOM (``in``/``out``) and an optional PAN (8 compass
+        # directions incl. diagonals): ``in``/``out`` (pure zoom),
+        # ``in_<pan>``/``out_<pan>`` (zoom + pan), and legacy bare-pan
+        # aliases (``left`` ... = zoom-in pans).  Kept in lockstep with the
+        # canonical ``cms.schemas.asset.KEN_BURNS_DIRECTIONS`` tuple — see
+        # migration 0044 for the matching DB constraint.
         CheckConstraint(
-            "effect_direction IN ('in','out','left','right','up','down')",
+            f"effect_direction IN ({_KEN_BURNS_DIRECTION_SQL_LIST})",
             name="ck_slideshow_slide_effect_direction_known",
         ),
         # FK columns are not auto-indexed in Postgres; the source-delete guard
@@ -121,9 +156,10 @@ class SlideshowSlide(Base):
     )
     # Ken Burns pan/zoom direction.  Only meaningful when ``effect`` is
     # ``ken_burns``.  ``in`` (default) reproduces the original zoom-in
-    # animation; ``out``/``left``/``right``/``up``/``down`` are the other
-    # presets.  Rendered by the chromium player and the composed-bundle
-    # slideshow renderer.
+    # animation; the full grammar is a ZOOM (``in``/``out``) plus an
+    # optional PAN (8 compass directions incl. diagonals) — e.g.
+    # ``out_up_right``.  Rendered by the chromium player and the
+    # composed-bundle slideshow renderer.  Allowed set: ``KEN_BURNS_DIRECTIONS``.
     effect_direction: Mapped[str] = mapped_column(
         String(16), nullable=False, default="in", server_default="in"
     )

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -41,6 +41,65 @@ def test_ken_burns_directions_model_matches_schema():
     assert tuple(MODEL_DIRS) == tuple(SCHEMA_DIRS)
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # already-canonical pass through unchanged
+        ("in", "in"),
+        ("out_down_right", "out_down_right"),
+        ("down", "down"),
+        # separators don't matter
+        ("out-down-right", "out_down_right"),
+        ("out down right", "out_down_right"),
+        ("out/down/right", "out_down_right"),
+        ("OUT_DOWN_RIGHT", "out_down_right"),
+        # word ORDER doesn't matter (the user's exact case)
+        ("out-right-down", "out_down_right"),
+        ("zoom out right down", "out_down_right"),
+        ("right_down", "down_right"),
+        ("up-left", "up_left"),
+        ("left up", "up_left"),
+        # filler words stripped
+        ("zoom in", "in"),
+        ("zoom out going up left", "out_up_left"),
+        # legacy bare pan
+        ("up right", "up_right"),
+    ],
+)
+def test_normalize_effect_direction_canonicalizes(raw, expected):
+    from cms.schemas.asset import (
+        KEN_BURNS_DIRECTIONS,
+        normalize_effect_direction,
+    )
+
+    out = normalize_effect_direction(raw)
+    assert out == expected
+    assert out in KEN_BURNS_DIRECTIONS
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "diagonal",          # unknown token
+        "up_down",           # two verticals — not a valid pan
+        "left_right",        # two horizontals
+        "in_out",            # contradictory zoom
+        "sideways",          # gibberish
+    ],
+)
+def test_normalize_effect_direction_passes_invalid_through(raw):
+    """Un-normalizable input is returned unchanged so the validator still
+    raises its descriptive error (rather than silently coercing)."""
+    from cms.schemas.asset import (
+        KEN_BURNS_DIRECTIONS,
+        normalize_effect_direction,
+    )
+
+    out = normalize_effect_direction(raw)
+    assert out == raw
+    assert out not in KEN_BURNS_DIRECTIONS
+
+
 # ── Helpers ──
 
 
@@ -906,6 +965,38 @@ class TestSlideFitEffect:
             },
         )
         assert resp.status_code in (400, 422), resp.text
+
+    @pytest.mark.parametrize(
+        "loose,canonical",
+        [
+            ("out-right-down", "out_down_right"),  # the user's MCP case
+            ("zoom out right down", "out_down_right"),
+            ("right_down", "down_right"),
+            ("ZOOM IN UP LEFT", "in_up_left"),
+        ],
+    )
+    async def test_create_normalizes_loose_effect_direction(
+        self, client, db_session, loose, canonical
+    ):
+        img = await _seed_image(
+            db_session, filename=f"kbn_{canonical}.png", is_global=True
+        )
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": f"kbn-{canonical}",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "effect": "ken_burns",
+                    "effect_direction": loose,
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["effect_direction"] == canonical
 
 
 # ── Source-delete guard ──

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -28,6 +28,19 @@ from cms.models.slideshow_slide import SlideshowSlide
 from cms.models.user import User
 
 
+def test_ken_burns_directions_model_matches_schema():
+    """The DB CHECK constraint (shared model) must allow exactly the same
+    direction tokens the Pydantic schema accepts.  Drift between the two is
+    what caused the HTTP 500 on Ken Burns save (schema widened to the full
+    zoom+pan grammar, DB CHECK left at the original 6 tokens).  Lock them
+    together so the next person who adds a direction can't reintroduce it.
+    """
+    from cms.schemas.asset import KEN_BURNS_DIRECTIONS as SCHEMA_DIRS
+    from shared.models.slideshow_slide import KEN_BURNS_DIRECTIONS as MODEL_DIRS
+
+    assert tuple(MODEL_DIRS) == tuple(SCHEMA_DIRS)
+
+
 # ── Helpers ──
 
 
@@ -785,6 +798,110 @@ class TestSlideFitEffect:
                     "source_asset_id": str(img.id),
                     "duration_ms": 1000,
                     "effect": "explode",
+                }],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.text
+
+    # ── Ken Burns effect_direction (agora#261) ──
+    # Regression for the HTTP 500 on save: the Ken Burns authoring UI emits
+    # the full direction grammar (ZOOM in/out + optional 8-way PAN incl.
+    # diagonals, e.g. ``out_up_right``), and the Pydantic schema allows it,
+    # but the DB CHECK constraint from migration 0043 only permitted the
+    # original six tokens.  Saving any diagonal/zoom+pan direction passed
+    # validation then violated the constraint on INSERT/UPDATE → 500.
+    # These go through the real DB, so they exercise the CHECK constraint
+    # widened in migration 0044.
+
+    @pytest.mark.parametrize(
+        "direction",
+        [
+            "in",
+            "out",
+            "out_up_right",  # the authoring default for a new ken_burns slide
+            "in_down_left",
+            "out_left",
+            "up_right",  # legacy bare-pan alias
+            "down",
+        ],
+    )
+    async def test_create_round_trips_effect_direction(
+        self, client, db_session, direction
+    ):
+        img = await _seed_image(
+            db_session, filename=f"kb_{direction}.png", is_global=True
+        )
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": f"kb-{direction}",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 2000,
+                    "effect": "ken_burns",
+                    "effect_direction": direction,
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["effect"] == "ken_burns"
+        assert slides[0]["effect_direction"] == direction
+
+    async def test_replace_round_trips_diagonal_effect_direction(
+        self, client, db_session
+    ):
+        img = await _seed_image(db_session, filename="kbrepl.png", is_global=True)
+        sid = (await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "kbrepl",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 1000}],
+            },
+        )).json()["id"]
+        put = await client.put(
+            f"/api/assets/{sid}/slides",
+            json={"slides": [{
+                "source_asset_id": str(img.id),
+                "duration_ms": 1000,
+                "effect": "ken_burns",
+                "effect_direction": "out_down_right",
+            }]},
+        )
+        assert put.status_code == 200, put.text
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["effect_direction"] == "out_down_right"
+
+    async def test_create_defaults_effect_direction_in(self, client, db_session):
+        img = await _seed_image(db_session, filename="kbdef.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "kbdef",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "effect": "ken_burns",
+                }],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        sid = resp.json()["id"]
+        slides = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"]
+        assert slides[0]["effect_direction"] == "in"
+
+    async def test_rejects_unknown_effect_direction(self, client, db_session):
+        img = await _seed_image(db_session, filename="kbbad.png", is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "kbbad",
+                "slides": [{
+                    "source_asset_id": str(img.id),
+                    "duration_ms": 1000,
+                    "effect": "ken_burns",
+                    "effect_direction": "diagonal",
                 }],
             },
         )


### PR DESCRIPTION
## Problem

Saving a slideshow slide with **Ken Burns** + any pan/zoom motion path returned **HTTP 500**, and the in-CMS assistant rejected natural phrasings like *"zoom out going right-down"* as invalid.

Two distinct root causes:

1. **Stale DB CHECK constraint (the 500).** The Pydantic `KEN_BURNS_DIRECTIONS` grammar was widened to 26 tokens (zoom + 8-way pan), but the `ck_slideshow_slide_effect_direction_known` constraint (model + migration 0043) stayed at the original 6 tokens. PR #798 made `out_up_right` the new-slide default, so nearly every Ken Burns save hit the constraint.
2. **Create path silently dropped `effect_direction`.** `create_slideshow_asset` built `SlideshowSlide(...)` without the field, so it always persisted `in`. The PUT/replace path was already correct.

Plus a UX gap: the MCP `set_slideshow_slides` tool never documented `effect_direction`, so the assistant guessed formats (`out-right-down`) the canonical grammar (`out_down_right`) rejected.

## Fix

- **DB constraint:** derive the CHECK from a canonical direction tuple in `shared/models/slideshow_slide.py` + migration **0044** to repair deployed DBs.
- **Create path:** pass `effect_direction` through in `cms/routers/assets.py`.
- **Lenient normalization:** new `normalize_effect_direction()` collapses separators, strips filler words, and reorders pan components vertical-first so **word order and separators never matter** (`"out-right-down"` / `"zoom out right down"` → `out_down_right`). Wired into the Pydantic validator so **every** entry point benefits (MCP, UI, create + replace). Un-normalizable input passes through so the validator still raises its descriptive error.
- **MCP docs:** document `effect_direction` + the full motion-path grammar in the `set_slideshow_slides` docstring.

## Tests

- Drift-guard locking the model tuple to the schema tuple.
- 13-case normalizer unit test + 5 invalid-passthrough cases.
- End-to-end API round-trip proving loose input persists canonical.
- Create round-trip / diagonal replace / default / reject cases.

All 81 in `tests/test_slideshow_assets.py` pass locally.
