### PR TITLE
Play tagged videos to full length inside tag blocks

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1509,6 +1509,30 @@ async def _load_tag_members(
     return out
 
 
+async def _load_tag_member_meta(
+    tag_members: dict[uuid.UUID, list[tuple[uuid.UUID, str]]],
+    db: AsyncSession,
+) -> dict[uuid.UUID, tuple[AssetType, float | None]]:
+    """Fetch ``(asset_type, duration_seconds)`` for every tag-block member.
+
+    Used by :func:`_compute_slideshow_duration_seconds` so a VIDEO member's
+    natural length feeds the denormalised slideshow duration (and therefore
+    schedule end-time math), matching the resolver which plays video
+    members to their natural end rather than the block's dwell time.
+    """
+    member_ids = {mid for members in tag_members.values() for mid, _ in members}
+    if not member_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(Asset.id, Asset.asset_type, Asset.duration_seconds).where(
+                Asset.id.in_(member_ids)
+            )
+        )
+    ).all()
+    return {aid: (atype, dur) for aid, atype, dur in rows}
+
+
 def _slide_row(slideshow_asset_id: uuid.UUID, idx: int, s: SlideIn) -> SlideshowSlide:
     """Build one ordered ``SlideshowSlide`` ORM row from a validated ``SlideIn``.
 
@@ -1752,21 +1776,30 @@ def _compute_slideshow_duration_seconds(
     slides: list[SlideIn],
     sources_by_id: dict[uuid.UUID, Asset],
     tag_members: dict[uuid.UUID, list[tuple[uuid.UUID, str]]] | None = None,
+    member_meta: dict[uuid.UUID, tuple[AssetType, float | None]] | None = None,
 ) -> float:
     """Sum slide durations for ``Asset.duration_seconds`` denormalisation.
 
     For ``play_to_end`` on a video, use the source's known media duration
     when available; otherwise fall back to the configured ``duration_ms``.
     Image slides always use the configured duration.  A ``tag`` block
