### PR TITLE
fix(slideshow): flip create chrome to edit mode after assistant mint

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -722,9 +722,9 @@
         <div id="ss-status" class="form-status" style="margin-top:0.75rem;"></div>
         <div style="display:flex; gap:0.5rem; margin-top:1rem;">
             <button type="submit" class="btn btn-primary" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
-            {% if edit_mode %}
-            <button type="button" class="btn btn-secondary" id="ss-preview-btn" onclick="previewSlideshowFromEditor()" title="Preview the saved slideshow">Preview</button>
-            {% endif %}
+            <!-- Rendered hidden in create mode; revealed by applyEditModeChrome()
+                 once the AI assistant mints a draft (slideshowMintDraft). -->
+            <button type="button" class="btn btn-secondary" id="ss-preview-btn" onclick="previewSlideshowFromEditor()" title="Preview the saved slideshow"{% if not edit_mode %} hidden{% endif %}>Preview</button>
             <a href="/assets" class="btn btn-secondary">Cancel</a>
         </div>
     </form>
@@ -1803,6 +1803,18 @@ function clearDirty() {
     _setSubmitEnabled(false);
 }
 
+// Flip the page chrome from create-mode to edit-mode after the AI
+// assistant mints a draft (slideshowMintDraft). In create mode the
+// submit button is labeled "Create" and the Preview button is rendered
+// hidden; once a real asset exists those should match edit mode. Mirrors
+// the server-side edit_mode template branches. Idempotent.
+function applyEditModeChrome() {
+    const submit = document.getElementById('ss-submit');
+    if (submit) submit.textContent = 'Save';
+    const preview = document.getElementById('ss-preview-btn');
+    if (preview) preview.hidden = false;
+}
+
 // Custom 3-button modal for unsaved-changes navigation: Save / Discard /
 // Cancel. Visually matches showConfirm in app.js by reusing the same
 // modal-overlay / modal-box / modal-actions classes via createModal().
@@ -1973,6 +1985,7 @@ window.slideshowMintDraft = async function () {
         SS_ASSET_ID = newId;
         SS_EDIT_MODE = true;
         SS_ORIG_NAME = name;
+        applyEditModeChrome();
         clearDirty();
         setStatus('Created.');
         try {

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -90,6 +90,23 @@ class TestSlideshowBuilderRoutes:
         # makeSlot() gates the backdrop on contain_blur images only.
         assert "s.fit === 'contain_blur' && !isVideo" in resp.text
 
+    async def test_create_mode_preview_btn_hidden_until_mint(self, client):
+        """Bug: AI-assistant slideshow create left the page in create-mode
+        chrome — Create button never flipped to Save and no Preview button
+        appeared. The Preview button must be rendered (hidden) in create
+        mode, and slideshowMintDraft must reveal it + relabel submit via
+        applyEditModeChrome()."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Preview button is present in create mode but hidden, so JS can
+        # reveal it after minting (rather than not existing at all).
+        assert 'id="ss-preview-btn"' in body
+        assert 'title="Preview the saved slideshow" hidden' in body
+        assert "applyEditModeChrome" in body
+        # The mint path flips the chrome to edit mode.
+        assert "applyEditModeChrome();" in body
+
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""
         from tests.test_ui_overhaul import _create_user, _login_as


### PR DESCRIPTION
## Problem
When the AI assistant created a slideshow, the create succeeded but the page stayed in **create-mode chrome**: the **Create** button never flipped to **Save** (and stayed grayed), and **no Preview button** appeared. Users couldn't tell the slideshow had been created or preview it without a manual reload.

Root cause: `slideshowMintDraft()` POSTs the draft and sets `SS_EDIT_MODE`/`SS_ASSET_ID` (+ `history.replaceState` to the edit URL) but never updates the DOM. The submit label is baked server-side (`Create` in create mode), and the Preview button was only rendered under `{% if edit_mode %}` — so it didn't exist in the create-mode DOM for JS to reveal.

## Fix
- Render the Preview button in create mode too, but `hidden`.
- Add `applyEditModeChrome()`: relabels submit `Create` → `Save` and reveals the Preview button. Idempotent.
- Call it from `slideshowMintDraft()` right after flipping `SS_EDIT_MODE = true`.

Now the post-create UI matches a normal saved slideshow (Save shown, disabled until next edit; Preview available).

## Tests
- New `test_create_mode_preview_btn_hidden_until_mint` asserts the Preview button ships hidden in create mode and the mint path calls `applyEditModeChrome()`.
- `tests/test_slideshow_builder_ui.py`: 18 passed locally.

Goodwill dev only.
