### PR TITLE
Slideshow editor: teach assistant to style dynamic tag blocks

### DIFF
--- a/cms/services/assistant/mcp_client.py
+++ b/cms/services/assistant/mcp_client.py
@@ -254,9 +254,15 @@ COMPOSED_EDITOR_TOOLS: frozenset[str] = (
 )
 
 # The slideshow-editor tool profile: discover/select assets + read+write
-# the current slideshow's slides.
+# the current slideshow's slides.  ``list_tags`` is included (read-only)
+# so the assistant can resolve a tag NAME (e.g. "summer-sale") to the
+# ``tag_id`` that a dynamic ``kind="tag"`` block requires.  Populating a
+# tag's membership (``tag_asset`` / ``untag_asset``) is deliberately NOT
+# here — those touch *other* assets, outside this mode's "only the
+# slideshow you have open" guardrail; membership is managed from the
+# library view.
 SLIDESHOW_EDITOR_TOOLS: frozenset[str] = (
-    frozenset({"list_assets", "get_asset"})
+    frozenset({"list_assets", "get_asset", "list_tags"})
     | SLIDESHOW_READ_TOOLS
     | SLIDESHOW_WRITE_TOOLS
 )

--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -176,24 +176,41 @@ Per-slide fields:
     - ``ken_burns`` — a slow, cinematic pan-and-zoom across the image.
   Effects render on images (and composed slides); a video slide plays
   its own motion, so ``ken_burns`` has no visible effect there.
+* ``effect_direction``: the Ken Burns motion path (only used when
+  ``effect`` is ``ken_burns``).  A zoom — ``in`` or ``out`` — optionally
+  combined with a pan: ``up`` / ``down`` / ``left`` / ``right`` or a
+  diagonal (``up_left`` / ``up_right`` / ``down_left`` / ``down_right``).
+  E.g. ``in`` (zoom in, no pan) or ``out_down_right`` (zoom out drifting
+  toward the bottom-right).  Word order and separators don't matter
+  (``"zoom out right down"`` is read as ``out_down_right``).  Default
+  ``in``.
 
 Dynamic tag blocks:
 * A slide can instead be a **tag block** that auto-expands at play
   time to every asset carrying a given tag — great for "show all our
   current promos" without re-editing the show as assets come and go.
