### PR TITLE
feat(slideshow): tag-based dynamic playlists (resolver foundation)

### DIFF
--- a/alembic/versions/0045_slideshow_tag_rule.py
+++ b/alembic/versions/0045_slideshow_tag_rule.py
@@ -1,0 +1,141 @@
+"""Alembic migration 0045 — tag-mode slideshows (agora-cms#806).
+
+Creates ``slideshow_tag_rules``: a 1:1 side table on a SLIDESHOW asset
+that switches it into *tag mode*.  A tag-mode slideshow has no
+``slideshow_slides`` rows; its deck is resolved live from the set of
+assets currently carrying ``tag_id`` (ordered by tag-membership creation
+time).  The presence of a row here is the mode switch the resolver keys
+off of.
+
+``anchor_at`` persists the wall-clock cycle anchor so newly-tagged
+assets can be appended at the tail of a *running* slideshow without
+re-flooring the anchor — the firmware player derives the on-screen slide
+as ``(now - started_at) % cycle_duration``, so a fixed anchor + tail-only
+appends keep every existing slide's offset unchanged (no restart/jump).
+
+The ``default_*`` columns carry the deck-level per-slide playback
+defaults (a tag deck has no per-slide authoring UI); they mirror
+``slideshow_slides`` column defaults so a tag deck behaves like a manual
+deck of default slides.
+
+SQLite (unit-test harness) can't ALTER TABLE ADD CONSTRAINT, but
+``create_table`` emits inline FKs/CHECKs fine on both dialects, so the
+table is created identically.  We only branch for the GIN/extension-free
+nature of this table (there is none) — no Postgres-only DDL here.
+
+Revision ID: 0045
+Revises: 0044
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0045"
+down_revision = "0044"
+branch_labels = None
+depends_on = None
+
+# Frozen copy of cms.models.slideshow_tag_rule.DEFAULT_TAG_SLIDE_DURATION_MS
+# — migrations must be self-contained and must not import live app code.
+_DEFAULT_DURATION_MS = 8000
+
+
+def _uuid_type(bind):
+    """UUID column type matching the dialect (Postgres in prod, SQLite in tests)."""
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.UUID(as_uuid=True)
+    return sa.String(length=36)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    uuid_t = _uuid_type(bind)
+
+    op.create_table(
+        "slideshow_tag_rules",
+        sa.Column("slideshow_asset_id", uuid_t, nullable=False),
+        sa.Column("tag_id", uuid_t, nullable=False),
+        sa.Column(
+            "order_by",
+            sa.String(length=32),
+            nullable=False,
+            server_default="tagged_at",
+        ),
+        sa.Column(
+            "default_duration_ms",
+            sa.Integer(),
+            nullable=False,
+            server_default=str(_DEFAULT_DURATION_MS),
+        ),
+        sa.Column(
+            "default_transition",
+            sa.String(length=16),
+            nullable=False,
+            server_default="cut",
+        ),
+        sa.Column(
+            "default_transition_ms",
+            sa.Integer(),
+            nullable=False,
+            server_default="600",
+        ),
+        sa.Column(
+            "default_fit",
+            sa.String(length=16),
+            nullable=False,
+            server_default="cover",
+        ),
+        sa.Column(
+            "default_effect",
+            sa.String(length=16),
+            nullable=False,
+            server_default="none",
+        ),
+        sa.Column(
+            "default_effect_direction",
+            sa.String(length=16),
+            nullable=False,
+            server_default="in",
+        ),
+        sa.Column("anchor_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+        sa.PrimaryKeyConstraint(
+            "slideshow_asset_id", name="pk_slideshow_tag_rules"
+        ),
+        sa.ForeignKeyConstraint(
+            ["slideshow_asset_id"],
+            ["assets.id"],
+            name="fk_slideshow_tag_rules_asset",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"],
+            ["tags.id"],
+            name="fk_slideshow_tag_rules_tag",
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "order_by IN ('tagged_at')",
+            name="ck_slideshow_tag_rule_order_by_known",
+        ),
+        sa.CheckConstraint(
+            "default_duration_ms > 0",
+            name="ck_slideshow_tag_rule_duration_pos",
+        ),
+    )
+    op.create_index(
+        "ix_slideshow_tag_rules_tag_id",
+        "slideshow_tag_rules",
+        ["tag_id"],
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0045 is not supported")

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -20,6 +20,7 @@ from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent  # noqa: F401
 from cms.models.schedule_missed_event import ScheduleMissedEvent  # noqa: F401
 from cms.models.setting import CMSSetting  # noqa: F401
 from cms.models.slideshow_slide import SlideshowSlide  # noqa: F401
+from cms.models.slideshow_tag_rule import SlideshowTagRule  # noqa: F401
 from cms.models.tag import Tag, AssetTag, DEFAULT_TAG_COLOR  # noqa: F401
 from cms.models.asset_view import AssetView  # noqa: F401
 from cms.models.chat_message import ChatMessage  # noqa: F401

--- a/cms/models/slideshow_tag_rule.py
+++ b/cms/models/slideshow_tag_rule.py
@@ -1,0 +1,143 @@
+"""SlideshowTagRule model — binds a SLIDESHOW asset to a tag (agora-cms#806).
+
+A *tag-mode* slideshow has no explicit ``slideshow_slides`` rows.  Its
+content is resolved live at sync-build time from the set of assets
+currently carrying ``tag_id``.  The presence of a ``SlideshowTagRule``
+row for a slideshow asset is therefore the mode switch: the resolver
+checks for one and, if found, builds the deck from the tag membership
+instead of from ``SlideshowSlide`` rows.
+
+Ordering & seamless insertion (Option B — append at tail)
+---------------------------------------------------------
+v1 orders members by **tag-membership creation time**
+(``asset_tags.created_at ASC``).  This is not merely a default — it is
+load-bearing for the "tag an asset and it appears in the running
+slideshow without a restart" guarantee:
+
+* The firmware player has no mutable playhead.  The on-screen slide is a
+  pure function ``(now - started_at) % cycle_duration`` over the slide
+  list.  Any change to the list or cycle length shifts that modulo and
+  would make the deck jump — unless the anchor is preserved AND the new
+  slide lands at a position the playhead has not yet reached this cycle.
+* Ordering by membership time means a newly-tagged asset always sorts to
+  the **tail** of the deck.  Combined with a persisted, never-re-floored
+  anchor (:attr:`anchor_at`), every existing slide keeps its offset in
+  the cycle, so the currently-displayed slide never moves; the new slide
+  first appears at the end of the in-flight cycle.
+
+Other orderings (alphabetical, upload time, …) could slot a new asset
+into the *middle* of the deck, shifting slides behind the playhead and
+breaking the no-restart guarantee.  They are intentionally deferred; v1
+exposes ``tagged_at`` only.
+
+Tags are CMS-only metadata, so this model lives in ``cms.models`` (not
+``shared.models``) alongside :class:`cms.models.tag.Tag` — the worker
+never resolves slideshows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cms.database import Base
+
+# Default per-slide display time for a tag-mode deck (8 s) — a sensible
+# image dwell.  Manual decks set this per slide; a tag deck has no per
+# slide UI, so the dwell is a single deck-level default on the rule.
+DEFAULT_TAG_SLIDE_DURATION_MS = 8000
+
+# v1 supports a single ordering — see the module docstring for why
+# ``tagged_at`` is required (not merely default) for seamless insertion.
+SLIDESHOW_TAG_ORDER_BY_VALUES = ("tagged_at",)
+
+
+class SlideshowTagRule(Base):
+    """Binds a SLIDESHOW asset to a tag; presence => tag-mode deck."""
+
+    __tablename__ = "slideshow_tag_rules"
+    __table_args__ = (
+        CheckConstraint(
+            "order_by IN ('tagged_at')",
+            name="ck_slideshow_tag_rule_order_by_known",
+        ),
+        CheckConstraint(
+            "default_duration_ms > 0",
+            name="ck_slideshow_tag_rule_duration_pos",
+        ),
+    )
+
+    # One rule per slideshow asset — the asset id IS the primary key, which
+    # enforces the 1:1 (a slideshow is either manual or tag-mode, never
+    # both) and gives the resolver an index-free PK lookup.
+    slideshow_asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("assets.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # How members are ordered within the deck.  See module docstring —
+    # ``tagged_at`` is the only v1 value and is required for the seamless
+    # tail-append guarantee.
+    order_by: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="tagged_at", server_default="tagged_at"
+    )
+
+    # Deck-level default per-slide playback settings.  A tag deck has no
+    # per-slide authoring UI, so these apply uniformly to every resolved
+    # member.  Defaults mirror SlideshowSlide's column defaults so a tag
+    # deck behaves like a hand-built one with default slides.
+    default_duration_ms: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_TAG_SLIDE_DURATION_MS,
+        server_default=str(DEFAULT_TAG_SLIDE_DURATION_MS),
+    )
+    default_transition: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="cut", server_default="cut"
+    )
+    default_transition_ms: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=600, server_default="600"
+    )
+    default_fit: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="cover", server_default="cover"
+    )
+    default_effect: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="none", server_default="none"
+    )
+    default_effect_direction: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="in", server_default="in"
+    )
+
+    # Persisted wall-clock cycle anchor (Option B stability).  Set once when
+    # the rule is created and thereafter NEVER re-floored, so appending a
+    # newly-tagged slide at the tail leaves every existing slide's offset
+    # in the cycle unchanged — the on-screen slide does not move.  The
+    # resolver emits this verbatim as the manifest ``started_at``.  Nullable
+    # so a defensively-created rule (or an old row) falls back to the
+    # per-build floor in the resolver.
+    anchor_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.current_timestamp(),
+    )

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -35,6 +35,8 @@ import logging
 
 from cms.models.asset import Asset, AssetType, AssetVariant, VariantStatus
 from cms.models.device import Device
