### PR TITLE
Fix three slideshow timeline tag-block nits

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -268,15 +268,13 @@ async def assets_status_json(
     # Slide counts for slideshow assets so the page poller can re-render the
     # "N slides" badge without it flipping back to "none" (the JS poller
     # would otherwise treat a slideshow with 0 variants as a generic asset).
+    # A dynamic ``tag`` block counts as its live expanded membership so the
+    # badge matches what the device/preview renders (see the helper).
     slide_counts: dict = {}
     slideshow_ids = [a.id for a in all_assets if a.asset_type == AssetType.SLIDESHOW]
     if slideshow_ids:
-        sc_rows = (await db.execute(
-            select(SlideshowSlide.slideshow_asset_id, sa_func.count())
-            .where(SlideshowSlide.slideshow_asset_id.in_(slideshow_ids))
-            .group_by(SlideshowSlide.slideshow_asset_id)
-        )).all()
-        slide_counts = {sid: cnt for sid, cnt in sc_rows}
+        from cms.services.slideshow_resolver import effective_slide_counts
+        slide_counts = await effective_slide_counts(slideshow_ids, db)
 
     assets_detail = []
     thumb_map = await _thumbnail_urls_for([a.id for a in all_assets], db)

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -26,9 +26,9 @@ import hashlib
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import logging
@@ -427,6 +427,68 @@ async def expand_tag_members(
         .order_by(AssetTag.created_at.asc(), AssetTag.id.asc())
     )
     return list(result.scalars().all())
+
+
+async def effective_slide_counts(
+    slideshow_ids: Sequence[uuid.UUID], db: AsyncSession
+) -> dict[uuid.UUID, int]:
+    """Return the *effective* slide count for each slideshow asset id.
+
+    A static ``asset`` slide counts as one.  A dynamic ``tag`` block counts
+    as the number of assets it currently expands to (its live tag
+    membership) — exactly what the device/preview renders — so a deck of
+    "2 static + 1 tag" reports ``2 + N`` rather than ``3``.  An empty tag
+    block (no current members) contributes ``0``, matching the resolver.
+
+    Done in two batched queries (one for the slide rows, one grouped
+    member count over every distinct tag referenced), so it stays O(1) in
+    deck length and membership size regardless of how many slideshows are
+    passed.
+    """
+    counts: dict[uuid.UUID, int] = {sid: 0 for sid in slideshow_ids}
+    if not slideshow_ids:
+        return counts
+
+    rows = (
+        await db.execute(
+            select(
+                SlideshowSlide.slideshow_asset_id,
+                SlideshowSlide.kind,
+                SlideshowSlide.tag_id,
+            ).where(SlideshowSlide.slideshow_asset_id.in_(slideshow_ids))
+        )
+    ).all()
+
+    # (slideshow_id, tag_id) for every tag block — kept per-row (not
+    # de-duplicated) so two blocks pointing at the same tag both expand.
+    tag_rows: list[tuple[uuid.UUID, uuid.UUID]] = []
+    tag_ids: set[uuid.UUID] = set()
+    for sid, kind, tag_id in rows:
+        if kind == "tag":
+            if tag_id is not None:
+                tag_rows.append((sid, tag_id))
+                tag_ids.add(tag_id)
+        else:
+            counts[sid] = counts.get(sid, 0) + 1
+
+    if tag_ids:
+        member_rows = (
+            await db.execute(
+                select(AssetTag.tag_id, func.count())
+                .join(Asset, Asset.id == AssetTag.asset_id)
+                .where(
+                    AssetTag.tag_id.in_(tag_ids),
+                    Asset.deleted_at.is_(None),
+                    Asset.asset_type.in_(_TAG_MEMBER_ASSET_TYPES),
+                )
+                .group_by(AssetTag.tag_id)
+            )
+        ).all()
+        member_counts = {tid: cnt for tid, cnt in member_rows}
+        for sid, tag_id in tag_rows:
+            counts[sid] = counts.get(sid, 0) + member_counts.get(tag_id, 0)
+
+    return counts
 
 
 async def plan_slideshow(

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -781,8 +781,10 @@
     text-align: center;
     max-width: 4.2rem;
 }
-/* Show/Hide members toggle, centred along the bottom of the tag thumb
-   (between the ‹ › move buttons). */
+/* "Expand members" control, centred along the bottom of the tag thumb
+   (between the ‹ › move buttons). A stacked-cards glyph (⧉) that implies
+   unstacking the tag block into its tagged member assets; the adjacent
+   label is the live member count when collapsed, ✕ when expanded. */
 .ssb-group-chev {
     position: absolute;
     bottom: 0.3rem;
@@ -793,17 +795,17 @@
     color: #06251f;
     border: none;
     border-radius: 0.8rem;
-    padding: 0.08rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 700;
+    padding: 0.1rem 0.55rem;
+    font-size: 0.78rem;
+    font-weight: 800;
     cursor: pointer;
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.3rem;
     white-space: nowrap;
 }
 .ssb-group-chev:hover { background: #1abc9c; }
-.ssb-group-chev-ico { font-size: 0.68rem; line-height: 1; }
+.ssb-group-chev-ico { font-size: 1.05rem; line-height: 1; }
 
 /* A tag slot turns into a horizontal group container when expanded: the
    compact header tile on the left, a scrollable member tray on the right.
@@ -1548,7 +1550,7 @@ function makeSlot(s, i) {
 
 // Render a dynamic tag block as a collapsible timeline group. Collapsed it
 // is a compact header tile (the same Fit + Motion + per-item duration as an
-// asset slot, plus a Show/Hide toggle); expanded it widens into a scrollable
+// asset slot, plus an expand control); expanded it widens into a scrollable
 // tray of read-only member previews — lazily fetched, point-in-time, in the
 // exact tagged-at order the device resolves. The group is a SINGLE flex item
 // so drag/reorder index math is untouched. Members are timed per-item (no
@@ -1564,8 +1566,11 @@ function makeTagSlot(s, i) {
     const tagName = s.tag_name || 'tag';
     const perSec = Math.max(1, Math.round((s.duration_ms || 8000) / 1000));
     const countLabel = memberCount === 1 ? '1 item' : `${memberCount} items`;
-    const chevIco = s._expanded ? '▾' : '▸';
-    const chevTxt = s._expanded ? 'Hide' : 'Show';
+    // Expand affordance: a stacked-cards glyph (⧉) implying "unstack into the
+    // tagged member assets". Collapsed shows the live member count; expanded
+    // shows ✕ to read as "close/restack". Text-free + obvious it expands.
+    const expandLabel = s._expanded ? '✕' : String(memberCount);
+    const expandTitle = s._expanded ? 'Collapse member assets' : 'Expand member assets';
 
     const head = document.createElement('div');
     head.className = 'ssb-group-head';
@@ -1576,8 +1581,8 @@ function makeTagSlot(s, i) {
             <button type="button" class="ssb-slot-remove" title="Remove" aria-label="Remove">✕</button>
             <button type="button" class="ssb-slot-move left"  title="Move left"  aria-label="Move left"  ${i === 0 ? 'disabled' : ''}>‹</button>
             <button type="button" class="ssb-slot-move right" title="Move right" aria-label="Move right" ${i === slides.length - 1 ? 'disabled' : ''}>›</button>
-            <button type="button" class="ssb-group-chev" aria-expanded="${s._expanded ? 'true' : 'false'}" title="${chevTxt} member assets">
-                <span class="ssb-group-chev-ico" aria-hidden="true">${chevIco}</span><span>${chevTxt}</span>
+            <button type="button" class="ssb-group-chev${s._expanded ? ' is-open' : ''}" aria-expanded="${s._expanded ? 'true' : 'false'}" title="${expandTitle}" aria-label="${expandTitle}">
+                <span class="ssb-group-chev-ico" aria-hidden="true">⧉</span><span>${expandLabel}</span>
             </button>
         </div>
         <div class="ssb-slot-meta">
@@ -1902,7 +1907,7 @@ function wireTransitionMenu(btn, menu, slideIdx, opts) {
             }
             btn.textContent = t.icon;
             btn.title = `${t.label}${titleSuffix} — click to change`;
-            // Refresh duration input enabled state without closing the popover.
+            // Refresh the duration input so it's correct on the next open.
             const di = menu.querySelector('.ssb-trans-dur-input');
             if (di) {
                 di.disabled = (t.id === 'cut');
@@ -1911,6 +1916,10 @@ function wireTransitionMenu(btn, menu, slideIdx, opts) {
             // Mark selected option visually.
             menu.querySelectorAll('.ssb-trans-opt').forEach(o => o.classList.remove('ssb-trans-opt-sel'));
             opt.classList.add('ssb-trans-opt-sel');
+            // Picking a transition commits the choice — close the popover.
+            // (The duration footer stays editable because its own handlers
+            //  stopPropagation, so adjusting ms never reaches here.)
+            try { menu.hidePopover(); } catch {}
         });
         if (t.id === current.id) opt.classList.add('ssb-trans-opt-sel');
         menu.appendChild(opt);

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1494,17 +1494,15 @@ async def assets_page(request: Request, db: AsyncSession = Depends(get_db)):
     sched_counts = dict(sched_counts_q.all())
 
     # Slide counts for slideshow assets — used by the assets table to show
-    # "N slides" in lieu of a transcoding-status badge.
+    # "N slides" in lieu of a transcoding-status badge.  A dynamic ``tag``
+    # block counts as its live expanded membership, so the badge matches
+    # what the device/preview actually renders (see effective_slide_counts).
     slide_counts: dict = {}
     if assets:
         slideshow_ids = [a.id for a in assets if a.asset_type == AssetType.SLIDESHOW]
         if slideshow_ids:
-            sc_rows = (await db.execute(
-                select(SlideshowSlide.slideshow_asset_id, func.count())
-                .where(SlideshowSlide.slideshow_asset_id.in_(slideshow_ids))
-                .group_by(SlideshowSlide.slideshow_asset_id)
-            )).all()
-            slide_counts = {sid: cnt for sid, cnt in sc_rows}
+            from cms.services.slideshow_resolver import effective_slide_counts
+            slide_counts = await effective_slide_counts(slideshow_ids, db)
 
     # Annotate each asset with variant summary + schedule count + group info
     all_group_assets = {}

--- a/tests/test_slideshow_tag_blocks.py
+++ b/tests/test_slideshow_tag_blocks.py
@@ -428,3 +428,73 @@ class TestTagBlockMemberTransition:
             s = (await client.get(f"/api/assets/{sid}/slides")).json()["slides"][0]
             assert s.get("member_transition") in (None, "")
             assert s.get("member_transition_ms") in (None,)
+
+
+@pytest.mark.asyncio
+class TestEffectiveSlideCounts:
+    """agora#806 nit: the library table/grid "N slides" badge must count a
+    dynamic ``tag`` block as its *live* expanded membership, not as 1, so the
+    badge matches what the device/preview actually renders."""
+
+    async def test_tag_block_counts_live_membership(self, client, db_session):
+        from cms.services.slideshow_resolver import effective_slide_counts
+
+        # 2 static images + a tag carrying 3 members → effective count 5.
+        s1 = await _seed_image(db_session, filename="s1.png", checksum="s1")
+        s2 = await _seed_image(db_session, filename="s2.png", checksum="s2")
+        tag = await _seed_tag(db_session, name="promo-count")
+        for n in range(3):
+            m = await _seed_image(
+                db_session, filename=f"mem{n}.png", checksum=f"mem{n}"
+            )
+            await _tag_asset(db_session, m, tag)
+
+        create = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "count-show",
+                "slides": [
+                    {"kind": "asset", "source_asset_id": str(s1.id), "duration_ms": 1000},
+                    {"kind": "tag", "tag_id": str(tag.id), "duration_ms": 1000},
+                    {"kind": "asset", "source_asset_id": str(s2.id), "duration_ms": 1000},
+                ],
+            },
+        )
+        assert create.status_code == 201, create.text
+        sid = uuid.UUID(create.json()["id"])
+
+        counts = await effective_slide_counts([sid], db_session)
+        assert counts[sid] == 5  # 2 static + 3 tag members
+
+        # Tagging one more asset bumps the live count without editing the deck.
+        extra = await _seed_image(db_session, filename="mem3.png", checksum="mem3")
+        await _tag_asset(db_session, extra, tag)
+        counts2 = await effective_slide_counts([sid], db_session)
+        assert counts2[sid] == 6
+
+    async def test_empty_tag_block_contributes_zero(self, client, db_session):
+        from cms.services.slideshow_resolver import effective_slide_counts
+
+        s1 = await _seed_image(db_session, filename="e1.png", checksum="e1")
+        tag = await _seed_tag(db_session, name="empty-tag")  # no members
+
+        create = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "empty-tag-show",
+                "slides": [
+                    {"kind": "asset", "source_asset_id": str(s1.id), "duration_ms": 1000},
+                    {"kind": "tag", "tag_id": str(tag.id), "duration_ms": 1000},
+                ],
+            },
+        )
+        assert create.status_code == 201, create.text
+        sid = uuid.UUID(create.json()["id"])
+
+        counts = await effective_slide_counts([sid], db_session)
+        assert counts[sid] == 1  # the lone static slide; empty tag adds 0
+
+    async def test_empty_input_returns_empty_mapping(self, db_session):
+        from cms.services.slideshow_resolver import effective_slide_counts
+
+        assert await effective_slide_counts([], db_session) == {}


### PR DESCRIPTION
Three small follow-up nits on the slideshow builder timeline + asset library, bundled together. **Goodwill dev only; no firmware change.**

### 1. Transition picker auto-close
Selecting a transition in the per-slide/tag-block transition popover now closes it (`menu.hidePopover()` on option-click). The duration footer input still stays editable because its handlers `stopPropagation`, so adjusting ms never trips the close.

### 2. Library "N slides" badge counts live tag membership
A dynamic `tag` block was counted as a single slide, so a deck of *2 static + 1 tag* showed **3** even though the device/preview renders *2 + (tag membership)*. New shared helper `effective_slide_counts()` in `slideshow_resolver.py` expands each tag block to its current non-deleted, displayable membership (matching `expand_tag_members`). Wired into both the table render (`ui.py`) and the status poller (`assets.py`). Empty tag block contributes 0.

### 3. Tag-block timeline expander affordance
Replaced the text `Show/Hide` toggle with a text-free **stacked-cards** control (`⧉`) that implies unstacking the tag block into its member assets: collapsed shows `⧉` + the live member count, expanded shows `⧉` + `✕`. Restyled `.ssb-group-chev` accordingly; click wiring unchanged.

### Tests
- `effective_slide_counts`: live membership (2 static + tag-of-3 => 5, +1 tagged => 6), empty tag => static count only, empty input => {}.
- Green locally: test_slideshow_tag_blocks (19), test_slideshow_resolver + test_slideshow_builder_ui (62), test_slideshow_assets (81).
