### PR TITLE
fix(composed): expand tag blocks when embedding a slideshow in a media widget

### DIFF
--- a/cms/composed/slideshow_expand.py
+++ b/cms/composed/slideshow_expand.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shared.models.asset import Asset
 from shared.models.slideshow_slide import SlideshowSlide
 from cms.schemas.asset import SLIDE_TRANSITIONS
+from cms.services.slideshow_resolver import expand_tag_members
 
 
 def composed_cell_transition(transition: str) -> str:
@@ -60,11 +61,23 @@ async def load_slideshow_members(
 ) -> list[tuple[SlideshowSlide, Asset | None]]:
     """Return the slideshow's slides in ``position`` order with their sources.
 
-    Each tuple is ``(slide, source_asset)``; ``source_asset`` is ``None``
-    when the slide's source row is missing (or, with
-    ``exclude_deleted=True``, soft-deleted).  Callers decide whether a
-    missing source is an error.  Returns an empty list when the slideshow
-    has no slides.
+    The deck is the hybrid tag-timeline: an ordered list of
+    :class:`~shared.models.slideshow_slide.SlideshowSlide` rows, each either
+    a static ``asset`` slide or a dynamic ``tag`` block.  A ``tag`` block is
+    expanded **in place** into its current members (via
+    :func:`~cms.services.slideshow_resolver.expand_tag_members`, the same
+    ordering the device resolver uses) so the caller never sees a tag row.
+    Every expanded member reuses the *same* tag-block row, inheriting its
+    playback columns (duration / transition / fit / effect) as deck-defaults
+    — matching the device-resolve path.
+
+    Each returned tuple is ``(slide, source_asset)``; ``source_asset`` is
+    ``None`` only when a static ``asset`` slide's source row is missing (or,
+    with ``exclude_deleted=True``, soft-deleted).  Callers decide whether a
+    missing source is an error.  Tag-block members are always non-deleted
+    (the expansion filters them), so they never yield a ``None`` source.
+    Returns an empty list when the slideshow has no slides (or expands to
+    none, e.g. only empty tag blocks).
     """
     slide_rows = (
         await db.execute(
@@ -76,11 +89,31 @@ async def load_slideshow_members(
     if not slide_rows:
         return []
 
-    src_ids = [s.source_asset_id for s in slide_rows]
-    src_q = select(Asset).where(Asset.id.in_(src_ids))
-    if exclude_deleted:
-        src_q = src_q.where(Asset.deleted_at.is_(None))
-    src_rows = (await db.execute(src_q)).scalars().all()
-    by_id = {a.id: a for a in src_rows}
+    # Walk the hybrid deck in position order, expanding each ``tag`` block
+    # into its ordered members.  A tag member inherits the block row's
+    # playback columns, so we pair every member with the same row object.
+    pairs: list[tuple[SlideshowSlide, uuid.UUID | None]] = []
+    for s in slide_rows:
+        if s.kind == "tag":
+            if s.tag_id is None:  # defensive — CHECK constraint forbids
+                continue
+            for member_id in await expand_tag_members(s.tag_id, db):
+                pairs.append((s, member_id))
+        else:
+            pairs.append((s, s.source_asset_id))
 
-    return [(s, by_id.get(s.source_asset_id)) for s in slide_rows]
+    if not pairs:
+        return []
+
+    src_ids = [mid for _s, mid in pairs if mid is not None]
+    by_id: dict[uuid.UUID, Asset] = {}
+    if src_ids:
+        src_q = select(Asset).where(Asset.id.in_(src_ids))
+        if exclude_deleted:
+            src_q = src_q.where(Asset.deleted_at.is_(None))
+        src_rows = (await db.execute(src_q)).scalars().all()
+        by_id = {a.id: a for a in src_rows}
+
+    return [
+        (s, by_id.get(mid) if mid is not None else None) for s, mid in pairs
+    ]

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1482,7 +1482,7 @@ async def _load_tag_members(
 ) -> dict[uuid.UUID, list[tuple[uuid.UUID, str]]]:
     """Return ordered ``(member_id, checksum)`` per tag.
 
-    Mirrors the resolver's ``_expand_tag_members`` ordering exactly
+    Mirrors the resolver's ``expand_tag_members`` ordering exactly
     (``AssetTag.created_at`` asc, ``AssetTag.id`` asc) and the same eligible
     asset-type filter, so duration/hash/member-count computed here match
     what the device actually plays.  Membership is dynamic — this is a

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -343,7 +343,7 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
         if row.kind == "tag":
             if row.tag_id is None:  # defensive — CHECK constraint forbids
                 continue
-            member_ids = await _expand_tag_members(row.tag_id, db)
+            member_ids = await expand_tag_members(row.tag_id, db)
             for aid in member_ids:
                 specs.append(
                     _SlideSpec(
@@ -381,7 +381,7 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
     return specs
 
 
-async def _expand_tag_members(
+async def expand_tag_members(
     tag_id: uuid.UUID, db: AsyncSession
 ) -> list[uuid.UUID]:
     """Return the ordered source-asset ids for a tag block.
@@ -391,6 +391,10 @@ async def _expand_tag_members(
     (tagged-at order) so a newly tagged asset always sorts to the tail of
     its block — the firmware applies the new deck at a loop boundary so the
     insert is seamless.
+
+    Shared with :func:`cms.composed.slideshow_expand.load_slideshow_members`
+    so the device-resolve and composed-embed paths can't drift on tag-block
+    membership/ordering.
     """
     result = await db.execute(
         select(Asset.id)

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -10,6 +10,7 @@ from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.tag import AssetTag, Tag
 
 
 def _text_layout(text: str = "hello preview") -> Layout:
@@ -515,6 +516,55 @@ class TestComposedPreviewSlideshowMedia:
         assert body.count("data:image/png;base64,") == 2
         assert "cw-ss-slide" in body
         assert "/assets/videos/" not in body
+
+    async def _make_slideshow_tag_block(self, db_session, tag):
+        ss = Asset(
+            filename=f"tagshow-{uuid.uuid4()}.slideshow",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(ss)
+        await db_session.flush()
+        db_session.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            kind="tag",
+            source_asset_id=None,
+            tag_id=tag.id,
+            tag_order_by="tagged_at",
+            position=0,
+            duration_ms=4000,
+            play_to_end=False,
+            transition="fade",
+            transition_ms=600,
+        ))
+        await db_session.flush()
+        return ss
+
+    async def test_preview_slideshow_tag_block_inlines_members(
+        self, client, db_session, tmp_path
+    ):
+        # Regression: a tag-mode slideshow member used to 422 with
+        # "references a missing source asset" because tag rows have a
+        # NULL source_asset_id.
+        storage = _storage_dir(tmp_path)
+        img1 = await self._make_image(db_session, storage, "t1.png")
+        img2 = await self._make_image(db_session, storage, "t2.png")
+        tag = Tag(name="promo")
+        db_session.add(tag)
+        await db_session.flush()
+        db_session.add(AssetTag(asset_id=img1.id, tag_id=tag.id))
+        db_session.add(AssetTag(asset_id=img2.id, tag_id=tag.id))
+        await db_session.flush()
+        ss = await self._make_slideshow_tag_block(db_session, tag)
+        asset = await self._make_composed_with(db_session, _media_layout(ss.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert body.count("data:image/png;base64,") == 2
+        assert "cw-ss-slide" in body
 
     async def test_preview_empty_slideshow_is_422(
         self, client, db_session, tmp_path

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -21,6 +21,7 @@ from cms.composed.schema import (
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.tag import AssetTag, Tag
 
 
 def _text_layout(text: str = "hello world") -> Layout:
@@ -477,6 +478,148 @@ async def _make_slideshow_asset(db_session, members, filename="show.slideshow") 
         ))
     await db_session.flush()
     return ss
+
+
+async def _make_tag(db_session, name="promo"):
+    tag = Tag(name=name)
+    db_session.add(tag)
+    await db_session.flush()
+    return tag
+
+
+async def _tag_asset(db_session, asset, tag):
+    db_session.add(AssetTag(asset_id=asset.id, tag_id=tag.id))
+    await db_session.flush()
+
+
+async def _make_slideshow_with_tag_block(
+    db_session, tag, *, duration_ms=4500, transition="fade", transition_ms=600,
+    filename="tagshow.slideshow",
+) -> Asset:
+    """Seed a SLIDESHOW container whose only slide is a ``kind='tag'`` block.
+
+    Tag blocks have ``source_asset_id IS NULL``; they expand at read time to
+    the tag's current membership.  This is the Phase 1 hybrid-timeline shape
+    that previously broke ``load_slideshow_members`` (NULL source -> 422).
+    """
+    ss = Asset(
+        filename=filename,
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(ss)
+    await db_session.flush()
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        kind="tag",
+        source_asset_id=None,
+        tag_id=tag.id,
+        tag_order_by="tagged_at",
+        position=0,
+        duration_ms=duration_ms,
+        play_to_end=False,
+        transition=transition,
+        transition_ms=transition_ms,
+    ))
+    await db_session.flush()
+    return ss
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_tag_block_expands_members(
+    db_session, mock_storage_and_dir
+):
+    """A composed slide embedding a tag-mode slideshow publishes its members.
+
+    Regression: ``load_slideshow_members`` used to read ``source_asset_id``
+    blindly (NULL for tag rows) -> ``(slide, None)`` -> PublishError
+    "references a missing source asset".
+    """
+    _, tmp_path = mock_storage_and_dir
+    img1 = await _make_image_asset(db_session, tmp_path, "p1.png")
+    img2 = await _make_image_asset(db_session, tmp_path, "p2.png")
+    tag = await _make_tag(db_session)
+    await _tag_asset(db_session, img1, tag)
+    await _tag_asset(db_session, img2, tag)
+    ss = await _make_slideshow_with_tag_block(db_session, tag)
+    asset, cs = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # Both tagged images expanded into stacked, client-cycled slides.
+    assert bundle_html.count("data:image/png;base64,") == 2
+    assert "cw-ss-slide" in bundle_html
+
+    await db_session.refresh(cs)
+    sources = {str(x) for x in cs.bundle_source_asset_ids}
+    # Tag MEMBER ids are tracked, not the container or the tag.
+    assert sources == {str(img1.id), str(img2.id)}
+    assert str(ss.id) not in sources
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_empty_tag_block_slideshow(
+    db_session, mock_storage_and_dir
+):
+    """A slideshow whose only slide is an empty tag block has no members."""
+    tag = await _make_tag(db_session, name="empty")
+    ss = await _make_slideshow_with_tag_block(db_session, tag)
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    with pytest.raises(PublishError, match="has no slides"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_mixed_asset_and_tag_rows(
+    db_session, mock_storage_and_dir
+):
+    """A deck mixing a static asset slide and a tag block expands both."""
+    _, tmp_path = mock_storage_and_dir
+    static_img = await _make_image_asset(db_session, tmp_path, "static.png")
+    tagged_img = await _make_image_asset(db_session, tmp_path, "tagged.png")
+    tag = await _make_tag(db_session, name="mix")
+    await _tag_asset(db_session, tagged_img, tag)
+
+    ss = Asset(
+        filename="mixshow.slideshow",
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(ss)
+    await db_session.flush()
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        source_asset_id=static_img.id,
+        position=0,
+        duration_ms=4000,
+        play_to_end=False,
+        transition="cut",
+        transition_ms=600,
+    ))
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        kind="tag",
+        source_asset_id=None,
+        tag_id=tag.id,
+        tag_order_by="tagged_at",
+        position=1,
+        duration_ms=4000,
+        play_to_end=False,
+        transition="fade",
+        transition_ms=600,
+    ))
+    await db_session.flush()
+    asset, cs = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    await db_session.refresh(cs)
+    sources = {str(x) for x in cs.bundle_source_asset_ids}
+    assert sources == {str(static_img.id), str(tagged_img.id)}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Embedding a tag-bearing slideshow inside a composed-slide media widget failed at preview/publish with `Slideshow <id> slide <id> references a missing source asset`.

## Root cause
The shared helper `load_slideshow_members` (`cms/composed/slideshow_expand.py`) predates the Phase 1 hybrid tag-timeline feature and read `source_asset_id` blindly. For `kind='tag'` slide rows that column is NULL, so every caller (render preview, device publish, media-picker filter) got a `(slide, None)` pair and raised 422.

## Fix
- `load_slideshow_members` now walks the hybrid deck and expands `kind='tag'` rows in place into their current tag membership, reusing the resolver's tag-expansion logic. Asset rows unchanged.
- Promoted `_expand_tag_members` -> public `expand_tag_members` in `cms/services/slideshow_resolver.py` so there's one shared copy (there were already two hand-copied versions of the tag-ordering query). No import cycle (services never imports composed).
- Updated the stale reference comment in `cms/routers/assets.py`.

## Tests
Regression coverage on both the publish and preview paths: tag-block expansion, empty tag block (`has no slides`), and a mixed asset+tag deck. Targeted suites green locally (`test_composed_publish`, `test_composed_preview`, `test_slideshow_resolver`, `test_slideshow_tag_blocks`, `test_composed_media_widget`).
