### PR TITLE
fix(slideshow): keep slot number/controls above blur-fill thumbnail

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -169,6 +169,9 @@
     font-size: 0.75rem;
     font-weight: bold;
     border-radius: 0.25rem;
+    /* Above the blur-fill foreground (.ssb-slot-thumb-fg, z-index 1)
+     * so the slide number/controls stay over the thumbnail. */
+    z-index: 2;
 }
 .ssb-slot-remove {
     position: absolute;
@@ -186,11 +189,13 @@
     align-items: center;
     justify-content: center;
     padding: 0;
+    z-index: 2;
 }
 .ssb-slot-remove:hover { background: #c0392b; }
 .ssb-slot-move {
     position: absolute;
     bottom: 0.3rem;
+    z-index: 2;
     background: rgba(0,0,0,0.65);
     color: #fff;
     border: none;

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -89,6 +89,12 @@ class TestSlideshowBuilderRoutes:
         assert "filter: blur(" in resp.text
         # makeSlot() gates the backdrop on contain_blur images only.
         assert "s.fit === 'contain_blur' && !isVideo" in resp.text
+        # The slide-number / remove / move overlays must sit above the
+        # blur foreground (z-index 1) so they aren't hidden under it.
+        for cls in (".ssb-slot-pos", ".ssb-slot-remove", ".ssb-slot-move"):
+            start = resp.text.index(cls + " {")
+            block = resp.text[start:start + 400]
+            assert "z-index: 2" in block, f"{cls} missing z-index above blur fg"
 
     async def test_new_page_requires_write_permission(self, app, db_session):
         """Direct nav to /assets/new/slideshow must be gated on assets:write."""


### PR DESCRIPTION
## Problem
The WYSIWYG blur-fill preview (#800) gave the contained foreground image `z-index: 1` (over the blurred backdrop). The slot overlays — slide-number badge, remove (red ✕) button and move arrows — are `position:absolute` with **no** `z-index`, so on `contain_blur` slots the blur foreground painted over them and they rendered **under** the image.

## Fix
Give `.ssb-slot-pos`, `.ssb-slot-remove` and `.ssb-slot-move` `z-index: 2` so they sit above the blur foreground (1) and backdrop (0). Non-blur slots are unaffected (they had no competing z-index).

## Tests
Extended `test_blur_fill_slot_preview_is_wysiwyg` to assert each overlay class carries `z-index: 2`. `tests/test_slideshow_builder_ui.py`: 18 passed locally.

Goodwill dev only.
