### PR TITLE
feat(slideshow): Phase 0 hybrid tag-timeline (model + resolver + migration)

### DIFF
--- a/alembic/versions/0046_hybrid_tag_timeline.py
+++ b/alembic/versions/0046_hybrid_tag_timeline.py
@@ -1,0 +1,125 @@
+"""Alembic migration 0046 — hybrid tag timeline (agora-cms#806 successor).
+
+Phase 0 of the hybrid tag-timeline redesign: a slideshow's deck becomes a
+single ordered list of ``slideshow_slides`` rows where each row is either a
+static ``asset`` slide (a specific source asset — the classic slide) or a
+dynamic ``tag`` block that expands in-place at resolve time to every
+non-deleted asset currently carrying ``tag_id``.
+
+This migration is **purely additive and backward-compatible**.  It does NOT
+migrate the legacy 1:1 ``slideshow_tag_rules`` rows (0045) into tag-kind
+slides, and does NOT drop that table — both happen in Phase 1.  Existing
+manual decks keep working unchanged: the new ``kind`` column defaults to
+``asset`` so every existing row is a static slide, and ``source_asset_id``
+stays populated.
+
+Changes:
+
+* ``assets.slideshow_anchor_at`` (nullable timestamptz) — the persisted,
+  set-once-never-re-floored cycle anchor for a slideshow that contains a
+  tag block, so growing the block leaves on-screen offsets stable.
+  Slideshow-only meaning, like ``assets.shuffle``.
+* ``slideshow_slides.kind`` (VARCHAR(8) NOT NULL DEFAULT 'asset') — the
+  slide kind discriminator (``asset`` | ``tag``).
+* ``slideshow_slides.tag_id`` (nullable UUID FK → tags.id ON DELETE
+  CASCADE) — the tag whose membership makes up a ``tag`` block.
+* ``slideshow_slides.tag_order_by`` (nullable VARCHAR(32)) — member
+  ordering within a tag block (``tagged_at`` in v1).
+* ``slideshow_slides.source_asset_id`` relaxed to NULLABLE (a ``tag``
+  block pins a tag, not a source asset).
+* Two CHECK constraints (kind value + kind/columns invariant) and an index
+  on ``tag_id``.
+
+The test harness builds the schema via ``Base.metadata.create_all`` (not
+these migrations), so SQLite-incompatible DDL (``ALTER TABLE ... ADD
+CONSTRAINT``) is fine here — this path only runs against Postgres.
+
+Revision ID: 0046
+Revises: 0045
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0046"
+down_revision = "0045"
+branch_labels = None
+depends_on = None
+
+
+def _uuid_type(bind):
+    """UUID column type matching the dialect (Postgres in prod)."""
+    if bind.dialect.name == "postgresql":
+        return sa.dialects.postgresql.UUID(as_uuid=True)
+    return sa.String(length=36)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    uuid_t = _uuid_type(bind)
+
+    # --- assets: per-slideshow persisted cycle anchor ---------------------
+    op.add_column(
+        "assets",
+        sa.Column("slideshow_anchor_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # --- slideshow_slides: kind discriminator + tag-block columns ---------
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "kind",
+            sa.String(length=8),
+            nullable=False,
+            server_default="asset",
+        ),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("tag_id", uuid_t, nullable=True),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("tag_order_by", sa.String(length=32), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_slideshow_slides_tag",
+        "slideshow_slides",
+        "tags",
+        ["tag_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # A tag block pins a tag, not a source asset, so source_asset_id must
+    # become nullable.  Every existing row is kind='asset' (the new
+    # default) and keeps its source_asset_id, so this widening is safe.
+    op.alter_column(
+        "slideshow_slides",
+        "source_asset_id",
+        existing_type=uuid_t,
+        nullable=True,
+    )
+
+    op.create_check_constraint(
+        "ck_slideshow_slide_kind_known",
+        "slideshow_slides",
+        "kind IN ('asset','tag')",
+    )
+    op.create_check_constraint(
+        "ck_slideshow_slide_kind_columns",
+        "slideshow_slides",
+        "(kind = 'asset' AND source_asset_id IS NOT NULL AND tag_id IS NULL) "
+        "OR (kind = 'tag' AND tag_id IS NOT NULL AND source_asset_id IS NULL)",
+    )
+    op.create_index(
+        "ix_slideshow_slides_tag_id",
+        "slideshow_slides",
+        ["tag_id"],
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0046 is not supported")

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -331,25 +331,25 @@ _TAG_MEMBER_ASSET_TYPES = (
 async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
     """Produce the ordered list of :class:`_SlideSpec` for ``asset``.
 