+from cms.models.slideshow_tag_rule import SlideshowTagRule
+from cms.models.tag import AssetTag
 from cms.schemas.protocol import (
     FetchAssetMessage,
     SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST,
@@ -111,6 +113,28 @@ class _SlidePlan:
     # siblings the device pre-fetches before showing the bundle.  Empty
     # for image/video slides.
     siblings: list[_SiblingPlan] = field(default_factory=list)
+
+
+@dataclass
+class _SlideSpec:
+    """A slide's *source-and-playback* description, before variant
+    resolution.  Abstracts over the two deck sources so
+    :func:`plan_slideshow` can iterate one uniform list:
+
+    * manual slideshows map each ``SlideshowSlide`` row → one spec;
+    * tag-mode decks (agora#806) map each tagged asset → one spec,
+      filling playback fields from the ``SlideshowTagRule`` defaults.
+    """
+
+    position: int
+    source_asset_id: uuid.UUID
+    duration_ms: int
+    play_to_end: bool
+    transition: str
+    transition_ms: int
+    fit: str
+    effect: str
+    effect_direction: str
 
 
 @dataclass
@@ -279,10 +303,103 @@ async def _plan_composed_siblings(
     return siblings
 
 
+async def _get_tag_rule(
+    asset_id: uuid.UUID, db: AsyncSession
+) -> Optional[SlideshowTagRule]:
+    """Return the :class:`SlideshowTagRule` for ``asset_id`` if the
+    slideshow is in tag mode, else ``None`` (manual mode).  Indexed PK
+    lookup — cheap to call on every resolve/build."""
+    result = await db.execute(
+        select(SlideshowTagRule).where(
+            SlideshowTagRule.slideshow_asset_id == asset_id
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+# Leaf, directly-displayable asset types a tag-mode deck may include.
+# SLIDESHOW is excluded to prevent nesting/recursion; WEBPAGE is excluded
+# (not a cacheable single-file display asset on this path).
+_TAG_MEMBER_ASSET_TYPES = (
+    AssetType.IMAGE,
+    AssetType.VIDEO,
+    AssetType.SAVED_STREAM,
+    AssetType.COMPOSED,
+)
+
+
+async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
+    """Produce the ordered list of :class:`_SlideSpec` for ``asset``.
+
+    Tag mode (a :class:`SlideshowTagRule` exists) builds the deck from
+    current tag membership, ordered by ``asset_tags.created_at`` so a
+    newly tagged asset always sorts to the tail; every member inherits
+    the rule's deck-level playback defaults.  Manual mode maps each
+    ``SlideshowSlide`` row to a spec, preserving per-slide settings.
+    """
+    rule = await _get_tag_rule(asset.id, db)
+    if rule is not None:
+        result = await db.execute(
+            select(Asset.id)
+            .join(AssetTag, AssetTag.asset_id == Asset.id)
+            .where(
+                AssetTag.tag_id == rule.tag_id,
+                Asset.deleted_at.is_(None),
+                Asset.asset_type.in_(_TAG_MEMBER_ASSET_TYPES),
+            )
+            .order_by(AssetTag.created_at.asc(), AssetTag.id.asc())
+        )
+        member_ids = result.scalars().all()
+        return [
+            _SlideSpec(
+                position=i,
+                source_asset_id=aid,
+                duration_ms=rule.default_duration_ms,
+                play_to_end=False,
+                transition=rule.default_transition,
+                transition_ms=rule.default_transition_ms,
+                fit=rule.default_fit,
+                effect=rule.default_effect,
+                effect_direction=rule.default_effect_direction,
+            )
+            for i, aid in enumerate(member_ids)
+        ]
+
+    rows_result = await db.execute(
+        select(SlideshowSlide)
+        .where(SlideshowSlide.slideshow_asset_id == asset.id)
+        .order_by(SlideshowSlide.position.asc())
+    )
+    return [
+        _SlideSpec(
+            position=row.position,
+            source_asset_id=row.source_asset_id,
+            duration_ms=row.duration_ms,
+            play_to_end=row.play_to_end,
+            transition=row.transition,
+            transition_ms=row.transition_ms,
+            fit=row.fit,
+            effect=row.effect,
+            effect_direction=row.effect_direction,
+        )
+        for row in rows_result.scalars().all()
+    ]
+
+
 async def plan_slideshow(
     asset: Asset, profile_id: Optional[uuid.UUID], db: AsyncSession
 ) -> SlideshowPlan:
     """Resolve every slide of ``asset`` against ``profile_id``.
+
+    The slide list comes from one of two sources, transparently to the
+    rest of this function (see :func:`_load_slide_specs`):
+
+    * **Manual mode** — explicit ``slideshow_slides`` rows, ordered by
+      ``position``.
+    * **Tag mode** (agora#806) — when a :class:`SlideshowTagRule` exists
+      for ``asset``, the deck is the set of assets currently carrying the
+      rule's tag, ordered by tag-membership creation time so a newly
+      tagged asset always lands at the tail (Option B seamless insert).
 
     For each slide the planner picks the latest READY variant for the
     device's profile when one exists; otherwise falls back to the raw
@@ -293,17 +410,11 @@ async def plan_slideshow(
     Two batched queries by source-asset-id keep this O(1) in slide count
     regardless of slideshow size.
     """
-    rows = (
-        await db.execute(
-            select(SlideshowSlide)
-            .where(SlideshowSlide.slideshow_asset_id == asset.id)
-            .order_by(SlideshowSlide.position.asc())
-        )
-    ).scalars().all()
-    if not rows:
+    specs = await _load_slide_specs(asset, db)
+    if not specs:
         return SlideshowPlan()
 
-    source_ids = [r.source_asset_id for r in rows]
+    source_ids = [s.source_asset_id for s in specs]
     sources_result = await db.execute(
         select(Asset).where(Asset.id.in_(source_ids))
     )
@@ -339,13 +450,13 @@ async def plan_slideshow(
                 ready_by_source[sid] = v
 
     plan = SlideshowPlan()
-    for slide_row in rows:
-        sid = slide_row.source_asset_id
+    for spec in specs:
+        sid = spec.source_asset_id
         src = sources_by_id.get(sid)
         if src is None or src.deleted_at is not None:
             plan.blockers.append(
                 SlideshowBlocker(
-                    slide_position=slide_row.position,
+                    slide_position=spec.position,
                     source_asset_id=sid,
                     source_filename=src.filename if src else "",
                     status=BLOCKER_SOURCE_DELETED,
@@ -353,17 +464,17 @@ async def plan_slideshow(
             )
             continue
         sp = _SlidePlan(
-            position=slide_row.position,
+            position=spec.position,
             source_asset_id=sid,
             source_filename=src.filename,
             source_asset_type=src.asset_type,
-            duration_ms=slide_row.duration_ms,
-            play_to_end=slide_row.play_to_end,
-            transition=slide_row.transition,
-            transition_ms=slide_row.transition_ms,
-            fit=slide_row.fit,
-            effect=slide_row.effect,
-            effect_direction=slide_row.effect_direction,
+            duration_ms=spec.duration_ms,
+            play_to_end=spec.play_to_end,
+            transition=spec.transition,
+            transition_ms=spec.transition_ms,
+            fit=spec.fit,
+            effect=spec.effect,
+            effect_direction=spec.effect_direction,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -375,7 +486,7 @@ async def plan_slideshow(
             if composed_unpublished_reason(src) is not None:
                 plan.blockers.append(
                     SlideshowBlocker(
-                        slide_position=slide_row.position,
+                        slide_position=spec.position,
                         source_asset_id=sid,
                         source_filename=src.filename,
                         status=BLOCKER_SOURCE_UNPUBLISHED,
@@ -386,7 +497,7 @@ async def plan_slideshow(
             if sib == _SIBLINGS_INFLIGHT:
                 plan.blockers.append(
                     SlideshowBlocker(
-                        slide_position=slide_row.position,
+                        slide_position=spec.position,
                         source_asset_id=sid,
                         source_filename=src.filename,
                         status=BLOCKER_VARIANT_PROCESSING,
@@ -424,7 +535,7 @@ async def plan_slideshow(
                         status = BLOCKER_VARIANT_CANCELLED
                     plan.blockers.append(
                         SlideshowBlocker(
-                            slide_position=slide_row.position,
+                            slide_position=spec.position,
                             source_asset_id=sid,
                             source_filename=src.filename,
                             status=status,
@@ -568,7 +679,17 @@ async def build_fetch_for_slideshow(
 
     # Phase 1b of agora#226 — wall-clock anchor support.
     cycle_duration_ms = sum(sp.duration_ms for sp in plan.slides)
-    started_at = _compute_cycle_anchor(cycle_duration_ms)
+    # Tag-mode decks (agora#806, Option B) carry a persisted anchor that is
+    # set once and NEVER re-floored, so appending a newly-tagged slide at
+    # the tail leaves every existing slide's cycle offset unchanged — the
+    # on-screen slide does not move.  Manual decks (and tag rules created
+    # before anchor support, where anchor_at is NULL) fall back to flooring
+    # ``now`` to a cycle boundary on every build.
+    rule = await _get_tag_rule(asset.id, db)
+    if rule is not None and rule.anchor_at is not None:
+        started_at = _format_anchor(rule.anchor_at)
+    else:
+        started_at = _compute_cycle_anchor(cycle_duration_ms)
 
     # Deck-level shuffle (agora#261).  Emit the bool + a stable per-asset
     # seed so every device derives the same per-cycle permutation and a
@@ -624,6 +745,18 @@ def _compute_cycle_anchor(cycle_duration_ms: int) -> Optional[str]:
     anchor = datetime.fromtimestamp(floor_ms / 1000, tz=timezone.utc)
     # ISO-8601 with millisecond precision, "Z" suffix for UTC.
     iso = anchor.isoformat(timespec="milliseconds")
+    return iso.replace("+00:00", "Z")
+
+
+def _format_anchor(dt: datetime) -> str:
+    """Format a UTC ``datetime`` as the same ISO-8601 ``Z`` string the
+    cycle-anchor helper emits, so a persisted tag-rule anchor is wire
+    identical to a computed one.  Naive datetimes are assumed UTC."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    iso = dt.isoformat(timespec="milliseconds")
     return iso.replace("+00:00", "Z")
 
 

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -938,3 +938,213 @@ class TestShuffleSeedAndChecksumFold:
             "asset-sha", [self._plan("left")], shuffle=False
         )
         assert in_ck != left_ck  # changing KB direction invalidates the cache
+
+
+# ---------------------------------------------------------------------------
+# Tag-mode dynamic playlists (agora#806)
+# ---------------------------------------------------------------------------
+
+async def _seed_tag(db, name="promo"):
+    from cms.models.tag import Tag
+
+    t = Tag(name=name)
+    db.add(t)
+    await db.commit()
+    await db.refresh(t)
+    return t
+
+
+async def _tag_asset(db, *, asset, tag, when):
+    """Create an ``AssetTag`` with an explicit ``created_at`` so tests can
+    control the ``tagged_at`` ordering that tag-mode decks rely on."""
+    from cms.models.tag import AssetTag
+
+    at = AssetTag(asset_id=asset.id, tag_id=tag.id, created_at=when)
+    db.add(at)
+    await db.commit()
+    await db.refresh(at)
+    return at
+
+
+async def _seed_tag_rule(
+    db, *, slideshow, tag, anchor_at=None, default_duration_ms=8000
+):
+    from cms.models.slideshow_tag_rule import SlideshowTagRule
+
+    r = SlideshowTagRule(
+        slideshow_asset_id=slideshow.id,
+        tag_id=tag.id,
+        default_duration_ms=default_duration_ms,
+        anchor_at=anchor_at,
+    )
+    db.add(r)
+    await db.commit()
+    await db.refresh(r)
+    return r
+
+
+@pytest.mark.asyncio
+class TestTagModeSlideshow:
+    async def test_resolves_members_in_tagged_at_order(self, db_session):
+        """A tag-mode deck builds its slide list from current tag
+        membership, ordered by ``asset_tags.created_at`` (tagged_at)."""
+        from datetime import datetime, timedelta, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "ptag1")
+        tag = await _seed_tag(db_session, "promo1")
+        a = await _seed_image(db_session, filename="a.png")
+        b = await _seed_image(db_session, filename="b.png")
+        c = await _seed_image(db_session, filename="c.png")
+        for img, ck in ((a, "va"), (b, "vb"), (c, "vc")):
+            await _seed_variant(
+                db_session, source=img, profile=profile, checksum=ck, ext="jpg",
+            )
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        # Tag order (non-alphabetical): c (oldest) -> a -> b (newest).
+        await _tag_asset(db_session, asset=c, tag=tag, when=base)
+        await _tag_asset(db_session, asset=a, tag=tag, when=base + timedelta(seconds=10))
+        await _tag_asset(db_session, asset=b, tag=tag, when=base + timedelta(seconds=20))
+
+        ss = await _seed_slideshow(
+            db_session, name="tagdeck", slides_data=[], checksum="tag-base",
+        )
+        await _seed_tag_rule(db_session, slideshow=ss, tag=tag)
+
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        assert [s.source_filename for s in plan.slides] == ["c.png", "a.png", "b.png"]
+        assert [s.position for s in plan.slides] == [0, 1, 2]
+        # Every member inherits the rule's deck-level duration default.
+        assert all(s.duration_ms == 8000 for s in plan.slides)
+
+    async def test_newly_tagged_asset_appends_at_tail(self, db_session):
+        """Tagging a new asset appends it at the tail, leaving existing
+        members in place (Option B no-restart guarantee)."""
+        from datetime import datetime, timedelta, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "ptag2")
+        tag = await _seed_tag(db_session, "promo2")
+        a = await _seed_image(db_session, filename="first.png")
+        b = await _seed_image(db_session, filename="second.png")
+        for img in (a, b):
+            await _seed_variant(db_session, source=img, profile=profile, ext="jpg")
+        base = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        await _tag_asset(db_session, asset=a, tag=tag, when=base)
+        await _tag_asset(db_session, asset=b, tag=tag, when=base + timedelta(seconds=10))
+        ss = await _seed_slideshow(
+            db_session, name="tagdeck2", slides_data=[], checksum="tb",
+        )
+        await _seed_tag_rule(db_session, slideshow=ss, tag=tag)
+
+        plan1 = await plan_slideshow(ss, profile.id, db_session)
+        assert [s.source_filename for s in plan1.slides] == ["first.png", "second.png"]
+
+        c = await _seed_image(db_session, filename="third.png")
+        await _seed_variant(db_session, source=c, profile=profile, ext="jpg")
+        await _tag_asset(db_session, asset=c, tag=tag, when=base + timedelta(seconds=20))
+
+        plan2 = await plan_slideshow(ss, profile.id, db_session)
+        assert [s.source_filename for s in plan2.slides] == [
+            "first.png", "second.png", "third.png",
+        ]
+        assert [s.position for s in plan2.slides] == [0, 1, 2]
+
+    async def test_tag_rule_overrides_manual_slides(self, db_session):
+        """When a SlideshowTagRule exists, the deck comes from tag
+        membership even if stale SlideshowSlide rows are also present."""
+        from datetime import datetime, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "ptag3")
+        manual_img = await _seed_image(db_session, filename="manual.png")
+        await _seed_variant(db_session, source=manual_img, profile=profile, ext="jpg")
+        ss = await _seed_slideshow(
+            db_session, name="tagdeck3",
+            slides_data=[(manual_img, 5000, False)], checksum="tb3",
+        )
+        tag = await _seed_tag(db_session, "promo3")
+        tag_img = await _seed_image(db_session, filename="tagged.png")
+        await _seed_variant(db_session, source=tag_img, profile=profile, ext="jpg")
+        await _tag_asset(
+            db_session, asset=tag_img, tag=tag,
+            when=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        await _seed_tag_rule(db_session, slideshow=ss, tag=tag)
+
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert [s.source_filename for s in plan.slides] == ["tagged.png"]
+
+    async def test_persisted_anchor_emitted_verbatim(self, db_session, app):
+        """A tag rule with a persisted ``anchor_at`` emits it verbatim as
+        ``started_at`` — NOT floored to a cycle boundary — so tail appends
+        never shift the on-screen slide."""
+        from datetime import datetime, timezone
+
+        from cms.services.slideshow_resolver import (
+            _format_anchor,
+            build_fetch_for_slideshow,
+        )
+
+        profile = await _seed_profile(db_session, "ptag4")
+        group = await _seed_group(db_session, "gtag4")
+        device = await _seed_device(
+            db_session, did="dtag4", group=group, profile=profile,
+        )
+        tag = await _seed_tag(db_session, "promo4")
+        img = await _seed_image(db_session, filename="anchor.png")
+        await _seed_variant(
+            db_session, source=img, profile=profile, checksum="av", ext="jpg",
+        )
+        await _tag_asset(
+            db_session, asset=img, tag=tag,
+            when=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        )
+        ss = await _seed_slideshow(
+            db_session, name="tagdeck4", slides_data=[], checksum="tb4",
+        )
+        anchor = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+        await _seed_tag_rule(db_session, slideshow=ss, tag=tag, anchor_at=anchor)
+
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        assert fetch.started_at == _format_anchor(anchor)
+
+    async def test_null_anchor_falls_back_to_floored(self, db_session, app):
+        """A tag rule with NULL ``anchor_at`` (created before anchor
+        support) falls back to the floored-to-cycle-boundary anchor."""
+        from datetime import datetime, timezone
+
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "ptag5")
+        group = await _seed_group(db_session, "gtag5")
+        device = await _seed_device(
+            db_session, did="dtag5", group=group, profile=profile,
+        )
+        tag = await _seed_tag(db_session, "promo5")
+        img = await _seed_image(db_session, filename="floor.png")
+        await _seed_variant(
+            db_session, source=img, profile=profile, checksum="fv", ext="jpg",
+        )
+        await _tag_asset(
+            db_session, asset=img, tag=tag,
+            when=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        ss = await _seed_slideshow(
+            db_session, name="tagdeck5", slides_data=[], checksum="tb5",
+        )
+        await _seed_tag_rule(db_session, slideshow=ss, tag=tag, anchor_at=None)
+
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        anchor = datetime.fromisoformat(fetch.started_at.replace("Z", "+00:00"))
+        assert int(anchor.timestamp() * 1000) % fetch.cycle_duration_ms == 0


### PR DESCRIPTION
## Tag-based dynamic playlists — resolver foundation (#806)

First CMS-side slice of **tag-based dynamic playlists**: tag an asset
and have it appear in a running slideshow **without restarting it**.

### Design (locked)
- **Option B — append at tail.** Newly-tagged assets land at the end
  of the deck so the on-screen slide never moves.
- Tag mode is detected by the presence of a `SlideshowTagRule` row
  (no new column on the shared `Asset` model).
- Member ordering is **`tagged_at`** (`AssetTag.created_at` ASC) —
  load-bearing for the no-restart guarantee.
- A **persisted wall-clock anchor** (`SlideshowTagRule.anchor_at`) is
  emitted verbatim when present so the device cycle stays stable as
  membership changes; NULL anchor → floored cycle anchor (existing
  behavior).

### Changes
- **`cms/models/slideshow_tag_rule.py`** (new) — 1:1 rule model
  (PK = `slideshow_asset_id`, tag FK, default playback fields,
  `anchor_at`).
- **`alembic/versions/0045_slideshow_tag_rule.py`** (new) — creates
  `slideshow_tag_rules` (`down_revision = 0044`).
- **`cms/services/slideshow_resolver.py`** — `plan_slideshow`
  refactored to be spec-based (`_SlideSpec` / `_load_slide_specs` /
  `_get_tag_rule`); tag-membership resolution branch; persisted-anchor
  emit branch (`_format_anchor`).
- **`cms/models/__init__.py`** — register `SlideshowTagRule`.
- **tests** — `TestTagModeSlideshow` (5 tests): tagged_at ordering,
  tail append, tag-rule overrides manual slides, persisted-anchor
  verbatim, null-anchor floored fallback.

### Tests
`33/33` resolver tests green locally (28 existing + 5 new).
Manual-mode behavior unchanged.

### Follow-ups (not this PR)
- Tag-rule create/edit API (sets `anchor_at` at creation)
- Tag-change push hook (tag/untag → reverse-lookup affected tag-mode
  decks → debounced device push)
- Builder UI for tag mode
- Untag-removal reflow behavior

Closes part of #806.
