### PR TITLE
feat(slideshow): tag-rule create/edit/delete API (#806)

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -25,6 +25,7 @@ from cms.models.device_profile import DeviceProfile
 from cms.models.group_asset import GroupAsset
 from cms.models.schedule import Schedule
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.slideshow_tag_rule import SlideshowTagRule
 from cms.models.tag import AssetTag, Tag
 from cms.models.user import User
 from cms.models.chat_thread import ChatThread
@@ -40,6 +41,8 @@ from cms.schemas.asset import (
     MAX_SLIDE_DURATION_MS,
     MAX_SLIDESHOW_SLIDES,
     SlideIn,
+    TagRuleIn,
+    TagRuleOut,
 )
 from cms.schemas.tag import TagOut
 from cms.services.audit_service import audit_log, compute_diff
@@ -2087,6 +2090,196 @@ async def _load_slideshow_for_write(
             status_code=403, detail="Only the slideshow owner can edit its slides"
         )
     return asset
+
+
+async def _count_tag_members(tag_id: uuid.UUID, db: AsyncSession) -> int:
+    """Count assets that would resolve into a tag-mode deck for ``tag_id``.
+
+    Mirrors the resolver's membership query (same eligible asset types,
+    same deleted-row exclusion) so the ``member_count`` surfaced by the
+    tag-rule API matches what the device will actually play.
+    """
+    from cms.services.slideshow_resolver import _TAG_MEMBER_ASSET_TYPES
+
+    return int(
+        (
+            await db.execute(
+                select(func.count())
+                .select_from(Asset)
+                .join(AssetTag, AssetTag.asset_id == Asset.id)
+                .where(
+                    AssetTag.tag_id == tag_id,
+                    Asset.deleted_at.is_(None),
+                    Asset.asset_type.in_(_TAG_MEMBER_ASSET_TYPES),
+                )
+            )
+        ).scalar_one()
+    )
+
+
+async def _tag_rule_out(
+    rule: SlideshowTagRule, db: AsyncSession
+) -> TagRuleOut:
+    """Build the API representation of a tag rule (tag name + live count)."""
+    tag_name = (
+        await db.execute(select(Tag.name).where(Tag.id == rule.tag_id))
+    ).scalar_one_or_none()
+    out = TagRuleOut.model_validate(rule)
+    out.tag_name = tag_name
+    out.member_count = await _count_tag_members(rule.tag_id, db)
+    return out
+
+
+@router.get("/{asset_id}/tag-rule")
+async def get_slideshow_tag_rule(
+    asset_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> TagRuleOut:
+    """Return the tag rule for a slideshow, or 404 if it's in manual mode.
+
+    A slideshow is in *tag mode* when a :class:`SlideshowTagRule` row
+    exists; its deck is resolved live from assets carrying the rule's
+    tag rather than from hand-authored ``slideshow_slides`` rows.
+    """
+    await _load_slideshow_for_write(asset_id, request, db)
+    rule = (
+        await db.execute(
+            select(SlideshowTagRule).where(
+                SlideshowTagRule.slideshow_asset_id == asset_id
+            )
+        )
+    ).scalar_one_or_none()
+    if rule is None:
+        raise HTTPException(status_code=404, detail="Slideshow has no tag rule")
+    return await _tag_rule_out(rule, db)
+
+
+@router.put("/{asset_id}/tag-rule")
+async def put_slideshow_tag_rule(
+    asset_id: uuid.UUID,
+    body: TagRuleIn,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> TagRuleOut:
+    """Create or replace a slideshow's tag rule (flip it into tag mode).
+
+    On create, ``anchor_at`` is stamped to *now* so the resolver anchors
+    the playback cycle at the moment tag mode was enabled. On edit, the
+    existing ``anchor_at`` is preserved so the on-screen slide never jumps
+    (the no-restart guarantee for agora-cms#806). Manual ``slideshow_slides``
+    rows are left intact so DELETE reverts cleanly to the manual deck.
+
+    Device propagation is automatic: ``build_device_sync`` re-resolves
+    every slideshow through the (tag-aware) resolver each scheduler tick,
+    so connected devices pick up the new deck within one eval interval —
+    no explicit push needed.
+    """
+    asset = await _load_slideshow_for_write(asset_id, request, db)
+
+    tag = (
+        await db.execute(select(Tag).where(Tag.id == body.tag_id))
+    ).scalar_one_or_none()
+    if tag is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    rule = (
+        await db.execute(
+            select(SlideshowTagRule).where(
+                SlideshowTagRule.slideshow_asset_id == asset_id
+            )
+        )
+    ).scalar_one_or_none()
+
+    created = rule is None
+    if rule is None:
+        rule = SlideshowTagRule(
+            slideshow_asset_id=asset_id,
+            anchor_at=datetime.now(timezone.utc),
+        )
+        db.add(rule)
+
+    rule.tag_id = body.tag_id
+    rule.order_by = "tagged_at"
+    rule.default_duration_ms = body.default_duration_ms
+    rule.default_transition = body.default_transition
+    rule.default_transition_ms = body.default_transition_ms
+    rule.default_fit = body.default_fit
+    rule.default_effect = body.default_effect
+    rule.default_effect_direction = body.default_effect_direction
+
+    await audit_log(
+        db,
+        user=user,
+        action="asset.set_tag_rule",
+        resource_type="asset",
+        resource_id=str(asset_id),
+        description=(
+            f"{'Enabled' if created else 'Updated'} tag mode on slideshow "
+            f"'{asset.display_name or asset.original_filename or asset.filename}' "
+            f"(tag '{tag.name}')"
+        ),
+        details={
+            "filename": asset.display_name or asset.original_filename or asset.filename,
+            "tag_id": str(body.tag_id),
+            "tag_name": tag.name,
+            "created": created,
+        },
+        request=request,
+    )
+    await db.commit()
+    await db.refresh(rule)
+    return await _tag_rule_out(rule, db)
+
+
+@router.delete("/{asset_id}/tag-rule")
+async def delete_slideshow_tag_rule(
+    asset_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(require_permission(ASSETS_WRITE)),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Delete a slideshow's tag rule, reverting it to manual mode.
+
+    Returns 404 if the slideshow has no tag rule. Manual ``slideshow_slides``
+    rows were never touched by tag mode, so the slideshow falls straight
+    back to its previously-authored deck (empty if none).
+    """
+    asset = await _load_slideshow_for_write(asset_id, request, db)
+    rule = (
+        await db.execute(
+            select(SlideshowTagRule).where(
+                SlideshowTagRule.slideshow_asset_id == asset_id
+            )
+        )
+    ).scalar_one_or_none()
+    if rule is None:
+        raise HTTPException(status_code=404, detail="Slideshow has no tag rule")
+
+    await db.execute(
+        delete(SlideshowTagRule).where(
+            SlideshowTagRule.slideshow_asset_id == asset_id
+        )
+    )
+    await audit_log(
+        db,
+        user=user,
+        action="asset.delete_tag_rule",
+        resource_type="asset",
+        resource_id=str(asset_id),
+        description=(
+            f"Disabled tag mode on slideshow "
+            f"'{asset.display_name or asset.original_filename or asset.filename}'"
+        ),
+        details={
+            "filename": asset.display_name or asset.original_filename or asset.filename,
+        },
+        request=request,
+    )
+    await db.commit()
+    return {"slideshow_id": str(asset_id), "tag_rule": None}
 
 
 @router.post("/{asset_id}/assistant/thread")

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -7,6 +7,7 @@ from typing import Optional
 from pydantic import BaseModel, Field, field_validator
 
 from cms.models.asset import AssetType, VariantStatus
+from cms.models.slideshow_tag_rule import DEFAULT_TAG_SLIDE_DURATION_MS
 from cms.schemas.tag import TagOut
 
 
@@ -358,4 +359,93 @@ class SlideOut(BaseModel):
     source_asset_type: AssetType
     source_duration_seconds: Optional[float] = None
     thumbnail_url: Optional[str] = None
+
+
+class TagRuleIn(BaseModel):
+    """Request body to create/replace a slideshow's tag rule (agora-cms#806).
+
+    Putting a tag rule on a slideshow asset flips it into *tag mode*: the
+    deck is resolved live from the set of assets carrying ``tag_id`` rather
+    than from hand-authored ``slideshow_slides`` rows.  ``order_by`` is not
+    exposed on the wire — v1 is hardcoded to ``tagged_at`` (the only value
+    that preserves the no-restart, append-at-tail guarantee).
+
+    The ``default_*`` fields apply uniformly to every resolved member, since
+    a tag deck has no per-slide authoring UI.  Their validators mirror
+    :class:`SlideIn` exactly so a tag deck behaves like a hand-built one
+    with default slides.
+    """
+
+    tag_id: uuid.UUID
+    default_duration_ms: int = Field(
+        DEFAULT_TAG_SLIDE_DURATION_MS,
+        ge=MIN_SLIDE_DURATION_MS,
+        le=MAX_SLIDE_DURATION_MS,
+    )
+    default_transition: str = Field(DEFAULT_SLIDE_TRANSITION)
+    default_transition_ms: int = Field(
+        DEFAULT_SLIDE_TRANSITION_MS,
+        ge=MIN_SLIDE_TRANSITION_MS,
+        le=MAX_SLIDE_TRANSITION_MS,
+    )
+    default_fit: str = Field(DEFAULT_SLIDE_FIT)
+    default_effect: str = Field(DEFAULT_SLIDE_EFFECT)
+    default_effect_direction: str = Field(DEFAULT_KEN_BURNS_DIRECTION)
+
+    @field_validator("default_transition")
+    @classmethod
+    def _validate_transition(cls, v: str) -> str:
+        if v not in SLIDE_TRANSITIONS:
+            raise ValueError(
+                f"default_transition must be one of {SLIDE_TRANSITIONS}, got {v!r}"
+            )
+        return v
+
+    @field_validator("default_fit")
+    @classmethod
+    def _validate_fit(cls, v: str) -> str:
+        if v not in SLIDE_FITS:
+            raise ValueError(f"default_fit must be one of {SLIDE_FITS}, got {v!r}")
+        return v
+
+    @field_validator("default_effect")
+    @classmethod
+    def _validate_effect(cls, v: str) -> str:
+        if v not in SLIDE_EFFECTS:
+            raise ValueError(f"default_effect must be one of {SLIDE_EFFECTS}, got {v!r}")
+        return v
+
+    @field_validator("default_effect_direction")
+    @classmethod
+    def _validate_effect_direction(cls, v: str) -> str:
+        v = normalize_effect_direction(v)
+        if v not in KEN_BURNS_DIRECTIONS:
+            raise ValueError(
+                f"default_effect_direction must be one of {KEN_BURNS_DIRECTIONS}, got {v!r}"
+            )
+        return v
+
+
+class TagRuleOut(BaseModel):
+    """A slideshow's tag rule, as returned by GET/PUT ``/{id}/tag-rule``.
+
+    ``member_count`` is the number of assets currently resolved into the
+    deck (eligible asset types carrying the tag), surfaced so the builder
+    UI can show "N items match" without a second round-trip.
+    """
+
+    model_config = {"from_attributes": True}
+
+    slideshow_asset_id: uuid.UUID
+    tag_id: uuid.UUID
+    tag_name: Optional[str] = None
+    order_by: str = "tagged_at"
+    default_duration_ms: int = DEFAULT_TAG_SLIDE_DURATION_MS
+    default_transition: str = DEFAULT_SLIDE_TRANSITION
+    default_transition_ms: int = DEFAULT_SLIDE_TRANSITION_MS
+    default_fit: str = DEFAULT_SLIDE_FIT
+    default_effect: str = DEFAULT_SLIDE_EFFECT
+    default_effect_direction: str = DEFAULT_KEN_BURNS_DIRECTION
+    anchor_at: Optional[datetime] = None
+    member_count: int = 0
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1375,6 +1375,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/assets/{asset_id}/tag-rule:
+    get:
+      summary: Get Slideshow Tag Rule
+      description: |-
+        Return the tag rule for a slideshow, or 404 if it's in manual mode.
+
+        A slideshow is in *tag mode* when a :class:`SlideshowTagRule` row
+        exists; its deck is resolved live from assets carrying the rule's
+        tag rather than from hand-authored ``slideshow_slides`` rows.
+      operationId: get_slideshow_tag_rule_api_assets__asset_id__tag_rule_get
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagRuleOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      summary: Put Slideshow Tag Rule
+      description: |-
+        Create or replace a slideshow's tag rule (flip it into tag mode).
+
+        On create, ``anchor_at`` is stamped to *now* so the resolver anchors
+        the playback cycle at the moment tag mode was enabled. On edit, the
+        existing ``anchor_at`` is preserved so the on-screen slide never jumps
+        (the no-restart guarantee for agora-cms#806). Manual ``slideshow_slides``
+        rows are left intact so DELETE reverts cleanly to the manual deck.
+
+        Device propagation is automatic: ``build_device_sync`` re-resolves
+        every slideshow through the (tag-aware) resolver each scheduler tick,
+        so connected devices pick up the new deck within one eval interval —
+        no explicit push needed.
+      operationId: put_slideshow_tag_rule_api_assets__asset_id__tag_rule_put
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagRuleIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagRuleOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Slideshow Tag Rule
+      description: |-
+        Delete a slideshow's tag rule, reverting it to manual mode.
+
+        Returns 404 if the slideshow has no tag rule. Manual ``slideshow_slides``
+        rows were never touched by tag mode, so the slideshow falls straight
+        back to its previously-authored deck (empty if none).
+      operationId: delete_slideshow_tag_rule_api_assets__asset_id__tag_rule_delete
+      parameters:
+      - name: asset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Asset Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Slideshow Tag Rule Api Assets  Asset Id  Tag Rule Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/assets/{asset_id}/assistant/thread:
     post:
       summary: Slideshow Assistant Thread
@@ -7190,6 +7296,121 @@ components:
       type: object
       title: TagPatch
       description: Request body for ``PATCH /api/tags/{id}``.  All fields optional.
+    TagRuleIn:
+      properties:
+        tag_id:
+          type: string
+          format: uuid
+          title: Tag Id
+        default_duration_ms:
+          type: integer
+          maximum: 3600000.0
+          minimum: 500.0
+          title: Default Duration Ms
+          default: 8000
+        default_transition:
+          type: string
+          title: Default Transition
+          default: cut
+        default_transition_ms:
+          type: integer
+          maximum: 5000.0
+          minimum: 0.0
+          title: Default Transition Ms
+          default: 600
+        default_fit:
+          type: string
+          title: Default Fit
+          default: cover
+        default_effect:
+          type: string
+          title: Default Effect
+          default: none
+        default_effect_direction:
+          type: string
+          title: Default Effect Direction
+          default: in
+      type: object
+      required:
+      - tag_id
+      title: TagRuleIn
+      description: |-
+        Request body to create/replace a slideshow's tag rule (agora-cms#806).
+
+        Putting a tag rule on a slideshow asset flips it into *tag mode*: the
+        deck is resolved live from the set of assets carrying ``tag_id`` rather
+        than from hand-authored ``slideshow_slides`` rows.  ``order_by`` is not
+        exposed on the wire — v1 is hardcoded to ``tagged_at`` (the only value
+        that preserves the no-restart, append-at-tail guarantee).
+
+        The ``default_*`` fields apply uniformly to every resolved member, since
+        a tag deck has no per-slide authoring UI.  Their validators mirror
+        :class:`SlideIn` exactly so a tag deck behaves like a hand-built one
+        with default slides.
+    TagRuleOut:
+      properties:
+        slideshow_asset_id:
+          type: string
+          format: uuid
+          title: Slideshow Asset Id
+        tag_id:
+          type: string
+          format: uuid
+          title: Tag Id
+        tag_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tag Name
+        order_by:
+          type: string
+          title: Order By
+          default: tagged_at
+        default_duration_ms:
+          type: integer
+          title: Default Duration Ms
+          default: 8000
+        default_transition:
+          type: string
+          title: Default Transition
+          default: cut
+        default_transition_ms:
+          type: integer
+          title: Default Transition Ms
+          default: 600
+        default_fit:
+          type: string
+          title: Default Fit
+          default: cover
+        default_effect:
+          type: string
+          title: Default Effect
+          default: none
+        default_effect_direction:
+          type: string
+          title: Default Effect Direction
+          default: in
+        anchor_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Anchor At
+        member_count:
+          type: integer
+          title: Member Count
+          default: 0
+      type: object
+      required:
+      - slideshow_asset_id
+      - tag_id
+      title: TagRuleOut
+      description: |-
+        A slideshow's tag rule, as returned by GET/PUT ``/{id}/tag-rule``.
+
+        ``member_count`` is the number of assets currently resolved into the
+        deck (eligible asset types carrying the tag), surfaced so the builder
+        UI can show "N items match" without a second round-trip.
     ToggleRequest:
       properties:
         enabled:

--- a/tests/test_slideshow_tag_rule_api.py
+++ b/tests/test_slideshow_tag_rule_api.py
@@ -1,0 +1,260 @@
+"""Tests for the slideshow tag-rule API (agora-cms#806, Option B).
+
+Covers GET / PUT / DELETE ``/api/assets/{id}/tag-rule``: the endpoints
+that flip a slideshow into *tag mode* (deck resolved live from assets
+carrying a tag) and back to manual mode.
+
+Asserted contract:
+
+* PUT creates a rule, stamps ``anchor_at`` to ~now, hardcodes
+  ``order_by="tagged_at"``, and reports the live ``member_count``.
+* PUT on an existing rule edits the defaults but PRESERVES ``anchor_at``
+  (the no-restart guarantee — the on-screen slide must not jump).
+* GET returns the rule (404 when manual mode).
+* DELETE removes the rule (404 when none); manual slides survive.
+* Validation: 404 for an unknown tag, 400 for a non-slideshow asset,
+  422 for a bad default field.
+* Owner/admin gating mirrors ``replace_slideshow_slides``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from cms.models.asset import Asset, AssetType
+from cms.models.audit_log import AuditLog
+from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.slideshow_tag_rule import SlideshowTagRule
+from cms.models.tag import AssetTag, Tag
+
+
+# ── Seed helpers ──
+
+
+async def _seed_image(db_session, *, filename="img.png", is_global=True):
+    asset = Asset(
+        filename=filename,
+        asset_type=AssetType.IMAGE,
+        size_bytes=1234,
+        checksum="img-cs",
+        is_global=is_global,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    await db_session.refresh(asset)
+    return asset
+
+
+async def _seed_tag(db_session, name="promos"):
+    tag = Tag(name=name)
+    db_session.add(tag)
+    await db_session.commit()
+    await db_session.refresh(tag)
+    return tag
+
+
+async def _tag_asset(db_session, asset, tag):
+    db_session.add(AssetTag(asset_id=asset.id, tag_id=tag.id))
+    await db_session.commit()
+
+
+async def _create_slideshow(client, name="tagdeck"):
+    create = await client.post(
+        "/api/assets/slideshow", json={"name": name, "slides": []}
+    )
+    assert create.status_code == 201, create.text
+    return create.json()["id"]
+
+
+@pytest.mark.asyncio
+class TestTagRuleApi:
+
+    async def test_get_404_when_no_rule(self, client, db_session):
+        sid = await _create_slideshow(client)
+        resp = await client.get(f"/api/assets/{sid}/tag-rule")
+        assert resp.status_code == 404
+
+    async def test_put_creates_rule_stamps_anchor_and_defaults(
+        self, client, db_session
+    ):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        before = datetime.now(timezone.utc)
+        resp = await client.put(
+            f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["slideshow_asset_id"] == sid
+        assert body["tag_id"] == str(tag.id)
+        assert body["tag_name"] == "promos"
+        assert body["order_by"] == "tagged_at"
+        # Schema defaults applied.
+        assert body["default_duration_ms"] == 8000
+        assert body["default_transition"] == "cut"
+        assert body["default_fit"] == "cover"
+        # anchor_at stamped to ~now on create.
+        anchor = datetime.fromisoformat(body["anchor_at"])
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=timezone.utc)
+        assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
+        assert anchor >= before.replace(microsecond=0)
+
+        rule = (
+            await db_session.execute(
+                select(SlideshowTagRule).where(
+                    SlideshowTagRule.slideshow_asset_id == uuid.UUID(sid)
+                )
+            )
+        ).scalar_one()
+        assert rule.anchor_at is not None
+
+    async def test_member_count_reflects_tagged_assets(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        img1 = await _seed_image(db_session, filename="m1.png")
+        img2 = await _seed_image(db_session, filename="m2.png")
+        await _tag_asset(db_session, img1, tag)
+        await _tag_asset(db_session, img2, tag)
+        resp = await client.put(
+            f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["member_count"] == 2
+
+    async def test_get_returns_existing_rule(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        await client.put(f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)})
+        resp = await client.get(f"/api/assets/{sid}/tag-rule")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["tag_id"] == str(tag.id)
+
+    async def test_put_edit_preserves_anchor_at(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        first = await client.put(
+            f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)}
+        )
+        anchor1 = first.json()["anchor_at"]
+
+        # Edit the defaults — anchor_at must NOT move (no-restart guarantee).
+        second = await client.put(
+            f"/api/assets/{sid}/tag-rule",
+            json={
+                "tag_id": str(tag.id),
+                "default_duration_ms": 12000,
+                "default_transition": "fade",
+            },
+        )
+        assert second.status_code == 200, second.text
+        body = second.json()
+        assert body["anchor_at"] == anchor1
+        assert body["default_duration_ms"] == 12000
+        assert body["default_transition"] == "fade"
+
+    async def test_put_can_switch_tag(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag_a = await _seed_tag(db_session, name="a")
+        tag_b = await _seed_tag(db_session, name="b")
+        await client.put(f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag_a.id)})
+        resp = await client.put(
+            f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag_b.id)}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["tag_id"] == str(tag_b.id)
+        # Still exactly one rule row (upsert, not insert).
+        rows = (
+            await db_session.execute(
+                select(SlideshowTagRule).where(
+                    SlideshowTagRule.slideshow_asset_id == uuid.UUID(sid)
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+
+    async def test_put_unknown_tag_404(self, client, db_session):
+        sid = await _create_slideshow(client)
+        resp = await client.put(
+            f"/api/assets/{sid}/tag-rule", json={"tag_id": str(uuid.uuid4())}
+        )
+        assert resp.status_code == 404
+        assert "tag" in resp.json()["detail"].lower()
+
+    async def test_put_non_slideshow_400(self, client, db_session):
+        img = await _seed_image(db_session)
+        tag = await _seed_tag(db_session)
+        resp = await client.put(
+            f"/api/assets/{img.id}/tag-rule", json={"tag_id": str(tag.id)}
+        )
+        assert resp.status_code == 400
+        assert "slideshow" in resp.json()["detail"].lower()
+
+    async def test_put_invalid_default_422(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        resp = await client.put(
+            f"/api/assets/{sid}/tag-rule",
+            json={"tag_id": str(tag.id), "default_transition": "not-a-transition"},
+        )
+        assert resp.status_code == 422
+
+    async def test_delete_removes_rule(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        await client.put(f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)})
+        resp = await client.delete(f"/api/assets/{sid}/tag-rule")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["tag_rule"] is None
+        # Rule gone.
+        assert (
+            await client.get(f"/api/assets/{sid}/tag-rule")
+        ).status_code == 404
+
+    async def test_delete_404_when_no_rule(self, client, db_session):
+        sid = await _create_slideshow(client)
+        resp = await client.delete(f"/api/assets/{sid}/tag-rule")
+        assert resp.status_code == 404
+
+    async def test_delete_leaves_manual_slides_intact(self, client, db_session):
+        # Tag mode coexists with (and overrides) a manual deck; deleting the
+        # rule must revert to that manual deck, so manual rows survive.
+        img = await _seed_image(db_session, filename="manual.png")
+        create = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "withmanual",
+                "slides": [{"source_asset_id": str(img.id), "duration_ms": 3000}],
+            },
+        )
+        assert create.status_code == 201, create.text
+        sid = create.json()["id"]
+        tag = await _seed_tag(db_session)
+        await client.put(f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)})
+        await client.delete(f"/api/assets/{sid}/tag-rule")
+
+        rows = (
+            await db_session.execute(
+                select(SlideshowSlide).where(
+                    SlideshowSlide.slideshow_asset_id == uuid.UUID(sid)
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+
+    async def test_put_and_delete_write_audit_log(self, client, db_session):
+        sid = await _create_slideshow(client)
+        tag = await _seed_tag(db_session)
+        await client.put(f"/api/assets/{sid}/tag-rule", json={"tag_id": str(tag.id)})
+        await client.delete(f"/api/assets/{sid}/tag-rule")
+        actions = (
+            await db_session.execute(
+                select(AuditLog.action).where(AuditLog.resource_id == sid)
+            )
+        ).scalars().all()
+        assert "asset.set_tag_rule" in actions
+        assert "asset.delete_tag_rule" in actions


### PR DESCRIPTION
## What

Adds the tag-rule CRUD HTTP API for tag-based dynamic slideshows (issue #806, Option B). A slideshow can now be flipped into **tag mode** — its deck resolves live from any assets carrying a chosen tag — and flipped back to manual.

The resolver foundation (model + migration + tag-aware resolver) shipped in #808. This PR adds the API that writes the rule rows.

## Endpoints (`/api/assets/{asset_id}/tag-rule`)

| Method | Behavior |
|--------|----------|
| GET | Return the rule, or 404 if the slideshow is in manual mode |
| PUT | Create/replace the rule. **Create** stamps `anchor_at=now`; **edit** PRESERVES `anchor_at` so the on-screen slide never jumps (no-restart guarantee) |
| DELETE | Revert to manual mode; hand-authored `slideshow_slides` rows are left intact |

## Notes

- `order_by` is hardcoded server-side to `tagged_at` (newest-tagged appended at the end — Option B).
- `member_count` mirrors the resolver's membership query exactly (eligible asset types + deleted-row exclusion), so the API count matches what devices play.
- `TagRuleIn` validators mirror `SlideIn` (transition/fit/effect/direction grammar + duration bounds) → 422 on bad input.
- Owner/admin gating via the reused `_load_slideshow_for_write` helper; audit rows `asset.set_tag_rule` / `asset.delete_tag_rule`.
- **Device propagation is automatic** — `build_device_sync` re-resolves every slideshow through the tag-aware resolver each scheduler tick (≤ one eval interval). No explicit push in v1.

## Tests

13 new API tests (create/edit/delete/get/validation/audit/member_count); resolver suite (33) still green. `docs/openapi.yaml` regenerated.

## Deferred (separate PRs)

Builder UI for tag mode; sub-second tag-change push hook.
