### PR TITLE
feat(slideshow): per-slide visibility windows to capability devices (schema 1.5)

### DIFF
--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -5,7 +5,7 @@ Protocol version: 2
 Any changes to this file MUST be mirrored in the device-side implementation.
 """
 
-from datetime import datetime
+from datetime import date as _date, datetime, time as _time
 from enum import Enum
 import re
 from typing import Literal, Optional
@@ -60,6 +60,23 @@ CAPABILITY_COMPOSED_SIBLINGS_V1 = "composed_siblings_v1"
 # slideshow-loop composed branch.
 CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
 
+# Per-slide visibility windows, evaluated *on the device* (Phase 2 of the
+# slideshow visibility feature).  A device advertising this capability is
+# sent EVERY slide of a windowed slideshow — including ones whose window is
+# currently closed — together with the window definition on each
+# ``SlideDescriptor`` (``valid_from``/``valid_to`` date range, ``active_days``
+# weekday mask, ``active_start``/``active_end`` time-of-day window).  The
+# player evaluates the window against the device's local wall clock and
+# shows/hides slides at exact local-clock boundaries (sub-scheduler-tick,
+# and while offline).  Because the emitted manifest carries the *definition*
+# (time-invariant) rather than a point-in-time resolved set, the resolved
+# checksum no longer changes every time a window opens/closes — the author
+# pushes once.  Devices WITHOUT this capability keep the Phase-1 behaviour:
+# the CMS resolver drops closed slides server-side each tick and re-pushes
+# when the visible set changes.  Pairs with the agora firmware PR that ports
+# the window predicate into the slideshow player.
+CAPABILITY_SLIDESHOW_VISIBILITY_V1 = "slideshow_visibility_v1"
+
 # Slideshow manifest schema version (semver, additive minor bumps).  The
 # wire format of the slideshow manifest is independent of the
 # higher-level ``PROTOCOL_VERSION``: protocol bumps describe the WS
@@ -103,11 +120,24 @@ CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
 #           seeded by ``(shuffle_seed, cycle_index)``.  Devices that
 #           don't understand 1.4 ignore both and play the authored
 #           order with the default zoom-in.
+#   "1.5" — adds optional per-slide visibility-window fields on
+#           ``SlideDescriptor``: ``valid_from``/``valid_to`` ("YYYY-MM-DD"
+#           inclusive date range), ``active_days`` (list[int], 0=Mon..6=Sun;
+#           None/empty = every day), and ``active_start``/``active_end``
+#           ("HH:MM:SS[.ffffff]" time-of-day window, start-inclusive /
+#           end-exclusive, wrapping past midnight when start > end).  All
+#           default None.  Only emitted to devices advertising
+#           ``slideshow_visibility_v1``; such devices receive ALL slides
+#           (including currently-closed ones) and evaluate visibility in the
+#           device's local timezone.  Devices that don't understand 1.5
+#           ignore the extras and keep the Phase-1 server-side drop.  Times
+#           and dates are serialized via ``isoformat()`` (full precision) so
+#           the firmware predicate is bit-for-bit identical to the CMS one.
 #
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.4"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.5"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -389,6 +419,24 @@ class SlideDescriptor(BaseModel):
     # asset's ``FetchAssetMessage.siblings``.  Empty / None means the
     # composed slide has no media siblings (all-text/clock bundle).
     siblings: Optional[list["Sibling"]] = None
+    # Per-slide visibility window (manifest schema 1.5).  All optional on the
+    # wire so v1.0–1.4 parsers ignore them; only emitted to devices that
+    # advertise ``slideshow_visibility_v1``.  When present the device shows
+    # the slide only when ALL set sub-conditions hold against its local wall
+    # clock.  Serialized via ``isoformat()`` (date: "YYYY-MM-DD"; time:
+    # "HH:MM:SS[.ffffff]") for exact CMS↔firmware predicate parity.
+    #   * ``valid_from`` / ``valid_to``  — inclusive calendar-date range.
+    #   * ``active_days``                — weekday allow-list, 0=Mon..6=Sun;
+    #                                      None or [] means "every day".
+    #   * ``active_start`` / ``active_end`` — time-of-day window,
+    #                                      start-inclusive / end-exclusive,
+    #                                      wrapping past midnight when
+    #                                      start > end.
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
+    active_days: Optional[list[int]] = None
+    active_start: Optional[str] = None
+    active_end: Optional[str] = None
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> "SlideDescriptor":
@@ -444,6 +492,35 @@ class SlideDescriptor(BaseModel):
                 f"SlideDescriptor.effect_direction must be one of "
                 f"{KEN_BURNS_DIRECTIONS}, got {self.effect_direction!r}"
             )
+        # Visibility-window fields (1.5) must round-trip through
+        # date/time.fromisoformat verbatim so the firmware predicate parses
+        # the exact same instant the CMS resolver compared against.
+        for _name in ("valid_from", "valid_to"):
+            _v = getattr(self, _name)
+            if _v is not None:
+                try:
+                    _date.fromisoformat(_v)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"SlideDescriptor.{_name} must be an ISO date "
+                        f"'YYYY-MM-DD', got {_v!r}"
+                    ) from exc
+        for _name in ("active_start", "active_end"):
+            _v = getattr(self, _name)
+            if _v is not None:
+                try:
+                    _time.fromisoformat(_v)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"SlideDescriptor.{_name} must be an ISO time "
+                        f"'HH:MM:SS[.ffffff]', got {_v!r}"
+                    ) from exc
+        if self.active_days is not None:
+            if any((not isinstance(d, int)) or d < 0 or d > 6 for d in self.active_days):
+                raise ValueError(
+                    "SlideDescriptor.active_days must be ints in [0, 6] "
+                    f"(0=Mon..6=Sun), got {self.active_days!r}"
+                )
         return self
 
 

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -29,6 +29,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLogEvent
 from cms.schemas.protocol import (
     CAPABILITY_COMPOSED_SIBLINGS_V1,
+    CAPABILITY_SLIDESHOW_VISIBILITY_V1,
     ConfigMessage,
     FetchAssetMessage,
     MessageType,
@@ -270,7 +271,14 @@ async def _resolve_asset_for_device(
         # and the resolved checksum agree.
         local_now = await device_local_now(device, db)
         return await build_fetch_for_slideshow(
-            asset, device, base_url, db, local_now=local_now
+            asset,
+            device,
+            base_url,
+            db,
+            local_now=local_now,
+            emit_windows=(
+                CAPABILITY_SLIDESHOW_VISIBILITY_V1 in (device.capabilities or [])
+            ),
         )
 
     storage = get_storage()

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -19,7 +19,11 @@ from cms.models.schedule_device_skip import ScheduleDeviceSkip
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.schedule_missed_event import ScheduleMissedEvent
 from cms.models.setting import CMSSetting
-from cms.schemas.protocol import ScheduleEntry, SyncMessage
+from cms.schemas.protocol import (
+    CAPABILITY_SLIDESHOW_VISIBILITY_V1,
+    ScheduleEntry,
+    SyncMessage,
+)
 from cms.services.transport import get_transport
 from cms import metrics as _metrics
 
@@ -1058,7 +1062,13 @@ async def build_device_sync(
         if key in slideshow_checksums:
             return slideshow_checksums[key]
         resolved = await resolved_slideshow_checksum(
-            asset, dev.profile_id, db, local_now=device_local_now
+            asset,
+            dev.profile_id,
+            db,
+            local_now=device_local_now,
+            emit_windows=(
+                CAPABILITY_SLIDESHOW_VISIBILITY_V1 in (dev.capabilities or [])
+            ),
         )
         if resolved is not None:
             slideshow_checksums[key] = resolved

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -113,6 +113,16 @@ class _SlidePlan:
     # siblings the device pre-fetches before showing the bundle.  Empty
     # for image/video slides.
     siblings: list[_SiblingPlan] = field(default_factory=list)
+    # Per-slide visibility window (manifest schema 1.5).  Populated only on
+    # the device-evaluated (capability) path; None on the Phase-1 server-drop
+    # path so the resolved checksum and emitted descriptor stay byte-identical
+    # for devices without ``slideshow_visibility_v1``.  Carry the typed DB
+    # values; serialization to wire strings happens at emit/fold time.
+    valid_from: Optional[date] = None
+    valid_to: Optional[date] = None
+    active_days: Optional[list[int]] = None
+    active_start: Optional[time] = None
+    active_end: Optional[time] = None
 
 
 @dataclass
@@ -141,7 +151,13 @@ class _SlideSpec:
     # to that dwell — so the resolver flips ``play_to_end`` on for video
     # members once the member's asset type is known (agora#806 follow-up).
     tag_member: bool = False
-
+    # Per-slide visibility window — carried only on the capability path
+    # (``emit_windows=True`` in :func:`_load_slide_specs`); None otherwise.
+    valid_from: Optional[date] = None
+    valid_to: Optional[date] = None
+    active_days: Optional[list[int]] = None
+    active_start: Optional[time] = None
+    active_end: Optional[time] = None
 
 @dataclass
 class SlideshowBlocker:
@@ -383,8 +399,57 @@ def _slide_window_open(row: SlideshowSlide, local_now: datetime) -> bool:
     return True
 
 
+# Per-slide visibility window helpers (manifest schema 1.5) ------------------
+
+#: An "all-None" window kwargs bundle, used on the Phase-1 server-drop path
+#: so :class:`_SlideSpec` / :class:`_SlidePlan` carry no window metadata.
+_EMPTY_WINDOW: dict = dict(
+    valid_from=None,
+    valid_to=None,
+    active_days=None,
+    active_start=None,
+    active_end=None,
+)
+
+
+def _row_window_kwargs(row: SlideshowSlide) -> dict:
+    """Extract a row's typed visibility-window columns as ``_SlideSpec``
+    constructor kwargs.  ``active_days`` is normalised so a falsy value
+    (``None`` or empty list) becomes ``None`` ("every day") — matching the
+    CMS write-side normaliser and the firmware predicate.
+    """
+    return dict(
+        valid_from=row.valid_from,
+        valid_to=row.valid_to,
+        active_days=(list(row.active_days) if row.active_days else None),
+        active_start=row.active_start,
+        active_end=row.active_end,
+    )
+
+
+def _window_wire_fields(p) -> dict:
+    """Serialize a plan's typed window values to their wire form.
+
+    Dates → ``"YYYY-MM-DD"``, times → ``"HH:MM:SS[.ffffff]"`` (full
+    ``.isoformat()`` precision so the firmware's ``time.fromisoformat``
+    round-trips verbatim — never truncate to ``HH:MM``).  ``active_days``
+    is emitted as a plain ``list[int]`` (or ``None``).
+    """
+    ad = p.active_days
+    return dict(
+        valid_from=p.valid_from.isoformat() if p.valid_from is not None else None,
+        valid_to=p.valid_to.isoformat() if p.valid_to is not None else None,
+        active_days=(list(ad) if ad else None),
+        active_start=p.active_start.isoformat() if p.active_start is not None else None,
+        active_end=p.active_end.isoformat() if p.active_end is not None else None,
+    )
+
+
 async def _load_slide_specs(
-    asset: Asset, db: AsyncSession, local_now: datetime | None = None
+    asset: Asset,
+    db: AsyncSession,
+    local_now: datetime | None = None,
+    emit_windows: bool = False,
 ) -> list[_SlideSpec]:
     """Produce the ordered list of :class:`_SlideSpec` for ``asset``.
 
