### PR TITLE
feat(slideshow): per-slide video clip (trim) + fix tagged-video play-to-end

### DIFF
--- a/alembic/versions/0050_slideshow_video_clip.py
+++ b/alembic/versions/0050_slideshow_video_clip.py
@@ -1,0 +1,60 @@
+"""slideshow_slides: per-slide video clip range
+
+Adds two nullable columns that restrict a VIDEO slide to a sub-range of
+its source asset, plus two CHECK constraints mirroring the Pydantic
+validators in ``cms.schemas.asset.SlideIn``:
+
+* ``clip_start_ms`` (``integer``) — offset into the source the device
+  seeks to before playing.  NULL = start at 0.
+* ``clip_duration_ms`` (``integer``) — how long to play from that offset.
+  NULL = play to the natural end of the source.
+
+Both columns are nullable with no server default — both NULL means
+"play the whole source / honour play_to_end", so an existing row renders
+byte-identically.  No backfill required.
+
+The clip is turned into the emitted per-slide ``duration_ms`` slot plus
+the wire ``clip_start_ms`` seek in the slideshow resolver, validated
+there against the probed ``Asset.duration_seconds`` real length (which
+is not knowable at the DB layer, hence only shape CHECKs here).
+
+Revision ID: 0050
+Revises: 0049
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0050"
+down_revision = "0049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("clip_start_ms", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "slideshow_slides",
+        sa.Column("clip_duration_ms", sa.Integer(), nullable=True),
+    )
+    # Offset non-negative.
+    op.create_check_constraint(
+        "ck_slideshow_slide_clip_start_nonneg",
+        "slideshow_slides",
+        "clip_start_ms IS NULL OR clip_start_ms >= 0",
+    )
+    # Clip length strictly positive.
+    op.create_check_constraint(
+        "ck_slideshow_slide_clip_duration_pos",
+        "slideshow_slides",
+        "clip_duration_ms IS NULL OR clip_duration_ms > 0",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0050 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1582,6 +1582,8 @@ def _slide_row(slideshow_asset_id: uuid.UUID, idx: int, s: SlideIn) -> Slideshow
         active_days=s.active_days,
         active_start=s.active_start,
         active_end=s.active_end,
+        clip_start_ms=s.clip_start_ms,
+        clip_duration_ms=s.clip_duration_ms,
     )
 
 
@@ -1703,6 +1705,51 @@ async def _load_and_validate_slide_sources(
                     "play_to_end is only valid for video sources"
                 ),
             )
+        # Per-slide video clip: only valid on a VIDEO source, and the clip
+        # window (start + duration) must fit inside the source's real probed
+        # length.  ``duration_seconds`` is populated once the transcoder
+        # probes the upload; if it's still None we can't verify the bound, so
+        # reject with a "still processing" message rather than emit a clip the
+        # resolver can't validate.
+        if s.clip_start_ms is not None or s.clip_duration_ms is not None:
+            if src.asset_type != AssetType.VIDEO:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Slide source '{src.filename}' is a "
+                        f"{src.asset_type.value}; video clipping "
+                        "(clip_start_ms/clip_duration_ms) is only valid for "
+                        "video sources"
+                    ),
+                )
+            if src.duration_seconds is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Slide source '{src.filename}' is still being "
+                        "processed; its duration isn't known yet, so it can't "
+                        "be clipped. Try again once processing finishes."
+                    ),
+                )
+            real_ms = round(src.duration_seconds * 1000)
+            start = s.clip_start_ms or 0
+            if start >= real_ms:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"clip_start_ms ({start}) is at or past the end of "
+                        f"'{src.filename}' ({real_ms} ms)"
+                    ),
+                )
+            if s.clip_duration_ms is not None and start + s.clip_duration_ms > real_ms:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Clip window for '{src.filename}' "
+                        f"(start {start} ms + duration {s.clip_duration_ms} ms) "
+                        f"exceeds the source length ({real_ms} ms)"
+                    ),
+                )
 
     if visible_ids is not None:
         visible_set = set(visible_ids)
@@ -2189,6 +2236,8 @@ async def list_slideshow_slides(
                 "active_end": slide.active_end.isoformat()
                 if slide.active_end
                 else None,
+                "clip_start_ms": slide.clip_start_ms,
+                "clip_duration_ms": slide.clip_duration_ms,
                 "source_asset_id": str(slide.source_asset_id),
                 "source_filename": src.filename if src else None,
                 "source_asset_type": src.asset_type.value if src else None,

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -366,7 +366,18 @@ class SlideIn(BaseModel):
     active_start: Optional[time] = None
     active_end: Optional[time] = None
 
-    @field_validator("kind")
+    # ── Per-slide video clip (both None = play whole source) ──
+    #
+    # Restrict a VIDEO ``asset`` slide to a sub-range of its source.
+    # ``clip_start_ms`` is the offset the device seeks to; ``clip_duration_ms``
+    # (None = "to the natural end") bounds how long to play from there.  Only
+    # meaningful for an ``asset`` slide whose source is a VIDEO — enforced
+    # against the resolved source type at the service/resolver layer (the
+    # source's asset_type isn't known to this schema).  Omitting both (what
+    # every pre-feature client does) means "play the whole source / honour
+    # play_to_end", so output is byte-identical.
+    clip_start_ms: Optional[int] = Field(None, ge=0)
+    clip_duration_ms: Optional[int] = Field(None, ge=MIN_SLIDE_DURATION_MS)
     @classmethod
     def _validate_kind(cls, v: str) -> str:
         if v not in ("asset", "tag"):
@@ -494,6 +505,11 @@ class SlideIn(BaseModel):
                 raise ValueError("tag slide must not carry source_asset_id")
             if self.play_to_end:
                 raise ValueError("tag slide cannot set play_to_end")
+            # A dynamic tag block expands to many members; there is no single
+            # source to clip, so reject clip fields rather than silently
+            # dropping them.
+            if self.clip_start_ms is not None or self.clip_duration_ms is not None:
+                raise ValueError("tag slide cannot set clip_start_ms/clip_duration_ms")
         return self
 
 
@@ -528,6 +544,9 @@ class SlideOut(BaseModel):
     active_days: Optional[list[int]] = None
     active_start: Optional[time] = None
     active_end: Optional[time] = None
+    # Per-slide video clip; both null = play whole source.
+    clip_start_ms: Optional[int] = None
+    clip_duration_ms: Optional[int] = None
     source_asset_id: Optional[uuid.UUID] = None
     source_filename: Optional[str] = None
     source_asset_type: Optional[AssetType] = None

--- a/cms/schemas/protocol.py
+++ b/cms/schemas/protocol.py
@@ -77,6 +77,23 @@ CAPABILITY_SLIDESHOW_COMPOSED_V1 = "slideshow_composed_v1"
 # the window predicate into the slideshow player.
 CAPABILITY_SLIDESHOW_VISIBILITY_V1 = "slideshow_visibility_v1"
 
+# Per-slide video clipping (manifest schema 1.6).  A device advertising
+# this capability is sent an optional per-slide ``clip_start_ms`` on the
+# ``SlideDescriptor`` (offset, in milliseconds, into the source video at
+# which playback of that slide begins).  The clip *length* is NOT a
+# separate wire field — it is already encoded by ``duration_ms`` (the
+# slot the device must fill on screen), so the source seek is
+# ``clip_start_ms + within_slot_offset`` and playback runs for
+# ``duration_ms``.  Only the seek offset is gated by this capability;
+# the underlying "``duration_ms`` == real on-screen playback time"
+# invariant (which also fixes ``play_to_end`` slots being clipped to the
+# authored dwell) is UNCONDITIONAL and applies to every device.  A
+# device WITHOUT this capability is sent ``clip_start_ms=0`` (the slot is
+# still length-correct — it just plays from the source's t=0 rather than
+# from the author's offset).  Pairs with the agora firmware PR that adds
+# the per-slide source seek to the slideshow player.
+CAPABILITY_SLIDESHOW_CLIP_V1 = "slideshow_clip_v1"
+
 # Slideshow manifest schema version (semver, additive minor bumps).  The
 # wire format of the slideshow manifest is independent of the
 # higher-level ``PROTOCOL_VERSION``: protocol bumps describe the WS
@@ -133,11 +150,26 @@ CAPABILITY_SLIDESHOW_VISIBILITY_V1 = "slideshow_visibility_v1"
 #           ignore the extras and keep the Phase-1 server-side drop.  Times
 #           and dates are serialized via ``isoformat()`` (full precision) so
 #           the firmware predicate is bit-for-bit identical to the CMS one.
+#   "1.6" — adds optional per-slide ``clip_start_ms`` (int, default 0) on
+#           ``SlideDescriptor``: the millisecond offset into the source
+#           video at which this slide's playback begins.  The clip length
+#           is carried by the existing ``duration_ms`` (the on-screen
+#           slot), so the device seeks the source to
+#           ``clip_start_ms + within_slot_offset`` and plays for
+#           ``duration_ms``.  Only emitted non-zero to devices advertising
+#           ``slideshow_clip_v1``; others receive ``clip_start_ms=0`` and
+#           play the (still length-correct) slot from t=0.  Independent of
+#           the clip seek, schema 1.6 also pins the invariant that a
+#           slide's ``duration_ms`` always equals its real on-screen
+#           playback time — in particular a ``play_to_end`` video slot is
+#           the video's full real length, not the authored dwell.  That
+#           invariant is unconditional (all schema versions / all
+#           devices); 1.6 only adds the optional non-zero start offset.
 #
 # Rule for future bumps: minor bumps are additive (old players ignore
 # unknown fields).  A breaking change bumps the *major* and is gated
 # via a new capability string (mirrors ``CAPABILITY_SLIDESHOW_V1``).
-SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.5"
+SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST = "1.6"
 SLIDESHOW_MANIFEST_SCHEMA_VERSION_DEFAULT = "1.0"
 
 # Binary-frame magic for chunked log responses (Stage 3c of #345).  Pi
@@ -437,6 +469,14 @@ class SlideDescriptor(BaseModel):
     active_days: Optional[list[int]] = None
     active_start: Optional[str] = None
     active_end: Optional[str] = None
+    # Per-slide video clip start offset (manifest schema 1.6).  Optional on
+    # the wire (default 0) so v1.0–1.5 parsers ignore it; only emitted
+    # non-zero to devices advertising ``slideshow_clip_v1``.  Milliseconds
+    # into the source video at which this slide begins playing.  The clip
+    # *length* is the existing ``duration_ms`` slot, so the device seeks the
+    # source to ``clip_start_ms + within_slot_offset`` and plays for
+    # ``duration_ms``.  Only meaningful for ``asset_type == "video"``.
+    clip_start_ms: int = 0
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> "SlideDescriptor":
@@ -452,6 +492,15 @@ class SlideDescriptor(BaseModel):
         if self.play_to_end and self.asset_type != "video":
             raise ValueError(
                 "SlideDescriptor.play_to_end=True is only valid for video sources"
+            )
+        if self.clip_start_ms < 0:
+            raise ValueError(
+                "SlideDescriptor.clip_start_ms must be >= 0, "
+                f"got {self.clip_start_ms}"
+            )
+        if self.clip_start_ms > 0 and self.asset_type != "video":
+            raise ValueError(
+                "SlideDescriptor.clip_start_ms > 0 is only valid for video sources"
             )
         if self.siblings is not None and self.asset_type != "composed":
             raise ValueError(

--- a/cms/services/device_inbound.py
+++ b/cms/services/device_inbound.py
@@ -29,6 +29,7 @@ from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLogEvent
 from cms.schemas.protocol import (
     CAPABILITY_COMPOSED_SIBLINGS_V1,
+    CAPABILITY_SLIDESHOW_CLIP_V1,
     CAPABILITY_SLIDESHOW_VISIBILITY_V1,
     ConfigMessage,
     FetchAssetMessage,
@@ -278,6 +279,9 @@ async def _resolve_asset_for_device(
             local_now=local_now,
             emit_windows=(
                 CAPABILITY_SLIDESHOW_VISIBILITY_V1 in (device.capabilities or [])
+            ),
+            emit_clip=(
+                CAPABILITY_SLIDESHOW_CLIP_V1 in (device.capabilities or [])
             ),
         )
 

--- a/cms/services/scheduler.py
+++ b/cms/services/scheduler.py
@@ -20,6 +20,7 @@ from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.schedule_missed_event import ScheduleMissedEvent
 from cms.models.setting import CMSSetting
 from cms.schemas.protocol import (
+    CAPABILITY_SLIDESHOW_CLIP_V1,
     CAPABILITY_SLIDESHOW_VISIBILITY_V1,
     ScheduleEntry,
     SyncMessage,
@@ -1068,6 +1069,9 @@ async def build_device_sync(
             local_now=device_local_now,
             emit_windows=(
                 CAPABILITY_SLIDESHOW_VISIBILITY_V1 in (dev.capabilities or [])
+            ),
+            emit_clip=(
+                CAPABILITY_SLIDESHOW_CLIP_V1 in (dev.capabilities or [])
             ),
         )
         if resolved is not None:

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -123,6 +123,15 @@ class _SlidePlan:
     active_days: Optional[list[int]] = None
     active_start: Optional[time] = None
     active_end: Optional[time] = None
+    # Per-slide video clip (P2).  ``clip_start_ms`` is the *emitted*
+    # (effective) source seek offset — already gated to 0 on the
+    # non-capable / non-device path by :func:`_effective_slide_playback`, so
+    # the wire descriptor and resolved checksum stay byte-identical for
+    # devices without ``slideshow_clip_v1``.  ``clip_duration_ms`` is the raw
+    # authored bound, carried for reference only (the slot is encoded by
+    # ``duration_ms``); it is NOT emitted on the wire or folded into the hash.
+    clip_start_ms: int = 0
+    clip_duration_ms: Optional[int] = None
 
 
 @dataclass
@@ -158,6 +167,13 @@ class _SlideSpec:
     active_days: Optional[list[int]] = None
     active_start: Optional[time] = None
     active_end: Optional[time] = None
+    # Per-slide video clip (P2) — raw authored values from the asset-kind
+    # row.  ``clip_start_ms`` is the source seek offset; ``clip_duration_ms``
+    # the bounded playback length (None = "to natural end").  Always 0 / None
+    # for tag-block members (the SlideIn schema rejects clip on tag kind).
+    clip_start_ms: int = 0
+    clip_duration_ms: Optional[int] = None
+
 
 @dataclass
 class SlideshowBlocker:
@@ -555,6 +571,8 @@ async def _load_slide_specs(
                     fit=row.fit,
                     effect=row.effect,
                     effect_direction=row.effect_direction,
+                    clip_start_ms=row.clip_start_ms or 0,
+                    clip_duration_ms=row.clip_duration_ms,
                     **win,
                 )
             )
@@ -652,12 +670,115 @@ async def effective_slide_counts(
     return counts
 
 
+def _effective_slide_playback(
+    spec: "_SlideSpec",
+    src: Asset,
+    *,
+    tag_member_play_to_end: bool,
+    emit_clip: bool,
+) -> tuple[int, bool, int]:
+    """Compute a slide's emitted ``(duration_ms, play_to_end, clip_start_ms)``.
+
+    This is the single place that reconciles three playback modes against the
+    anchored-cycle invariant — *the emitted ``duration_ms`` MUST equal the
+    real on-screen time the slide occupies* — so the wall-clock anchor math
+    in ``plan_slideshow`` (``cycle_duration_ms = sum(duration_ms)``) and the
+    firmware loop stay in lock-step:
+
+    ====================  ==========  ===========  =====================
+    mode                  duration_ms play_to_end  clip_start_ms (emitted)
+    ====================  ==========  ===========  =====================
+    image / plain         auth dwell  False        0
+    play_to_end video     real_dur    True         0
+    bounded clip          clip_dur    False        clip_start (if emit_clip)
+    clip → natural end    real_dur−X  True         clip_start (if emit_clip)
+    ====================  ==========  ===========  =====================
+
+    **P1 fix (play_to_end → real-duration slot) is UNCONDITIONAL** — every
+    device gets the correct slot length so the anchored cycle is right even
+    on firmware that ignores ``play_to_end``.  Only the *seek offset*
+    (``clip_start_ms``) is gated by ``emit_clip`` (capability
+    ``slideshow_clip_v1``).
+
+    On the non-capable / non-device path (``emit_clip=False``) a bounded or
+    clip→end slide is emitted **length-preserving**: the slot length is kept
+    (so the cycle stays correct) but ``clip_start_ms`` is forced to 0 and
+    ``play_to_end`` to False — the device plays the *wrong window* of the
+    source from t=0 for the right number of ms, never the full source.  This
+    keeps the resolved checksum byte-identical to a pre-clip deck for those
+    devices except where the slot length itself genuinely changed.
+    """
+    is_video = src.asset_type in (AssetType.VIDEO, AssetType.SAVED_STREAM)
+
+    # Real source length in ms (rounded).  None for un-probed assets.
+    real_ms: Optional[int] = None
+    if is_video and src.duration_seconds is not None:
+        real_ms = int(round(src.duration_seconds * 1000))
+
+    start = spec.clip_start_ms or 0
+    clip_dur = spec.clip_duration_ms
+    wants_play_to_end = (
+        spec.play_to_end or (tag_member_play_to_end and is_video)
+    )
+
+    # Bounded clip: a video member with an explicit clip length.
+    if is_video and clip_dur is not None and clip_dur > 0:
+        if not emit_clip:
+            # Length-preserving fallback: keep the slot, drop the offset.
+            return clip_dur, False, 0
+        return clip_dur, False, start
+
+    # Clip → natural end (offset only, no explicit length) OR a plain
+    # play_to_end video.  Slot is the real remaining length.
+    if wants_play_to_end:
+        if real_ms is None:
+            # Un-probed video: we can't compute the real slot.  Fall back to
+            # the authored dwell (degraded — matches pre-fix behaviour) and
+            # warn loudly so the operator re-probes the source.
+            logger.warning(
+                "slideshow slide %s: play_to_end video %s has no probed "
+                "duration_seconds; falling back to authored dwell %dms "
+                "(slot may be wrong)",
+                spec.position,
+                src.filename,
+                spec.duration_ms,
+            )
+            # Offset still honored if capable, but the slot is the dwell.
+            return spec.duration_ms, True, (start if emit_clip else 0)
+        slot = real_ms - start
+        if slot <= 0:
+            # Defensive: offset at/after EOF — should be rejected at input.
+            logger.warning(
+                "slideshow slide %s: clip_start_ms %d >= real duration %dms "
+                "for %s; using authored dwell",
+                spec.position,
+                start,
+                real_ms,
+                src.filename,
+            )
+            return spec.duration_ms, True, 0
+        if real_ms > 4 * 60 * 60 * 1000:
+            logger.info(
+                "slideshow slide %s: very long play_to_end video %s "
+                "(%dms ≈ %.1fh) — anchored cycle slot is large",
+                spec.position,
+                src.filename,
+                real_ms,
+                real_ms / 3_600_000.0,
+            )
+        return slot, True, (start if emit_clip else 0)
+
+    # Plain image / non-play_to_end slide: authored dwell, no clip.
+    return spec.duration_ms, False, 0
+
+
 async def plan_slideshow(
     asset: Asset,
     profile_id: Optional[uuid.UUID],
     db: AsyncSession,
     local_now: datetime | None = None,
     emit_windows: bool = False,
+    emit_clip: bool = False,
 ) -> SlideshowPlan:
     """Resolve every slide of ``asset`` against ``profile_id``.
 