-  Set ``kind: "tag"`` and ``tag_id`` (from ``list_tags`` /
-  ``create_tag``) INSTEAD of ``source_asset_id``.
-* A tag block has no ``play_to_end`` (it isn't one clip). Its
-  ``duration_ms`` / ``transition`` / ``fit`` / ``effect`` become the
-  defaults every expanded member inherits. VIDEO members
-  automatically play their full length; ``duration_ms`` only governs
-  image/composed members.
+  Set ``kind: "tag"`` and ``tag_id`` INSTEAD of ``source_asset_id``.
+  Use ``list_tags`` to turn a tag NAME the operator gives you (e.g.
+  "summer-sale") into its ``tag_id``.
+* A tag block's members are **dynamic** — they're whatever assets carry
+  the tag at play time, so you CANNOT style or time them one at a time
+  (there are no per-member fields).  Instead, every playback field you
+  set on the block becomes the DEFAULT that all members inherit:
+  ``duration_ms``, ``transition``, ``transition_ms``, ``fit``,
+  ``effect``, ``effect_direction``.  So a request like "make each promo
+  zoom in" or "give the group a fade" means setting that one field on
+  the block, not editing individual slides.
 * ``transition`` is the transition INTO the block; ``member_transition``
   (+ ``member_transition_ms``) is the transition used BETWEEN the
   block's members. Omit them to reuse ``transition`` / ``transition_ms``.
-* To control what shows in a tag block, manage the tag's membership:
-  ``tag_asset(tag_id, asset_ids)`` adds the tag to assets,
-  ``untag_asset(tag_id, asset_ids)`` removes it. Both are idempotent.
+* A tag block has no ``play_to_end`` (it isn't one clip). VIDEO members
+  automatically play their full length; ``duration_ms`` only governs
+  image/composed members.
+* You can add, remove, reorder, and fully style/time tag blocks from
+  here.  But you CANNOT change which assets are in a tag, or create new
+  tags, from the slideshow editor — that is done in the asset library.
+  If the operator names a tag that ``list_tags`` doesn't return, tell
+  them to create it (and tag its assets) in the library first.
 
 Facts (fixed):
 * A slideshow can hold at most 50 slides.

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -242,6 +242,33 @@ class TestBuildSystemPrompt:
         # effect values incl. Ken Burns are described.
         assert "ken_burns" in prompt
 
+    def test_editor_prompt_documents_tag_block_styling(self):
+        """The tag-block section must teach the assistant that it can
+        style/time blocks (incl. member_transition + effect_direction),
+        that members are dynamic (no per-member styling), and that
+        membership/tag-creation is NOT done from the editor."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        # Tag-block playback controls are advertised.
+        assert "tag block" in prompt
+        assert "member_transition" in prompt
+        assert "effect_direction" in prompt
+        # Resolving a tag name to its id is via list_tags.
+        assert "list_tags" in prompt
+        # Members are dynamic — the assistant must NOT think it can style
+        # them one at a time.
+        assert "dynamic" in prompt.lower()
+        # Membership / tag creation is library-side; the editor prompt must
+        # NOT promise membership/creation tools it cannot call in this mode.
+        assert "tag_asset" not in prompt
+        assert "untag_asset" not in prompt
+        assert "create_tag" not in prompt
+        assert "library" in prompt.lower()
+
     def test_slideshow_mode_without_id_falls_back_to_general(self):
         from cms.services.assistant.prompts import build_system_prompt
 
@@ -255,6 +282,38 @@ class TestBuildSystemPrompt:
 
         prompt = build_system_prompt(self._user())
         assert "Slideshow Assistant" not in prompt
+
+
+class TestSlideshowEditorToolProfile:
+    """The slideshow-editor mode exposes exactly the tools needed to
+    discover assets/tags and read+write the open slideshow — and nothing
+    that would let it mutate other assets, tag membership, or global tags.
+    """
+
+    def test_list_tags_is_in_editor_profile(self):
+        """``list_tags`` (read) lets the assistant resolve a tag name to
+        the ``tag_id`` a dynamic tag block requires."""
+        from cms.services.assistant.mcp_client import (
+            MODE_SLIDESHOW_EDITOR,
+            tools_for_mode,
+        )
+
+        tools = tools_for_mode(MODE_SLIDESHOW_EDITOR)
+        assert "list_tags" in tools
+        assert "set_slideshow_slides" in tools
+        assert "get_slideshow" in tools
+
+    def test_membership_and_tag_creation_excluded_from_editor(self):
+        """Editor mode must stay tight: no tag-membership writes (which
+        touch OTHER assets) and no global tag CRUD."""
+        from cms.services.assistant.mcp_client import (
+            MODE_SLIDESHOW_EDITOR,
+            tools_for_mode,
+        )
+
+        tools = tools_for_mode(MODE_SLIDESHOW_EDITOR)
+        for forbidden in ("tag_asset", "untag_asset", "create_tag", "delete_tag"):
+            assert forbidden not in tools
 
 
 # ── builder template drawer gating (feature-flag-gated, both modes) ──


### PR DESCRIPTION
## What

Follow-up to #826. Makes the **slideshow-edit-page assistant** actually
able to add and style dynamic **tag blocks**, and fixes a prompt/profile
mismatch that shipped in #826.

### The two problems

1. **No `list_tags` in editor mode.** `set_slideshow_slides` can write a
   `kind:"tag"` block, but the editor tool profile
   (`SLIDESHOW_EDITOR_TOOLS`) didn't include `list_tags`, so the
   assistant had no way to resolve a tag **name** -> `tag_id`. Asking it
   to "add the #summer-sale tag to the timeline" would dead-end.
2. **Editor prompt promised tools it can't call.** #826's editor prompt
   referenced `tag_asset` / `untag_asset` / `create_tag`, none of which
   are in `SLIDESHOW_EDITOR_TOOLS` — those calls would fail
   "tool not available" in editor mode.

## Changes

- **`mcp_client.py`** — add `list_tags` (read-only) to
  `SLIDESHOW_EDITOR_TOOLS`. Membership writes (`tag_asset`/`untag_asset`)
  and global tag CRUD (`create_tag`/`delete_tag`) stay **out** of editor
  mode by design: they touch other assets / global state, outside the
  "only the slideshow you have open" guardrail. Membership + tag creation
  remain a **library** action.
- **`prompts.py`** — document `effect_direction` (Ken Burns motion path)
  for slides, and rewrite the tag-block section so the assistant knows:
  - block playback fields (`duration_ms`, `transition`, `transition_ms`,
    `fit`, `effect`, `effect_direction`, `member_transition`,
    `member_transition_ms`) are **block-level defaults all members
    inherit** — members are **dynamic** and can't be styled one at a time;
  - `member_transition` is between members, `transition` is into the
    block; videos auto play-to-end;
  - membership changes + tag creation happen in the **asset library**,
    not the editor.
- **tests** — assert the editor tool profile (`list_tags` in;
  `tag_asset`/`untag_asset`/`create_tag`/`delete_tag` out) and the new
  prompt guidance.

## Scope / safety

Prompt + read-tool-allowlist + tests only. No CMS routes or schemas
changed (no openapi regen). Goodwill **dev** only; normal CI.

Targeted tests: `tests/test_slideshow_editor_assistant.py` 19 passed.