-    Tag mode (a :class:`SlideshowTagRule` exists) builds the deck from
-    current tag membership, ordered by ``asset_tags.created_at`` so a
-    newly tagged asset always sorts to the tail; every member inherits
-    the rule's deck-level playback defaults.  Manual mode maps each
-    ``SlideshowSlide`` row to a spec, preserving per-slide settings.
+    Two deck sources, transparently unified:
+
+    * **Hybrid timeline** (agora#806 successor) — the ordered
+      ``SlideshowSlide`` rows.  Each row is either a static ``asset``
+      slide (one spec, its own playback settings) or a dynamic ``tag``
+      block that expands in-place to current tag membership, every
+      expanded member inheriting the row's playback columns as
+      deck-defaults.  A deck with only ``asset`` rows behaves exactly as
+      a classic manual slideshow.
+    * **Legacy tag rule** (agora#806/#810) — when a 1:1
+      :class:`SlideshowTagRule` exists *and* the deck has no
+      ``SlideshowSlide`` rows, the whole deck is that rule's tag
+      membership.  Retained for backward compatibility with decks created
+      before the hybrid timeline; superseded by ``tag``-kind slides and
+      removed once those decks are migrated.
     """
     rule = await _get_tag_rule(asset.id, db)
     if rule is not None:
-        result = await db.execute(
-            select(Asset.id)
-            .join(AssetTag, AssetTag.asset_id == Asset.id)
-            .where(
-                AssetTag.tag_id == rule.tag_id,
-                Asset.deleted_at.is_(None),
-                Asset.asset_type.in_(_TAG_MEMBER_ASSET_TYPES),
-            )
-            .order_by(AssetTag.created_at.asc(), AssetTag.id.asc())
-        )
-        member_ids = result.scalars().all()
+        member_ids = await _expand_tag_members(rule.tag_id, db)
         return [
             _SlideSpec(
                 position=i,
@@ -365,25 +365,86 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
             for i, aid in enumerate(member_ids)
         ]
 
+    # Hybrid timeline (agora#806 successor): a single ordered list of
+    # SlideshowSlide rows where each row is either a static ``asset`` slide
+    # or a dynamic ``tag`` block that expands in-place to current tag
+    # membership.  Walk in position order, assigning a running deck index
+    # so expanded members get unique, contiguous positions.  This subsumes
+    # the legacy manual-only mapping (a deck with no tag rows behaves
+    # exactly as before).
     rows_result = await db.execute(
         select(SlideshowSlide)
         .where(SlideshowSlide.slideshow_asset_id == asset.id)
         .order_by(SlideshowSlide.position.asc())
     )
-    return [
-        _SlideSpec(
-            position=row.position,
-            source_asset_id=row.source_asset_id,
-            duration_ms=row.duration_ms,
-            play_to_end=row.play_to_end,
-            transition=row.transition,
-            transition_ms=row.transition_ms,
-            fit=row.fit,
-            effect=row.effect,
-            effect_direction=row.effect_direction,
+    rows = rows_result.scalars().all()
+
+    specs: list[_SlideSpec] = []
+    pos = 0
+    for row in rows:
+        if row.kind == "tag":
+            if row.tag_id is None:  # defensive — CHECK constraint forbids
+                continue
+            member_ids = await _expand_tag_members(row.tag_id, db)
+            for aid in member_ids:
+                specs.append(
+                    _SlideSpec(
+                        position=pos,
+                        source_asset_id=aid,
+                        duration_ms=row.duration_ms,
+                        # Tag-block members never play-to-end — the block
+                        # owns a single deck-default dwell time.
+                        play_to_end=False,
+                        transition=row.transition,
+                        transition_ms=row.transition_ms,
+                        fit=row.fit,
+                        effect=row.effect,
+                        effect_direction=row.effect_direction,
+                    )
+                )
+                pos += 1
+        else:
+            if row.source_asset_id is None:  # defensive — CHECK forbids
+                continue
+            specs.append(
+                _SlideSpec(
+                    position=pos,
+                    source_asset_id=row.source_asset_id,
+                    duration_ms=row.duration_ms,
+                    play_to_end=row.play_to_end,
+                    transition=row.transition,
+                    transition_ms=row.transition_ms,
+                    fit=row.fit,
+                    effect=row.effect,
+                    effect_direction=row.effect_direction,
+                )
+            )
+            pos += 1
+    return specs
+
+
+async def _expand_tag_members(
+    tag_id: uuid.UUID, db: AsyncSession
+) -> list[uuid.UUID]:
+    """Return the ordered source-asset ids for a tag block.
+
+    Members are every non-deleted, directly-displayable asset currently
+    carrying ``tag_id``, ordered by ``asset_tags.created_at`` ascending
+    (tagged-at order) so a newly tagged asset always sorts to the tail of
+    its block — the firmware applies the new deck at a loop boundary so the
+    insert is seamless.
+    """
+    result = await db.execute(
+        select(Asset.id)
+        .join(AssetTag, AssetTag.asset_id == Asset.id)
+        .where(
+            AssetTag.tag_id == tag_id,
+            Asset.deleted_at.is_(None),
+            Asset.asset_type.in_(_TAG_MEMBER_ASSET_TYPES),
         )
-        for row in rows_result.scalars().all()
-    ]
+        .order_by(AssetTag.created_at.asc(), AssetTag.id.asc())
+    )
+    return list(result.scalars().all())
 
 
 async def plan_slideshow(
@@ -682,12 +743,17 @@ async def build_fetch_for_slideshow(
     # Tag-mode decks (agora#806, Option B) carry a persisted anchor that is
     # set once and NEVER re-floored, so appending a newly-tagged slide at
     # the tail leaves every existing slide's cycle offset unchanged — the
-    # on-screen slide does not move.  Manual decks (and tag rules created
-    # before anchor support, where anchor_at is NULL) fall back to flooring
-    # ``now`` to a cycle boundary on every build.
+    # on-screen slide does not move.  Both the hybrid timeline
+    # (``asset.slideshow_anchor_at``, set once a tag block first appears)
+    # and the legacy tag rule (``rule.anchor_at``) supply such an anchor.
+    # Plain manual decks (and pre-anchor tag rules where the anchor is
+    # NULL) fall back to flooring ``now`` to a cycle boundary on every
+    # build.
     rule = await _get_tag_rule(asset.id, db)
     if rule is not None and rule.anchor_at is not None:
         started_at = _format_anchor(rule.anchor_at)
+    elif asset.slideshow_anchor_at is not None:
+        started_at = _format_anchor(asset.slideshow_anchor_at)
     else:
         started_at = _compute_cycle_anchor(cycle_duration_ms)
 

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -75,6 +75,18 @@ class Asset(Base):
     shuffle: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )
+    # Deck-level cycle anchor for SLIDESHOW assets (hybrid tag timeline,
+    # agora#806 successor).  Set once when a slideshow first gains a
+    # dynamic (tag-kind) slide and then NEVER re-floored, so growing a tag
+    # block leaves every existing slide's cycle offset stable — the
+    # on-screen slide does not jump (the firmware loop-boundary apply
+    # handles mid-timeline growth seamlessly).  NULL means "no persisted
+    # anchor"; the resolver then floors ``now`` to a cycle boundary on each
+    # build (the original manual-slideshow behaviour).  Slideshow-only
+    # meaning, like ``shuffle``; NULL for all other asset types.
+    slideshow_anchor_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     # Capture progress (SAVED_STREAM): 0.0-100.0 while ffmpeg runs, NULL when
     # not yet started.  Populated by worker during _capture_stream; cleared
     # on recapture.  Mirrors AssetVariant.progress so the UI can show a

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -108,6 +108,25 @@ class SlideshowSlide(Base):
         # FK columns are not auto-indexed in Postgres; the source-delete guard
         # and ACL re-check queries scan by source_asset_id.
         Index("ix_slideshow_slides_source_asset_id", "source_asset_id"),
+        # Hybrid tag timeline (agora#806 successor).  A slide is one of two
+        # kinds: a static ``asset`` entry (a specific source asset — the
+        # original slide) or a dynamic ``tag`` entry (a tag that expands
+        # in-place at resolve time to every non-deleted asset carrying it).
+        CheckConstraint(
+            "kind IN ('asset','tag')",
+            name="ck_slideshow_slide_kind_known",
+        ),
+        # Kind/columns invariant: an ``asset`` entry pins a source asset and
+        # carries no tag; a ``tag`` entry pins a tag and carries no source
+        # asset (its source assets are resolved dynamically from membership).
+        CheckConstraint(
+            "(kind = 'asset' AND source_asset_id IS NOT NULL AND tag_id IS NULL) "
+            "OR (kind = 'tag' AND tag_id IS NOT NULL AND source_asset_id IS NULL)",
+            name="ck_slideshow_slide_kind_columns",
+        ),
+        # FK columns aren't auto-indexed; tag-block expansion + the
+        # tag-delete guard scan by tag_id.
+        Index("ix_slideshow_slides_tag_id", "tag_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -119,10 +138,35 @@ class SlideshowSlide(Base):
         nullable=False,
         index=True,
     )
-    source_asset_id: Mapped[uuid.UUID] = mapped_column(
+    # Slide kind discriminator.  ``asset`` (default) is a static slide
+    # pinning ``source_asset_id``; ``tag`` is a dynamic block pinning
+    # ``tag_id`` that expands in-place to current tag membership at resolve
+    # time, every expanded member inheriting this row's playback columns
+    # (duration/transition/fit/effect) as deck-defaults.
+    kind: Mapped[str] = mapped_column(
+        String(8), nullable=False, default="asset", server_default="asset"
+    )
+    # For ``asset`` kind: the pinned source media (RESTRICT — can't be
+    # deleted while referenced).  NULL for ``tag`` kind, where the source
+    # assets are resolved dynamically from tag membership.
+    source_asset_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("assets.id", ondelete="RESTRICT"),
-        nullable=False,
+        nullable=True,
+    )
+    # For ``tag`` kind: the tag whose members make up this block.  CASCADE
+    # so deleting a tag removes its dynamic blocks from every slideshow.
+    # NULL for ``asset`` kind.
+    tag_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    # For ``tag`` kind: how members are ordered within the block.  Only
+    # ``tagged_at`` (AssetTag.created_at asc) is supported in v1, matching
+    # the retired SlideshowTagRule.  NULL/ignored for ``asset`` kind.
+    tag_order_by: Mapped[str | None] = mapped_column(
+        String(32), nullable=True
     )
     position: Mapped[int] = mapped_column(Integer, nullable=False)
     duration_ms: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -1148,3 +1148,240 @@ class TestTagModeSlideshow:
         assert fetch is not None
         anchor = datetime.fromisoformat(fetch.started_at.replace("Z", "+00:00"))
         assert int(anchor.timestamp() * 1000) % fetch.cycle_duration_ms == 0
+
+
+
+async def _seed_hybrid_slideshow(db, *, name, entries, checksum="", anchor_at=None):
+    """Seed a hybrid-timeline slideshow directly.
+
+    ``entries`` is an ordered list of dicts, each either:
+      * ``{"asset": <Asset>, "duration_ms": int, ...}`` — a static slide
+      * ``{"tag": <Tag>, "duration_ms": int, ...}`` — a dynamic tag block
+
+    Optional per-entry overrides: ``play_to_end``, ``transition``,
+    ``transition_ms``, ``fit``, ``effect``, ``effect_direction``.
+    ``anchor_at`` sets the persisted per-slideshow cycle anchor.
+    """
+    ss = Asset(
+        filename=name,
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum=checksum,
+        is_global=True,
+        slideshow_anchor_at=anchor_at,
+    )
+    db.add(ss)
+    await db.commit()
+    await db.refresh(ss)
+    for idx, e in enumerate(entries):
+        is_tag = "tag" in e
+        db.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            kind="tag" if is_tag else "asset",
+            source_asset_id=None if is_tag else e["asset"].id,
+            tag_id=e["tag"].id if is_tag else None,
+            tag_order_by="tagged_at" if is_tag else None,
+            position=idx,
+            duration_ms=e.get("duration_ms", 5000),
+            play_to_end=e.get("play_to_end", False),
+            transition=e.get("transition", "cut"),
+            transition_ms=e.get("transition_ms", 600),
+            fit=e.get("fit", "cover"),
+            effect=e.get("effect", "none"),
+            effect_direction=e.get("effect_direction", "in"),
+        ))
+    await db.commit()
+    await db.refresh(ss)
+    return ss
+
+
+@pytest.mark.asyncio
+class TestHybridTagTimeline:
+    """Phase 0 of the hybrid tag-timeline redesign (agora#806 successor):
+    a deck is an ordered list of static ``asset`` slides and dynamic
+    ``tag`` blocks that expand in-place at resolve time."""
+
+    async def test_asset_only_timeline_unchanged(self, db_session):
+        """A timeline of only ``asset``-kind slides resolves exactly like a
+        classic manual slideshow (backward-compatibility regression)."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "phyb1")
+        a = await _seed_image(db_session, filename="one.png")
+        b = await _seed_image(db_session, filename="two.png")
+        for img in (a, b):
+            await _seed_variant(db_session, source=img, profile=profile, ext="jpg")
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb1",
+            entries=[
+                {"asset": a, "duration_ms": 4000},
+                {"asset": b, "duration_ms": 6000},
+            ],
+            checksum="hb1",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        assert [s.source_filename for s in plan.slides] == ["one.png", "two.png"]
+        assert [s.position for s in plan.slides] == [0, 1]
+        assert [s.duration_ms for s in plan.slides] == [4000, 6000]
+
+    async def test_tag_block_expands_in_place(self, db_session):
+        """A ``tag``-kind slide expands to its members in tagged_at order,
+        each inheriting the row's playback columns."""
+        from datetime import datetime, timedelta, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "phyb2")
+        tag = await _seed_tag(db_session, "promoH2")
+        x = await _seed_image(db_session, filename="x.png")
+        y = await _seed_image(db_session, filename="y.png")
+        for img in (x, y):
+            await _seed_variant(db_session, source=img, profile=profile, ext="jpg")
+        base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        await _tag_asset(db_session, asset=y, tag=tag, when=base)
+        await _tag_asset(db_session, asset=x, tag=tag, when=base + timedelta(seconds=5))
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb2",
+            entries=[{"tag": tag, "duration_ms": 7000, "transition": "fade"}],
+            checksum="hb2",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        # tagged_at order: y (older) then x.
+        assert [s.source_filename for s in plan.slides] == ["y.png", "x.png"]
+        assert [s.position for s in plan.slides] == [0, 1]
+        # Members inherit the tag row's playback columns.
+        assert all(s.duration_ms == 7000 for s in plan.slides)
+        assert all(s.transition == "fade" for s in plan.slides)
+        # Tag members never play-to-end.
+        assert all(s.play_to_end is False for s in plan.slides)
+
+    async def test_hybrid_ordering_contiguous_positions(self, db_session):
+        """asset, tag(block of 2), asset -> a single contiguous position
+        sequence with the tag members spliced in the middle."""
+        from datetime import datetime, timedelta, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "phyb3")
+        tag = await _seed_tag(db_session, "promoH3")
+        head = await _seed_image(db_session, filename="head.png")
+        tail = await _seed_image(db_session, filename="tail.png")
+        m1 = await _seed_image(db_session, filename="m1.png")
+        m2 = await _seed_image(db_session, filename="m2.png")
+        for img in (head, tail, m1, m2):
+            await _seed_variant(db_session, source=img, profile=profile, ext="jpg")
+        base = datetime(2026, 6, 2, tzinfo=timezone.utc)
+        await _tag_asset(db_session, asset=m1, tag=tag, when=base)
+        await _tag_asset(db_session, asset=m2, tag=tag, when=base + timedelta(seconds=5))
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb3",
+            entries=[
+                {"asset": head, "duration_ms": 3000},
+                {"tag": tag, "duration_ms": 5000},
+                {"asset": tail, "duration_ms": 9000},
+            ],
+            checksum="hb3",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        assert [s.source_filename for s in plan.slides] == [
+            "head.png", "m1.png", "m2.png", "tail.png",
+        ]
+        assert [s.position for s in plan.slides] == [0, 1, 2, 3]
+        # Static slides keep their own durations; tag members inherit 5000.
+        assert [s.duration_ms for s in plan.slides] == [3000, 5000, 5000, 9000]
+
+    async def test_static_plus_tag_member_dedup_plays_twice(self, db_session):
+        """A static slide for asset X and a tag block also containing X
+        intentionally yields X twice (no dedup in v1)."""
+        from datetime import datetime, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "phyb4")
+        tag = await _seed_tag(db_session, "promoH4")
+        dup = await _seed_image(db_session, filename="dup.png")
+        await _seed_variant(db_session, source=dup, profile=profile, ext="jpg")
+        await _tag_asset(
+            db_session, asset=dup, tag=tag,
+            when=datetime(2026, 6, 3, tzinfo=timezone.utc),
+        )
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb4",
+            entries=[
+                {"asset": dup, "duration_ms": 4000},
+                {"tag": tag, "duration_ms": 5000},
+            ],
+            checksum="hb4",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        assert [s.source_filename for s in plan.slides] == ["dup.png", "dup.png"]
+        assert [s.position for s in plan.slides] == [0, 1]
+
+    async def test_persisted_slideshow_anchor_emitted_verbatim(self, db_session, app):
+        """``assets.slideshow_anchor_at`` is emitted verbatim as
+        ``started_at`` for a hybrid deck (no flooring), so tag-block growth
+        leaves the on-screen slide stable."""
+        from datetime import datetime, timezone
+
+        from cms.services.slideshow_resolver import (
+            _format_anchor,
+            build_fetch_for_slideshow,
+        )
+
+        profile = await _seed_profile(db_session, "phyb5")
+        group = await _seed_group(db_session, "ghyb5")
+        device = await _seed_device(
+            db_session, did="dhyb5", group=group, profile=profile,
+        )
+        tag = await _seed_tag(db_session, "promoH5")
+        img = await _seed_image(db_session, filename="anc.png")
+        await _seed_variant(
+            db_session, source=img, profile=profile, checksum="ancv", ext="jpg",
+        )
+        await _tag_asset(
+            db_session, asset=img, tag=tag,
+            when=datetime(2026, 6, 4, tzinfo=timezone.utc),
+        )
+        anchor = datetime(2026, 6, 4, 9, 30, 0, tzinfo=timezone.utc)
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb5",
+            entries=[{"tag": tag, "duration_ms": 5000}],
+            checksum="hb5", anchor_at=anchor,
+        )
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        assert fetch.started_at == _format_anchor(anchor)
+
+    async def test_null_slideshow_anchor_falls_back_to_floored(self, db_session, app):
+        """A hybrid deck with NULL ``slideshow_anchor_at`` floors ``now`` to
+        a cycle boundary (classic manual-slideshow behaviour)."""
+        from datetime import datetime
+
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "phyb6")
+        group = await _seed_group(db_session, "ghyb6")
+        device = await _seed_device(
+            db_session, did="dhyb6", group=group, profile=profile,
+        )
+        a = await _seed_image(db_session, filename="floorhyb.png")
+        await _seed_variant(
+            db_session, source=a, profile=profile, checksum="fhv", ext="jpg",
+        )
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hyb6",
+            entries=[{"asset": a, "duration_ms": 5000}],
+            checksum="hb6",
+        )
+        fetch = await build_fetch_for_slideshow(
+            ss, device, "https://cms.example", db_session,
+        )
+        assert fetch is not None
+        anchor = datetime.fromisoformat(fetch.started_at.replace("Z", "+00:00"))
+        assert int(anchor.timestamp() * 1000) % fetch.cycle_duration_ms == 0


