### PR TITLE
feat(slideshow): Deck-source toggle for tag-based dynamic slideshows

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -611,6 +611,57 @@
     align-items: flex-end;
 }
 .ssb-toolbar > * { flex: 1; min-width: 200px; }
+
+/* Deck source toggle + tag-mode panel */
+.ssb-decksource {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+    padding: 0.85rem 1rem;
+    background: #1b1b1f;
+    border: 1px solid #333;
+    border-radius: 8px;
+}
+.ssb-decksource-label { font-weight: 600; }
+.ssb-decksource-hint { font-size: 0.8rem; flex-basis: 100%; }
+.ssb-seg { display: inline-flex; border: 1px solid #444; border-radius: 6px; overflow: hidden; }
+.ssb-seg-btn {
+    background: #232327;
+    color: #ccc;
+    border: 0;
+    padding: 0.45rem 0.95rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+.ssb-seg-btn + .ssb-seg-btn { border-left: 1px solid #444; }
+.ssb-seg-btn.active { background: #16a085; color: #fff; font-weight: 600; }
+.ssb-active-mode { font-size: 0.8rem; color: #9aa; }
+.ssb-active-mode .dot { color: #16a085; }
+
+.ssb-tagpanel {
+    margin-top: 1rem;
+    padding: 1.1rem 1.2rem;
+    background: #1b1b1f;
+    border: 1px solid #333;
+    border-radius: 8px;
+}
+.ssb-tag-defaults {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 0.85rem;
+    margin-top: 0.5rem;
+}
+.ssb-tag-count { font-size: 0.85rem; margin: 0.35rem 0 0; }
+.ssb-tag-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+.ssb-tag-anchor { font-size: 0.8rem; }
 </style>
 
 <h1>{% if edit_mode %}Edit Slideshow{% else %}New Slideshow{% endif %}
@@ -657,9 +708,99 @@
         <p class="text-muted" style="font-size:0.85rem; margin-top:0.5rem;">
             Group assignments are managed via the Assets page actions.
         </p>
+
+        <div class="ssb-decksource">
+            <span class="ssb-decksource-label">Deck source</span>
+            <div class="ssb-seg" role="tablist" aria-label="Deck source">
+                <button type="button" class="ssb-seg-btn" id="ss-mode-manual"
+                        data-mode="manual" onclick="setDeckMode('manual')">Manual deck</button>
+                <button type="button" class="ssb-seg-btn" id="ss-mode-tag"
+                        data-mode="tag" onclick="setDeckMode('tag')">By tag</button>
+            </div>
+            <span class="ssb-active-mode" id="ss-active-mode"></span>
+            <span class="text-muted ssb-decksource-hint">
+                Tag mode resolves the deck live from every asset carrying the
+                chosen tag — newly-tagged assets appear automatically, no
+                re-save needed.
+            </span>
+        </div>
+
+        <div id="ss-tagmode-panel" class="ssb-tagpanel" hidden>
+            <div class="form-group" style="margin-bottom:0.5rem;">
+                <label for="ss-tag-select">Tag</label>
+                <select id="ss-tag-select" class="form-control"
+                        onchange="onTagFieldChange(); refreshTagMemberPreview();">
+                    <option value="">— Select a tag —</option>
+                    {% for t in all_tags %}
+                    <option value="{{ t.id }}">{{ t.name }}</option>
+                    {% endfor %}
+                </select>
+                <p class="ssb-tag-count text-muted" id="ss-tag-count">
+                    Pick a tag to see how many assets match.
+                </p>
+            </div>
+
+            <h4 style="margin:0.75rem 0 0; font-size:0.9rem;">Defaults for tagged slides</h4>
+            <div class="ssb-tag-defaults">
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-duration">Slide duration (s)</label>
+                    <input type="number" id="ss-tag-duration" class="form-control"
+                           min="1" max="3600" step="1" value="8" onchange="onTagFieldChange()">
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-transition">Transition</label>
+                    <select id="ss-tag-transition" class="form-control" onchange="onTagFieldChange()">
+                        <option value="cut">Cut (none)</option>
+                        <option value="fade">Fade</option>
+                        <option value="fade_black">Fade through black</option>
+                        <option value="dissolve">Dissolve</option>
+                        <option value="push">Push</option>
+                        <option value="wipe">Wipe</option>
+                        <option value="zoom">Zoom</option>
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-transition-ms">Transition (ms)</label>
+                    <input type="number" id="ss-tag-transition-ms" class="form-control"
+                           min="0" max="5000" step="50" value="600" onchange="onTagFieldChange()">
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-fit">Fit</label>
+                    <select id="ss-tag-fit" class="form-control" onchange="onTagFieldChange()">
+                        <option value="cover">Cover (crop to fill)</option>
+                        <option value="contain">Contain (letterbox)</option>
+                        <option value="contain_blur">Contain (blurred bg)</option>
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-effect">Effect</label>
+                    <select id="ss-tag-effect" class="form-control"
+                            onchange="onTagFieldChange(); syncTagEffectDir()">
+                        <option value="none">None</option>
+                        <option value="ken_burns">Ken Burns (pan/zoom)</option>
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="ss-tag-effectdir">Ken Burns direction</label>
+                    <select id="ss-tag-effectdir" class="form-control" onchange="onTagFieldChange()">
+                        <option value="in">Zoom in</option>
+                        <option value="out">Zoom out</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="ssb-tag-actions">
+                <button type="button" class="btn btn-primary" id="ss-tag-apply"
+                        onclick="applyTagRule()">Apply tag rule</button>
+                <button type="button" class="btn btn-secondary" id="ss-tag-disable"
+                        onclick="disableTagMode()" hidden>Switch to manual deck</button>
+                <span class="ssb-tag-anchor text-muted" id="ss-tag-anchor" hidden></span>
+            </div>
+            <div id="ss-tag-status" class="form-status" style="margin-top:0.5rem;"></div>
+        </div>
         {% endif %}
 
-        <div style="margin-top:1.25rem;">
+        <div class="ss-manual-only" style="margin-top:1.25rem;">
             <h3 style="margin:0 0 0.5rem; font-size:1rem; display:flex; align-items:center; gap:0.5rem;">
                 Library
                 <span class="text-muted" style="font-weight:normal; font-size:0.85rem;">— drag onto the timeline, or click to append</span>
@@ -687,7 +828,7 @@
             </div>
         </div>
 
-        <div class="ssb-timeline-head">
+        <div class="ssb-timeline-head ss-manual-only">
             <h3>Timeline</h3>
             <div class="ssb-totals">
                 <label style="font-weight:normal; font-size:0.85rem; color:#aaa; display:inline-flex; align-items:center; gap:0.3rem; cursor:pointer;"
@@ -712,7 +853,7 @@
                 Total: <strong id="ss-total">0.0s</strong>
             </div>
         </div>
-        <div id="ss-timeline-wrap" class="ssb-timeline-wrap">
+        <div id="ss-timeline-wrap" class="ssb-timeline-wrap ss-manual-only">
             <div id="ss-timeline" class="ssb-timeline"></div>
         </div>
 
@@ -721,7 +862,7 @@
 
         <div id="ss-status" class="form-status" style="margin-top:0.75rem;"></div>
         <div style="display:flex; gap:0.5rem; margin-top:1rem;">
-            <button type="submit" class="btn btn-primary" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
+            <button type="submit" class="btn btn-primary ss-manual-only" id="ss-submit" disabled>{% if edit_mode %}Save{% else %}Create{% endif %}</button>
             <!-- Rendered hidden in create mode; revealed by applyEditModeChrome()
                  once the AI assistant mints a draft (slideshowMintDraft). -->
             <button type="button" class="btn btn-secondary" id="ss-preview-btn" onclick="previewSlideshowFromEditor()" title="Preview the saved slideshow"{% if not edit_mode %} hidden{% endif %}>Preview</button>
@@ -748,6 +889,7 @@
 {% endif %}
 
 <script id="ss-initial-slides" type="application/json">{{ slides | tojson }}</script>
+<script id="ss-initial-tagrule" type="application/json">{{ tag_rule | tojson }}</script>
 <script>
 let SS_EDIT_MODE = {{ 'true' if edit_mode else 'false' }};
 let SS_ASSET_ID = {{ asset_id | tojson if asset_id else 'null' }};
@@ -760,6 +902,7 @@ let SS_ORIG_NAME = {% if edit_mode %}{{ asset_name | tojson }}{% else %}""{% end
 const SS_MAX_SLIDES = 50;
 
 let slides = JSON.parse(document.getElementById('ss-initial-slides').textContent || '[]');
+let SS_TAG_RULE = JSON.parse(document.getElementById('ss-initial-tagrule').textContent || 'null');
 let availableAssets = [];
 let selectedGroupIds = [];
 let deckShuffle = {% if deck_shuffle %}true{% else %}false{% endif %};
@@ -1781,7 +1924,187 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     document.addEventListener('dragend', _clearDropActive);
     document.addEventListener('drop', _clearDropActive);
+
+    initTagMode();
 });
+
+// ---------- Tag-based dynamic deck (agora-cms#806) ----------
+// The "Deck source" toggle only switches which editor is visible; the
+// persisted mode is changed by the explicit Apply / Switch-to-manual
+// buttons, which call PUT / DELETE /api/assets/{id}/tag-rule.
+let SS_DECK_MODE = 'manual';
+
+function _tagPanelEl(id) { return document.getElementById(id); }
+
+function initTagMode() {
+    if (!SS_EDIT_MODE) return;
+    if (SS_TAG_RULE) {
+        prefillTagFields(SS_TAG_RULE);
+    }
+    setDeckMode(SS_TAG_RULE ? 'tag' : 'manual', true);
+    syncTagEffectDir();
+    updateTagModeChrome();
+}
+
+function prefillTagFields(rule) {
+    const set = (id, val) => { const e = _tagPanelEl(id); if (e != null && val != null) e.value = val; };
+    set('ss-tag-select', rule.tag_id);
+    if (rule.default_duration_ms != null) {
+        set('ss-tag-duration', Math.round(rule.default_duration_ms / 1000));
+    }
+    set('ss-tag-transition', rule.default_transition);
+    set('ss-tag-transition-ms', rule.default_transition_ms);
+    set('ss-tag-fit', rule.default_fit);
+    set('ss-tag-effect', rule.default_effect);
+    set('ss-tag-effectdir', rule.default_effect_direction);
+}
+
+function setDeckMode(mode, silent) {
+    SS_DECK_MODE = (mode === 'tag') ? 'tag' : 'manual';
+    const isTag = SS_DECK_MODE === 'tag';
+    document.querySelectorAll('.ss-manual-only').forEach(el => { el.hidden = isTag; });
+    const panel = _tagPanelEl('ss-tagmode-panel');
+    if (panel) panel.hidden = !isTag;
+    const mBtn = _tagPanelEl('ss-mode-manual');
+    const tBtn = _tagPanelEl('ss-mode-tag');
+    if (mBtn) mBtn.classList.toggle('active', !isTag);
+    if (tBtn) tBtn.classList.toggle('active', isTag);
+    if (isTag && !silent) refreshTagMemberPreview();
+}
+
+// Reflects the *persisted* mode + active-rule chrome (badge, anchor,
+// Switch-to-manual visibility). Call after any PUT/DELETE.
+function updateTagModeChrome() {
+    const active = !!SS_TAG_RULE;
+    const badge = _tagPanelEl('ss-active-mode');
+    if (badge) {
+        badge.innerHTML = active
+            ? `<span class="dot">●</span> Active: <strong>By tag</strong>`
+            : `Active: <strong>Manual deck</strong>`;
+    }
+    const disableBtn = _tagPanelEl('ss-tag-disable');
+    if (disableBtn) disableBtn.hidden = !active;
+    const anchor = _tagPanelEl('ss-tag-anchor');
+    if (anchor) {
+        if (active && SS_TAG_RULE.anchor_at) {
+            const d = new Date(SS_TAG_RULE.anchor_at);
+            anchor.textContent = `Anchored ${isNaN(d) ? SS_TAG_RULE.anchor_at : d.toLocaleString()}`;
+            anchor.hidden = false;
+        } else {
+            anchor.hidden = true;
+        }
+    }
+    const applyBtn = _tagPanelEl('ss-tag-apply');
+    if (applyBtn) applyBtn.textContent = active ? 'Update tag rule' : 'Apply tag rule';
+}
+
+function syncTagEffectDir() {
+    const eff = _tagPanelEl('ss-tag-effect');
+    const dir = _tagPanelEl('ss-tag-effectdir');
+    if (eff && dir) dir.disabled = (eff.value === 'none');
+}
+
+function onTagFieldChange() { /* placeholder for future live validation */ }
+
+function _setTagStatus(msg, isError) {
+    const el = _tagPanelEl('ss-tag-status');
+    if (!el) return;
+    el.textContent = msg || '';
+    el.style.color = isError ? '#e74c3c' : '#16a085';
+}
+
+async function refreshTagMemberPreview() {
+    const sel = _tagPanelEl('ss-tag-select');
+    const countEl = _tagPanelEl('ss-tag-count');
+    if (!sel || !countEl) return;
+    const tagId = sel.value;
+    if (!tagId) {
+        countEl.textContent = 'Pick a tag to see how many assets match.';
+        return;
+    }
+    countEl.textContent = 'Counting matching assets…';
+    try {
+        const qs = 'type=image&type=video&type=composed&page_size=1&tag_id=' + encodeURIComponent(tagId);
+        const r = await fetch('/api/assets/page?' + qs, { headers: {'Accept': 'application/json'} });
+        if (!r.ok) throw new Error('count failed');
+        const data = await r.json();
+        const n = (data.total_estimate != null) ? data.total_estimate : (data.items ? data.items.length : 0);
+        countEl.textContent = `~${n} asset${n === 1 ? '' : 's'} currently match this tag.`;
+    } catch (e) {
+        countEl.textContent = 'Could not load the match count.';
+    }
+}
+
+function _collectTagRuleBody() {
+    const sel = _tagPanelEl('ss-tag-select');
+    const durS = parseInt(_tagPanelEl('ss-tag-duration').value, 10);
+    const tms = parseInt(_tagPanelEl('ss-tag-transition-ms').value, 10);
+    return {
+        tag_id: sel.value,
+        default_duration_ms: (isNaN(durS) ? 8 : durS) * 1000,
+        default_transition: _tagPanelEl('ss-tag-transition').value,
+        default_transition_ms: isNaN(tms) ? 600 : tms,
+        default_fit: _tagPanelEl('ss-tag-fit').value,
+        default_effect: _tagPanelEl('ss-tag-effect').value,
+        default_effect_direction: _tagPanelEl('ss-tag-effectdir').value,
+    };
+}
+
+async function applyTagRule() {
+    if (!SS_EDIT_MODE || !SS_ASSET_ID) return;
+    const body = _collectTagRuleBody();
+    if (!body.tag_id) { _setTagStatus('Select a tag first.', true); return; }
+    const btn = _tagPanelEl('ss-tag-apply');
+    if (btn) btn.disabled = true;
+    _setTagStatus('Applying…', false);
+    try {
+        const r = await fetch(`/api/assets/${SS_ASSET_ID}/tag-rule`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(body),
+        });
+        if (!r.ok) {
+            let detail = 'Could not apply the tag rule.';
+            try { const j = await r.json(); if (j.detail) detail = (typeof j.detail === 'string') ? j.detail : JSON.stringify(j.detail); } catch (e) {}
+            _setTagStatus(detail, true);
+            return;
+        }
+        const out = await r.json();
+        SS_TAG_RULE = out;
+        const n = out.member_count;
+        const countEl = _tagPanelEl('ss-tag-count');
+        if (countEl && n != null) countEl.textContent = `${n} asset${n === 1 ? '' : 's'} match this tag right now.`;
+        updateTagModeChrome();
+        _setTagStatus('Tag rule applied — devices update within ~15s.', false);
+    } catch (e) {
+        _setTagStatus('Network error applying the tag rule.', true);
+    } finally {
+        if (btn) btn.disabled = false;
+    }
+}
+
+async function disableTagMode() {
+    if (!SS_EDIT_MODE || !SS_ASSET_ID) return;
+    if (!confirm('Switch back to a manual deck? The tag rule will be removed; your existing slides are kept.')) return;
+    const btn = _tagPanelEl('ss-tag-disable');
+    if (btn) btn.disabled = true;
+    _setTagStatus('Switching…', false);
+    try {
+        const r = await fetch(`/api/assets/${SS_ASSET_ID}/tag-rule`, { method: 'DELETE' });
+        if (!r.ok && r.status !== 404) {
+            _setTagStatus('Could not switch to manual deck.', true);
+            return;
+        }
+        SS_TAG_RULE = null;
+        updateTagModeChrome();
+        _setTagStatus('', false);
+        setDeckMode('manual');
+    } catch (e) {
+        _setTagStatus('Network error switching to manual deck.', true);
+    } finally {
+        if (btn) btn.disabled = false;
+    }
+}
 
 // ---------- Unsaved-changes tracking ----------
 let __ssDirty = false;

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -2085,7 +2085,7 @@ async function applyTagRule() {
 
 async function disableTagMode() {
     if (!SS_EDIT_MODE || !SS_ASSET_ID) return;
-    if (!confirm('Switch back to a manual deck? The tag rule will be removed; your existing slides are kept.')) return;
+    if (!await showConfirm('Switch back to a manual deck? The tag rule will be removed; your existing slides are kept.')) return;
     const btn = _tagPanelEl('ss-tag-disable');
     if (btn) btn.disabled = true;
     _setTagStatus('Switching…', false);

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1695,6 +1695,11 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
         "asset_is_global": False,
         "deck_shuffle": False,
         "assistant_enabled": assistant_on,
+        # Tag-based dynamic playlist rule (agora-cms#806). None == manual
+        # deck; a dict flips the builder into "tag mode" on load. Only ever
+        # populated in edit mode (the tag-rule API requires an existing
+        # slideshow asset).
+        "tag_rule": None,
     }
 
     if asset_id is not None:
@@ -1738,6 +1743,35 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
         asset_group_rows = (await db.execute(
             select(GroupAsset.group_id).where(GroupAsset.asset_id == asset_id)
         )).scalars().all()
+        # If this slideshow is in tag mode, surface the rule so the builder
+        # can prefill the tag-mode panel (otherwise it defaults to manual).
+        from cms.models.slideshow_tag_rule import SlideshowTagRule
+        tag_rule_row = (await db.execute(
+            select(SlideshowTagRule).where(
+                SlideshowTagRule.slideshow_asset_id == asset_id
+            )
+        )).scalar_one_or_none()
+        tag_rule_ctx = None
+        if tag_rule_row is not None:
+            from cms.routers.assets import _count_tag_members
+            tr_tag_name = (await db.execute(
+                select(Tag.name).where(Tag.id == tag_rule_row.tag_id)
+            )).scalar_one_or_none()
+            tag_rule_ctx = {
+                "tag_id": str(tag_rule_row.tag_id),
+                "tag_name": tr_tag_name,
+                "default_duration_ms": tag_rule_row.default_duration_ms,
+                "default_transition": tag_rule_row.default_transition,
+                "default_transition_ms": tag_rule_row.default_transition_ms,
+                "default_fit": tag_rule_row.default_fit,
+                "default_effect": tag_rule_row.default_effect,
+                "default_effect_direction": tag_rule_row.default_effect_direction,
+                "anchor_at": (
+                    tag_rule_row.anchor_at.isoformat()
+                    if tag_rule_row.anchor_at else None
+                ),
+                "member_count": await _count_tag_members(tag_rule_row.tag_id, db),
+            }
         ctx.update({
             "edit_mode": True,
             "asset": asset,
@@ -1747,6 +1781,7 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
             "asset_groups": [str(g) for g in asset_group_rows],
             "asset_is_global": bool(asset.is_global),
             "deck_shuffle": bool(getattr(asset, "shuffle", False)),
+            "tag_rule": tag_rule_ctx,
         })
     return ctx
 

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -8,6 +8,8 @@ import pytest
 
 from cms.models.asset import Asset, AssetType
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.slideshow_tag_rule import SlideshowTagRule
+from cms.models.tag import AssetTag, Tag
 from cms.models.user import User
 
 
@@ -255,3 +257,79 @@ class TestSlideshowLoopTransitionUI:
         assert "slides.length >= 2" in body
         # Loop control binds to slides[0].
         assert "buildTransitionGap(gap, 0, /*isLoop*/ true)" in body
+
+
+class TestSlideshowBuilderTagMode:
+    """Builder "Deck source" toggle / tag-mode panel (agora-cms#806).
+
+    The panel is edit-mode only (the tag-rule API needs an existing
+    slideshow asset) and prefills from any existing SlideshowTagRule.
+    """
+
+    async def test_edit_page_renders_deck_source_toggle(self, client, db_session):
+        asset = await _seed_slideshow(db_session, name="Toggleable", slides=2)
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Deck-source segmented toggle + tag-mode panel are present.
+        assert 'id="ss-mode-manual"' in body
+        assert 'id="ss-mode-tag"' in body
+        assert 'id="ss-tagmode-panel"' in body
+        # Live member-count preview + apply/disable controls are wired in.
+        assert 'id="ss-tag-count"' in body
+        assert "function applyTagRule(" in body
+        assert "function disableTagMode(" in body
+
+    async def test_new_page_omits_tag_mode_panel(self, client):
+        """Create mode has no asset yet, so the tag-rule API can't be
+        called — the panel/toggle must be gated out entirely."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert 'id="ss-tagmode-panel"' not in body
+        assert 'id="ss-mode-tag"' not in body
+
+    async def test_edit_page_manual_deck_has_null_tag_rule(self, client, db_session):
+        """A manual slideshow (no rule) seeds the JSON island with null so
+        the builder boots in manual mode."""
+        asset = await _seed_slideshow(db_session, name="Manual", slides=1)
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert 'id="ss-initial-tagrule"' in body
+        # tag_rule context is None -> the island renders JSON null.
+        assert '<script id="ss-initial-tagrule" type="application/json">null</script>' in body
+
+    async def test_edit_page_prefills_existing_tag_rule(self, client, db_session):
+        """A tag-mode slideshow surfaces its rule (tag id, member count,
+        defaults) in the JSON island the builder hydrates from."""
+        asset = await _seed_slideshow(db_session, name="TagMode", slides=0)
+        tag = Tag(name="Weekly Sale", color="#ff0000")
+        db_session.add(tag)
+        await db_session.flush()
+        # One eligible member so member_count is a non-zero, asserted value.
+        member = Asset(
+            filename="promo.png", asset_type=AssetType.IMAGE,
+            size_bytes=10, is_global=True,
+        )
+        db_session.add(member)
+        await db_session.flush()
+        db_session.add(AssetTag(asset_id=member.id, tag_id=tag.id))
+        db_session.add(SlideshowTagRule(
+            slideshow_asset_id=asset.id,
+            tag_id=tag.id,
+            default_duration_ms=12000,
+            default_transition="fade",
+            default_fit="contain",
+        ))
+        await db_session.commit()
+
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # The rule's tag id + live member count ride in the hydration island.
+        assert str(tag.id) in body
+        assert '"member_count": 1' in body or '"member_count":1' in body
+        assert '"default_duration_ms": 12000' in body or '"default_duration_ms":12000' in body
+        # Tag name is available for the picker / chrome.
+        assert "Weekly Sale" in body


### PR DESCRIPTION
## What

Adds a **Deck source** toggle (Manual / By tag) to the slideshow builder so a user can flip an existing slideshow into **tag-based dynamic mode** from the UI, instead of hand-calling the tag-rule API. This is the deferred builder-UI follow-up to the tag-rule CRUD API (#806, shipped in #809).

When **By tag** is selected, the slideshow's deck resolves live from every eligible asset (image/video/composed) carrying the chosen tag — tagging an asset adds it to the running slideshow without a rebuild.

## Scope

**Edit-mode only.** The tag-rule `PUT`/`DELETE` endpoints require an already-saved slideshow asset, so the toggle is gated behind `edit_mode`. New-slideshow mode renders without the panel (verified).

## Changes

- **`cms/ui.py`** — edit-mode builder context loads the existing tag rule (`tag_id`, `tag_name`, all `default_*` fields, `anchor_at`, `member_count` via `_count_tag_members`).
- **`cms/templates/slideshow_builder.html`** — Deck-source segmented toggle, tag-mode settings panel, `.ss-manual-only` gating, `ss-initial-tagrule` JSON island + `SS_TAG_RULE` global, and tag-mode JS. Wires `GET/PUT/DELETE /api/assets/{id}/tag-rule` with a live "~N items match" preview via `/api/assets/page?tag_id=`.
- **`tests/`** — `TestSlideshowBuilderTagMode`: toggle present in edit mode, omitted in new mode, `null` vs prefilled tag-rule island.

The mode toggle is view-only; server state changes only via **Apply** (PUT) / **Disable** (DELETE). No API surface changed (no `docs/openapi.yaml` diff).

## Tests

`tests/test_slideshow_builder_ui.py` — 22 passed locally.
