### PR TITLE
Add Fit + Motion controls to slideshow tag blocks

### DIFF
--- a/cms/composed/slideshow_expand.py
+++ b/cms/composed/slideshow_expand.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shared.models.asset import Asset
 from shared.models.slideshow_slide import SlideshowSlide
 from cms.schemas.asset import SLIDE_TRANSITIONS
+from cms.services.slideshow_resolver import expand_tag_members
 
 
 def composed_cell_transition(transition: str) -> str:
@@ -60,11 +61,23 @@ async def load_slideshow_members(
 ) -> list[tuple[SlideshowSlide, Asset | None]]:
     """Return the slideshow's slides in ``position`` order with their sources.
 
-    Each tuple is ``(slide, source_asset)``; ``source_asset`` is ``None``
-    when the slide's source row is missing (or, with
-    ``exclude_deleted=True``, soft-deleted).  Callers decide whether a
-    missing source is an error.  Returns an empty list when the slideshow
-    has no slides.
+    The deck is the hybrid tag-timeline: an ordered list of
+    :class:`~shared.models.slideshow_slide.SlideshowSlide` rows, each either
+    a static ``asset`` slide or a dynamic ``tag`` block.  A ``tag`` block is
+    expanded **in place** into its current members (via
+    :func:`~cms.services.slideshow_resolver.expand_tag_members`, the same
+    ordering the device resolver uses) so the caller never sees a tag row.
+    Every expanded member reuses the *same* tag-block row, inheriting its
+    playback columns (duration / transition / fit / effect) as deck-defaults
+    — matching the device-resolve path.
+
+    Each returned tuple is ``(slide, source_asset)``; ``source_asset`` is
+    ``None`` only when a static ``asset`` slide's source row is missing (or,
+    with ``exclude_deleted=True``, soft-deleted).  Callers decide whether a
+    missing source is an error.  Tag-block members are always non-deleted
+    (the expansion filters them), so they never yield a ``None`` source.
+    Returns an empty list when the slideshow has no slides (or expands to
+    none, e.g. only empty tag blocks).
     """
     slide_rows = (
         await db.execute(
@@ -76,11 +89,31 @@ async def load_slideshow_members(
     if not slide_rows:
         return []
 
-    src_ids = [s.source_asset_id for s in slide_rows]
-    src_q = select(Asset).where(Asset.id.in_(src_ids))
-    if exclude_deleted:
-        src_q = src_q.where(Asset.deleted_at.is_(None))
-    src_rows = (await db.execute(src_q)).scalars().all()
-    by_id = {a.id: a for a in src_rows}
+    # Walk the hybrid deck in position order, expanding each ``tag`` block
+    # into its ordered members.  A tag member inherits the block row's
+    # playback columns, so we pair every member with the same row object.
+    pairs: list[tuple[SlideshowSlide, uuid.UUID | None]] = []
+    for s in slide_rows:
+        if s.kind == "tag":
+            if s.tag_id is None:  # defensive — CHECK constraint forbids
+                continue
+            for member_id in await expand_tag_members(s.tag_id, db):
+                pairs.append((s, member_id))
+        else:
+            pairs.append((s, s.source_asset_id))
 
-    return [(s, by_id.get(s.source_asset_id)) for s in slide_rows]
+    if not pairs:
+        return []
+
+    src_ids = [mid for _s, mid in pairs if mid is not None]
+    by_id: dict[uuid.UUID, Asset] = {}
+    if src_ids:
+        src_q = select(Asset).where(Asset.id.in_(src_ids))
+        if exclude_deleted:
+            src_q = src_q.where(Asset.deleted_at.is_(None))
+        src_rows = (await db.execute(src_q)).scalars().all()
+        by_id = {a.id: a for a in src_rows}
+
+    return [
+        (s, by_id.get(mid) if mid is not None else None) for s, mid in pairs
+    ]

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1482,7 +1482,7 @@ async def _load_tag_members(
 ) -> dict[uuid.UUID, list[tuple[uuid.UUID, str]]]:
     """Return ordered ``(member_id, checksum)`` per tag.
 
-    Mirrors the resolver's ``_expand_tag_members`` ordering exactly
+    Mirrors the resolver's ``expand_tag_members`` ordering exactly
     (``AssetTag.created_at`` asc, ``AssetTag.id`` asc) and the same eligible
     asset-type filter, so duration/hash/member-count computed here match
     what the device actually plays.  Membership is dynamic — this is a

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -343,7 +343,7 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
         if row.kind == "tag":
             if row.tag_id is None:  # defensive — CHECK constraint forbids
                 continue
-            member_ids = await _expand_tag_members(row.tag_id, db)
+            member_ids = await expand_tag_members(row.tag_id, db)
             for aid in member_ids:
                 specs.append(
                     _SlideSpec(
@@ -381,7 +381,7 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
     return specs
 
 
-async def _expand_tag_members(
+async def expand_tag_members(
     tag_id: uuid.UUID, db: AsyncSession
 ) -> list[uuid.UUID]:
     """Return the ordered source-asset ids for a tag block.
@@ -391,6 +391,10 @@ async def _expand_tag_members(
     (tagged-at order) so a newly tagged asset always sorts to the tail of
     its block — the firmware applies the new deck at a loop boundary so the
     insert is seamless.
+
+    Shared with :func:`cms.composed.slideshow_expand.load_slideshow_members`
+    so the device-resolve and composed-embed paths can't drift on tag-block
+    membership/ordering.
     """
     result = await db.execute(
         select(Asset.id)

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -1132,6 +1132,65 @@ function renderTimeline() {
     renderTagPalette();
 }
 
+// Shared per-slide Fit + Motion (Ken Burns) control block. Used by both
+// the static-asset tile (makeSlot) and the dynamic tag-block tile
+// (makeTagSlot) so the two never drift. The controls bind to
+// ``slides[i].fit`` / ``.effect`` / ``.effect_direction`` via the
+// kind-agnostic update handlers; for a tag block the chosen fit/motion
+// becomes the deck-default every expanded member inherits.
+function fitEffectCtlHtml(s, i) {
+    const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
+    const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
+    const dirToken = (function () { const p = kbParse(s.effect_direction); return kbCompose(p.zoom, p.pan); })();
+    const kbMenuId = `ssb-kb-menu-${i}`;
+    const dirCtl = `
+                <label class="ssb-slot-fx-item ssb-slot-kbdir" title="Ken Burns motion"
+                       style="${effectVal === 'ken_burns' ? '' : 'display:none;'}">
+                    <span>Motion path</span>
+                    <button type="button" class="ssb-slot-kbbtn"
+                            aria-label="Customize Ken Burns motion">
+                        <span class="ssb-kbbtn-label">${escapeHtml(kbLabel(dirToken))}</span>
+                        <span class="ssb-kbbtn-arrow" aria-hidden="true">⚙</span>
+                    </button>
+                </label>
+                <div id="${kbMenuId}" class="ssb-kb-menu" popover="auto"></div>`;
+    return `
+            <div class="ssb-slot-fx">
+                <label class="ssb-slot-fx-item" title="How the slide fills the screen">
+                    <span>Fit</span>
+                    <select class="ssb-slot-fit" aria-label="Fit">
+                        <option value="cover" ${fitVal === 'cover' ? 'selected' : ''}>Fill (cover)</option>
+                        <option value="contain" ${fitVal === 'contain' ? 'selected' : ''}>Fit (contain)</option>
+                        <option value="contain_blur" ${fitVal === 'contain_blur' ? 'selected' : ''}>Fit + blur fill</option>
+                    </select>
+                </label>
+                <label class="ssb-slot-fx-item" title="Motion effect while the slide is shown">
+                    <span>Motion</span>
+                    <select class="ssb-slot-effect" aria-label="Motion effect">
+                        <option value="none" ${effectVal === 'none' ? 'selected' : ''}>None</option>
+                        <option value="ken_burns" ${effectVal === 'ken_burns' ? 'selected' : ''}>Ken Burns</option>
+                    </select>
+                </label>
+                ${dirCtl}
+            </div>`;
+}
+
+// Attach the change/click listeners for a Fit + Motion control block
+// previously rendered via ``fitEffectCtlHtml`` into ``slot``.
+function wireFitEffectCtls(slot, i) {
+    const fitSel = slot.querySelector('.ssb-slot-fit');
+    if (fitSel) fitSel.addEventListener('change', (e) => updateSlideFit(i, e.target.value));
+    const effectSel = slot.querySelector('.ssb-slot-effect');
+    if (effectSel) effectSel.addEventListener('change', (e) => updateSlideEffect(i, e.target.value));
+    const kbBtn = slot.querySelector('.ssb-slot-kbbtn');
+    if (kbBtn) {
+        kbBtn.addEventListener('click', () => {
+            const menu = slot.querySelector('.ssb-kb-menu');
+            if (menu) buildKbMenu(menu, kbBtn, i);
+        });
+    }
+}
+
 function makeSlot(s, i) {
     const slot = document.createElement('div');
     slot.className = 'ssb-slot';
@@ -1182,40 +1241,7 @@ function makeSlot(s, i) {
             </label>`
         : '';
 
-    const fitVal = (s.fit === 'contain' || s.fit === 'contain_blur') ? s.fit : 'cover';
-    const effectVal = (s.effect === 'ken_burns') ? 'ken_burns' : 'none';
-    const dirToken = (function () { const p = kbParse(s.effect_direction); return kbCompose(p.zoom, p.pan); })();
-    const kbMenuId = `ssb-kb-menu-${i}`;
-    const dirCtl = `
-                <label class="ssb-slot-fx-item ssb-slot-kbdir" title="Ken Burns motion"
-                       style="${effectVal === 'ken_burns' ? '' : 'display:none;'}">
-                    <span>Motion path</span>
-                    <button type="button" class="ssb-slot-kbbtn"
-                            aria-label="Customize Ken Burns motion">
-                        <span class="ssb-kbbtn-label">${escapeHtml(kbLabel(dirToken))}</span>
-                        <span class="ssb-kbbtn-arrow" aria-hidden="true">⚙</span>
-                    </button>
-                </label>
-                <div id="${kbMenuId}" class="ssb-kb-menu" popover="auto"></div>`;
-    const fitEffectCtl = `
-            <div class="ssb-slot-fx">
-                <label class="ssb-slot-fx-item" title="How the slide fills the screen">
-                    <span>Fit</span>
-                    <select class="ssb-slot-fit" aria-label="Fit">
-                        <option value="cover" ${fitVal === 'cover' ? 'selected' : ''}>Fill (cover)</option>
-                        <option value="contain" ${fitVal === 'contain' ? 'selected' : ''}>Fit (contain)</option>
-                        <option value="contain_blur" ${fitVal === 'contain_blur' ? 'selected' : ''}>Fit + blur fill</option>
-                    </select>
-                </label>
-                <label class="ssb-slot-fx-item" title="Motion effect while the slide is shown">
-                    <span>Motion</span>
-                    <select class="ssb-slot-effect" aria-label="Motion effect">
-                        <option value="none" ${effectVal === 'none' ? 'selected' : ''}>None</option>
-                        <option value="ken_burns" ${effectVal === 'ken_burns' ? 'selected' : ''}>Ken Burns</option>
-                    </select>
-                </label>
-                ${dirCtl}
-            </div>`;
+    const fitEffectCtl = fitEffectCtlHtml(s, i);
 
     slot.innerHTML = `
         <div class="ssb-slot-thumb-wrap">
@@ -1253,17 +1279,7 @@ function makeSlot(s, i) {
     slot.querySelector('input[type=number]').addEventListener('change', (e) => updateSlideDuration(i, e.target.value));
     const pte = slot.querySelector('input[type=checkbox]');
     if (pte) pte.addEventListener('change', (e) => updateSlidePlayToEnd(i, e.target.checked));
-    const fitSel = slot.querySelector('.ssb-slot-fit');
-    if (fitSel) fitSel.addEventListener('change', (e) => updateSlideFit(i, e.target.value));
-    const effectSel = slot.querySelector('.ssb-slot-effect');
-    if (effectSel) effectSel.addEventListener('change', (e) => updateSlideEffect(i, e.target.value));
-    const kbBtn = slot.querySelector('.ssb-slot-kbbtn');
-    if (kbBtn) {
-        kbBtn.addEventListener('click', () => {
-            const menu = slot.querySelector('.ssb-kb-menu');
-            if (menu) buildKbMenu(menu, kbBtn, i);
-        });
-    }
+    wireFitEffectCtls(slot, i);
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -1275,9 +1291,12 @@ function makeSlot(s, i) {
     return slot;
 }
 
-// Render a dynamic tag block as a distinct timeline tile. No asset preview,
-// no fit/effect/play-to-end controls. Reuses the standard remove/move/
-// duration wiring so the block can be reordered, removed, and re-timed.
+// Render a dynamic tag block as a distinct timeline tile. No asset preview
+// and no play-to-end control (members are timed per-item, not per-video),
+// but it does expose the same Fit + Motion controls as an asset slot — the
+// chosen values become the deck-default every expanded member inherits.
+// Reuses the standard remove/move/duration wiring so the block can be
+// reordered, removed, and re-timed.
 function makeTagSlot(s, i) {
     const slot = document.createElement('div');
     slot.className = 'ssb-slot ssb-slot-tag';
@@ -1306,6 +1325,7 @@ function makeTagSlot(s, i) {
                        aria-label="Per-item duration in seconds">
                 <span style="color:#888;">s each</span>
             </div>
+            ${fitEffectCtlHtml(s, i)}
         </div>`;
 
     slot.querySelector('.ssb-slot-remove').addEventListener('click', (e) => {
@@ -1321,6 +1341,8 @@ function makeTagSlot(s, i) {
         moveSlide(i, +1);
     });
     slot.querySelector('input[type=number]').addEventListener('change', (e) => updateSlideDuration(i, e.target.value));
+    // Fit/motion picked here is the deck-default every expanded member inherits.
+    wireFitEffectCtls(slot, i);
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';

--- a/tests/test_composed_preview.py
+++ b/tests/test_composed_preview.py
@@ -10,6 +10,7 @@ from cms.composed.schema import Cell, Layout, WidgetInstance, empty_layout
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.tag import AssetTag, Tag
 
 
 def _text_layout(text: str = "hello preview") -> Layout:
@@ -515,6 +516,55 @@ class TestComposedPreviewSlideshowMedia:
         assert body.count("data:image/png;base64,") == 2
         assert "cw-ss-slide" in body
         assert "/assets/videos/" not in body
+
+    async def _make_slideshow_tag_block(self, db_session, tag):
+        ss = Asset(
+            filename=f"tagshow-{uuid.uuid4()}.slideshow",
+            asset_type=AssetType.SLIDESHOW,
+            size_bytes=0,
+            checksum="",
+            is_global=True,
+        )
+        db_session.add(ss)
+        await db_session.flush()
+        db_session.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            kind="tag",
+            source_asset_id=None,
+            tag_id=tag.id,
+            tag_order_by="tagged_at",
+            position=0,
+            duration_ms=4000,
+            play_to_end=False,
+            transition="fade",
+            transition_ms=600,
+        ))
+        await db_session.flush()
+        return ss
+
+    async def test_preview_slideshow_tag_block_inlines_members(
+        self, client, db_session, tmp_path
+    ):
+        # Regression: a tag-mode slideshow member used to 422 with
+        # "references a missing source asset" because tag rows have a
+        # NULL source_asset_id.
+        storage = _storage_dir(tmp_path)
+        img1 = await self._make_image(db_session, storage, "t1.png")
+        img2 = await self._make_image(db_session, storage, "t2.png")
+        tag = Tag(name="promo")
+        db_session.add(tag)
+        await db_session.flush()
+        db_session.add(AssetTag(asset_id=img1.id, tag_id=tag.id))
+        db_session.add(AssetTag(asset_id=img2.id, tag_id=tag.id))
+        await db_session.flush()
+        ss = await self._make_slideshow_tag_block(db_session, tag)
+        asset = await self._make_composed_with(db_session, _media_layout(ss.id))
+
+        resp = await client.get(f"/composed/{asset.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert body.count("data:image/png;base64,") == 2
+        assert "cw-ss-slide" in body
 
     async def test_preview_empty_slideshow_is_422(
         self, client, db_session, tmp_path

--- a/tests/test_composed_publish.py
+++ b/tests/test_composed_publish.py
@@ -21,6 +21,7 @@ from cms.composed.schema import (
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
 from cms.models.slideshow_slide import SlideshowSlide
+from cms.models.tag import AssetTag, Tag
 
 
 def _text_layout(text: str = "hello world") -> Layout:
@@ -477,6 +478,148 @@ async def _make_slideshow_asset(db_session, members, filename="show.slideshow") 
         ))
     await db_session.flush()
     return ss
+
+
+async def _make_tag(db_session, name="promo"):
+    tag = Tag(name=name)
+    db_session.add(tag)
+    await db_session.flush()
+    return tag
+
+
+async def _tag_asset(db_session, asset, tag):
+    db_session.add(AssetTag(asset_id=asset.id, tag_id=tag.id))
+    await db_session.flush()
+
+
+async def _make_slideshow_with_tag_block(
+    db_session, tag, *, duration_ms=4500, transition="fade", transition_ms=600,
+    filename="tagshow.slideshow",
+) -> Asset:
+    """Seed a SLIDESHOW container whose only slide is a ``kind='tag'`` block.
+
+    Tag blocks have ``source_asset_id IS NULL``; they expand at read time to
+    the tag's current membership.  This is the Phase 1 hybrid-timeline shape
+    that previously broke ``load_slideshow_members`` (NULL source -> 422).
+    """
+    ss = Asset(
+        filename=filename,
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(ss)
+    await db_session.flush()
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        kind="tag",
+        source_asset_id=None,
+        tag_id=tag.id,
+        tag_order_by="tagged_at",
+        position=0,
+        duration_ms=duration_ms,
+        play_to_end=False,
+        transition=transition,
+        transition_ms=transition_ms,
+    ))
+    await db_session.flush()
+    return ss
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_tag_block_expands_members(
+    db_session, mock_storage_and_dir
+):
+    """A composed slide embedding a tag-mode slideshow publishes its members.
+
+    Regression: ``load_slideshow_members`` used to read ``source_asset_id``
+    blindly (NULL for tag rows) -> ``(slide, None)`` -> PublishError
+    "references a missing source asset".
+    """
+    _, tmp_path = mock_storage_and_dir
+    img1 = await _make_image_asset(db_session, tmp_path, "p1.png")
+    img2 = await _make_image_asset(db_session, tmp_path, "p2.png")
+    tag = await _make_tag(db_session)
+    await _tag_asset(db_session, img1, tag)
+    await _tag_asset(db_session, img2, tag)
+    ss = await _make_slideshow_with_tag_block(db_session, tag)
+    asset, cs = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    bundle_html = (tmp_path / asset.filename).read_text()
+    # Both tagged images expanded into stacked, client-cycled slides.
+    assert bundle_html.count("data:image/png;base64,") == 2
+    assert "cw-ss-slide" in bundle_html
+
+    await db_session.refresh(cs)
+    sources = {str(x) for x in cs.bundle_source_asset_ids}
+    # Tag MEMBER ids are tracked, not the container or the tag.
+    assert sources == {str(img1.id), str(img2.id)}
+    assert str(ss.id) not in sources
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_empty_tag_block_slideshow(
+    db_session, mock_storage_and_dir
+):
+    """A slideshow whose only slide is an empty tag block has no members."""
+    tag = await _make_tag(db_session, name="empty")
+    ss = await _make_slideshow_with_tag_block(db_session, tag)
+    asset, _ = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    with pytest.raises(PublishError, match="has no slides"):
+        await publish_composed_slide(asset.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_publish_slideshow_mixed_asset_and_tag_rows(
+    db_session, mock_storage_and_dir
+):
+    """A deck mixing a static asset slide and a tag block expands both."""
+    _, tmp_path = mock_storage_and_dir
+    static_img = await _make_image_asset(db_session, tmp_path, "static.png")
+    tagged_img = await _make_image_asset(db_session, tmp_path, "tagged.png")
+    tag = await _make_tag(db_session, name="mix")
+    await _tag_asset(db_session, tagged_img, tag)
+
+    ss = Asset(
+        filename="mixshow.slideshow",
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+    )
+    db_session.add(ss)
+    await db_session.flush()
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        source_asset_id=static_img.id,
+        position=0,
+        duration_ms=4000,
+        play_to_end=False,
+        transition="cut",
+        transition_ms=600,
+    ))
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=ss.id,
+        kind="tag",
+        source_asset_id=None,
+        tag_id=tag.id,
+        tag_order_by="tagged_at",
+        position=1,
+        duration_ms=4000,
+        play_to_end=False,
+        transition="fade",
+        transition_ms=600,
+    ))
+    await db_session.flush()
+    asset, cs = await _make_composed(db_session, layout=_media_layout(ss.id))
+
+    await publish_composed_slide(asset.id, db_session)
+
+    await db_session.refresh(cs)
+    sources = {str(x) for x in cs.bundle_source_asset_ids}
+    assert sources == {str(static_img.id), str(tagged_img.id)}
 
 
 @pytest.mark.asyncio

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -313,6 +313,26 @@ class TestSlideshowBuilderTagPalette:
         body = resp.text
         assert "payload.kind === 'tag'" in body
 
+    async def test_tag_block_exposes_fit_and_motion_controls(self, client):
+        """A dynamic tag block must expose the same Fit + Motion controls
+        as an asset slide. The chosen values become the deck-default every
+        expanded member inherits (the write path already serializes
+        fit/effect/effect_direction for kind='tag'). Regression for the
+        builder gap where makeTagSlot rendered no fit/motion controls, so a
+        tag block was silently locked to cover/none."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Shared helpers exist (asset + tag tiles render identical controls).
+        assert "function fitEffectCtlHtml(" in body
+        assert "function wireFitEffectCtls(" in body
+        # makeTagSlot wires both the markup and the listeners.
+        start = body.index("function makeTagSlot(")
+        end = body.index("function ", start + 1)
+        tag_fn = body[start:end]
+        assert "fitEffectCtlHtml(s, i)" in tag_fn
+        assert "wireFitEffectCtls(slot, i)" in tag_fn
+
     async def test_palette_renders_in_edit_mode(self, client, db_session):
         """The palette must also be present when editing a saved
         slideshow, not just on the create page."""


### PR DESCRIPTION
Adds the Fit + Motion (Ken Burns) controls to the dynamic **tag block** timeline tile in the slideshow builder.

## Problem
A tag block in the slideshow builder rendered no Fit/Motion controls, so it was silently locked to the JS-default cover/
one. The backend already supports it/ffect/ffect_direction end-to-end for `kind="tag"` (serializeSlide -> SlideIn -> SlideshowSlide -> render.py/publish.py -> media.py) — the gap was UI-only.

## Change
- Refactor the shared Fit + Motion markup + wiring out of `makeSlot` into `fitEffectCtlHtml` / `wireFitEffectCtls` helpers (code reuse).
- Use them in both `makeSlot` and `makeTagSlot`.
- The chosen fit/motion on a tag tile is the **deck-default** every expanded member inherits — consistent with how the tag tile already exposes a single per-item duration.
- Regression test pins that `makeTagSlot` wires both the markup and the listeners.

Dev-only feature. 23/23 `test_slideshow_builder_ui.py` green locally.