### PR TITLE
ci: measure per-test durations for shard balancing (Phase 0, do-not-merge)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,10 +233,24 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-timeout pytest-cov pytest-xdist httpx aiosqlite psycopg2-binary
+          pip install pytest pytest-asyncio pytest-timeout pytest-cov pytest-xdist pytest-split httpx aiosqlite psycopg2-binary
 
+      # Phase 0 (measurement-only): --store-durations writes a machine-readable
+      # per-test timing map (.test_durations) used by pytest-split to balance
+      # shards. --durations=50 prints the 50 slowest tests to the log. Neither
+      # changes pass/fail behaviour; this run is otherwise identical to the
+      # normal gate. Remove both flags once the durations map is committed.
       - name: Run tests
-        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -q -rs --durations=20 --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
+        run: python -m pytest tests/ --ignore=tests/e2e -n auto --dist=loadfile --tb=short -q -rs --durations=50 --store-durations --durations-path .test_durations --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
+
+      - name: Upload test durations map
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-durations
+          path: .test_durations
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,6 +249,7 @@ jobs:
         with:
           name: test-durations
           path: .test_durations
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
 


### PR DESCRIPTION
**Phase 0 of the CI speedup — measurement only. Do not merge.**

This PR exists to run the `test` job once and capture a real per-test timing map. It does **not** change pass/fail behaviour and should be **closed, not merged** (merging would leave profiling flags on `main`).

### What it does
- Adds `pytest-split` to the test deps.
- Runs the existing suite with `--store-durations --durations-path .test_durations` to emit a machine-readable timing map, uploaded as the `test-durations` artifact.
- Bumps `--durations=20` -> `--durations=50` to log the slowest tests.

### Why
The upcoming sharding PR uses `pytest-split` to fan the ~35 min suite across 4 standard runners. `pytest-split` balances shards by **summed historical runtime**, which requires this map. Without it, shards split by test *count* and end up lopsided.

### Next
Download the `test-durations` artifact + slowest-test log, commit the map into the sharding PR, then close this one.