### PR DESCRIPTION
## Phase 0 — Hybrid tag-timeline (data model + resolver + migration)

Foundation for the agora#806 successor design: a slideshow deck becomes an ordered list of slides where each row is either a **static `asset` slide** (a specific source asset) or a **dynamic `tag` block** that expands in-place at resolve time to all current members of that tag.

This replaces the rejected #806/#810 whole-deck-only tag-rule approach with a per-slide model, so a deck can interleave fixed slides with one or more tag blocks.

### What's in Phase 0 (additive / backward-compatible only)
- **Model:** `SlideshowSlide` gains `kind` ('asset'|'tag'), `tag_id`, `tag_order_by`; `source_asset_id` relaxed to nullable; kind CHECK constraints + `tag_id` index. `Asset` gains `slideshow_anchor_at` (set-once cycle anchor so a growing tag block doesn't shift on-screen offsets).
- **Resolver:** `_load_slide_specs` does a unified ordered walk; `kind=='tag'` rows expand via a new `_expand_tag_members` helper (tagged_at order). Legacy `SlideshowTagRule` path reuses the same helper. Anchor block reads `asset.slideshow_anchor_at`.
- **Migration:** alembic 0046, additive only (columns / FK / nullable-relax / CHECKs / index; no data migration, no drops).

### Compatibility
- Existing manual decks: `kind` defaults to `'asset'`, `source_asset_id` stays populated → behave identically.
- Existing #810 tag-rule decks: a `SlideshowTagRule` exists → resolver short-circuits to the legacy branch, unchanged.
- No deck has both paths. Dedup is intentionally allowed (a static slide + a tag block both containing X → X plays twice).

### Tests
New `TestHybridTagTimeline`: asset-only regression, tag-block in-place expansion, hybrid contiguous ordering, static+tag dedup, persisted anchor emitted verbatim, NULL anchor floored. **39/39 `test_slideshow_resolver.py` green locally.**

Not wired into any write-path/UI yet — Phase 1 (API), Phase 2 (builder UI), Phase 3 (firmware) follow. **Dev-only.**