@@ -394,14 +459,18 @@ async def _load_slide_specs(
     tag membership, every expanded member inheriting the row's playback
     columns as deck-defaults.  A deck with only ``asset`` rows behaves
     exactly as a classic manual slideshow.
+
+    Per-slide visibility windows (manifest schema 1.5) have two paths:
+
+    * ``emit_windows=False`` (default — devices without
+      ``slideshow_visibility_v1`` and every non-device caller): closed
+      slides are *dropped server-side* when ``local_now`` is supplied
+      (Phase-1 behaviour); specs carry no window metadata.
+    * ``emit_windows=True`` (capability devices): closed slides are
+      *kept* and their window columns are copied onto every emitted spec
+      (including each expanded tag member) so the device evaluates the
+      window itself at exact local-clock boundaries, including offline.
     """
-    # Hybrid timeline: a single ordered list of SlideshowSlide rows where
-    # each row is either a static ``asset`` slide or a dynamic ``tag``
-    # block that expands in-place to current tag membership.  Walk in
-    # position order, assigning a running deck index so expanded members
-    # get unique, contiguous positions.  This subsumes the legacy
-    # manual-only mapping (a deck with no tag rows behaves exactly as
-    # before).
     rows_result = await db.execute(
         select(SlideshowSlide)
         .where(SlideshowSlide.slideshow_asset_id == asset.id)
@@ -412,14 +481,18 @@ async def _load_slide_specs(
     specs: list[_SlideSpec] = []
     pos = 0
     for row in rows:
-        # Per-slide visibility window (agora#…): when a device-local now is
-        # supplied, drop rows whose window is closed.  ``local_now is None``
-        # (the API/builder readiness path) means "show every slide" so the
-        # editor preview and existing tests are unaffected.  Applies to both
-        # ``asset`` and ``tag`` rows; a closed ``tag`` row skips its whole
-        # in-place expansion.
-        if local_now is not None and not _slide_window_open(row, local_now):
-            continue
+        # Per-slide visibility window (schema 1.5).  On the server-drop
+        # path, when a device-local now is supplied, drop rows whose window
+        # is closed.  ``local_now is None`` (the API/builder readiness path)
+        # means "show every slide" so the editor preview and existing tests
+        # are unaffected.  Applies to both ``asset`` and ``tag`` rows; a
+        # closed ``tag`` row skips its whole in-place expansion.  On the
+        # capability path (``emit_windows``) closed rows are KEPT and their
+        # window is carried onto each spec for device-side evaluation.
+        if not emit_windows:
+            if local_now is not None and not _slide_window_open(row, local_now):
+                continue
+        win = _row_window_kwargs(row) if emit_windows else _EMPTY_WINDOW
         if row.kind == "tag":
             if row.tag_id is None:  # defensive — CHECK constraint forbids
                 continue
@@ -464,6 +537,7 @@ async def _load_slide_specs(
                         fit=row.fit,
                         effect=row.effect,
                         effect_direction=row.effect_direction,
+                        **win,
                     )
                 )
                 pos += 1
@@ -481,6 +555,7 @@ async def _load_slide_specs(
                     fit=row.fit,
                     effect=row.effect,
                     effect_direction=row.effect_direction,
+                    **win,
                 )
             )
             pos += 1
@@ -582,6 +657,7 @@ async def plan_slideshow(
     profile_id: Optional[uuid.UUID],
     db: AsyncSession,
     local_now: datetime | None = None,
+    emit_windows: bool = False,
 ) -> SlideshowPlan:
     """Resolve every slide of ``asset`` against ``profile_id``.
 
@@ -605,7 +681,9 @@ async def plan_slideshow(
     Two batched queries by source-asset-id keep this O(1) in slide count
     regardless of slideshow size.
     """
-    specs = await _load_slide_specs(asset, db, local_now=local_now)
+    specs = await _load_slide_specs(
+        asset, db, local_now=local_now, emit_windows=emit_windows
+    )
     if not specs:
         return SlideshowPlan()
 
@@ -677,6 +755,15 @@ async def plan_slideshow(
             fit=spec.fit,
             effect=spec.effect,
             effect_direction=spec.effect_direction,
+            # Carry the per-slide visibility window through to the emitted
+            # descriptor + resolved checksum.  None on the server-drop path
+            # (emit_windows=False) → byte-identical wire + hash for devices
+            # without ``slideshow_visibility_v1``.
+            valid_from=spec.valid_from,
+            valid_to=spec.valid_to,
+            active_days=spec.active_days,
+            active_start=spec.active_start,
+            active_end=spec.active_end,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -759,7 +846,10 @@ async def plan_slideshow(
 
 
 def _compute_resolved_manifest_checksum(
-    asset_checksum: str, slides: list[_SlidePlan], shuffle: bool = False
+    asset_checksum: str,
+    slides: list[_SlidePlan],
+    shuffle: bool = False,
+    emit_windows: bool = False,
 ) -> str:
     """Per-device-profile resolved checksum.
 
@@ -772,6 +862,15 @@ def _compute_resolved_manifest_checksum(
     the manifest.  The companion ``shuffle_seed`` is intentionally NOT
     folded — it's a stable function of the asset id so a re-fetch keeps
     the same per-cycle order without perturbing the checksum.
+
+    Per-slide visibility windows (schema 1.5) are folded **only** when
+    ``emit_windows`` is True (the capability path).  This keeps the digest
+    byte-identical to the pre-1.5 behaviour for every device that doesn't
+    advertise ``slideshow_visibility_v1`` — so bumping the resolver does
+    NOT trigger a fleet-wide one-shot re-push.  On the capability path the
+    *window definitions* (time-invariant) are folded, not their evaluated
+    open/closed state, so the hash is stable across scheduler ticks and an
+    author pushes the change exactly once.
     """
     h = hashlib.sha256()
     h.update((asset_checksum or "").encode())
@@ -788,6 +887,13 @@ def _compute_resolved_manifest_checksum(
         # siblings — intentional, avoids serving a stale cached bundle.)
         for sib in s.siblings:
             h.update(f"|sib|{sib.source_asset_id}|{sib.checksum or ''}".encode())
+        if emit_windows:
+            w = _window_wire_fields(s)
+            days = ",".join(str(d) for d in (w["active_days"] or []))
+            h.update(
+                f"|w|{w['valid_from'] or ''}|{w['valid_to'] or ''}|{days}|"
+                f"{w['active_start'] or ''}|{w['active_end'] or ''}".encode()
+            )
     return h.hexdigest()
 
 
@@ -796,6 +902,7 @@ async def resolved_slideshow_checksum(
     profile_id: Optional[uuid.UUID],
     db: AsyncSession,
     local_now: datetime | None = None,
+    emit_windows: bool = False,
 ) -> Optional[str]:
     """Return the resolved manifest checksum for ``asset`` on a given profile.
 
@@ -804,15 +911,21 @@ async def resolved_slideshow_checksum(
     and ``default_asset_checksum`` reflect per-profile variant choice.
 
     ``local_now`` (device effective local time) drives per-slide visibility
-    windows: closed slides are dropped before the checksum is computed, so a
-    slide opening/closing flips the resolved hash and triggers a one-shot
-    device manifest refresh.
+    windows.  With ``emit_windows=False`` (devices without
+    ``slideshow_visibility_v1``) closed slides are dropped before the
+    checksum is computed, so a slide opening/closing flips the resolved hash
+    and triggers a one-shot device manifest refresh.  With
+    ``emit_windows=True`` closed slides are KEPT and their time-invariant
+    window definitions are folded, so the device evaluates the window itself
+    and the hash only changes when an author edits the window.
     """
-    plan = await plan_slideshow(asset, profile_id, db, local_now=local_now)
+    plan = await plan_slideshow(
+        asset, profile_id, db, local_now=local_now, emit_windows=emit_windows
+    )
     if not plan.ready:
         return None
     return _compute_resolved_manifest_checksum(
-        asset.checksum or "", plan.slides, bool(asset.shuffle)
+        asset.checksum or "", plan.slides, bool(asset.shuffle), emit_windows
     )
 
 
@@ -846,6 +959,7 @@ async def build_fetch_for_slideshow(
     base_url: str,
     db: AsyncSession,
     local_now: datetime | None = None,
+    emit_windows: bool = False,
 ) -> Optional[FetchAssetMessage]:
     """Build a slideshow ``FetchAssetMessage`` for ``device``.
 
@@ -853,9 +967,15 @@ async def build_fetch_for_slideshow(
     contract as the existing video/image resolver.
 
     ``local_now`` (device effective local time) drives per-slide visibility
-    windows; closed slides are dropped from the emitted manifest.
+    windows.  With ``emit_windows=False`` closed slides are dropped from the
+    emitted manifest (server-side evaluation).  With ``emit_windows=True``
+    (devices advertising ``slideshow_visibility_v1``) closed slides are KEPT
+    and their window metadata is carried on each ``SlideDescriptor`` so the
+    device evaluates the window itself at exact local-clock boundaries.
     """
-    plan = await plan_slideshow(asset, device.profile_id, db, local_now=local_now)
+    plan = await plan_slideshow(
+        asset, device.profile_id, db, local_now=local_now, emit_windows=emit_windows
+    )
     if not plan.ready:
         return None
 
@@ -893,6 +1013,7 @@ async def build_fetch_for_slideshow(
                     )
                 )
 
+        win = _window_wire_fields(sp) if emit_windows else _EMPTY_WINDOW
         descriptors.append(
             SlideDescriptor(
                 asset_name=sp.source_filename,
@@ -908,11 +1029,16 @@ async def build_fetch_for_slideshow(
                 effect=sp.effect,
                 effect_direction=sp.effect_direction,
                 siblings=wire_siblings,
+                valid_from=win["valid_from"],
+                valid_to=win["valid_to"],
+                active_days=win["active_days"],
+                active_start=win["active_start"],
+                active_end=win["active_end"],
             )
         )
 
     resolved = _compute_resolved_manifest_checksum(
-        asset.checksum or "", plan.slides, bool(asset.shuffle)
+        asset.checksum or "", plan.slides, bool(asset.shuffle), emit_windows
     )
 
     # Phase 1b of agora#226 — wall-clock anchor support.

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -331,7 +331,11 @@
     text-transform: uppercase;
     padding: 0 0.3rem;
 }
-.ssb-vis-pair { display: flex; gap: 0.4rem; align-items: center; }
+/* Stack the start/"to"/end controls vertically. Native date & time inputs
+   have an intrinsic minimum width and refuse to shrink below it, so a
+   side-by-side row overflows (and clips the end field) in the narrow
+   per-slide column. Stacking guarantees both ends always fit. */
+.ssb-vis-pair { display: flex; flex-direction: column; gap: 0.2rem; align-items: stretch; }
 .ssb-vis-pair input[type=date],
 .ssb-vis-pair input[type=time] {
     background: #2a2a2a;
@@ -340,11 +344,21 @@
     border-radius: 4px;
     padding: 0.18rem 0.3rem;
     font-size: 0.72rem;
-    flex: 1 1 0;
+    flex: 0 0 auto;
+    width: 100%;
     min-width: 0;
+    box-sizing: border-box;
     color-scheme: dark;
 }
-.ssb-vis-to { color: #777; font-size: 0.7rem; flex: 0 0 auto; }
+.ssb-vis-to {
+    color: #777;
+    font-size: 0.6rem;
+    flex: 0 0 auto;
+    align-self: flex-start;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-left: 0.1rem;
+}
 .ssb-vis-days { display: flex; gap: 3px; flex-wrap: wrap; }
 .ssb-vis-day {
     width: 26px;

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1776,6 +1776,11 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                     "tag_name": tag_name_map.get(slide.tag_id),
                     "tag_order_by": slide.tag_order_by,
                     "member_count": tag_member_counts.get(slide.tag_id, 0),
+                    "valid_from": slide.valid_from.isoformat() if slide.valid_from else None,
+                    "valid_to": slide.valid_to.isoformat() if slide.valid_to else None,
+                    "active_days": slide.active_days,
+                    "active_start": slide.active_start.isoformat() if slide.active_start else None,
+                    "active_end": slide.active_end.isoformat() if slide.active_end else None,
                 })
                 continue
             slides.append({
@@ -1798,6 +1803,11 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                     src.duration_seconds if src is not None else None
                 ),
                 "thumbnail_url": src_thumb_map.get(src.id) if src is not None else None,
+                "valid_from": slide.valid_from.isoformat() if slide.valid_from else None,
+                "valid_to": slide.valid_to.isoformat() if slide.valid_to else None,
+                "active_days": slide.active_days,
+                "active_start": slide.active_start.isoformat() if slide.active_start else None,
+                "active_end": slide.active_end.isoformat() if slide.active_end else None,
             })
         asset_group_rows = (await db.execute(
             select(GroupAsset.group_id).where(GroupAsset.asset_id == asset_id)

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import date, time
 
 import pytest
 
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.asyncio
 
 async def _seed_slideshow(
     db_session, *, name="My Show", is_global=True, slides=0,
-    slide_fit="cover", slide_effect="none",
+    slide_fit="cover", slide_effect="none", slide_window=None,
 ):
     asset = Asset(
         filename=name,
@@ -48,6 +49,7 @@ async def _seed_slideshow(
                 play_to_end=False,
                 fit=slide_fit,
                 effect=slide_effect,
+                **(slide_window or {}),
             ))
     await db_session.commit()
     return asset
@@ -168,6 +170,31 @@ class TestSlideshowBuilderRoutes:
         body = resp.text
         assert '"fit": "contain"' in body or '"fit":"contain"' in body
         assert '"effect": "ken_burns"' in body or '"effect":"ken_burns"' in body
+
+    async def test_edit_page_hydrates_visibility_windows(self, client, db_session):
+        """Regression: per-slide visibility windows must survive the
+        save -> reopen round-trip. The edit-page JSON island
+        (ss-initial-slides) is the hydration source; if the window
+        columns are dropped here the editor shows blank visibility on
+        reload even though the rule is still applied server-side."""
+        asset = await _seed_slideshow(
+            db_session, name="VisShow", slides=1,
+            slide_window={
+                "valid_from": date(2026, 12, 1),
+                "valid_to": date(2026, 12, 26),
+                "active_start": time(13, 0),
+                "active_end": time(14, 0),
+                "active_days": [0, 1, 2, 3, 4],
+            },
+        )
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert "2026-12-01" in body
+        assert "2026-12-26" in body
+        assert "13:00:00" in body
+        assert "14:00:00" in body
+        assert '"active_days": [0, 1, 2, 3, 4]' in body or '"active_days":[0,1,2,3,4]' in body
 
     async def test_edit_page_wires_in_editor_rename(self, client, db_session):
         """Edit mode must persist a renamed slideshow in-editor. The /slides

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -424,7 +424,7 @@ class TestSlideshowResolver:
             ss, device, "https://cms.example", db_session,
         )
         assert fetch is not None
-        assert fetch.manifest_schema_version == "1.4"
+        assert fetch.manifest_schema_version == "1.5"
         assert fetch.cycle_duration_ms == 7500
         assert fetch.started_at is not None
         assert fetch.started_at.endswith("Z")

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -152,9 +152,10 @@ class TestSlideshowV10Contract:
         # composed-in-slideshow bumped it to "1.2" (composed slide
         # descriptors + per-slide siblings); per-slide fit/effect bumps
         # it to "1.3"; per-slide effect_direction + deck shuffle bumps
-        # it to "1.4".  DEFAULT stays at "1.0" — that's the "no version
-        # on the wire" fallback.
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.4"
+        # it to "1.4"; per-slide visibility windows (device-evaluated,
+        # capability slideshow_visibility_v1) bumps it to "1.5".  DEFAULT
+        # stays at "1.0" — that's the "no version on the wire" fallback.
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.5"
 
     def test_forward_wall_clock_fields_are_ignored(self):
         """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to

--- a/tests/test_slideshow_visibility.py
+++ b/tests/test_slideshow_visibility.py
@@ -309,3 +309,96 @@ class TestLoadSlideSpecsWindowing:
         now = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
         specs = await _load_slide_specs(ss, db_session, now)
         assert specs == []
+
+
+@pytest.mark.asyncio
+class TestLoadSlideSpecsEmitWindows:
+    """``emit_windows=True`` (the capability path) keeps closed slides and
+    carries their typed window columns onto the spec so the device evaluates
+    the window itself."""
+
+    async def test_closed_slide_kept_and_window_carried(self, db_session):
+        a = await _seed_image(db_session, filename="always2.png")
+        b = await _seed_image(db_session, filename="xmas2.png")
+        win = {"valid_from": date(2026, 12, 1), "valid_to": date(2026, 12, 26)}
+        ss = await _seed_slideshow_with_windows(db_session, [(a, {}), (b, win)])
+        # June is outside the December window, but emit_windows keeps it.
+        now = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+        specs = await _load_slide_specs(ss, db_session, now, emit_windows=True)
+        assert {s.source_asset_id for s in specs} == {a.id, b.id}
+        bspec = next(s for s in specs if s.source_asset_id == b.id)
+        assert bspec.valid_from == date(2026, 12, 1)
+        assert bspec.valid_to == date(2026, 12, 26)
+        # The unwindowed slide carries all-None window fields.
+        aspec = next(s for s in specs if s.source_asset_id == a.id)
+        assert aspec.valid_from is None and aspec.valid_to is None
+
+    async def test_active_days_normalised_to_none_when_empty(self, db_session):
+        a = await _seed_image(db_session, filename="daily.png")
+        ss = await _seed_slideshow_with_windows(db_session, [(a, {})])
+        now = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+        specs = await _load_slide_specs(ss, db_session, now, emit_windows=True)
+        assert specs[0].active_days is None
+
+
+class TestResolvedChecksumWindows:
+    """Pure-function tests for the ``emit_windows`` checksum fold.
+
+    These pin the R1 regression guarantee: the non-capability digest is
+    byte-identical regardless of window definitions (no spurious fleet
+    re-push), while the capability digest folds the time-invariant window
+    definition (author edits → exactly one re-push, stable across ticks).
+    """
+
+    def _plan(self, pos, *, checksum, **win):
+        from cms.models.asset import AssetType as _AT
+        from cms.services.slideshow_resolver import _SlidePlan
+        return _SlidePlan(
+            position=pos,
+            source_asset_id=uuid4(),
+            source_filename=f"s{pos}.png",
+            source_asset_type=_AT.IMAGE,
+            duration_ms=5000,
+            play_to_end=False,
+            checksum=checksum,
+            **win,
+        )
+
+    def test_noncap_digest_ignores_window_definitions(self):
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum as cs,
+        )
+        plain = self._plan(0, checksum="x")
+        windowed = self._plan(
+            0, checksum="x", valid_from=date(2026, 12, 1), valid_to=date(2026, 12, 26)
+        )
+        # Same source id so the only difference is the window definition.
+        windowed.source_asset_id = plain.source_asset_id
+        windowed.source_filename = plain.source_filename
+        assert cs("a", [plain], False, False) == cs("a", [windowed], False, False)
+
+    def test_cap_digest_folds_window_definition(self):
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum as cs,
+        )
+        plain = self._plan(0, checksum="x")
+        windowed = self._plan(0, checksum="x", active_start=time(13, 0), active_end=time(14, 0))
+        windowed.source_asset_id = plain.source_asset_id
+        windowed.source_filename = plain.source_filename
+        # On the capability path the window is folded → different digest.
+        assert cs("a", [plain], False, True) != cs("a", [windowed], False, True)
+
+    def test_cap_digest_stable_across_ticks(self):
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum as cs,
+        )
+        p = self._plan(0, checksum="x", valid_from=date(2026, 12, 1))
+        # Two folds of the identical time-invariant window → identical digest.
+        assert cs("a", [p], False, True) == cs("a", [p], False, True)
+
+    def test_cap_digest_differs_from_noncap_when_windowed(self):
+        from cms.services.slideshow_resolver import (
+            _compute_resolved_manifest_checksum as cs,
+        )
+        p = self._plan(0, checksum="x", valid_from=date(2026, 12, 1))
+        assert cs("a", [p], False, True) != cs("a", [p], False, False)


### PR DESCRIPTION
## What

Phase 2 (PR1, CMS) of **per-slide visibility windows** for slideshows.
Bumps the slideshow manifest schema **1.4 → 1.5** and carries
time-invariant window metadata onto each `SlideDescriptor` for devices
that advertise `slideshow_visibility_v1`, so firmware can evaluate
windows at exact local-clock boundaries (sub-tick + offline).

Phase 1 (shipped) drops closed slides server-side each scheduler tick.
This PR adds the device-facing path **without** changing Phase 1
behavior for any current device.

## Changes

- **`protocol.py`** — `SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST` →
  `"1.5"`; new `CAPABILITY_SLIDESHOW_VISIBILITY_V1`; `SlideDescriptor`
  window fields (`valid_from`/`valid_to`/`active_start`/`active_end`/
  `active_days`) + validators.
- **`slideshow_resolver.py`** — `emit_windows` dual-path. Default
  `False` keeps every existing caller **byte-identical** to Phase 1
  (drop closed rows, no window fields, no window bytes in checksum).
  When `True`, closed slides are kept with window metadata and the
  resolved-manifest checksum folds the **time-invariant** window
  definitions (stable across ticks → one re-push per author edit, not
  per tick).
- **`scheduler.py` / `device_inbound.py`** — set `emit_windows` from
  the device capability at the two device-facing call sites.

## Bug fix bundled in

**Editor hydration:** the server-rendered `ss-initial-slides` island
(`ui._slideshow_builder_context`) omitted the 5 window fields, so the
builder hydrated blank on reopen even though the DB held them and the
rule applied. Added the fields to both the tag-slide and asset-slide
dicts, matching the `/api/assets/{id}/slides` serialization. Regression
test asserts the island now carries them.

## Safety / rollout

- Non-cap digest stays **byte-identical** to pre-1.5 → zero-impact
  fleet deploy (no device advertises the capability yet).
- Firmware forward-tolerates `1.5` best-effort until **PR2** (agora)
  ports the `_slide_window_open` predicate and bumps
  `PLAYER_MAX_MANIFEST_SCHEMA_VERSION`.

## Tests

`emit_windows` resolver paths, cap/non-cap checksum invariants, and a
builder-UI regression for the hydration island. Targeted suites green
locally (visibility + schema-contract + resolver: 117 passed;
builder-UI: 24 passed).

## Note on the tagged-video duration question

Verified separately: VIDEO members of a dynamic tag block already play
their full natural length (`slideshow_resolver.py` flips `play_to_end`
on for video tag members; images keep the dwell). Covered by
`test_slideshow_tag_blocks.py::test_create_tag_block_video_member_uses_natural_duration`.
No change needed.