@@ -736,20 +857,23 @@ async def plan_slideshow(
                 )
             )
             continue
+        eff_duration_ms, eff_play_to_end, eff_clip_start_ms = (
+            _effective_slide_playback(
+                spec,
+                src,
+                # A VIDEO member of a dynamic tag block plays its full natural
+                # length rather than being clipped to the block's dwell time.
+                tag_member_play_to_end=spec.tag_member,
+                emit_clip=emit_clip,
+            )
+        )
         sp = _SlidePlan(
             position=spec.position,
             source_asset_id=sid,
             source_filename=src.filename,
             source_asset_type=src.asset_type,
-            duration_ms=spec.duration_ms,
-            # A VIDEO member of a dynamic tag block plays its full natural
-            # length rather than being clipped to the block's dwell time
-            # (matches a standalone video slide with play_to_end on).  Other
-            # member types (image, saved_stream, composed) keep the dwell.
-            play_to_end=(
-                spec.play_to_end
-                or (spec.tag_member and src.asset_type == AssetType.VIDEO)
-            ),
+            duration_ms=eff_duration_ms,
+            play_to_end=eff_play_to_end,
             transition=spec.transition,
             transition_ms=spec.transition_ms,
             fit=spec.fit,
@@ -764,6 +888,11 @@ async def plan_slideshow(
             active_days=spec.active_days,
             active_start=spec.active_start,
             active_end=spec.active_end,
+            # Emitted (effective) clip offset — 0 unless the device advertises
+            # ``slideshow_clip_v1`` (emit_clip).  ``clip_duration_ms`` is
+            # carried for reference; the slot is encoded by ``duration_ms``.
+            clip_start_ms=eff_clip_start_ms,
+            clip_duration_ms=spec.clip_duration_ms,
         )
         # File-asset slides need a download URL.  Saved streams are
         # behaviourally videos; treat them as such for variant lookup.
@@ -881,6 +1010,14 @@ def _compute_resolved_manifest_checksum(
             f"{s.duration_ms}|{int(s.play_to_end)}|{s.transition}|{s.transition_ms}|"
             f"{s.fit}|{s.effect}|{s.effect_direction}".encode()
         )
+        # Fold the *emitted* clip offset only when non-zero.  It's already 0
+        # on the non-capable path (``_effective_slide_playback`` gates it on
+        # ``emit_clip``), so this keeps the digest byte-identical for devices
+        # without ``slideshow_clip_v1`` while still re-pushing once when an
+        # author trims a clip for a capable device.  The clip *length* needs
+        # no separate fold — it always flows through ``duration_ms`` above.
+        if s.clip_start_ms:
+            h.update(f"|clip={s.clip_start_ms}".encode())
         # Fold each composed sibling's checksum so a re-transcoded sibling
         # video flips the resolved hash and prompts a device refetch.
         # (Stricter than the standalone-composed path, which doesn't fold
@@ -903,6 +1040,7 @@ async def resolved_slideshow_checksum(
     db: AsyncSession,
     local_now: datetime | None = None,
     emit_windows: bool = False,
+    emit_clip: bool = False,
 ) -> Optional[str]:
     """Return the resolved manifest checksum for ``asset`` on a given profile.
 
@@ -920,7 +1058,12 @@ async def resolved_slideshow_checksum(
     and the hash only changes when an author edits the window.
     """
     plan = await plan_slideshow(
-        asset, profile_id, db, local_now=local_now, emit_windows=emit_windows
+        asset,
+        profile_id,
+        db,
+        local_now=local_now,
+        emit_windows=emit_windows,
+        emit_clip=emit_clip,
     )
     if not plan.ready:
         return None
@@ -960,6 +1103,7 @@ async def build_fetch_for_slideshow(
     db: AsyncSession,
     local_now: datetime | None = None,
     emit_windows: bool = False,
+    emit_clip: bool = False,
 ) -> Optional[FetchAssetMessage]:
     """Build a slideshow ``FetchAssetMessage`` for ``device``.
 
@@ -974,7 +1118,12 @@ async def build_fetch_for_slideshow(
     device evaluates the window itself at exact local-clock boundaries.
     """
     plan = await plan_slideshow(
-        asset, device.profile_id, db, local_now=local_now, emit_windows=emit_windows
+        asset,
+        device.profile_id,
+        db,
+        local_now=local_now,
+        emit_windows=emit_windows,
+        emit_clip=emit_clip,
     )
     if not plan.ready:
         return None
@@ -1023,6 +1172,7 @@ async def build_fetch_for_slideshow(
                 size_bytes=sp.size_bytes or 0,
                 duration_ms=sp.duration_ms,
                 play_to_end=sp.play_to_end,
+                clip_start_ms=sp.clip_start_ms,
                 transition=sp.transition,
                 transition_ms=sp.transition_ms,
                 fit=sp.fit,

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -311,6 +311,38 @@
 .ssb-vis-state.ssb-on { color: #1abc9c; }
 .ssb-vis-body { display: none; flex-direction: column; gap: 0.5rem; }
 .ssb-vis-body.ssb-open { display: flex; }
+/* Per-slide video trim (clip) control — same grammar as the visibility block. */
+.ssb-slot-trim {
+    border-top: 1px dashed #3a3a3a;
+    margin-top: 0.1rem;
+    padding-top: 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.ssb-trim-head {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    color: #bbb;
+    font-size: 0.72rem;
+    font-weight: 600;
+    user-select: none;
+}
+.ssb-trim-chev {
+    color: #1abc9c;
+    font-size: 0.65rem;
+    transition: transform 0.12s ease;
+    display: inline-block;
+}
+.ssb-trim-head.ssb-open .ssb-trim-chev { transform: rotate(90deg); }
+.ssb-trim-state { color: #666; font-weight: 400; margin-left: auto; }
+.ssb-trim-state.ssb-on { color: #1abc9c; }
+.ssb-trim-body { display: flex; flex-direction: column; gap: 0.4rem; }
+.ssb-trim-start { display: flex; align-items: center; gap: 0.4rem; font-size: 0.72rem; color: #ccc; }
+.ssb-trim-start input { width: 4.5rem; }
+.ssb-trim-summary { font-size: 0.72rem; color: #8fd9c9; }
 .ssb-vis-radio { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.72rem; color: #ccc; }
 .ssb-vis-radio label { display: flex; gap: 0.4rem; align-items: center; cursor: pointer; }
 .ssb-vis-radio input { accent-color: #1abc9c; }
@@ -1795,6 +1827,152 @@ function toggleSlideVisDay(i, day) {
     renderTimeline();
 }
 
+// ---- Per-slide video clip / trim (CMS-side sub-range of a video source) ----
+// A video slide may play only a sub-range of its source: a start offset
+// (``clip_start_ms``) plus, when "play to end" is off, a fixed length
+// (``clip_duration_ms`` == the slide's ``duration_ms``).  Offset 0 + no fixed
+// length == the legacy whole-video behaviour and is serialized byte-identically
+// (clip_start_ms 0 / clip_duration_ms null), so untouched decks never change.
+// Images never carry a clip.  ``s._trimOpen`` is a UI-only flag and is never
+// serialized.  The on-device seek (clip_start_ms) only takes effect on devices
+// advertising the ``slideshow_clip_v1`` capability; the length math is honoured
+// everywhere.
+
+// Milliseconds -> "M:SS" (e.g. 65000 -> "1:05").
+function clipFmtTime(ms) {
+    const total = Math.max(0, Math.round((Number(ms) || 0) / 1000));
+    const m = Math.floor(total / 60);
+    const sec = total % 60;
+    return `${m}:${String(sec).padStart(2, '0')}`;
+}
+
+// True iff a video slide carries a real start offset (the only field that
+// distinguishes a clipped slide from a plain dwell/whole-video slide).
+function trimIsClipped(s) {
+    return s && s.source_asset_type === 'video' && (s.clip_start_ms || 0) > 0;
+}
+
+// Effective on-screen playback length (ms) for a slide, accounting for trim:
+//   - play to end:  source length minus the start offset (or dwell when the
+//                   source duration isn't probed yet)
+//   - otherwise:    ``duration_ms`` (which holds the clip length when clipped,
+//                   or the plain dwell when not)
+function effectivePlaybackMs(s) {
+    if (!s || s.source_asset_type !== 'video') return s ? s.duration_ms : 0;
+    const startMs = s.clip_start_ms || 0;
+    if (s.play_to_end) {
+        if (s.source_duration_seconds) {
+            return Math.max(1000, Math.round(s.source_duration_seconds * 1000) - startMs);
+        }
+        return s.duration_ms;
+    }
+    return s.duration_ms;
+}
+
+// Plain-language description of the playing window, e.g. "0:05 → end (≈ 1:21)"
+// or "0:05 – 0:13 (8s)".
+function trimSummary(s) {
+    const startMs = s.clip_start_ms || 0;
+    if (s.play_to_end) {
+        const eff = effectivePlaybackMs(s);
+        return s.source_duration_seconds
+            ? `${clipFmtTime(startMs)} → end (≈ ${clipFmtTime(eff)})`
+            : `${clipFmtTime(startMs)} → end`;
+    }
+    const lenMs = s.duration_ms || 0;
+    const lenSec = Math.max(1, Math.round(lenMs / 1000));
+    return `${clipFmtTime(startMs)} – ${clipFmtTime(startMs + lenMs)} (${lenSec}s)`;
+}
+
+// The collapsible "Trim" control block appended into ``.ssb-slot-meta`` for
+// video slides only.  Holds the start-offset input plus a live hint; the
+// playback *length* stays owned by the existing duration / play-to-end
+// controls above (no duplicate play-to-end here).
+function trimCtlHtml(s, i) {
+    if (s.source_asset_type !== 'video') return '';
+    const clipped = trimIsClipped(s);
+    const open = !!s._trimOpen || clipped;
+    const stateTxt = clipped ? 'Trimmed' : 'Full';
+    const fieldsStyle = open ? '' : 'display:none;';
+    const startSec = (s.clip_start_ms || 0) / 1000;
+    // Round to a whole second for the input, but allow 0.
+    const startVal = startSec ? String(Math.round(startSec * 10) / 10) : '0';
+    const maxStart = s.source_duration_seconds
+        ? Math.max(0, Math.floor(s.source_duration_seconds) - 1)
+        : 3600;
+    const hint = clipped
+        ? `<div class="ssb-trim-summary">${escapeHtml(trimSummary(s))}</div>`
+        : '';
+    return `
+        <div class="ssb-slot-trim">
+            <div class="ssb-trim-head${open ? ' ssb-open' : ''}" role="button" tabindex="0" aria-expanded="${open ? 'true' : 'false'}">
+                <span class="ssb-trim-chev" aria-hidden="true">▶</span>
+                <span>Trim</span>
+                <span class="ssb-trim-state${clipped ? ' ssb-on' : ''}">${stateTxt}</span>
+            </div>
+            <div class="ssb-trim-body" style="${fieldsStyle}">
+                <label class="ssb-trim-start" title="Skip this many seconds into the video before it starts playing">
+                    <span>Start at</span>
+                    <input type="number" class="ssb-trim-start-input" min="0" max="${maxStart}" step="1"
+                           value="${escapeHtml(startVal)}" aria-label="Start offset in seconds">
+                    <span style="color:#888;">s</span>
+                </label>
+                <div class="ssb-trim-note text-muted" style="font-size:0.72rem;">
+                    Length is set by the duration / play-to-end controls above.
+                </div>
+                ${hint}
+            </div>
+        </div>`;
+}
+
+// Attach listeners for a trim control block previously rendered into ``slot``.
+function wireTrimCtls(slot, i) {
+    const head = slot.querySelector('.ssb-trim-head');
+    if (head) {
+        head.addEventListener('click', () => toggleSlideTrimOpen(i));
+        head.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleSlideTrimOpen(i); }
+        });
+    }
+    const startInput = slot.querySelector('.ssb-trim-start-input');
+    if (startInput) {
+        startInput.addEventListener('change', (e) => updateSlideClipStart(i, e.target.value));
+    }
+}
+
+function toggleSlideTrimOpen(i) {
+    const s = slides[i];
+    if (!s) return;
+    s._trimOpen = !s._trimOpen;
+    renderTimeline();
+}
+
+// Set a video slide's start offset (seconds).  Clamps to [0, sourceLen-1] and,
+// when a fixed clip length is in play (play-to-end off), shrinks the length so
+// start + length never exceeds the source — mirroring the server-side bound.
+function updateSlideClipStart(i, v) {
+    const s = slides[i];
+    if (!s || s.source_asset_type !== 'video') return;
+    let sec = parseFloat(v);
+    if (!isFinite(sec) || sec < 0) sec = 0;
+    const durMs = s.source_duration_seconds
+        ? Math.round(s.source_duration_seconds * 1000)
+        : null;
+    let startMs = Math.round(sec * 1000);
+    if (durMs != null) startMs = Math.min(startMs, Math.max(0, durMs - 1000));
+    s.clip_start_ms = startMs;
+    // Keep the open state sticky once the user has engaged the control so the
+    // section doesn't collapse out from under them when they zero the offset.
+    if (startMs > 0) s._trimOpen = true;
+    // Re-clamp a fixed clip length against the new offset.
+    if (durMs != null && !s.play_to_end && startMs > 0) {
+        const maxLen = durMs - startMs;
+        if (maxLen > 0 && s.duration_ms > maxLen) s.duration_ms = maxLen;
+    }
+    markDirty();
+    renderTimeline();
+}
+
 function makeSlot(s, i) {
     const slot = document.createElement('div');
     slot.className = 'ssb-slot';
@@ -1833,10 +2011,7 @@ function makeSlot(s, i) {
     } else {
         thumb = `<video class="ssb-slot-thumb" style="${fitStyle}" src="${thumbSrc}" preload="metadata" muted playsinline></video>`;
     }
-    const effectiveSec = s.play_to_end && isVideo && s.source_duration_seconds
-        ? s.source_duration_seconds
-        : (s.duration_ms / 1000);
-    const displaySec = Math.max(1, Math.round(effectiveSec));
+    const displaySec = Math.max(1, Math.round(effectivePlaybackMs(s) / 1000));
 
     const playToEndCtl = isVideo
         ? `<label class="ssb-slot-pte" title="Play the full video">
@@ -1867,6 +2042,7 @@ function makeSlot(s, i) {
             </div>
             ${playToEndCtl}
             ${fitEffectCtl}
+            ${trimCtlHtml(s, i)}
             ${visibilityCtlHtml(s, i)}
         </div>`;
 
@@ -1887,6 +2063,7 @@ function makeSlot(s, i) {
     if (pte) pte.addEventListener('change', (e) => updateSlidePlayToEnd(i, e.target.checked));
     wireFitEffectCtls(slot, i);
     wireVisibilityCtls(slot, i);
+    wireTrimCtls(slot, i);
 
     slot.addEventListener('dragstart', (e) => {
         e.dataTransfer.effectAllowed = 'copyMove';
@@ -2495,9 +2672,7 @@ function updateTotals() {
             return;
         }
         const isVideo = s.source_asset_type === 'video';
-        const dur = s.play_to_end && isVideo && s.source_duration_seconds
-            ? Math.round(s.source_duration_seconds * 1000)
-            : s.duration_ms;
+        const dur = isVideo ? effectivePlaybackMs(s) : s.duration_ms;
         totalMs += dur;
     });
     document.getElementById('ss-total').textContent = fmtDur(totalMs / 1000);
@@ -2507,7 +2682,24 @@ function updateTotals() {
 function updateSlideDuration(i, v) {
     const seconds = parseFloat(v);
     if (!isFinite(seconds) || seconds <= 0) return;
-    slides[i].duration_ms = Math.round(seconds * 1000);
+    const s = slides[i];
+    let ms = Math.round(seconds * 1000);
+    // For a bounded clip (video, fixed length, with a start offset), the clip
+    // can't run past the end of the source — mirror the server-side bound.
+    if (s.source_asset_type === 'video' && !s.play_to_end
+            && (s.clip_start_ms || 0) > 0 && s.source_duration_seconds) {
+        const maxLen = Math.round(s.source_duration_seconds * 1000) - (s.clip_start_ms || 0);
+        if (maxLen > 0 && ms > maxLen) {
+            ms = maxLen;
+            // The input over-shot the clip window; re-render so the field
+            // reflects the clamp and the trim hint updates.
+            slides[i].duration_ms = ms;
+            markDirty();
+            renderTimeline();
+            return;
+        }
+    }
+    slides[i].duration_ms = ms;
     markDirty();
     updateTotals();
 }
@@ -2533,11 +2725,24 @@ function serializeSlide(s) {
             ...serializeVisibility(s),
         };
     }
+    // Clip (trim) fields. A start offset of 0 with no fixed clip length is the
+    // legacy whole-video / plain-dwell behaviour and MUST serialize as
+    // clip_start_ms:0 / clip_duration_ms:null so untouched decks stay
+    // byte-identical. A fixed clip length is engaged ONLY for a video with a
+    // real start offset and play-to-end off; otherwise duration_ms is the
+    // authority and clip_duration_ms stays null.
+    const isVideoSlide = s.source_asset_type === 'video';
+    const clipStartMs = isVideoSlide ? (s.clip_start_ms || 0) : 0;
+    const clipDurationMs = (isVideoSlide && !s.play_to_end && clipStartMs > 0)
+        ? s.duration_ms
+        : null;
     return {
         kind: 'asset',
         source_asset_id: s.source_asset_id,
         duration_ms: s.duration_ms,
         play_to_end: !!s.play_to_end,
+        clip_start_ms: clipStartMs,
+        clip_duration_ms: clipDurationMs,
         transition: s.transition || 'cut',
         transition_ms: (typeof s.transition_ms === 'number') ? s.transition_ms : 600,
         fit: s.fit || 'cover',
@@ -2621,6 +2826,8 @@ function addSlideFromAsset(assetId, atIndex) {
         source_filename: a.display_name || a.original_filename || a.filename,
         source_asset_type: a.asset_type,
         source_duration_seconds: a.duration_seconds,
+        clip_start_ms: 0,
+        clip_duration_ms: null,
         thumbnail_url: a.thumbnail_url || null,
     };
     const idx = Math.max(0, Math.min(atIndex, slides.length));
@@ -2656,6 +2863,8 @@ function addAllVisible() {
             source_filename: a.display_name || a.original_filename || a.filename,
             source_asset_type: a.asset_type,
             source_duration_seconds: a.duration_seconds,
+            clip_start_ms: 0,
+            clip_duration_ms: null,
             thumbnail_url: a.thumbnail_url || null,
         };
         slides.push(slide);

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -1802,6 +1802,8 @@ async def _slideshow_builder_context(request, db, *, asset_id=None):
                 "source_duration_seconds": (
                     src.duration_seconds if src is not None else None
                 ),
+                "clip_start_ms": slide.clip_start_ms,
+                "clip_duration_ms": slide.clip_duration_ms,
                 "thumbnail_url": src_thumb_map.get(src.id) if src is not None else None,
                 "valid_from": slide.valid_from.isoformat() if slide.valid_from else None,
                 "valid_to": slide.valid_to.isoformat() if slide.valid_to else None,

--- a/shared/models/slideshow_slide.py
+++ b/shared/models/slideshow_slide.py
@@ -190,6 +190,27 @@ class SlideshowSlide(Base):
             "active_days IS NULL OR active_days <@ '{0,1,2,3,4,5,6}'::smallint[]",
             name="ck_slideshow_slide_active_days",
         ).ddl_if(dialect="postgresql"),
+        # ── Per-slide video clip (agora video-clip) ──
+        #
+        # Restrict a VIDEO slide to a sub-range of its source.  Both NULL by
+        # default = "play the whole source / honour play_to_end" — existing
+        # rows are byte-identical and unaffected.  ``clip_start_ms`` is the
+        # offset into the source the device seeks to before playing;
+        # ``clip_duration_ms`` is how long to play from that offset (NULL =
+        # "to the natural end").  The resolver turns these into the emitted
+        # ``duration_ms`` slot + wire ``clip_start_ms`` seek; the playback
+        # bound (start+duration) must stay within the source's real length,
+        # enforced in the resolver against the probed ``Asset.duration_seconds``
+        # (not knowable at the DB layer).  These CHECKs are belt-and-braces
+        # shape guards mirroring the Pydantic validators.
+        CheckConstraint(
+            "clip_start_ms IS NULL OR clip_start_ms >= 0",
+            name="ck_slideshow_slide_clip_start_nonneg",
+        ),
+        CheckConstraint(
+            "clip_duration_ms IS NULL OR clip_duration_ms > 0",
+            name="ck_slideshow_slide_clip_duration_pos",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -309,6 +330,13 @@ class SlideshowSlide(Base):
     # one-sided window.
     active_start: Mapped[time | None] = mapped_column(Time, nullable=True)
     active_end: Mapped[time | None] = mapped_column(Time, nullable=True)
+    # ── Per-slide video clip (agora video-clip) ──
+    # Both NULL = play the whole source (honour play_to_end / dwell).
+    # ``clip_start_ms`` seeks into the source; ``clip_duration_ms`` (NULL =
+    # to natural end) bounds how long to play.  The resolver maps these to
+    # the emitted ``duration_ms`` slot + wire ``clip_start_ms`` seek.
+    clip_start_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    clip_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -370,3 +370,102 @@ class TestSlideshowBuilderTagPalette:
         body = resp.text
         assert 'id="ss-tags-palette"' in body
         assert 'id="ss-all-tags"' in body
+
+
+async def _seed_clipped_video_slideshow(db_session, *, start_ms, clip_ms):
+    """Seed a slideshow with one VIDEO slide carrying a clip (trim) window."""
+    show = Asset(
+        filename="ClipShow",
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum="v1",
+        duration_seconds=10.0,
+        is_global=True,
+    )
+    db_session.add(show)
+    await db_session.flush()
+    src = Asset(
+        filename=f"clip-{uuid.uuid4().hex[:6]}.mp4",
+        asset_type=AssetType.VIDEO,
+        size_bytes=1000,
+        duration_seconds=86.0,
+        is_global=True,
+    )
+    db_session.add(src)
+    await db_session.flush()
+    db_session.add(SlideshowSlide(
+        slideshow_asset_id=show.id,
+        source_asset_id=src.id,
+        position=0,
+        duration_ms=clip_ms if clip_ms is not None else 5000,
+        play_to_end=clip_ms is None,
+        clip_start_ms=start_ms,
+        clip_duration_ms=clip_ms,
+    ))
+    await db_session.commit()
+    return show
+
+
+class TestSlideshowBuilderTrimUI:
+    """The per-slide video trim (clip) control."""
+
+    async def test_builder_bakes_trim_helpers(self, client):
+        """Trim render + wiring + the effective-playback helper must be
+        baked into the builder JS."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert "function trimCtlHtml(" in body
+        assert "function wireTrimCtls(" in body
+        assert "function effectivePlaybackMs(" in body
+        assert "function updateSlideClipStart(" in body
+        # The trim block is only rendered for video slides.
+        assert "if (s.source_asset_type !== 'video') return '';" in body
+        # Trim block is appended into the slot meta + wired up.
+        assert "${trimCtlHtml(s, i)}" in body
+        assert "wireTrimCtls(slot, i);" in body
+
+    async def test_serialize_uses_byte_identical_clip_rule(self, client):
+        """clip_duration_ms must stay null unless a video has a real start
+        offset AND play-to-end is off, so un-trimmed decks serialize
+        byte-identically (clip_start_ms:0 / clip_duration_ms:null)."""
+        resp = await client.get("/assets/new/slideshow")
+        body = resp.text
+        # The serialize rule predicate.
+        assert "(isVideoSlide && !s.play_to_end && clipStartMs > 0)" in body
+        # clip fields are emitted on the asset wire shape.
+        assert "clip_start_ms: clipStartMs," in body
+        assert "clip_duration_ms: clipDurationMs," in body
+
+    async def test_new_slides_init_clip_defaults(self, client):
+        """Fresh slides (single + bulk add) start un-trimmed."""
+        resp = await client.get("/assets/new/slideshow")
+        body = resp.text
+        assert body.count("clip_start_ms: 0,") >= 2
+        assert body.count("clip_duration_ms: null,") >= 2
+
+    async def test_edit_page_hydrates_clip_fields(self, client, db_session):
+        """Regression: a clipped video slide must round-trip its clip
+        window through the ss-initial-slides hydration island, otherwise
+        the trim UI shows 'Full' on reload even though the server still
+        clips the playback."""
+        asset = await _seed_clipped_video_slideshow(
+            db_session, start_ms=5000, clip_ms=8000,
+        )
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert '"clip_start_ms": 5000' in body or '"clip_start_ms":5000' in body
+        assert '"clip_duration_ms": 8000' in body or '"clip_duration_ms":8000' in body
+
+    async def test_edit_page_hydrates_play_to_end_clip(self, client, db_session):
+        """A clip-from-offset-to-end slide (play_to_end, start>0, no fixed
+        length) hydrates with clip_start_ms set and clip_duration_ms null."""
+        asset = await _seed_clipped_video_slideshow(
+            db_session, start_ms=5000, clip_ms=None,
+        )
+        resp = await client.get(f"/assets/{asset.id}/slideshow")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        assert '"clip_start_ms": 5000' in body or '"clip_start_ms":5000' in body
+        assert '"clip_duration_ms": null' in body or '"clip_duration_ms":null' in body

--- a/tests/test_slideshow_resolver.py
+++ b/tests/test_slideshow_resolver.py
@@ -24,6 +24,7 @@ from cms.models.device import Device, DeviceGroup, DeviceStatus
 from cms.models.device_profile import DeviceProfile
 from cms.models.slideshow_slide import SlideshowSlide
 from cms.schemas.protocol import (
+    CAPABILITY_SLIDESHOW_CLIP_V1,
     CAPABILITY_SLIDESHOW_COMPOSED_V1,
     CAPABILITY_SLIDESHOW_V1,
 )
@@ -162,6 +163,41 @@ async def _seed_slideshow(db, *, name, slides_data, checksum=""):
     return ss
 
 
+async def _seed_clip_slideshow(db, *, name, slides_data, checksum=""):
+    """Seed a slideshow whose slides may carry clip fields.
+
+    ``slides_data`` is a list of
+    ``(source_asset, duration_ms, play_to_end, clip_start_ms, clip_duration_ms)``.
+    ``clip_start_ms`` is an int; ``clip_duration_ms`` is an int or ``None``.
+    Used by the video-clip resolver tests.
+    """
+    ss = Asset(
+        filename=name,
+        asset_type=AssetType.SLIDESHOW,
+        size_bytes=0,
+        checksum=checksum,
+        is_global=True,
+    )
+    db.add(ss)
+    await db.commit()
+    await db.refresh(ss)
+    for idx, (src, dur_ms, pte, clip_start, clip_dur) in enumerate(slides_data):
+        db.add(SlideshowSlide(
+            slideshow_asset_id=ss.id,
+            source_asset_id=src.id,
+            position=idx,
+            duration_ms=dur_ms,
+            play_to_end=pte,
+            transition="cut",
+            transition_ms=600,
+            clip_start_ms=clip_start,
+            clip_duration_ms=clip_dur,
+        ))
+    await db.commit()
+    await db.refresh(ss)
+    return ss
+
+
 async def _seed_group(db, name="g"):
     g = DeviceGroup(name=name)
     db.add(g)
@@ -216,7 +252,10 @@ class TestSlideshowResolver:
         plan = await plan_slideshow(ss, profile.id, db_session)
         assert plan.ready
         assert [s.checksum for s in plan.slides] == ["img-variant", "vid-variant"]
-        assert [s.duration_ms for s in plan.slides] == [5000, 8000]
+        # P1 fix: a play_to_end video slide is sized to its REAL duration
+        # (10000ms) rather than its authored dwell (8000ms), so the anchored
+        # cycle math matches the real on-screen time.
+        assert [s.duration_ms for s in plan.slides] == [5000, 10000]
         assert plan.slides[1].play_to_end is True
 
     async def test_empty_slideshow_is_not_ready(self, db_session):
@@ -424,7 +463,7 @@ class TestSlideshowResolver:
             ss, device, "https://cms.example", db_session,
         )
         assert fetch is not None
-        assert fetch.manifest_schema_version == "1.5"
+        assert fetch.manifest_schema_version == "1.6"
         assert fetch.cycle_duration_ms == 7500
         assert fetch.started_at is not None
         assert fetch.started_at.endswith("Z")
@@ -1480,3 +1519,196 @@ class TestHybridTagTimeline:
         assert fetch is not None
         anchor = datetime.fromisoformat(fetch.started_at.replace("Z", "+00:00"))
         assert int(anchor.timestamp() * 1000) % fetch.cycle_duration_ms == 0
+
+
+# ---------------------------------------------------------------------------
+# Video clip / play_to_end slot tests (P1 fix + slideshow_clip_v1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSlideshowVideoClip:
+    """Cover ``_effective_slide_playback`` end-to-end through the resolver:
+
+    - P1 fix: play_to_end videos report their REAL duration (unconditional).
+    - Bounded clips + clip-to-natural-end gated by ``slideshow_clip_v1``
+      (``emit_clip``).
+    - Non-capable devices get a length-preserving slot (clip_start forced 0).
+    - Checksum byte-identity for non-capable decks.
+    """
+
+    async def test_play_to_end_uses_real_duration_unconditionally(self, db_session):
+        """A play_to_end video is sized to its real length even when the
+        device can't clip (P1 fix is unconditional)."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip1")
+        vid = await _seed_video(db_session, filename="pte.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-pte",
+            slides_data=[(vid, 8000, True, 0, None)],
+        )
+        # emit_clip=False (non-capable) still gets the real 20000ms slot.
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=False)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 20000
+        assert plan.slides[0].play_to_end is True
+        assert plan.slides[0].clip_start_ms == 0
+
+    async def test_play_to_end_unprobed_video_falls_back_to_dwell(self, db_session):
+        """An un-probed (duration_seconds=None) play_to_end video can't be
+        sized to real length, so it falls back to the authored dwell."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip2")
+        vid = await _seed_video(db_session, filename="noprobe.mp4", duration=None)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-noprobe",
+            slides_data=[(vid, 7000, True, 0, None)],
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=True)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 7000
+        assert plan.slides[0].play_to_end is True
+
+    async def test_bounded_clip_capable_device(self, db_session):
+        """A bounded clip on a capable device: slot = clip length, NOT
+        play_to_end, and the seek offset is emitted."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip3")
+        vid = await _seed_video(db_session, filename="bounded.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-bounded",
+            slides_data=[(vid, 8000, False, 3000, 5000)],
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=True)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 5000
+        assert plan.slides[0].play_to_end is False
+        assert plan.slides[0].clip_start_ms == 3000
+
+    async def test_bounded_clip_noncapable_is_length_preserving(self, db_session):
+        """A bounded clip on a NON-capable device keeps the slot length but
+        forces the seek offset to 0 (plays the wrong window, right length)."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip4")
+        vid = await _seed_video(db_session, filename="bounded2.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-bounded-nc",
+            slides_data=[(vid, 8000, False, 3000, 5000)],
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=False)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 5000
+        assert plan.slides[0].play_to_end is False
+        assert plan.slides[0].clip_start_ms == 0
+
+    async def test_clip_to_natural_end_capable(self, db_session):
+        """Offset-only clip (no explicit length) with play_to_end: slot is
+        the real remaining length and the offset is emitted."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip5")
+        vid = await _seed_video(db_session, filename="tonatend.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-tonatend",
+            slides_data=[(vid, 8000, True, 3000, None)],
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=True)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 17000  # 20000 - 3000
+        assert plan.slides[0].play_to_end is True
+        assert plan.slides[0].clip_start_ms == 3000
+
+    async def test_clip_offset_past_eof_falls_back_to_dwell(self, db_session):
+        """A clip_start at/after EOF can't yield a positive slot, so it
+        defensively falls back to the authored dwell with no offset."""
+        from cms.services.slideshow_resolver import plan_slideshow
+
+        profile = await _seed_profile(db_session, "pclip6")
+        vid = await _seed_video(db_session, filename="pasteof.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-pasteof",
+            slides_data=[(vid, 8000, True, 25000, None)],
+        )
+        plan = await plan_slideshow(ss, profile.id, db_session, emit_clip=True)
+        assert plan.ready
+        assert plan.slides[0].duration_ms == 8000
+        assert plan.slides[0].clip_start_ms == 0
+
+    async def test_wire_emits_clip_start_for_capable_device(self, db_session):
+        """build_fetch_for_slideshow emits ``clip_start_ms`` on the wire
+        descriptor for a capable device and 0 for a non-capable one."""
+        from cms.services.slideshow_resolver import build_fetch_for_slideshow
+
+        profile = await _seed_profile(db_session, "pclip7")
+        group = await _seed_group(db_session, "gclip7")
+        vid = await _seed_video(db_session, filename="wireclip.mp4", duration=20.0)
+        await _seed_variant(db_session, source=vid, profile=profile, ext="mp4")
+        ss = await _seed_clip_slideshow(
+            db_session, name="clip-wire",
+            slides_data=[(vid, 8000, False, 3000, 5000)],
+        )
+        cap_dev = await _seed_device(
+            db_session, did="dclip-cap", group=group, profile=profile,
+            capabilities=[CAPABILITY_SLIDESHOW_V1, CAPABILITY_SLIDESHOW_CLIP_V1],
+        )
+        nc_dev = await _seed_device(
+            db_session, did="dclip-nc", group=group, profile=profile,
+            capabilities=[CAPABILITY_SLIDESHOW_V1],
+        )
+        cap_fetch = await build_fetch_for_slideshow(
+            ss, cap_dev, "https://cms.example", db_session,
+            emit_clip=True,
+        )
+        nc_fetch = await build_fetch_for_slideshow(
+            ss, nc_dev, "https://cms.example", db_session,
+            emit_clip=False,
+        )
+        assert cap_fetch is not None and nc_fetch is not None
+        assert cap_fetch.slides[0].clip_start_ms == 3000
+        assert nc_fetch.slides[0].clip_start_ms == 0
+
+    async def test_noncapable_clip_checksum_is_byte_identical(self, db_session):
+        """A non-capable device's resolved checksum for a clipped deck is
+        identical to a plain deck with the same slot length (the clip offset
+        is never folded on the non-capable path)."""
+        from cms.services.slideshow_resolver import resolved_slideshow_checksum
+
+        profile = await _seed_profile(db_session, "pclip8")
+        vid = await _seed_video(
+            db_session, filename="cksum.mp4", duration=20.0, checksum="vsha",
+        )
+        await _seed_variant(
+            db_session, source=vid, profile=profile, checksum="vv", ext="mp4",
+        )
+        clipped = await _seed_clip_slideshow(
+            db_session, name="cksum-clip",
+            slides_data=[(vid, 8000, False, 3000, 5000)],
+            checksum="base",
+        )
+        plain = await _seed_clip_slideshow(
+            db_session, name="cksum-plain",
+            slides_data=[(vid, 5000, False, 0, None)],
+            checksum="base",
+        )
+        cs_clip = await resolved_slideshow_checksum(
+            clipped, profile.id, db_session, emit_clip=False,
+        )
+        cs_plain = await resolved_slideshow_checksum(
+            plain, profile.id, db_session, emit_clip=False,
+        )
+        assert cs_clip is not None
+        assert cs_clip == cs_plain
+        # And a capable device DOES fold the offset -> different hash.
+        cs_clip_cap = await resolved_slideshow_checksum(
+            clipped, profile.id, db_session, emit_clip=True,
+        )
+        assert cs_clip_cap != cs_clip

--- a/tests/test_slideshow_schema_contract.py
+++ b/tests/test_slideshow_schema_contract.py
@@ -153,9 +153,11 @@ class TestSlideshowV10Contract:
         # descriptors + per-slide siblings); per-slide fit/effect bumps
         # it to "1.3"; per-slide effect_direction + deck shuffle bumps
         # it to "1.4"; per-slide visibility windows (device-evaluated,
-        # capability slideshow_visibility_v1) bumps it to "1.5".  DEFAULT
+        # capability slideshow_visibility_v1) bumps it to "1.5";
+        # per-slide video clipping (clip_start_ms, capability
+        # slideshow_clip_v1) bumps it to "1.6".  DEFAULT
         # stays at "1.0" — that's the "no version on the wire" fallback.
-        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.5"
+        assert SLIDESHOW_MANIFEST_SCHEMA_VERSION_LATEST == "1.6"
 
     def test_forward_wall_clock_fields_are_ignored(self):
         """Phase 1b adds ``cycle_duration_ms`` and ``started_at`` to


### PR DESCRIPTION
## Per-slide video clip (trim) + tagged-video play-to-end fix

Combined PR: a new per-slide **video trim** feature for the slideshow
builder, plus a fix for a live **P1 regression** where tagged/video
slides ignored `play_to_end` and were cut to the dynamic dwell
duration.

### P1 fix
Video sources in a slideshow once again play their **full duration**
when `play_to_end` is on, regardless of the dynamic duration rule
(images still follow the duration rule). The resolver's
`_effective_slide_playback` was conflating the two; it now restores
play-to-end for video.

### New: video trim
A video slide can now play only a sub-range instead of always from
t=0. Two new columns on `slideshow_slides`:

- `clip_start_ms` — offset into the source where playback begins
- `clip_duration_ms` — bounded length (NULL = play to natural end)

Four playback states, mapped by offset × play_to_end:

| offset | play_to_end | result | stored |
|--------|-------------|--------|--------|
| 0 | on | full video | `start=0, dur=NULL` (byte-identical to legacy) |
| 0 | off, N | legacy dwell | `start=0, dur=NULL, duration_ms=N` (byte-identical) |
| >0 | on | clip offset → EOF | `start=offset, dur=NULL` |
| >0 | off, N | bounded clip | `start=offset, dur=N` |

**Un-trimmed decks serialize byte-identically** — the default UI
emission is `clip_start_ms:0 / clip_duration_ms:null`, verified by the
existing non-capable checksum test.

### Builder UI
- Collapsible **Trim** control on video slides only (mirrors the
  Visibility control): "Start at N s" offset + live summary.
- `effectivePlaybackMs()` drives slot display and total runtime.
- Clamping mirrors the backend invariant (offset < real duration;
  bounded clips can't exceed source length).
- `ss-initial-slides` hydration carries the clip fields so a trim
  survives the save → reopen round-trip.

### Wire / schema
- Manifest schema bumped to **1.6**.
- `GET /slides` echoes clip fields; the resolver emits them on the
  slide descriptor.
- Input validation rejects `start >= real_ms` and
  `start + clip_duration_ms > real_ms`.

### Tests
- 8 resolver/clip tests, schema-contract bump to 1.6.
- 5 new builder trim-UI tests (helpers baked, byte-identical serialize
  rule, default init, edit-page clip hydration for bounded + to-EOF).

### Follow-up (separate PR)
Firmware support for the `clip_start_ms` seek (`loop = not has_clip`,
SNAP guard, `slideshow_clip_v1` capability) ships separately in
`sslivins/agora`. Devices that don't yet advertise the capability keep
receiving byte-identical legacy manifests.
