### PR TITLE
Fix asset-library tag picker popovers rendering off-screen

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -2914,7 +2914,10 @@ window.addEventListener("pageshow", _rerunAllGates);
 // opts.align:     "right" (default — right-edge to right-edge of anchor)
 //                 or "left" (left-edge to left-edge of anchor)
 function positionPopover(popover, opts = {}) {
-    let btn = document.querySelector(`[popovertarget="${popover.id}"]`);
+    // An explicit anchor wins — needed for shared popovers reused across many
+    // rows (e.g. the per-row "+ tag" picker), where a popovertarget lookup
+    // would resolve to the first matching button, not the clicked one.
+    let btn = opts.anchor || document.querySelector(`[popovertarget="${popover.id}"]`);
     if (!btn) {
         // Fallback for popovers opened via onclick (e.g. group-popup, whose
         // `+` button lives as a sibling inside a .group-picker-wrap and does

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -224,7 +224,7 @@
         {% if user_groups | length > 0 or is_admin %}
         <span class="bulk-group-picker" style="position:relative; display:inline-block;">
             <button type="button" class="btn btn-secondary btn-sm"
-                    onclick="event.stopPropagation(); document.getElementById('bulk-add-group-popup').showPopover()">+ Add to group</button>
+                    popovertarget="bulk-add-group-popup">+ Add to group</button>
             <div id="bulk-add-group-popup" popover class="group-popup">
                 {% for g in user_groups %}
                 <button type="button" class="group-popup-item"
@@ -237,7 +237,7 @@
         </span>
         <span class="bulk-group-picker" style="position:relative; display:inline-block;">
             <button type="button" class="btn btn-secondary btn-sm"
-                    onclick="event.stopPropagation(); document.getElementById('bulk-remove-group-popup').showPopover()">− Remove from group</button>
+                    popovertarget="bulk-remove-group-popup">− Remove from group</button>
             <div id="bulk-remove-group-popup" popover class="group-popup">
                 {% for g in user_groups %}
                 <button type="button" class="group-popup-item"
@@ -252,7 +252,7 @@
         {% if all_tags | length > 0 %}
         <span class="bulk-tag-picker" style="position:relative; display:inline-block;">
             <button type="button" class="btn btn-secondary btn-sm"
-                    onclick="event.stopPropagation(); document.getElementById('bulk-add-tag-popup').showPopover()">🏷 Add tag</button>
+                    popovertarget="bulk-add-tag-popup">🏷 Add tag</button>
             <div id="bulk-add-tag-popup" popover class="group-popup">
                 {% for t in all_tags %}
                 <button type="button" class="group-popup-item"
@@ -264,7 +264,7 @@
         </span>
         <span class="bulk-tag-picker" style="position:relative; display:inline-block;">
             <button type="button" class="btn btn-secondary btn-sm"
-                    onclick="event.stopPropagation(); document.getElementById('bulk-remove-tag-popup').showPopover()">− Remove tag</button>
+                    popovertarget="bulk-remove-tag-popup">− Remove tag</button>
             <div id="bulk-remove-tag-popup" popover class="group-popup">
                 {% for t in all_tags %}
                 <button type="button" class="group-popup-item"
@@ -2064,14 +2064,16 @@ function fallbackCopy(text, onSuccess) {
             } else if (hint) {
                 hint.style.display = 'none';
             }
-            // Position near the clicked + button.
+            // Open first so the top-layer popover has a measurable size, then
+            // anchor it to the clicked "+ tag" button using the shared,
+            // viewport-aware positioner (handles below/above flip + horizontal
+            // clamp). The old manual math added window.scrollY/scrollX, which
+            // pushed a top-layer (fixed) popover off-screen on a scrolled page.
             const target = (ev && ev.currentTarget) || (ev && ev.target);
-            if (target && pop.style) {
-                const rect = target.getBoundingClientRect();
-                pop.style.top  = (rect.bottom + window.scrollY + 4) + 'px';
-                pop.style.left = (rect.left + window.scrollX) + 'px';
-            }
             try { pop.showPopover(); } catch (e) {}
+            if (target && typeof positionPopover === 'function') {
+                positionPopover(pop, { placement: 'below', align: 'left', anchor: target });
+            }
         },
         addTagToCurrentRow: async (tagId) => {
             const pop = document.getElementById('row-add-tag-popup');


### PR DESCRIPTION
## Two asset-library tag-picker popover bugs

Both reported during user testing of the asset library. Root cause is
shared: `.group-popup[popover]` elements are parked at
`top/left:-9999px` and rely on `positionPopover()` to place them on
open. When `positionPopover` can't find an anchor it returns early,
leaving the popover off-screen.

### 1. Per-row "+ tag" picker renders far down / off-screen (table view)
`openRowAddTagPicker` added `window.scrollY`/`scrollX` to
`getBoundingClientRect()` coords. A native popover is in the top layer
(`position:fixed`, viewport-relative), so adding scroll offsets pushes
it off-screen on a scrolled page.

**Fix:** reuse the canonical `positionPopover()` with an explicit
`anchor`. The shared `#row-add-tag-popup` is reused across every row,
so a `popovertarget` lookup would resolve to the wrong button — hence
the new `opts.anchor` (highest-priority anchor source).

### 2. Bulk "Add tag" / "Remove tag" (and group) buttons do nothing (grid + table)
The four bulk popovers opened via `onclick=showPopover()` with **no**
`popovertarget` and a wrapper class `positionPopover` doesn't
recognize (`.bulk-tag-picker` / `.bulk-group-picker`, not
`.group-picker-wrap`). So `positionPopover` found no anchor, returned
early, and the popover stayed parked at -9999px — the button appeared
to do nothing.

**Fix:** the four bulk popovers are unique singletons, so converting
their buttons to the native `popovertarget` attribute both toggles the
popover and gives `positionPopover` its anchor via the existing
`[popovertarget=...]` lookup. (User only noticed the tag buttons, but
the group buttons had the identical bug — all four fixed.)

## Changes
- `cms/static/app.js`: `positionPopover` honors `opts.anchor` first.
- `cms/templates/assets.html`: `openRowAddTagPicker` uses
  `positionPopover(..., {anchor})`; four bulk buttons switched to
  `popovertarget`.

## Validation
- `node --check cms/static/app.js` OK
- assets.html Jinja parse OK
- Dev-facing CMS asset-library UI; client-side JS/markup only.
