### PR TITLE
Fix spurious "Reload Site?" prompt after creating a schedule

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -2465,7 +2465,7 @@ async function toggleSchedule(scheduleId, enabled) {
 async function _replaceScheduleRow(scheduleId) {
     try {
         const rowResp = await fetch(`/api/schedules/${scheduleId}/row`);
-        if (!rowResp.ok) { location.reload(); return; }
+        if (!rowResp.ok) { window.cwSuppressUnloadGuard?.(); location.reload(); return; }
         const html = await rowResp.text();
         const tmp = document.createElement('tbody');
         tmp.innerHTML = html;
@@ -2475,7 +2475,7 @@ async function _replaceScheduleRow(scheduleId) {
             existing.replaceWith(fresh);
         } else {
             const tbody = document.getElementById('active-schedules-tbody');
-            if (!tbody) { location.reload(); return; }
+            if (!tbody) { window.cwSuppressUnloadGuard?.(); location.reload(); return; }
             // Remove placeholder "No schedules yet" row if present.
             const empty = tbody.querySelector('tr[data-empty-row]');
             if (empty) empty.remove();
@@ -2512,6 +2512,7 @@ async function _replaceScheduleRow(scheduleId) {
             window._rememberSchedule(scheduleId, scheduleData);
         }
     } catch (e) {
+        window.cwSuppressUnloadGuard?.();
         location.reload();
     }
 }
@@ -2577,6 +2578,7 @@ async function createSchedule(form) {
             form.reset();
             showToast("Schedule created");
         } else {
+            window.cwSuppressUnloadGuard?.();
             location.reload();
         }
     } else if (resp) {

--- a/cms/templates/schedules.html
+++ b/cms/templates/schedules.html
@@ -1280,6 +1280,7 @@ function editSchedule(s) {
                 }
             }
             if (wasExpired !== newIsExpired) {
+                _suppressUnloadGuard = true;
                 location.reload();
                 return;
             }
@@ -1287,6 +1288,7 @@ function editSchedule(s) {
                 await _replaceScheduleRow(s.id);
                 showToast('Schedule updated');
             } else {
+                _suppressUnloadGuard = true;
                 location.reload();
             }
         }
@@ -1303,6 +1305,12 @@ function editSchedule(s) {
 // uses the browser's native beforeunload prompt; the edit modal uses showConfirm.
 let _createFormSnapshot = null;
 let _editModalDirtyTracker = null;
+// Set true immediately before an intentional programmatic reload that
+// follows a successful save, so the beforeunload guard below doesn't
+// prompt "Reload Site?" for changes that are in fact already persisted.
+// The page is unloading anyway, so the flag never needs resetting.
+let _suppressUnloadGuard = false;
+window.cwSuppressUnloadGuard = () => { _suppressUnloadGuard = true; };
 
 function _serializeFormInputs(root) {
     if (!root) return "";
@@ -1342,6 +1350,7 @@ function _isEditModalDirty() {
 }
 
 window.addEventListener('beforeunload', (e) => {
+    if (_suppressUnloadGuard) return;
     if (_isCreateFormDirty() || _isEditModalDirty()) {
         e.preventDefault();
         // Modern browsers ignore custom text; setting returnValue triggers the prompt.

--- a/tests/test_schedule_create_reload_guard.py
+++ b/tests/test_schedule_create_reload_guard.py
@@ -1,0 +1,59 @@
+"""Regression test for the spurious "Reload Site?" prompt after creating
+a schedule.
+
+Background
+----------
+Creating a schedule POSTs ``/api/schedules`` (which persists the row) and
+then swaps the new row into the table in place via
+``_replaceScheduleRow()`` BEFORE ``form.reset()`` clears the create
+form's dirty state. ``_replaceScheduleRow`` has several
+``location.reload()`` fallbacks that fire when the ``/row`` HTML-fragment
+fetch transiently fails. Because the reload happens while the create form
+is still dirty, the page's ``beforeunload`` guard (added so users don't
+lose unsaved edits) pops the native "Reload Site? Changes you made may
+not be saved." prompt — even though the schedule was already saved.
+
+The fix exposes ``window.cwSuppressUnloadGuard()`` from schedules.html,
+honored by the ``beforeunload`` handler, and calls it immediately before
+every post-save programmatic reload (in both app.js and the edit-modal
+path in schedules.html).
+
+This test pins that wiring so the guard can't silently regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_APP_JS = _ROOT / "cms" / "static" / "app.js"
+_SCHEDULES_HTML = _ROOT / "cms" / "templates" / "schedules.html"
+
+
+def test_schedules_html_defines_suppress_guard():
+    src = _SCHEDULES_HTML.read_text(encoding="utf-8")
+    # The flag and the global setter must be defined.
+    assert "let _suppressUnloadGuard = false;" in src
+    assert "window.cwSuppressUnloadGuard = () =>" in src
+    # The beforeunload handler must early-return when suppressed, and that
+    # early-return must come before the dirty-check that triggers the prompt.
+    assert "if (_suppressUnloadGuard) return;" in src
+    guard_idx = src.index("if (_suppressUnloadGuard) return;")
+    dirty_idx = src.index("_isCreateFormDirty() || _isEditModalDirty()")
+    assert guard_idx < dirty_idx
+
+
+def test_app_js_suppresses_guard_before_post_save_reloads():
+    src = _APP_JS.read_text(encoding="utf-8")
+    # Every location.reload() inside the schedule create/replace path must
+    # be preceded by the suppress call (optional-chained because app.js is
+    # shared across pages where the global may not exist).
+    create_section = src[src.index("async function _replaceScheduleRow") :
+                         src.index("// ── User & Role Management ──")]
+    # Each reload in this section is a post-save programmatic reload.
+    for chunk in create_section.split("location.reload();")[:-1]:
+        assert "window.cwSuppressUnloadGuard?.();" in chunk.rsplit(";", 2)[-1] or \
+            "cwSuppressUnloadGuard" in chunk[-120:], (
+            "a post-save location.reload() in the schedule path is not "
+            "preceded by window.cwSuppressUnloadGuard?.()"
+        )


### PR DESCRIPTION
## Problem

When creating a schedule, users **sometimes** get a native browser `Reload Site? — Changes you made may not be saved.` modal — even though the schedule **was** saved.

## Root cause

`createSchedule()` persists the row (`POST /api/schedules` succeeds), then calls `_replaceScheduleRow()` to swap the new row into the table in place **before** `form.reset()` clears the create form's dirty state. `_replaceScheduleRow` has `location.reload()` fallbacks that fire when the `/api/schedules/{id}/row` fragment fetch transiently fails. Because that reload runs while the create form is still dirty, the page's `beforeunload` guard sets `returnValue` → Chrome shows the prompt.

This explains both the intermittency (only when the fragment fetch transiently fails) and "but the changes are saved" (the POST already succeeded).

## Fix

- `schedules.html`: add `_suppressUnloadGuard` flag + `window.cwSuppressUnloadGuard()` setter; early-return in the `beforeunload` handler when suppressed.
- Call `window.cwSuppressUnloadGuard?.()` immediately before every post-save programmatic reload: the three in `_replaceScheduleRow` and the `createSchedule` fallback (`app.js`), and the two edit-modal reloads (`schedules.html`).
- Set immediately-before-reload (not a permanent latch) so a later genuine edit still warns on tab close.

## Tests

`tests/test_schedule_create_reload_guard.py` pins the wiring in both source files (2 passing).