-    contributes ``member_count × duration_ms`` (each expanded member plays
-    for the block's configured per-slide duration).
+    contributes the sum of its members' play durations: a VIDEO member
+    plays its full natural length (``member_meta`` duration when known,
+    falling back to ``duration_ms``) — mirroring the resolver, which flips
+    ``play_to_end`` on for video tag-members — while every other member
+    type uses the block's configured per-slide ``duration_ms``.
     """
     tag_members = tag_members or {}
+    member_meta = member_meta or {}
     total_ms = 0.0
     for s in slides:
         if s.kind == "tag":
-            member_count = len(tag_members.get(s.tag_id, ()))
-            total_ms += member_count * s.duration_ms
+            for member_id, _csum in tag_members.get(s.tag_id, ()):
+                m_type, m_dur = member_meta.get(member_id, (None, None))
+                if m_type == AssetType.VIDEO and m_dur:
+                    total_ms += m_dur * 1000.0
+                else:
+                    total_ms += s.duration_ms
             continue
         src = sources_by_id[s.source_asset_id]
         if (
@@ -1981,8 +2014,9 @@ async def create_slideshow_asset(
     tag_members = await _load_tag_members(
         list({s.tag_id for s in slides if s.kind == "tag"}), db
     )
+    member_meta = await _load_tag_member_meta(tag_members, db)
     duration_seconds = _compute_slideshow_duration_seconds(
-        slides, sources_by_id, tag_members
+        slides, sources_by_id, tag_members, member_meta
     )
     manifest_content_hash = _compute_slideshow_manifest_content_hash(
         slides, sources_by_id, tag_members
@@ -2229,8 +2263,9 @@ async def replace_slideshow_slides(
     tag_members = await _load_tag_members(
         list({s.tag_id for s in slides if s.kind == "tag"}), db
     )
+    member_meta = await _load_tag_member_meta(tag_members, db)
     duration_seconds = _compute_slideshow_duration_seconds(
-        slides, sources_by_id, tag_members
+        slides, sources_by_id, tag_members, member_meta
     )
     manifest_content_hash = _compute_slideshow_manifest_content_hash(
         slides, sources_by_id, tag_members

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -134,6 +134,12 @@ class _SlideSpec:
     fit: str
     effect: str
     effect_direction: str
+    # True when this spec was expanded from a dynamic ``tag`` block.  The
+    # block owns a single dwell time for all members, but a VIDEO member
+    # should still play its full natural length rather than being truncated
+    # to that dwell — so the resolver flips ``play_to_end`` on for video
+    # members once the member's asset type is known (agora#806 follow-up).
+    tag_member: bool = False
 
 
 @dataclass
@@ -370,9 +376,15 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
                         position=pos,
                         source_asset_id=aid,
                         duration_ms=row.duration_ms,
-                        # Tag-block members never play-to-end — the block
-                        # owns a single deck-default dwell time.
+                        # Tag-block members share the block's single dwell
+                        # time, but a VIDEO member plays to its natural end
+                        # instead of being clipped to that dwell.  We don't
+                        # know the member's asset type here (it's resolved
+                        # later from ``sources_by_id``), so mark the spec as a
+                        # tag member and let ``_plan_slides`` flip
+                        # ``play_to_end`` on for videos.
                         play_to_end=False,
+                        tag_member=True,
                         transition=m_trans,
                         transition_ms=m_trans_ms,
                         fit=row.fit,
@@ -575,7 +587,14 @@ async def plan_slideshow(
             source_filename=src.filename,
             source_asset_type=src.asset_type,
             duration_ms=spec.duration_ms,
-            play_to_end=spec.play_to_end,
+            # A VIDEO member of a dynamic tag block plays its full natural
+            # length rather than being clipped to the block's dwell time
+            # (matches a standalone video slide with play_to_end on).  Other
+            # member types (image, saved_stream, composed) keep the dwell.
+            play_to_end=(
+                spec.play_to_end
+                or (spec.tag_member and src.asset_type == AssetType.VIDEO)
+            ),
             transition=spec.transition,
             transition_ms=spec.transition_ms,
             fit=spec.fit,

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -1249,8 +1249,41 @@ class TestHybridTagTimeline:
         # Members inherit the tag row's playback columns.
         assert all(s.duration_ms == 7000 for s in plan.slides)
         assert all(s.transition == "fade" for s in plan.slides)
-        # Tag members never play-to-end.
+        # Image tag members never play-to-end (they use the block dwell).
         assert all(s.play_to_end is False for s in plan.slides)
+
+    async def test_tag_block_video_member_plays_to_end(self, db_session):
+        """A VIDEO member of a tag block plays its full natural length
+        (``play_to_end`` True), while image members in the same block keep
+        the block's dwell time (``play_to_end`` False).  The block owns one
+        dwell time, but a video shouldn't be truncated to it."""
+        from datetime import datetime, timedelta, timezone
+
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "phybvid")
+        tag = await _seed_tag(db_session, "promoVid")
+        img = await _seed_image(db_session, filename="still.png")
+        vid = await _seed_video(db_session, filename="clip.mp4", duration=30.0)
+        await _seed_variant(db_session, source=img, profile=profile, ext="jpg")
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        await _tag_asset(db_session, asset=img, tag=tag, when=base)
+        await _tag_asset(
+            db_session, asset=vid, tag=tag, when=base + timedelta(seconds=5)
+        )
+        ss = await _seed_hybrid_slideshow(
+            db_session, name="hybvid",
+            entries=[{"tag": tag, "duration_ms": 8000}],
+            checksum="hbv",
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session)
+        assert plan.ready
+        by_name = {s.source_filename: s for s in plan.slides}
+        # Image member: clipped to the block's 8s dwell.
+        assert by_name["still.png"].play_to_end is False
+        # Video member: plays its full natural length.
+        assert by_name["clip.mp4"].play_to_end is True
 
     async def test_member_transition_applies_to_rest_only(self, db_session):
         """When ``member_transition`` is set, member 0 keeps the block's

--- a/tests/test_slideshow_tag_blocks.py
+++ b/tests/test_slideshow_tag_blocks.py
@@ -39,6 +39,24 @@ async def _seed_image(db_session, *, filename="img.png", is_global=True, checksu
     return asset
 
 
+async def _seed_video(
+    db_session, *, filename="clip.mp4", is_global=True, checksum="vid-cs",
+    duration_seconds=30.0,
+):
+    asset = Asset(
+        filename=filename,
+        asset_type=AssetType.VIDEO,
+        size_bytes=4321,
+        checksum=checksum,
+        is_global=is_global,
+        duration_seconds=duration_seconds,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    await db_session.refresh(asset)
+    return asset
+
+
 async def _seed_tag(db_session, *, name="weekly-sale"):
     tag = Tag(name=name)
     db_session.add(tag)
@@ -147,6 +165,36 @@ class TestSlideshowTagBlockCreate:
         ss = await db_session.get(Asset, uuid.UUID(create.json()["id"]))
         await db_session.refresh(ss)
         assert ss.duration_seconds == pytest.approx(6.0)
+
+    async def test_create_tag_block_video_member_uses_natural_duration(
+        self, client, db_session
+    ):
+        """A VIDEO member of a tag block contributes its full natural
+        length to the denormalised slideshow duration, not the block's
+        per-slide dwell.  This mirrors the resolver flipping video members
+        to play-to-end, so schedule end-times stay correct."""
+        tag = await _seed_tag(db_session, name="vid-dur")
+        img = await _seed_image(db_session, filename="still.png")
+        vid = await _seed_video(
+            db_session, filename="clip.mp4", duration_seconds=30.0
+        )
+        await _tag_asset(db_session, img, tag)
+        await _tag_asset(db_session, vid, tag)
+
+        create = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "vid-dur-show",
+                "slides": [
+                    {"kind": "tag", "tag_id": str(tag.id), "duration_ms": 8000},
+                ],
+            },
+        )
+        assert create.status_code == 201, create.text
+        # image member: 8s dwell; video member: 30s natural => 38.0 s total.
+        ss = await db_session.get(Asset, uuid.UUID(create.json()["id"]))
+        await db_session.refresh(ss)
+        assert ss.duration_seconds == pytest.approx(38.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a **video** is tagged into a dynamic tag block, it inherited the
block's single per-slide dwell time. A 30s clip in an 8s-dwell block
only played for 8s. Reported by user.

## Fix (implicit — no new UI)

Per the user's chosen approach: **video members of a tag block always
play their full natural length; images keep the block dwell.**

- **Resolver** (`cms/services/slideshow_resolver.py`): added a
  `tag_member` flag to `_SlideSpec`; in `_plan_slides`, a member
  resolves with `play_to_end=True` only when it's a tag member *and*
  an `AssetType.VIDEO`. Standalone slides are unchanged; image /
  stream members keep the block dwell.
- **Duration denorm** (`cms/routers/assets.py`):
  `_compute_slideshow_duration_seconds` now sums video members'
  natural durations (falling back to the dwell when the natural length
  is unknown), so `Asset.duration_seconds` — consumed by
  `schedules.py` end-time math — stays correct. New
  `_load_tag_member_meta` helper; `member_meta` wired into both the
  create and replace callsites.

The resolver's per-slide hash already folds in `play_to_end`, so video
members flipping naturally invalidates the device-facing resolved hash
and triggers a refetch. No separate hash change needed.

## Tests

- Resolver: a tag block with one image + one 30s video member → the
  video resolves `play_to_end=True`, the image `False`.
- Denorm: creating a slideshow with a tag block (8s dwell, one image +
  one 30s video) → `duration_seconds == 38.0` (8 + 30), not
  `member_count × dwell`.
- `tests/test_slideshow_tag_blocks.py tests/test_slideshow_resolver.py`
  → **60 passed** locally.

Goodwill dev only. No firmware change.
