### PR TITLE
fix(slideshow): stop per-slide visibility end date/time being clipped

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -331,7 +331,11 @@
     text-transform: uppercase;
     padding: 0 0.3rem;
 }
-.ssb-vis-pair { display: flex; gap: 0.4rem; align-items: center; }
+/* Stack the start/"to"/end controls vertically. Native date & time inputs
+   have an intrinsic minimum width and refuse to shrink below it, so a
+   side-by-side row overflows (and clips the end field) in the narrow
+   per-slide column. Stacking guarantees both ends always fit. */
+.ssb-vis-pair { display: flex; flex-direction: column; gap: 0.2rem; align-items: stretch; }
 .ssb-vis-pair input[type=date],
 .ssb-vis-pair input[type=time] {
     background: #2a2a2a;
@@ -340,11 +344,21 @@
     border-radius: 4px;
     padding: 0.18rem 0.3rem;
     font-size: 0.72rem;
-    flex: 1 1 0;
+    flex: 0 0 auto;
+    width: 100%;
     min-width: 0;
+    box-sizing: border-box;
     color-scheme: dark;
 }
-.ssb-vis-to { color: #777; font-size: 0.7rem; flex: 0 0 auto; }
+.ssb-vis-to {
+    color: #777;
+    font-size: 0.6rem;
+    flex: 0 0 auto;
+    align-self: flex-start;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-left: 0.1rem;
+}
 .ssb-vis-days { display: flex; gap: 3px; flex-wrap: wrap; }
 .ssb-vis-day {
     width: 26px;


### PR DESCRIPTION
Native date & time inputs have an intrinsic minimum width and won't shrink below it, so the side-by-side start/to/end row overflowed the narrow per-slide column and clipped the end (to) field.

Stack each from/to pair vertically (start over end, with the 'to' label between) so both ends always fit regardless of column width.

CSS-only change inside the builder \<style>\ block. Goodwill dev.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>