### PR TITLE
feat(slideshow): per-slide visibility windows

### DIFF
--- a/alembic/versions/0049_slideshow_visibility_window.py
+++ b/alembic/versions/0049_slideshow_visibility_window.py
@@ -1,0 +1,85 @@
+"""slideshow_slides: per-slide visibility window
+
+Adds five nullable columns that restrict WHEN an individual slide is
+eligible to be shown, plus three CHECK constraints mirroring the
+Pydantic validators in ``cms.schemas.asset.SlideIn``:
+
+* ``valid_from`` / ``valid_to`` (``date``) — local-calendar date range,
+  INCLUSIVE both ends.  A single-day window (from == to) is allowed.
+* ``active_days`` (``smallint[]``) — weekdays 0=Mon..6=Sun the slide may
+  show on.  NULL or empty = every day.
+* ``active_start`` / ``active_end`` (``time``) — local time-of-day
+  window.  ``active_start`` is inclusive, ``active_end`` is exclusive;
+  ``active_start > active_end`` wraps past midnight (e.g. 22:00..02:00).
+
+All five columns are nullable with no server default — NULL means
+"unrestricted on this axis", so an existing row (all five NULL) is
+always visible and renders byte-identically.  No backfill required.
+
+The window is evaluated server-side in the slideshow resolver against
+the requesting device's effective local time; a slide whose window is
+closed is dropped from the resolved deck.
+
+Revision ID: 0049
+Revises: 0048
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0049"
+down_revision = "0048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("valid_from", sa.Date(), nullable=True),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("valid_to", sa.Date(), nullable=True),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column(
+            "active_days",
+            postgresql.ARRAY(sa.SmallInteger()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("active_start", sa.Time(), nullable=True),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("active_end", sa.Time(), nullable=True),
+    )
+    # Date range coherent: single-day (from == to) allowed.
+    op.create_check_constraint(
+        "ck_slideshow_slide_valid_range",
+        "slideshow_slides",
+        "valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from",
+    )
+    # Time window non-degenerate: equal start/end rejected; wrap allowed.
+    op.create_check_constraint(
+        "ck_slideshow_slide_time_window",
+        "slideshow_slides",
+        "active_start IS NULL OR active_end IS NULL OR active_start <> active_end",
+    )
+    # Weekday set stays within 0..6 (Mon..Sun).
+    op.create_check_constraint(
+        "ck_slideshow_slide_active_days",
+        "slideshow_slides",
+        "active_days IS NULL OR active_days <@ '{0,1,2,3,4,5,6}'::smallint[]",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0049 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1557,6 +1557,11 @@ def _slide_row(slideshow_asset_id: uuid.UUID, idx: int, s: SlideIn) -> Slideshow
             fit=s.fit,
             effect=s.effect,
             effect_direction=s.effect_direction,
+            valid_from=s.valid_from,
+            valid_to=s.valid_to,
+            active_days=s.active_days,
+            active_start=s.active_start,
+            active_end=s.active_end,
         )
     return SlideshowSlide(
         slideshow_asset_id=slideshow_asset_id,
@@ -1572,6 +1577,11 @@ def _slide_row(slideshow_asset_id: uuid.UUID, idx: int, s: SlideIn) -> Slideshow
         fit=s.fit,
         effect=s.effect,
         effect_direction=s.effect_direction,
+        valid_from=s.valid_from,
+        valid_to=s.valid_to,
+        active_days=s.active_days,
+        active_start=s.active_start,
+        active_end=s.active_end,
     )
 
 
@@ -2136,6 +2146,19 @@ async def list_slideshow_slides(
                     "fit": slide.fit,
                     "effect": slide.effect,
                     "effect_direction": slide.effect_direction,
+                    "valid_from": slide.valid_from.isoformat()
+                    if slide.valid_from
+                    else None,
+                    "valid_to": slide.valid_to.isoformat()
+                    if slide.valid_to
+                    else None,
+                    "active_days": slide.active_days,
+                    "active_start": slide.active_start.isoformat()
+                    if slide.active_start
+                    else None,
+                    "active_end": slide.active_end.isoformat()
+                    if slide.active_end
+                    else None,
                     "tag_id": str(slide.tag_id) if slide.tag_id else None,
                     "tag_name": tag_name_map.get(slide.tag_id),
                     "tag_order_by": slide.tag_order_by,
@@ -2155,6 +2178,17 @@ async def list_slideshow_slides(
                 "fit": slide.fit,
                 "effect": slide.effect,
                 "effect_direction": slide.effect_direction,
+                "valid_from": slide.valid_from.isoformat()
+                if slide.valid_from
+                else None,
+                "valid_to": slide.valid_to.isoformat() if slide.valid_to else None,
+                "active_days": slide.active_days,
+                "active_start": slide.active_start.isoformat()
+                if slide.active_start
+                else None,
+                "active_end": slide.active_end.isoformat()
+                if slide.active_end
+                else None,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.filename if src else None,
                 "source_asset_type": src.asset_type.value if src else None,

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for asset API."""
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime, time
 from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -347,6 +347,25 @@ class SlideIn(BaseModel):
     # zoom-in animation, so existing slides don't change.
     effect_direction: str = Field(DEFAULT_KEN_BURNS_DIRECTION)
 
+    # ── Per-slide visibility window (all None = always visible) ──
+    #
+    # Restrict WHEN this slide is eligible to show.  Evaluated server-side
+    # against the requesting device's effective local time; a closed slide
+    # is dropped from the resolved deck.  Every field is optional — omitting
+    # all five (what every pre-feature client does) means "always visible".
+    # These fields apply to BOTH ``asset`` and ``tag`` kinds.
+    #
+    # Local-calendar date range, INCLUSIVE both ends.
+    valid_from: Optional[date] = None
+    valid_to: Optional[date] = None
+    # Weekdays the slide may show on, 0=Mon..6=Sun.  None/empty = every day.
+    # Normalised (de-duped, sorted, ``[]`` → None) by the validator below.
+    active_days: Optional[list[int]] = None
+    # Local time-of-day window: ``active_start`` inclusive, ``active_end``
+    # exclusive; start > end wraps past midnight (e.g. 22:00..02:00).
+    active_start: Optional[time] = None
+    active_end: Optional[time] = None
+
     @field_validator("kind")
     @classmethod
     def _validate_kind(cls, v: str) -> str:
@@ -405,6 +424,50 @@ class SlideIn(BaseModel):
             )
         return v
 
