### PR TITLE
Collapsible tag-block member preview in slideshow timeline

### DIFF
--- a/cms/routers/tags.py
+++ b/cms/routers/tags.py
@@ -179,3 +179,74 @@ async def delete_tag(
         request=request,
     )
     await db.commit()
+
+
+@router.get(
+    "/{tag_id}/members",
+    dependencies=[Depends(require_permission(ASSETS_READ))],
+)
+async def list_tag_members(
+    tag_id: uuid.UUID,
+    user: User = Depends(require_permission(ASSETS_READ)),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return a tag's current member assets in device-resolve order.
+
+    Powers the slideshow builder's collapsible tag-block preview. The
+    members are exactly what the slideshow resolver would expand this tag
+    into — eligible asset types only, ordered ``tagged_at`` ascending —
+    intersected with the caller's visible-asset ACL and enriched with each
+    asset's ready thumbnail URL. Membership is dynamic, so this is a
+    point-in-time snapshot, not a stored ordering.
+
+    Reuses :func:`cms.services.slideshow_resolver.expand_tag_members` so the
+    preview can't drift from the order the device actually plays.
+    """
+    from cms.models.asset import Asset
+    from cms.routers.assets import _thumbnail_urls_for, _visible_asset_ids
+    from cms.services.slideshow_resolver import expand_tag_members
+
+    tag = (
+        await db.execute(select(Tag).where(Tag.id == tag_id))
+    ).scalar_one_or_none()
+    if tag is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    member_ids = await expand_tag_members(tag_id, db)
+
+    # Intersect with the caller's visible set (None = unrestricted/admin),
+    # preserving resolve order.
+    visible = await _visible_asset_ids(user, db)
+    if visible is not None:
+        allowed = set(visible)
+        member_ids = [aid for aid in member_ids if aid in allowed]
+
+    total = len(member_ids)
+    thumbs = await _thumbnail_urls_for(member_ids, db) if member_ids else {}
+
+    detail: dict[uuid.UUID, dict] = {}
+    if member_ids:
+        rows = (
+            await db.execute(
+                select(
+                    Asset.id,
+                    Asset.asset_type,
+                    Asset.display_name,
+                    Asset.original_filename,
+                    Asset.filename,
+                    Asset.duration_seconds,
+                ).where(Asset.id.in_(member_ids))
+            )
+        ).all()
+        for aid, atype, dname, ofn, fn, dur in rows:
+            type_str = atype.value if hasattr(atype, "value") else str(atype)
+            detail[aid] = {
+                "id": str(aid),
+                "asset_type": type_str,
+                "name": dname or ofn or fn or str(aid),
+                "thumbnail_url": thumbs.get(aid),
+                "duration_seconds": dur,
+            }
+
+    members = [detail[aid] for aid in member_ids if aid in detail]
+    return {"tag_id": str(tag_id), "total": total, "members": members}

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -711,6 +711,160 @@
     color: #888;
     font-size: 0.82rem;
 }
+
+/* ---- Dynamic tag block: icon + collapsible member-preview group ---- */
+.ssb-slot-tag-thumb {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #15413a, #0f2c27);
+}
+.ssb-slot-tag-icon {
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: #1abc9c;
+    opacity: 0.85;
+    line-height: 1;
+}
+/* Show/Hide members toggle, centred along the bottom of the tag thumb
+   (between the ‹ › move buttons). */
+.ssb-group-chev {
+    position: absolute;
+    bottom: 0.3rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    background: rgba(26,188,156,0.92);
+    color: #06251f;
+    border: none;
+    border-radius: 0.8rem;
+    padding: 0.08rem 0.55rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
+}
+.ssb-group-chev:hover { background: #1abc9c; }
+.ssb-group-chev-ico { font-size: 0.68rem; line-height: 1; }
+
+/* A tag slot turns into a horizontal group container when expanded: the
+   compact header tile on the left, a scrollable member tray on the right.
+   It stays a SINGLE flex item so drag-index math is unchanged. */
+.ssb-slot-group {
+    flex: 0 0 auto;
+    flex-direction: row;
+    align-items: stretch;
+}
+.ssb-slot-group .ssb-group-head {
+    flex: 0 0 180px;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.ssb-slot-group.ssb-expanded { border-color: #1abc9c; }
+
+.ssb-group-tray {
+    display: flex;
+    align-items: stretch;
+    gap: 0.4rem;
+    padding: 0.5rem;
+    background: rgba(26,188,156,0.06);
+    border-left: 2px dashed rgba(26,188,156,0.4);
+    overflow-x: auto;
+    max-width: 760px;
+}
+.ssb-group-tray-loading,
+.ssb-group-tray-empty {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #8fd6c6;
+    font-size: 0.8rem;
+    padding: 0 0.75rem;
+    white-space: nowrap;
+}
+.ssb-group-retry {
+    background: rgba(26,188,156,0.15);
+    color: #1abc9c;
+    border: 1px solid rgba(26,188,156,0.5);
+    border-radius: 0.25rem;
+    font-size: 0.72rem;
+    padding: 0.1rem 0.4rem;
+    cursor: pointer;
+}
+.ssb-group-retry:hover { background: rgba(26,188,156,0.3); }
+.ssb-member {
+    flex: 0 0 120px;
+    display: flex;
+    flex-direction: column;
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 0.3rem;
+    overflow: hidden;
+}
+.ssb-member-thumb-wrap {
+    position: relative;
+    aspect-ratio: 16/9;
+    background: #000;
+    overflow: hidden;
+}
+.ssb-member-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    pointer-events: none;
+}
+.ssb-member-ord {
+    position: absolute;
+    top: 0.2rem;
+    left: 0.2rem;
+    background: rgba(0,0,0,0.75);
+    color: #fff;
+    font-size: 0.66rem;
+    font-weight: 700;
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.2rem;
+}
+.ssb-member-badge {
+    position: absolute;
+    bottom: 0.2rem;
+    right: 0.2rem;
+    background: rgba(0,0,0,0.72);
+    color: #1abc9c;
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.05rem 0.3rem;
+    border-radius: 0.2rem;
+}
+.ssb-member-name {
+    padding: 0.25rem 0.35rem;
+    font-size: 0.68rem;
+    color: #bbb;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.ssb-member-more {
+    flex: 0 0 96px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background: rgba(26,188,156,0.1);
+    border: 1px dashed rgba(26,188,156,0.5);
+    border-radius: 0.3rem;
+    color: #1abc9c;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+.ssb-member-more:hover { background: rgba(26,188,156,0.2); }
 </style>
 
 <h1>{% if edit_mode %}Edit Slideshow{% else %}New Slideshow{% endif %}
@@ -879,6 +1033,12 @@ const SS_MAX_SLIDES = 50;
 let slides = JSON.parse(document.getElementById('ss-initial-slides').textContent || '[]');
 const SS_ALL_TAGS = JSON.parse(document.getElementById('ss-all-tags').textContent || '[]');
 const SS_TAG_DEFAULT_DURATION_MS = 8000;
+// Lazily-fetched, point-in-time member previews for an expanded tag block,
+// keyed by tag_id -> {status:'loading'|'ready'|'error', members:[], total}.
+// UI-only (never serialized); membership is dynamic so this is a snapshot.
+const SS_TAG_MEMBER_CACHE = {};
+// How many member tiles a tag tray shows before the "+N more" reveal.
+const SS_TAG_TRAY_PREVIEW = 6;
 let availableAssets = [];
 let selectedGroupIds = [];
 let deckShuffle = {% if deck_shuffle %}true{% else %}false{% endif %};
@@ -1291,15 +1451,17 @@ function makeSlot(s, i) {
     return slot;
 }
 
-// Render a dynamic tag block as a distinct timeline tile. No asset preview
-// and no play-to-end control (members are timed per-item, not per-video),
-// but it does expose the same Fit + Motion controls as an asset slot — the
-// chosen values become the deck-default every expanded member inherits.
-// Reuses the standard remove/move/duration wiring so the block can be
-// reordered, removed, and re-timed.
+// Render a dynamic tag block as a collapsible timeline group. Collapsed it
+// is a compact header tile (the same Fit + Motion + per-item duration as an
+// asset slot, plus a Show/Hide toggle); expanded it widens into a scrollable
+// tray of read-only member previews — lazily fetched, point-in-time, in the
+// exact tagged-at order the device resolves. The group is a SINGLE flex item
+// so drag/reorder index math is untouched. Members are timed per-item (no
+// play-to-end). Fit/Motion picked here is the deck-default every expanded
+// member inherits.
 function makeTagSlot(s, i) {
     const slot = document.createElement('div');
-    slot.className = 'ssb-slot ssb-slot-tag';
+    slot.className = 'ssb-slot ssb-slot-tag ssb-slot-group' + (s._expanded ? ' ssb-expanded' : '');
     slot.draggable = true;
     slot.dataset.slotIndex = String(i);
 
@@ -1307,14 +1469,21 @@ function makeTagSlot(s, i) {
     const tagName = s.tag_name || 'tag';
     const perSec = Math.max(1, Math.round((s.duration_ms || 8000) / 1000));
     const countLabel = memberCount === 1 ? '1 item' : `${memberCount} items`;
+    const chevIco = s._expanded ? '▾' : '▸';
+    const chevTxt = s._expanded ? 'Hide' : 'Show';
 
-    slot.innerHTML = `
+    const head = document.createElement('div');
+    head.className = 'ssb-group-head';
+    head.innerHTML = `
         <div class="ssb-slot-thumb-wrap ssb-slot-tag-thumb">
             <div class="ssb-slot-tag-icon" aria-hidden="true">#</div>
             <div class="ssb-slot-pos">${i + 1}</div>
             <button type="button" class="ssb-slot-remove" title="Remove" aria-label="Remove">✕</button>
             <button type="button" class="ssb-slot-move left"  title="Move left"  aria-label="Move left"  ${i === 0 ? 'disabled' : ''}>‹</button>
             <button type="button" class="ssb-slot-move right" title="Move right" aria-label="Move right" ${i === slides.length - 1 ? 'disabled' : ''}>›</button>
+            <button type="button" class="ssb-group-chev" aria-expanded="${s._expanded ? 'true' : 'false'}" title="${chevTxt} member assets">
+                <span class="ssb-group-chev-ico" aria-hidden="true">${chevIco}</span><span>${chevTxt}</span>
+            </button>
         </div>
         <div class="ssb-slot-meta">
             <div class="ssb-slot-name" title="Dynamic tag: ${escapeHtml(tagName)}">#${escapeHtml(tagName)}</div>
@@ -1327,22 +1496,32 @@ function makeTagSlot(s, i) {
             </div>
             ${fitEffectCtlHtml(s, i)}
         </div>`;
+    slot.appendChild(head);
 
-    slot.querySelector('.ssb-slot-remove').addEventListener('click', (e) => {
+    head.querySelector('.ssb-slot-remove').addEventListener('click', (e) => {
         e.stopPropagation();
         removeSlide(i);
     });
-    slot.querySelector('.ssb-slot-move.left').addEventListener('click', (e) => {
+    head.querySelector('.ssb-slot-move.left').addEventListener('click', (e) => {
         e.stopPropagation();
         moveSlide(i, -1);
     });
-    slot.querySelector('.ssb-slot-move.right').addEventListener('click', (e) => {
+    head.querySelector('.ssb-slot-move.right').addEventListener('click', (e) => {
         e.stopPropagation();
         moveSlide(i, +1);
     });
-    slot.querySelector('input[type=number]').addEventListener('change', (e) => updateSlideDuration(i, e.target.value));
-    // Fit/motion picked here is the deck-default every expanded member inherits.
+    head.querySelector('input[type=number]').addEventListener('change', (e) => updateSlideDuration(i, e.target.value));
+    head.querySelector('.ssb-group-chev').addEventListener('click', (e) => {
+        e.stopPropagation();
+        toggleTagExpand(i);
+    });
+    // Query scope is the whole slot, but the fit/effect controls live in head
+    // (already appended), so this wires them correctly.
     wireFitEffectCtls(slot, i);
+
+    if (s._expanded) {
+        slot.appendChild(makeTagTray(s));
+    }
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -1353,6 +1532,132 @@ function makeTagSlot(s, i) {
 
     return slot;
 }
+
+// Build the expanded member tray for a tag block from the lazy cache. Shows
+// up to SS_TAG_TRAY_PREVIEW tiles, then a "+N more" reveal (sets s._showAll).
+function makeTagTray(s) {
+    const tray = document.createElement('div');
+    tray.className = 'ssb-group-tray';
+    const cache = SS_TAG_MEMBER_CACHE[s.tag_id];
+
+    if (!cache || cache.status === 'loading') {
+        tray.innerHTML = '<div class="ssb-group-tray-loading">Loading members…</div>';
+        return tray;
+    }
+    if (cache.status === 'error') {
+        tray.innerHTML = '<div class="ssb-group-tray-empty">Couldn’t load members. ' +
+            '<button type="button" class="ssb-group-retry">Retry</button></div>';
+        tray.querySelector('.ssb-group-retry').addEventListener('click', (e) => {
+            e.stopPropagation();
+            loadTagMembers(s.tag_id, true);
+        });
+        return tray;
+    }
+
+    const members = cache.members || [];
+    if (!members.length) {
+        tray.innerHTML = '<div class="ssb-group-tray-empty">No matching assets carry this tag yet.</div>';
+        return tray;
+    }
+
+    const showAll = !!s._showAll;
+    const shown = showAll ? members : members.slice(0, SS_TAG_TRAY_PREVIEW);
+    shown.forEach((m, idx) => tray.appendChild(makeMemberTile(m, idx)));
+
+    const remaining = members.length - shown.length;
+    if (remaining > 0) {
+        const more = document.createElement('div');
+        more.className = 'ssb-member-more';
+        more.setAttribute('role', 'button');
+        more.tabIndex = 0;
+        more.textContent = '+' + remaining + ' more';
+        more.title = 'Show all ' + members.length + ' members';
+        more.addEventListener('click', (e) => {
+            e.stopPropagation();
+            s._showAll = true;
+            renderTimeline();
+        });
+        tray.appendChild(more);
+    }
+    return tray;
+}
+
+// One read-only member preview tile. Mirrors makeSlot's image/video thumb
+// logic so a video member renders exactly like a standalone video slot.
+function makeMemberTile(m, idx) {
+    const tile = document.createElement('div');
+    tile.className = 'ssb-member';
+
+    const isVideo = m.asset_type === 'video';
+    const isComposed = m.asset_type === 'composed';
+    const thumbSrc = m.thumbnail_url || ('/api/assets/' + m.id + '/preview');
+    let inner;
+    if (m.thumbnail_url || !isVideo) {
+        inner = '<img class="ssb-member-thumb" src="' + escapeHtml(thumbSrc) + '" alt="" loading="lazy">';
+    } else {
+        inner = '<video class="ssb-member-thumb" src="' + escapeHtml(thumbSrc) + '" preload="metadata" muted playsinline></video>';
+    }
+    const badge = isVideo
+        ? '<div class="ssb-member-badge">video</div>'
+        : (isComposed ? '<div class="ssb-member-badge">slide</div>' : '');
+    const name = m.name || m.id;
+
+    tile.innerHTML =
+        '<div class="ssb-member-thumb-wrap">' +
+            inner +
+            '<div class="ssb-member-ord">' + (idx + 1) + '</div>' +
+            badge +
+        '</div>' +
+        '<div class="ssb-member-name" title="' + escapeHtml(name) + '">' + escapeHtml(name) + '</div>';
+    return tile;
+}
+
+// Toggle a tag block's expanded state. Lazy-fetches members on first expand
+// (or after a prior error). UI-only flags live on the slide object and are
+// never serialized.
+function toggleTagExpand(i) {
+    const s = slides[i];
+    if (!s || s.kind !== 'tag') return;
+    s._expanded = !s._expanded;
+    if (!s._expanded) {
+        renderTimeline();
+        return;
+    }
+    const cache = SS_TAG_MEMBER_CACHE[s.tag_id];
+    if (!cache || cache.status === 'error') {
+        loadTagMembers(s.tag_id, true);  // sets loading + re-renders, then again on resolve
+    } else {
+        renderTimeline();
+    }
+}
+
+// Fetch a tag's member previews into SS_TAG_MEMBER_CACHE and re-render. Cached
+// per tag_id; pass force=true to refetch (retry / explicit refresh).
+function loadTagMembers(tagId, force) {
+    const existing = SS_TAG_MEMBER_CACHE[tagId];
+    if (existing && existing.status === 'loading') return;
+    if (existing && existing.status === 'ready' && !force) return;
+
+    SS_TAG_MEMBER_CACHE[tagId] = { status: 'loading', members: [], total: 0 };
+    renderTimeline();
+
+    fetch('/api/tags/' + encodeURIComponent(tagId) + '/members', { headers: { 'Accept': 'application/json' } })
+        .then((r) => { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
+        .then((data) => {
+            const members = Array.isArray(data.members) ? data.members : [];
+            SS_TAG_MEMBER_CACHE[tagId] = {
+                status: 'ready',
+                members: members,
+                total: Number.isFinite(data.total) ? data.total : members.length,
+            };
+            renderTimeline();
+        })
+        .catch(() => {
+            SS_TAG_MEMBER_CACHE[tagId] = { status: 'error', members: [], total: 0 };
+            renderTimeline();
+        });
+}
+
 // The mpv-based legacy fleet renders any non-``cut`` value as an instant
 // swap (it ignores transitions entirely); the chromium-player shell that
 // ships on every supported Pi today renders the rest. ``cut`` keeps

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2031,6 +2031,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/tags/{tag_id}/members:
+    get:
+      summary: List Tag Members
+      description: |-
+        Return a tag's current member assets in device-resolve order.
+
+        Powers the slideshow builder's collapsible tag-block preview. The
+        members are exactly what the slideshow resolver would expand this tag
+        into — eligible asset types only, ordered ``tagged_at`` ascending —
+        intersected with the caller's visible-asset ACL and enriched with each
+        asset's ready thumbnail URL. Membership is dynamic, so this is a
+        point-in-time snapshot, not a stored ordering.
+
+        Reuses :func:`cms.services.slideshow_resolver.expand_tag_members` so the
+        preview can't drift from the order the device actually plays.
+      operationId: list_tag_members_api_tags__tag_id__members_get
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Tag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/asset-views:
     get:
       summary: List Views

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -210,3 +210,99 @@ class TestAssetBulkTagActions:
         assert sorted(data["succeeded"]) == sorted(str(a.id) for a in assets)
         assert len(data["failed"]) == 1
         assert data["failed"][0]["status"] == 404
+
+
+@pytest.mark.asyncio
+class TestTagMembersEndpoint:
+    """GET /api/tags/{tag_id}/members — the slideshow-builder tag preview."""
+
+    async def _tag_assets(self, db_session, tag_id, assets, base_ts):
+        """Attach assets to a tag with strictly increasing tagged-at order."""
+        import datetime as _dt
+
+        from cms.models.tag import AssetTag
+
+        for offset, a in enumerate(assets):
+            db_session.add(
+                AssetTag(
+                    asset_id=a.id,
+                    tag_id=tag_id,
+                    created_at=base_ts + _dt.timedelta(seconds=offset),
+                )
+            )
+        await db_session.commit()
+
+    async def test_404_when_tag_missing(self, client):
+        resp = await client.get(
+            "/api/tags/00000000-0000-0000-0000-000000000000/members"
+        )
+        assert resp.status_code == 404
+
+    async def test_returns_members_in_tagged_at_order(self, client, db_session):
+        import datetime as _dt
+        import uuid as _uuid
+
+        assets = await _seed_assets(db_session, n=3)
+        t = await _create_tag(client, "ordered")
+        tid = _uuid.UUID(t["id"])
+        # Attach in reverse asset order so insertion order != id order; the
+        # endpoint must echo tagged-at (created_at) ascending.
+        expected = list(reversed(assets))
+        await self._tag_assets(
+            db_session, tid, expected, _dt.datetime(2026, 1, 1, 12, 0, 0)
+        )
+
+        resp = await client.get(f"/api/tags/{t['id']}/members")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["tag_id"] == t["id"]
+        assert data["total"] == 3
+        assert [m["id"] for m in data["members"]] == [str(a.id) for a in expected]
+        # Shape: every tile carries the fields the builder tray reads.
+        first = data["members"][0]
+        assert set(first) >= {
+            "id",
+            "asset_type",
+            "name",
+            "thumbnail_url",
+            "duration_seconds",
+        }
+        assert first["asset_type"] == "image"
+
+    async def test_excludes_ineligible_asset_types(self, client, db_session):
+        import datetime as _dt
+        import uuid as _uuid
+
+        from cms.models.asset import Asset, AssetType
+
+        img = (await _seed_assets(db_session, n=1))[0]
+        # A WEBPAGE is not a tag-deck-eligible leaf type and must be filtered.
+        web = Asset(
+            filename="page.url",
+            original_filename="page.url",
+            asset_type=AssetType.WEBPAGE,
+            size_bytes=10,
+            checksum="webchk",
+        )
+        db_session.add(web)
+        await db_session.commit()
+        await db_session.refresh(web)
+
+        t = await _create_tag(client, "mixed")
+        tid = _uuid.UUID(t["id"])
+        await self._tag_assets(
+            db_session, tid, [img, web], _dt.datetime(2026, 1, 1, 12, 0, 0)
+        )
+
+        resp = await client.get(f"/api/tags/{t['id']}/members")
+        assert resp.status_code == 200, resp.text
+        ids = [m["id"] for m in resp.json()["members"]]
+        assert ids == [str(img.id)]
+
+    async def test_empty_tag_returns_no_members(self, client):
+        t = await _create_tag(client, "lonely")
+        resp = await client.get(f"/api/tags/{t['id']}/members")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["members"] == []


### PR DESCRIPTION
## Collapsible tag-block member preview in the slideshow timeline

Dynamic tag blocks in the slideshow builder timeline now render as a
**collapsible inline group**. Collapsed by default (compact tag tile);
expanding shows the tag's member assets as read-only previews, lazily
fetched and cached client-side.

Approved off an interactive mockup with these design answers:
- Show the first ~6 members with an option to expand to all
- Default collapsed
- Lazy-fetch + client cache
- Video members render exactly like a standalone video slot

### Backend
- New `GET /api/tags/{tag_id}/members` (`cms/routers/tags.py`):
  returns the tag's eligible member assets
  (IMAGE/VIDEO/SAVED_STREAM/COMPOSED) in tagged-at order, ACL-filtered
  to the caller's visible set, each with `thumbnail_url` and
  `duration_seconds`. `404` when the tag does not exist. Reuses
  `expand_tag_members`, `_visible_asset_ids`, `_thumbnail_urls_for`.

### Frontend (`cms/templates/slideshow_builder.html`)
- `makeTagSlot` rewritten as a collapsible group: compact tile + a
  Show/Hide chevron; the expanded state renders a member tray.
- New helpers `makeTagTray` / `makeMemberTile` / `toggleTagExpand` /
  `loadTagMembers`. First 6 members shown with an expand-to-all
  affordance. Video members use the same `<video>` preview as a
  standalone video slot.
- Expand/collapse state and the members cache are **UI-only** — never
  serialized into the saved slide JSON (verified against
  `serializeSlide`).

### Tests
- `TestTagMembersEndpoint` in `tests/test_tags_api.py`: 404 for a
  missing tag, tagged-at ordering + response shape, eligibility
  filtering (excludes WEBPAGE), and the empty-tag case.

### Notes
- Goodwill **dev** only. Purely additive (new endpoint + UI-only
  state); no migrations or firmware changes.
- Validated locally: 18/18 `test_tags_api.py` and 33/33
  slideshow tag-block + builder UI tests green.