+    @field_validator("active_days")
+    @classmethod
+    def _validate_active_days(cls, v: Optional[list[int]]) -> Optional[list[int]]:
+        """Normalise the weekday set: de-dupe, sort, ``[]`` → None.
+
+        Each entry must be 0..6 (Mon..Sun).  An empty list is treated as
+        "no restriction" (same as None / every day) so a client that clears
+        all weekday chips round-trips to the always-visible state rather
+        than a slide that can never show.
+        """
+        if v is None:
+            return None
+        for d in v:
+            if d < 0 or d > 6:
+                raise ValueError(
+                    f"active_days entries must be 0..6 (Mon..Sun), got {d}"
+                )
+        uniq = sorted(set(v))
+        return uniq or None
+
+    @model_validator(mode="after")
+    def _validate_visibility_window(self) -> "SlideIn":
+        """Cross-field visibility-window coherence (mirrors DB CHECKs).
+
+        * ``valid_to`` must be >= ``valid_from`` when both set (single-day
+          window allowed).
+        * ``active_start`` and ``active_end`` must differ when both set
+          (equal would be a degenerate empty window; a wrap-around window
+          where start > end is fine and means "spans midnight").
+        """
+        if (
+            self.valid_from is not None
+            and self.valid_to is not None
+            and self.valid_to < self.valid_from
+        ):
+            raise ValueError("valid_to must be on or after valid_from")
+        if (
+            self.active_start is not None
+            and self.active_end is not None
+            and self.active_start == self.active_end
+        ):
+            raise ValueError("active_start and active_end must differ")
+        return self
+
     @model_validator(mode="after")
     def _validate_kind_columns(self) -> "SlideIn":
         """Enforce the kind/columns invariant mirroring the DB CHECK.
@@ -459,7 +522,12 @@ class SlideOut(BaseModel):
     fit: str = DEFAULT_SLIDE_FIT
     effect: str = DEFAULT_SLIDE_EFFECT
     effect_direction: str = DEFAULT_KEN_BURNS_DIRECTION
-    # Populated for ``asset`` kind; null for ``tag`` kind.
+    # Per-slide visibility window; all null = always visible.
+    valid_from: Optional[date] = None
+    valid_to: Optional[date] = None
+    active_days: Optional[list[int]] = None
+    active_start: Optional[time] = None
+    active_end: Optional[time] = None
     source_asset_id: Optional[uuid.UUID] = None
     source_filename: Optional[str] = None
     source_asset_type: Optional[AssetType] = None

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -260,8 +260,18 @@ async def _resolve_asset_for_device(
     """
     if asset.asset_type == AssetType.SLIDESHOW:
         # Lazy import — avoids a circular reference at module import time.
-        from cms.services.slideshow_resolver import build_fetch_for_slideshow
-        return await build_fetch_for_slideshow(asset, device, base_url, db)
+        from cms.services.slideshow_resolver import (
+            build_fetch_for_slideshow,
+            device_local_now,
+        )
+
+        # Device effective local time drives per-slide visibility windows;
+        # the scheduler tick uses the same predicate so the emitted manifest
+        # and the resolved checksum agree.
+        local_now = await device_local_now(device, db)
+        return await build_fetch_for_slideshow(
+            asset, device, base_url, db, local_now=local_now
+        )
 
     storage = get_storage()
 

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -998,6 +998,17 @@ async def build_device_sync(
     if not dev:
         return None
 
+    # Device effective local time for per-slide visibility windows.  A
+    # per-device IANA tz override takes precedence over the CMS global tz
+    # (it mirrors the wire ``timezone`` the device itself applies), falling
+    # back to the CMS tz when unset/invalid.  Distinct from ``local_now``
+    # above, which is intentionally CMS-global for schedule-date eval.
+    try:
+        device_tz = ZoneInfo(dev.timezone or cms_tz)
+    except Exception:
+        device_tz = ZoneInfo(cms_tz)
+    device_local_now = now.astimezone(device_tz)
+
     # Resolve default asset (device → group fallback)
     default_asset_name = None
     default_asset_checksum = None
@@ -1046,7 +1057,9 @@ async def build_device_sync(
         key = str(asset.id)
         if key in slideshow_checksums:
             return slideshow_checksums[key]
-        resolved = await resolved_slideshow_checksum(asset, dev.profile_id, db)
+        resolved = await resolved_slideshow_checksum(
+            asset, dev.profile_id, db, local_now=device_local_now
+        )
         if resolved is not None:
             slideshow_checksums[key] = resolved
         return resolved

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -25,8 +25,9 @@ from __future__ import annotations
 import hashlib
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Optional, Sequence
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -319,7 +320,72 @@ _TAG_MEMBER_ASSET_TYPES = (
 )
 
 
-async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
+def _slide_window_open(row: SlideshowSlide, local_now: datetime) -> bool:
+    """Return True iff ``row``'s per-slide visibility window is open at
+    ``local_now`` (a tz-aware datetime in the device's effective local
+    timezone).
+
+    A slide is VISIBLE iff ALL configured constraints pass.  Any unset
+    (NULL) constraint is "always open" for that dimension, so a row with
+    no window columns set is always visible (byte-identical to the
+    pre-feature behaviour).
+
+    Constraints (see per-slide-visibility-design.md):
+      * Date range ``[valid_from, valid_to]`` — both ends INCLUSIVE,
+        floating local-calendar dates.
+      * Weekday set ``active_days`` (0=Mon .. 6=Sun) — empty/None = all.
+      * Time-of-day ``[active_start, active_end)`` — start INCLUSIVE,
+        end EXCLUSIVE; ``active_start > active_end`` is an overnight
+        wrap (e.g. 22:00..02:00).
+
+    Wrap + weekday interaction: for the post-midnight tail of a wrapped
+    window the effective weekday is *yesterday's* (the window "belongs"
+    to the day it opened), so a Fri 22:00..02:00 slide is still open at
+    Sat 00:30 when ``active_days`` lists Friday only.
+    """
+    d: date = local_now.date()
+    t: time = local_now.time()
+
+    # 1. Date range (inclusive both ends).
+    if row.valid_from is not None and d < row.valid_from:
+        return False
+    if row.valid_to is not None and d > row.valid_to:
+        return False
+
+    start = row.active_start
+    end = row.active_end
+
+    # 2. Effective weekday — shift to yesterday for a wrapped window's tail.
+    if start is not None and end is not None and start > end and t < end:
+        effective_wd = (local_now - timedelta(days=1)).weekday()
+    else:
+        effective_wd = local_now.weekday()
+
+    # 3. Weekday set.
+    if row.active_days and effective_wd not in row.active_days:
+        return False
+
+    # 4. Time-of-day window.
+    if start is not None and end is not None:
+        if start < end:
+            if not (start <= t < end):
+                return False
+        else:  # overnight wrap
+            if not (t >= start or t < end):
+                return False
+    elif start is not None:
+        if t < start:
+            return False
+    elif end is not None:
+        if t >= end:
+            return False
+
+    return True
+
+
+async def _load_slide_specs(
+    asset: Asset, db: AsyncSession, local_now: datetime | None = None
+) -> list[_SlideSpec]:
     """Produce the ordered list of :class:`_SlideSpec` for ``asset``.
 
     The deck is a single ordered list of ``SlideshowSlide`` rows.  Each
@@ -346,6 +412,14 @@ async def _load_slide_specs(asset: Asset, db: AsyncSession) -> list[_SlideSpec]:
     specs: list[_SlideSpec] = []
     pos = 0
     for row in rows:
+        # Per-slide visibility window (agora#…): when a device-local now is
+        # supplied, drop rows whose window is closed.  ``local_now is None``
+        # (the API/builder readiness path) means "show every slide" so the
+        # editor preview and existing tests are unaffected.  Applies to both
+        # ``asset`` and ``tag`` rows; a closed ``tag`` row skips its whole
+        # in-place expansion.
+        if local_now is not None and not _slide_window_open(row, local_now):
+            continue
         if row.kind == "tag":
             if row.tag_id is None:  # defensive — CHECK constraint forbids
                 continue
@@ -504,7 +578,10 @@ async def effective_slide_counts(
 
 
 async def plan_slideshow(
-    asset: Asset, profile_id: Optional[uuid.UUID], db: AsyncSession
+    asset: Asset,
+    profile_id: Optional[uuid.UUID],
+    db: AsyncSession,
+    local_now: datetime | None = None,
 ) -> SlideshowPlan:
     """Resolve every slide of ``asset`` against ``profile_id``.
 
@@ -528,7 +605,7 @@ async def plan_slideshow(
     Two batched queries by source-asset-id keep this O(1) in slide count
     regardless of slideshow size.
     """
-    specs = await _load_slide_specs(asset, db)
+    specs = await _load_slide_specs(asset, db, local_now=local_now)
     if not specs:
         return SlideshowPlan()
 
@@ -715,15 +792,23 @@ def _compute_resolved_manifest_checksum(
 
 
 async def resolved_slideshow_checksum(
-    asset: Asset, profile_id: Optional[uuid.UUID], db: AsyncSession
+    asset: Asset,
+    profile_id: Optional[uuid.UUID],
+    db: AsyncSession,
+    local_now: datetime | None = None,
 ) -> Optional[str]:
     """Return the resolved manifest checksum for ``asset`` on a given profile.
 
     ``None`` if the slideshow isn't ready for the profile (any blockers).
     Used by :func:`build_device_sync` so ``ScheduleEntry.asset_checksum``
     and ``default_asset_checksum`` reflect per-profile variant choice.
+
+    ``local_now`` (device effective local time) drives per-slide visibility
+    windows: closed slides are dropped before the checksum is computed, so a
+    slide opening/closing flips the resolved hash and triggers a one-shot
+    device manifest refresh.
     """
-    plan = await plan_slideshow(asset, profile_id, db)
+    plan = await plan_slideshow(asset, profile_id, db, local_now=local_now)
     if not plan.ready:
         return None
     return _compute_resolved_manifest_checksum(
@@ -731,18 +816,46 @@ async def resolved_slideshow_checksum(
     )
 
 
+async def device_local_now(device: Device, db: AsyncSession) -> datetime:
+    """Return the current time in ``device``'s effective local timezone.
+
+    A per-device IANA tz override takes precedence over the CMS global
+    ``timezone`` setting (mirroring the wire ``timezone`` the device
+    applies locally); falls back to UTC when neither is set or the value
+    is invalid.  Drives per-slide visibility-window evaluation in
+    :func:`build_fetch_for_slideshow` / :func:`resolved_slideshow_checksum`.
+    """
+    from cms.models.setting import CMSSetting  # lazy: avoid import cycle
+
+    tz_name = getattr(device, "timezone", None)
+    if not tz_name:
+        row = await db.execute(
+            select(CMSSetting.value).where(CMSSetting.key == "timezone")
+        )
+        tz_name = row.scalar_one_or_none() or "UTC"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = ZoneInfo("UTC")
+    return datetime.now(timezone.utc).astimezone(tz)
+
+
 async def build_fetch_for_slideshow(
     asset: Asset,
     device: Device,
     base_url: str,
     db: AsyncSession,
+    local_now: datetime | None = None,
 ) -> Optional[FetchAssetMessage]:
     """Build a slideshow ``FetchAssetMessage`` for ``device``.
 
     Returns ``None`` if the slideshow isn't ready (any blockers) — same
     contract as the existing video/image resolver.
+
+    ``local_now`` (device effective local time) drives per-slide visibility
+    windows; closed slides are dropped from the emitted manifest.
     """
-    plan = await plan_slideshow(asset, device.profile_id, db)
+    plan = await plan_slideshow(asset, device.profile_id, db, local_now=local_now)
     if not plan.ready:
         return None
 

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -281,6 +281,120 @@
     width: 100%;
 }
 
+/* ---- Per-slide visibility window ---- */
+.ssb-slot-vis {
+    border-top: 1px dashed #3a3a3a;
+    margin-top: 0.1rem;
+    padding-top: 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.ssb-vis-head {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    color: #bbb;
+    font-size: 0.72rem;
+    font-weight: 600;
+    user-select: none;
+}
+.ssb-vis-chev {
+    color: #1abc9c;
+    font-size: 0.65rem;
+    transition: transform 0.12s ease;
+    display: inline-block;
+}
+.ssb-vis-head.ssb-open .ssb-vis-chev { transform: rotate(90deg); }
+.ssb-vis-state { color: #666; font-weight: 400; margin-left: auto; }
+.ssb-vis-state.ssb-on { color: #1abc9c; }
+.ssb-vis-body { display: none; flex-direction: column; gap: 0.5rem; }
+.ssb-vis-body.ssb-open { display: flex; }
+.ssb-vis-radio { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.72rem; color: #ccc; }
+.ssb-vis-radio label { display: flex; gap: 0.4rem; align-items: center; cursor: pointer; }
+.ssb-vis-radio input { accent-color: #1abc9c; }
+.ssb-vis-fields { display: flex; flex-direction: column; gap: 0.45rem; }
+.ssb-vis-fs {
+    border: 1px solid #333;
+    border-radius: 6px;
+    margin: 0;
+    padding: 0.4rem 0.5rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+.ssb-vis-fs legend {
+    font-size: 0.6rem;
+    color: #8fd9c9;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0 0.3rem;
+}
+.ssb-vis-pair { display: flex; gap: 0.4rem; align-items: center; }
+.ssb-vis-pair input[type=date],
+.ssb-vis-pair input[type=time] {
+    background: #2a2a2a;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 0.18rem 0.3rem;
+    font-size: 0.72rem;
+    flex: 1 1 0;
+    min-width: 0;
+    color-scheme: dark;
+}
+.ssb-vis-to { color: #777; font-size: 0.7rem; flex: 0 0 auto; }
+.ssb-vis-days { display: flex; gap: 3px; flex-wrap: wrap; }
+.ssb-vis-day {
+    width: 26px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #444;
+    border-radius: 5px;
+    background: #242424;
+    color: #888;
+    font-size: 0.66rem;
+    cursor: pointer;
+    user-select: none;
+}
+.ssb-vis-day.ssb-on {
+    background: #16a085;
+    border-color: #1abc9c;
+    color: #06231d;
+    font-weight: 700;
+}
+.ssb-vis-summary {
+    font-size: 0.66rem;
+    color: #8fd9c9;
+    background: rgba(26,188,156,0.08);
+    border: 1px solid rgba(26,188,156,0.25);
+    border-radius: 5px;
+    padding: 0.35rem 0.45rem;
+    line-height: 1.3;
+}
+/* thumbnail clock badge marking a windowed slide */
+.ssb-slot-vbadge {
+    position: absolute;
+    bottom: 0.3rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(26,188,156,0.92);
+    color: #06231d;
+    font-size: 0.6rem;
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: 10px;
+    z-index: 2;
+    pointer-events: none;
+    max-width: calc(100% - 3.4rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Transition gap between slots */
 .ssb-gap {
     flex: 0 0 44px;
@@ -1448,6 +1562,210 @@ function wireFitEffectCtls(slot, i) {
     }
 }
 
+// ---- Per-slide visibility window (CMS-side scheduling of a single slide) ----
+// A slide may be limited to a future date range, a time-of-day window
+// (overnight wrap supported), specific weekdays, or any mixture. NULL/empty on
+// every field == "always show". These fields are persisted per-slide and
+// evaluated server-side by the resolver; the device manifest simply omits a
+// closed slide. UI-only flags ``s._visOpen`` / ``s._visLimit`` survive
+// re-render and are never serialized.
+const VIS_DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];          // 0=Mon..6=Sun
+const VIS_DAY_FULL = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const VIS_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// True iff the slide carries any real window constraint.
+function visHasWindow(s) {
+    if (!s) return false;
+    return !!(s.valid_from || s.valid_to || s.active_start || s.active_end ||
+              (Array.isArray(s.active_days) && s.active_days.length));
+}
+
+// 'YYYY-MM-DD' -> 'Dec 1' (parsed by hand to avoid any timezone shift).
+function visFmtDate(d) {
+    if (!d) return '';
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(d));
+    if (!m) return String(d);
+    return `${VIS_MONTHS[parseInt(m[2], 10) - 1]} ${parseInt(m[3], 10)}`;
+}
+
+// 'HH:MM[:SS]' -> '1:00 PM'.
+function visFmtTime(t) {
+    if (!t) return '';
+    const m = /^(\d{2}):(\d{2})/.exec(String(t));
+    if (!m) return String(t);
+    let h = parseInt(m[1], 10);
+    const min = m[2];
+    const ap = h < 12 ? 'AM' : 'PM';
+    h = h % 12; if (h === 0) h = 12;
+    return `${h}:${min} ${ap}`;
+}
+
+// '<input type=time>' wants 'HH:MM' (or HH:MM:SS); trim the server's seconds.
+function visTimeInputVal(t) { return t ? String(t).slice(0, 5) : ''; }
+
+// Render an active_days array into 'Mon–Fri' (contiguous) or 'Mon, Wed, Fri'.
+function visDaysLabel(days) {
+    if (!Array.isArray(days) || !days.length) return '';
+    const ds = Array.from(new Set(days)).filter((d) => d >= 0 && d <= 6).sort((a, b) => a - b);
+    if (!ds.length) return '';
+    if (ds.length === 7) return 'Every day';
+    let contiguous = true;
+    for (let k = 1; k < ds.length; k++) { if (ds[k] !== ds[k - 1] + 1) { contiguous = false; break; } }
+    if (contiguous && ds.length > 2) return `${VIS_DAY_FULL[ds[0]]}–${VIS_DAY_FULL[ds[ds.length - 1]]}`;
+    return ds.map((d) => VIS_DAY_FULL[d]).join(', ');
+}
+
+// Plain-language summary line, e.g. "Dec 1 – Dec 26 · 9:00 AM – 5:00 PM · Mon–Fri".
+function visSummary(s) {
+    const parts = [];
+    if (s.valid_from && s.valid_to) parts.push(`${visFmtDate(s.valid_from)} – ${visFmtDate(s.valid_to)}`);
+    else if (s.valid_from) parts.push(`From ${visFmtDate(s.valid_from)}`);
+    else if (s.valid_to) parts.push(`Until ${visFmtDate(s.valid_to)}`);
+    if (s.active_start && s.active_end) parts.push(`${visFmtTime(s.active_start)} – ${visFmtTime(s.active_end)}`);
+    else if (s.active_start) parts.push(`From ${visFmtTime(s.active_start)}`);
+    else if (s.active_end) parts.push(`Until ${visFmtTime(s.active_end)}`);
+    const dl = visDaysLabel(s.active_days);
+    if (dl) parts.push(dl);
+    return parts.length ? parts.join(' · ') : 'Always visible';
+}
+
+// Compact thumbnail badge for a windowed slide (clock glyph + short summary).
+function visBadgeHtml(s) {
+    if (!visHasWindow(s)) return '';
+    return `<div class="ssb-slot-vbadge" title="${escapeHtml(visSummary(s))}">⏱ ${escapeHtml(visSummary(s))}</div>`;
+}
+
+// The collapsible "Visibility" control block appended into ``.ssb-slot-meta``.
+function visibilityCtlHtml(s, i) {
+    const limit = !!(s._visLimit || visHasWindow(s));
+    const open = !!s._visOpen;
+    const stateTxt = limit ? 'Limited' : 'Always';
+    const fieldsStyle = limit ? '' : 'display:none;';
+    const daysChips = VIS_DAY_LABELS.map((lab, d) => {
+        const on = Array.isArray(s.active_days) && s.active_days.includes(d);
+        return `<span class="ssb-vis-day${on ? ' ssb-on' : ''}" data-day="${d}" role="button" tabindex="0" title="${VIS_DAY_FULL[d]}">${lab}</span>`;
+    }).join('');
+    const summary = limit && visHasWindow(s)
+        ? `<div class="ssb-vis-summary">${escapeHtml(visSummary(s))}</div>`
+        : '';
+    return `
+        <div class="ssb-slot-vis">
+            <div class="ssb-vis-head${open ? ' ssb-open' : ''}" role="button" tabindex="0" aria-expanded="${open ? 'true' : 'false'}">
+                <span class="ssb-vis-chev" aria-hidden="true">▶</span>
+                <span>Visibility</span>
+                <span class="ssb-vis-state${limit ? ' ssb-on' : ''}">${stateTxt}</span>
+            </div>
+            <div class="ssb-vis-body${open ? ' ssb-open' : ''}">
+                <div class="ssb-vis-radio">
+                    <label><input type="radio" name="ssb-vis-mode-${i}" value="always" ${limit ? '' : 'checked'}><span>Always show this slide</span></label>
+                    <label><input type="radio" name="ssb-vis-mode-${i}" value="limit" ${limit ? 'checked' : ''}><span>Limit when this slide shows</span></label>
+                </div>
+                <div class="ssb-vis-fields" style="${fieldsStyle}">
+                    <fieldset class="ssb-vis-fs">
+                        <legend>Date range</legend>
+                        <div class="ssb-vis-pair">
+                            <input type="date" class="ssb-vis-valid-from" value="${escapeHtml(s.valid_from || '')}" aria-label="Start date">
+                            <span class="ssb-vis-to">to</span>
+                            <input type="date" class="ssb-vis-valid-to" value="${escapeHtml(s.valid_to || '')}" aria-label="End date">
+                        </div>
+                    </fieldset>
+                    <fieldset class="ssb-vis-fs">
+                        <legend>Time of day</legend>
+                        <div class="ssb-vis-pair">
+                            <input type="time" class="ssb-vis-active-start" value="${escapeHtml(visTimeInputVal(s.active_start))}" aria-label="Start time">
+                            <span class="ssb-vis-to">to</span>
+                            <input type="time" class="ssb-vis-active-end" value="${escapeHtml(visTimeInputVal(s.active_end))}" aria-label="End time">
+                        </div>
+                    </fieldset>
+                    <fieldset class="ssb-vis-fs">
+                        <legend>Days of week</legend>
+                        <div class="ssb-vis-days">${daysChips}</div>
+                    </fieldset>
+                    ${summary}
+                </div>
+            </div>
+        </div>`;
+}
+
+// Attach listeners for a visibility control block previously rendered into ``slot``.
+function wireVisibilityCtls(slot, i) {
+    const head = slot.querySelector('.ssb-vis-head');
+    if (head) {
+        head.addEventListener('click', () => toggleSlideVisOpen(i));
+        head.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleSlideVisOpen(i); }
+        });
+    }
+    slot.querySelectorAll(`input[name="ssb-vis-mode-${i}"]`).forEach((r) => {
+        r.addEventListener('change', (e) => setSlideVisMode(i, e.target.value));
+    });
+    const bind = (sel, field) => {
+        const el = slot.querySelector(sel);
+        if (el) el.addEventListener('change', (e) => updateSlideVisField(i, field, e.target.value));
+    };
+    bind('.ssb-vis-valid-from', 'valid_from');
+    bind('.ssb-vis-valid-to', 'valid_to');
+    bind('.ssb-vis-active-start', 'active_start');
+    bind('.ssb-vis-active-end', 'active_end');
+    slot.querySelectorAll('.ssb-vis-day').forEach((chip) => {
+        const d = Number(chip.dataset.day);
+        chip.addEventListener('click', () => toggleSlideVisDay(i, d));
+        chip.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleSlideVisDay(i, d); }
+        });
+    });
+}
+
+function toggleSlideVisOpen(i) {
+    const s = slides[i];
+    if (!s) return;
+    s._visOpen = !s._visOpen;
+    renderTimeline();
+}
+
+// Switch a slide between "always" and "limited" visibility. Choosing "always"
+// clears every window field; choosing "limit" just opens the editor (fields
+// start empty and the slide stays always-visible until the user fills one in).
+function setSlideVisMode(i, mode) {
+    const s = slides[i];
+    if (!s) return;
+    if (mode === 'always') {
+        s._visLimit = false;
+        s.valid_from = null;
+        s.valid_to = null;
+        s.active_start = null;
+        s.active_end = null;
+        s.active_days = null;
+    } else {
+        s._visLimit = true;
+        s._visOpen = true;
+    }
+    markDirty();
+    renderTimeline();
+}
+
+function updateSlideVisField(i, field, value) {
+    const s = slides[i];
+    if (!s) return;
+    s[field] = value ? value : null;
+    if (visHasWindow(s)) s._visLimit = true;
+    markDirty();
+    renderTimeline();
+}
+
+function toggleSlideVisDay(i, day) {
+    const s = slides[i];
+    if (!s || day < 0 || day > 6) return;
+    let days = Array.isArray(s.active_days) ? s.active_days.slice() : [];
+    const at = days.indexOf(day);
+    if (at >= 0) days.splice(at, 1); else days.push(day);
+    days = Array.from(new Set(days)).sort((a, b) => a - b);
+    s.active_days = days.length ? days : null;
+    if (visHasWindow(s)) s._visLimit = true;
+    markDirty();
+    renderTimeline();
+}
+
 function makeSlot(s, i) {
     const slot = document.createElement('div');
     slot.className = 'ssb-slot';
@@ -1507,6 +1825,7 @@ function makeSlot(s, i) {
             <button type="button" class="ssb-slot-remove" title="Remove" aria-label="Remove">✕</button>
             <button type="button" class="ssb-slot-move left"  title="Move left"  aria-label="Move left"  ${i === 0 ? 'disabled' : ''}>‹</button>
             <button type="button" class="ssb-slot-move right" title="Move right" aria-label="Move right" ${i === slides.length - 1 ? 'disabled' : ''}>›</button>
+            ${visBadgeHtml(s)}
         </div>
         <div class="ssb-slot-meta">
             <div class="ssb-slot-name" title="${escapeHtml(s.source_filename || '')}">${escapeHtml(s.source_filename || s.source_asset_id)}</div>
@@ -1519,6 +1838,7 @@ function makeSlot(s, i) {
             </div>
             ${playToEndCtl}
             ${fitEffectCtl}
+            ${visibilityCtlHtml(s, i)}
         </div>`;
 
     slot.querySelector('.ssb-slot-remove').addEventListener('click', (e) => {
@@ -1537,6 +1857,7 @@ function makeSlot(s, i) {
     const pte = slot.querySelector('input[type=checkbox]');
     if (pte) pte.addEventListener('change', (e) => updateSlidePlayToEnd(i, e.target.checked));
     wireFitEffectCtls(slot, i);
+    wireVisibilityCtls(slot, i);
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -1584,6 +1905,7 @@ function makeTagSlot(s, i) {
             <button type="button" class="ssb-group-chev${s._expanded ? ' is-open' : ''}" aria-expanded="${s._expanded ? 'true' : 'false'}" title="${expandTitle}" aria-label="${expandTitle}">
                 <span class="ssb-group-chev-ico" aria-hidden="true">⧉</span><span>${expandLabel}</span>
             </button>
+            ${visBadgeHtml(s)}
         </div>
         <div class="ssb-slot-meta">
             <div class="ssb-slot-tag-sub text-muted" style="font-size:0.78rem;">Dynamic · ${escapeHtml(countLabel)}</div>
@@ -1594,6 +1916,7 @@ function makeTagSlot(s, i) {
                 <span style="color:#888;">s each</span>
             </div>
             ${fitEffectCtlHtml(s, i)}
+            ${visibilityCtlHtml(s, i)}
         </div>`;
     slot.appendChild(head);
 
@@ -1617,6 +1940,7 @@ function makeTagSlot(s, i) {
     // Query scope is the whole slot, but the fit/effect controls live in head
     // (already appended), so this wires them correctly.
     wireFitEffectCtls(slot, i);
+    wireVisibilityCtls(slot, i);
 
     if (s._expanded) {
         slot.appendChild(makeTagTray(s, i));
@@ -2177,6 +2501,7 @@ function serializeSlide(s) {
             fit: s.fit || 'cover',
             effect: s.effect || 'none',
             effect_direction: s.effect_direction || 'in',
+            ...serializeVisibility(s),
         };
     }
     return {
@@ -2189,6 +2514,19 @@ function serializeSlide(s) {
         fit: s.fit || 'cover',
         effect: s.effect || 'none',
         effect_direction: s.effect_direction || 'in',
+        ...serializeVisibility(s),
+    };
+}
+
+// Per-slide visibility-window fields, shared by both serialize branches. NULL /
+// empty == always visible. UI-only flags (_visOpen/_visLimit) are never emitted.
+function serializeVisibility(s) {
+    return {
+        valid_from: s.valid_from || null,
+        valid_to: s.valid_to || null,
+        active_days: (Array.isArray(s.active_days) && s.active_days.length) ? s.active_days : null,
+        active_start: s.active_start || null,
+        active_end: s.active_end || null,
     };
 }
 

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -8,22 +8,32 @@ slideshow (CASCADE on parent delete) and pin their source assets in place
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     CheckConstraint,
+    Date,
     DateTime,
     ForeignKey,
     Index,
     Integer,
+    SmallInteger,
     String,
+    Time,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from shared.database import Base
+
+# ``active_days`` is a Postgres ``smallint[]`` so a Mon/Wed/Fri window is a
+# single column we can constrain with ``<@``.  On SQLite (the unit-test
+# matrix) ARRAY has no type compiler, so fall back to JSON storage of the
+# same list — identical Python round-trip, Postgres keeps the native array.
+_SMALLINT_ARRAY = ARRAY(SmallInteger).with_variant(JSON(), "sqlite")
 
 
 # Canonical Ken Burns direction grammar — kept in lockstep with
@@ -145,6 +155,41 @@ class SlideshowSlide(Base):
         # FK columns aren't auto-indexed; tag-block expansion + the
         # tag-delete guard scan by tag_id.
         Index("ix_slideshow_slides_tag_id", "tag_id"),
+        # Per-slide visibility window (agora per-slide-visibility).  All five
+        # columns are NULL by default, meaning "always visible" — existing
+        # rows are byte-identical and unaffected.  When set they restrict the
+        # slide to a local-calendar date range (``valid_from``..``valid_to``,
+        # inclusive both ends), a set of weekdays (``active_days``, 0=Mon..
+        # 6=Sun; NULL/empty = every day) and/or a local time-of-day window
+        # (``active_start``..``active_end``, end-exclusive, wrap-around
+        # allowed when start > end).  The device-effective-local-time
+        # predicate is evaluated server-side in the slideshow resolver; the
+        # closed slide is simply dropped from the resolved deck.  These DB
+        # CHECKs mirror the Pydantic validators as belt-and-braces guards
+        # against out-of-band INSERTs.
+        #
+        # Date range coherent: a single-day window (from == to) is allowed.
+        CheckConstraint(
+            "valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from",
+            name="ck_slideshow_slide_valid_range",
+        ),
+        # Time window non-degenerate: equal start/end would be an empty (or
+        # full) window depending on interpretation, so reject it.  A
+        # wrap-around window (start > end, e.g. 22:00..02:00) is allowed.
+        CheckConstraint(
+            "active_start IS NULL OR active_end IS NULL OR active_start <> active_end",
+            name="ck_slideshow_slide_time_window",
+        ),
+        # Weekday set stays within 0..6 (Mon..Sun).  ``<@`` is Postgres array
+        # containment: every element of ``active_days`` must be in the
+        # canonical weekday set.  The operator is Postgres-only, so the CHECK
+        # is emitted only on the ``postgresql`` dialect — on the SQLite test
+        # schema ``active_days`` is a JSON column and this guard is supplied
+        # instead by the ``SlideIn`` Pydantic validator.
+        CheckConstraint(
+            "active_days IS NULL OR active_days <@ '{0,1,2,3,4,5,6}'::smallint[]",
+            name="ck_slideshow_slide_active_days",
+        ).ddl_if(dialect="postgresql"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -238,6 +283,32 @@ class SlideshowSlide(Base):
     effect_direction: Mapped[str] = mapped_column(
         String(16), nullable=False, default="in", server_default="in"
     )
+    # ── Per-slide visibility window (all NULL = always visible) ──
+    #
+    # These five nullable columns restrict WHEN a slide is eligible to be
+    # shown.  They are evaluated server-side in the slideshow resolver
+    # against the requesting device's effective local time; a slide whose
+    # window is closed is dropped from the resolved deck (which changes the
+    # manifest checksum and triggers a single push).  NULL means
+    # "unrestricted on this axis", so a row with all five NULL is always
+    # visible — exactly the pre-feature behaviour.
+    #
+    # Local-calendar date range, INCLUSIVE both ends (floating dates, not
+    # timestamps — a Christmas slide set 2026-12-01..2026-12-26 means those
+    # local calendar days regardless of tz).
+    valid_from: Mapped[date | None] = mapped_column(Date, nullable=True)
+    valid_to: Mapped[date | None] = mapped_column(Date, nullable=True)
+    # Weekdays the slide may show on, 0=Mon..6=Sun.  NULL or empty = every
+    # day.  Stored as a smallint[] so a Mon/Wed/Fri window is one column.
+    active_days: Mapped[list[int] | None] = mapped_column(
+        _SMALLINT_ARRAY, nullable=True
+    )
+    # Local time-of-day window.  ``active_start`` is INCLUSIVE, ``active_end``
+    # is EXCLUSIVE.  When start > end the window wraps past midnight
+    # (e.g. 22:00..02:00).  Either bound may be NULL for an open-ended
+    # one-sided window.
+    active_start: Mapped[time | None] = mapped_column(Time, nullable=True)
+    active_end: Mapped[time | None] = mapped_column(Time, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/tests/test_slideshow_visibility.py
+++ b/tests/test_slideshow_visibility.py
@@ -1,0 +1,311 @@
+"""Per-slide visibility-window tests (agora per-slide-visibility).
+
+Covers the three layers of the feature:
+
+* :func:`cms.services.slideshow_resolver._slide_window_open` — the pure
+  device-local-time predicate (date range / time-of-day / weekday /
+  overnight-wrap / mixtures).
+* :class:`cms.schemas.asset.SlideIn` validators — ``active_days``
+  normalisation and the cross-field window-coherence checks that mirror
+  the DB CHECK constraints.
+* :func:`cms.services.slideshow_resolver._load_slide_specs` — closed
+  slides are dropped from the resolved deck when a device-local now is
+  supplied, and ``local_now is None`` (the builder/readiness path) shows
+  every slide unchanged.
+
+The predicate + validator suites are pure functions (no DB); only the
+``_load_slide_specs`` suite touches the session fixture.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cms.models.asset import Asset, AssetType
+from cms.models.slideshow_slide import SlideshowSlide
+from cms.schemas.asset import SlideIn
+from cms.services.slideshow_resolver import _load_slide_specs, _slide_window_open
+
+# An ``asset`` kind slide requires a ``source_asset_id`` (model validator),
+# so every ``SlideIn(kind="asset", ...)`` below pins this dummy id.  The
+# window validators run BEFORE the kind/columns validator, so the
+# rejection tests still fail on the window check (the right reason) — this
+# only keeps the *success* cases from tripping the source-required rule.
+SID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# _slide_window_open — pure predicate
+# ---------------------------------------------------------------------------
+
+def _row(**kw):
+    """A minimal slide-row stub exposing only the five window columns.
+
+    ``_slide_window_open`` reads nothing else, so a ``SimpleNamespace`` is
+    faithful and keeps these tests DB-free.
+    """
+    defaults = dict(
+        valid_from=None,
+        valid_to=None,
+        active_days=None,
+        active_start=None,
+        active_end=None,
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def _dt(y, m, d, hh=12, mm=0):
+    return datetime(y, m, d, hh, mm, tzinfo=timezone.utc)
+
+
+class TestSlideWindowOpen:
+    def test_no_window_is_always_open(self):
+        assert _slide_window_open(_row(), _dt(2026, 12, 25, 3, 0)) is True
+
+    def test_date_range_inclusive_both_ends(self):
+        row = _row(valid_from=date(2026, 12, 1), valid_to=date(2026, 12, 26))
+        assert _slide_window_open(row, _dt(2026, 11, 30)) is False  # day before
+        assert _slide_window_open(row, _dt(2026, 12, 1)) is True   # start incl.
+        assert _slide_window_open(row, _dt(2026, 12, 26)) is True  # end incl.
+        assert _slide_window_open(row, _dt(2026, 12, 27)) is False  # day after
+
+    def test_only_valid_from(self):
+        row = _row(valid_from=date(2026, 6, 1))
+        assert _slide_window_open(row, _dt(2026, 5, 31)) is False
+        assert _slide_window_open(row, _dt(2026, 6, 1)) is True
+        assert _slide_window_open(row, _dt(2030, 1, 1)) is True
+
+    def test_only_valid_to(self):
+        row = _row(valid_to=date(2026, 6, 1))
+        assert _slide_window_open(row, _dt(2026, 6, 1)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 2)) is False
+
+    def test_normal_time_window_start_incl_end_excl(self):
+        # 13:00 inclusive .. 14:00 exclusive.
+        row = _row(active_start=time(13, 0), active_end=time(14, 0))
+        assert _slide_window_open(row, _dt(2026, 6, 1, 12, 59)) is False
+        assert _slide_window_open(row, _dt(2026, 6, 1, 13, 0)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 1, 13, 59)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 1, 14, 0)) is False  # excl.
+
+    def test_only_active_start(self):
+        row = _row(active_start=time(9, 0))
+        assert _slide_window_open(row, _dt(2026, 6, 1, 8, 59)) is False
+        assert _slide_window_open(row, _dt(2026, 6, 1, 9, 0)) is True
+
+    def test_only_active_end(self):
+        row = _row(active_end=time(17, 0))
+        assert _slide_window_open(row, _dt(2026, 6, 1, 16, 59)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 1, 17, 0)) is False
+
+    def test_overnight_wrap_window(self):
+        # 22:00 .. 02:00 spans midnight.
+        row = _row(active_start=time(22, 0), active_end=time(2, 0))
+        assert _slide_window_open(row, _dt(2026, 6, 1, 21, 59)) is False
+        assert _slide_window_open(row, _dt(2026, 6, 1, 22, 0)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 1, 23, 30)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 2, 1, 59)) is True
+        assert _slide_window_open(row, _dt(2026, 6, 2, 2, 0)) is False
+
+    def test_weekday_only(self):
+        # 2026-06-01 is a Monday (weekday 0).
+        row = _row(active_days=[0, 2, 4])  # Mon, Wed, Fri
+        assert _slide_window_open(row, _dt(2026, 6, 1)) is True   # Mon
+        assert _slide_window_open(row, _dt(2026, 6, 2)) is False  # Tue
+        assert _slide_window_open(row, _dt(2026, 6, 3)) is True   # Wed
+
+    def test_empty_weekday_list_is_every_day(self):
+        # Resolver treats an empty list the same as None (no restriction).
+        assert _slide_window_open(_row(active_days=[]), _dt(2026, 6, 2)) is True
+
+    def test_wrap_tail_belongs_to_opening_days_weekday(self):
+        # Fri 22:00 .. Sat 02:00, allowed only on Friday (weekday 4).
+        # 2026-06-05 is a Friday; 2026-06-06 is a Saturday.
+        row = _row(active_start=time(22, 0), active_end=time(2, 0), active_days=[4])
+        # Friday night inside the window -> open.
+        assert _slide_window_open(row, _dt(2026, 6, 5, 23, 0)) is True
+        # Saturday 00:30 is the wrap tail -> effective weekday is Friday -> open.
+        assert _slide_window_open(row, _dt(2026, 6, 6, 0, 30)) is True
+        # Saturday 22:00 is a *fresh* opening on Saturday -> not allowed.
+        assert _slide_window_open(row, _dt(2026, 6, 6, 22, 0)) is False
+
+    def test_full_mixture_all_constraints(self):
+        # Christmas-week flash sale: Dec 1-26, 1-2pm, weekdays only.
+        row = _row(
+            valid_from=date(2026, 12, 1),
+            valid_to=date(2026, 12, 26),
+            active_start=time(13, 0),
+            active_end=time(14, 0),
+            active_days=[0, 1, 2, 3, 4],
+        )
+        # 2026-12-04 is a Friday (in range, weekday ok), 13:30 in window.
+        assert _slide_window_open(row, _dt(2026, 12, 4, 13, 30)) is True
+        # Right day/time but out of date range.
+        assert _slide_window_open(row, _dt(2026, 11, 27, 13, 30)) is False
+        # In range + weekday but wrong time.
+        assert _slide_window_open(row, _dt(2026, 12, 4, 9, 0)) is False
+        # In range + time but a weekend (2026-12-05 is Saturday).
+        assert _slide_window_open(row, _dt(2026, 12, 5, 13, 30)) is False
+
+
+# ---------------------------------------------------------------------------
+# SlideIn validators
+# ---------------------------------------------------------------------------
+
+class TestSlideInValidators:
+    def test_active_days_deduped_and_sorted(self):
+        s = SlideIn(source_asset_id=SID, kind="asset", active_days=[4, 0, 4, 2])
+        assert s.active_days == [0, 2, 4]
+
+    def test_active_days_empty_becomes_none(self):
+        s = SlideIn(source_asset_id=SID, kind="asset", active_days=[])
+        assert s.active_days is None
+
+    def test_active_days_out_of_range_rejected(self):
+        with pytest.raises(ValueError):
+            SlideIn(source_asset_id=SID, kind="asset", active_days=[7])
+        with pytest.raises(ValueError):
+            SlideIn(source_asset_id=SID, kind="asset", active_days=[-1])
+
+    def test_valid_to_before_valid_from_rejected(self):
+        with pytest.raises(ValueError):
+            SlideIn(
+                source_asset_id=SID,
+                kind="asset",
+                valid_from=date(2026, 12, 26),
+                valid_to=date(2026, 12, 1),
+            )
+
+    def test_single_day_window_allowed(self):
+        s = SlideIn(
+            source_asset_id=SID,
+            kind="asset",
+            valid_from=date(2026, 12, 25),
+            valid_to=date(2026, 12, 25),
+        )
+        assert s.valid_from == s.valid_to == date(2026, 12, 25)
+
+    def test_equal_start_end_time_rejected(self):
+        with pytest.raises(ValueError):
+            SlideIn(
+                source_asset_id=SID,
+                kind="asset",
+                active_start=time(9, 0),
+                active_end=time(9, 0),
+            )
+
+    def test_wrap_around_time_window_allowed(self):
+        s = SlideIn(
+            source_asset_id=SID,
+            kind="asset",
+            active_start=time(22, 0),
+            active_end=time(2, 0),
+        )
+        assert s.active_start == time(22, 0)
+        assert s.active_end == time(2, 0)
+
+    def test_iso_string_times_and_dates_parse(self):
+        s = SlideIn(
+            source_asset_id=SID,
+            kind="asset",
+            valid_from="2026-12-01",
+            valid_to="2026-12-26",
+            active_start="13:00",
+            active_end="14:00",
+        )
+        assert s.valid_from == date(2026, 12, 1)
+        assert s.active_start == time(13, 0)
+
+
+# ---------------------------------------------------------------------------
+# _load_slide_specs — closed slides dropped (integration)
+# ---------------------------------------------------------------------------
+
+async def _seed_image(db, *, filename):
+    a = Asset(
+        filename=filename,
+        asset_type=AssetType.IMAGE,
+        size_bytes=100,
+        checksum=f"sha-{filename}",
+        is_global=True,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+async def _seed_slideshow_with_windows(db, srcs_and_windows):
+    """``srcs_and_windows`` is a list of ``(source_asset, window_kwargs)``."""
+    ss = Asset(
+        filename="vis-deck",
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="",
+        is_global=True,
+    )
+    db.add(ss)
+    await db.commit()
+    await db.refresh(ss)
+    for idx, (src, win) in enumerate(srcs_and_windows):
+        db.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            source_asset_id=src.id,
+            position=idx,
+            duration_ms=5000,
+            play_to_end=False,
+            **win,
+        ))
+    await db.commit()
+    await db.refresh(ss)
+    return ss
+
+
+@pytest.mark.asyncio
+class TestLoadSlideSpecsWindowing:
+    async def test_none_local_now_shows_all_slides(self, db_session):
+        a = await _seed_image(db_session, filename="open.png")
+        b = await _seed_image(db_session, filename="future.png")
+        ss = await _seed_slideshow_with_windows(db_session, [
+            (a, {}),
+            (b, {"valid_from": date(2099, 1, 1)}),  # far future
+        ])
+        # local_now=None -> builder/readiness path -> no filtering.
+        specs = await _load_slide_specs(ss, db_session, None)
+        assert {s.source_asset_id for s in specs} == {a.id, b.id}
+
+    async def test_closed_slide_dropped_when_local_now_supplied(self, db_session):
+        a = await _seed_image(db_session, filename="always.png")
+        b = await _seed_image(db_session, filename="xmas.png")
+        ss = await _seed_slideshow_with_windows(db_session, [
+            (a, {}),
+            (b, {"valid_from": date(2026, 12, 1), "valid_to": date(2026, 12, 26)}),
+        ])
+        # A date outside the December window: only the always-on slide survives.
+        now = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+        specs = await _load_slide_specs(ss, db_session, now)
+        assert [s.source_asset_id for s in specs] == [a.id]
+
+    async def test_open_slide_kept_when_local_now_in_window(self, db_session):
+        b = await _seed_image(db_session, filename="xmas.png")
+        ss = await _seed_slideshow_with_windows(db_session, [
+            (b, {"valid_from": date(2026, 12, 1), "valid_to": date(2026, 12, 26)}),
+        ])
+        now = datetime(2026, 12, 10, 12, 0, tzinfo=timezone.utc)
+        specs = await _load_slide_specs(ss, db_session, now)
+        assert [s.source_asset_id for s in specs] == [b.id]
+
+    async def test_whole_deck_closed_yields_empty_specs(self, db_session):
+        a = await _seed_image(db_session, filename="only.png")
+        ss = await _seed_slideshow_with_windows(db_session, [
+            (a, {"active_start": time(13, 0), "active_end": time(14, 0)}),
+        ])
+        # 09:00 is outside the 1-2pm window -> deck resolves empty.
+        now = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
+        specs = await _load_slide_specs(ss, db_session, now)
+        assert specs == []


### PR DESCRIPTION
## Per-slide visibility windows

Lets a single slide inside a slideshow deck be restricted to show only during:
- a **future date range** (e.g. a Christmas promo that goes live Dec 1–26),
- a **time-of-day window** (e.g. an "afternoon super sale" slide that only shows 1–2 PM),
- specific **weekdays**, or
- **any mixture** of the above.

Slides default to **always-visible** — existing rows are byte-identical and unaffected.

### How it works
The 5 new columns are evaluated **server-side in the slideshow resolver** against the requesting device's effective local time. A slide whose window is closed is simply dropped from the resolved deck, which changes the manifest checksum and triggers a single push. **No firmware change** — the device just receives a deck without the hidden slide.

`local_now=None` (builder / readiness / API paths) skips all filtering; only the scheduler + `device_inbound` pass a real local time.

### Backend
- `SlideshowSlide` + alembic `0049`: `valid_from` / `valid_to` (local date range, inclusive), `active_days` (Postgres `smallint[]`, 0=Mon..6=Sun), `active_start` / `active_end` (local time-of-day, end-exclusive, wrap-around allowed).
- DB CHECK constraints mirror the Pydantic validators. The weekday-set containment CHECK uses Postgres `<@` and is **gated to the `postgresql` dialect via `ddl_if()`** so the SQLite test schema still builds.
- `SlideIn` / `SlideOut` validate + round-trip the new fields.

### UI
- Per-slide visibility editor in `slideshow_builder.html`.

### Also fixes a latent SQLite CI regression
`active_days ARRAY(SmallInteger)` had no SQLite type compiler, which broke `CREATE TABLE slideshow_slides` across the **entire integration-test matrix**. Now uses `ARRAY(SmallInteger).with_variant(JSON(), "sqlite")`, mirroring `composed_slide._UUID_ARRAY`. This PR both **ships the feature/tests** and **un-breaks the SQLite matrix**, so CI must go green.

### Notes
- **Manifest schema version intentionally NOT bumped** — the 5 fields are CMS-internal (DB + resolver), never emitted to the device `SlideDescriptor`.
- Tests: `tests/test_slideshow_visibility.py` (24) — predicate, validator, and integration windowing coverage. Existing `test_slideshow_resolver.py` (40) re-verified green.

**Goodwill dev only.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
