### PR TITLE
fix(slideshow): don't reject no-op video clip on image/unprobed slides

### DIFF
--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -1711,7 +1711,14 @@ async def _load_and_validate_slide_sources(
         # probes the upload; if it's still None we can't verify the bound, so
         # reject with a "still processing" message rather than emit a clip the
         # resolver can't validate.
-        if s.clip_start_ms is not None or s.clip_duration_ms is not None:
+        #
+        # NOTE: a *no-op* clip (``clip_start_ms`` 0/None AND ``clip_duration_ms``
+        # None) is the legacy whole-asset default that EVERY slide serializes
+        # (images included, so untouched decks stay byte-identical).  It must
+        # not trip the video-only / still-processing checks below -- only an
+        # actual clip (start > 0 or a fixed duration) engages them.
+        has_clip = bool(s.clip_start_ms) or s.clip_duration_ms is not None
+        if has_clip:
             if src.asset_type != AssetType.VIDEO:
                 raise HTTPException(
                     status_code=400,

--- a/tests/test_slideshow_assets.py
+++ b/tests/test_slideshow_assets.py
@@ -349,6 +349,67 @@ class TestSlideshowCreate:
         assert resp.status_code == 400
         assert "play_to_end" in resp.json()["detail"]
 
+    async def test_allows_noop_clip_on_image(self, client, db_session):
+        # Every slide the builder serializes carries clip_start_ms:0 /
+        # clip_duration_ms:null (the legacy whole-asset default). That no-op
+        # must NOT trip the video-only clip guard on an image source.
+        img = await _seed_image(db_session, is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "x",
+                "slides": [
+                    {
+                        "source_asset_id": str(img.id),
+                        "duration_ms": 1000,
+                        "clip_start_ms": 0,
+                        "clip_duration_ms": None,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    async def test_rejects_real_clip_on_image(self, client, db_session):
+        # An actual clip (start > 0) on an image is still rejected.
+        img = await _seed_image(db_session, is_global=True)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "x",
+                "slides": [
+                    {
+                        "source_asset_id": str(img.id),
+                        "duration_ms": 1000,
+                        "clip_start_ms": 5000,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "video clipping" in resp.json()["detail"]
+
+    async def test_allows_noop_clip_on_unprobed_video(self, client, db_session):
+        # A plain untrimmed video whose duration hasn't been probed yet
+        # (duration_seconds is None) must still save -- the no-op clip
+        # default must not trip the "still being processed" guard.
+        vid = await _seed_video(db_session, is_global=True, duration=None)
+        resp = await client.post(
+            "/api/assets/slideshow",
+            json={
+                "name": "x",
+                "slides": [
+                    {
+                        "source_asset_id": str(vid.id),
+                        "duration_ms": 1000,
+                        "clip_start_ms": 0,
+                        "clip_duration_ms": None,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
     async def test_rejects_duration_too_small(self, client, db_session):
         img = await _seed_image(db_session, is_global=True)
         resp = await client.post(


### PR DESCRIPTION
## Problem

Saving a slideshow that contains an **image** slide failed server-side validation with:

> Slide source 'goodwill_splash.png' is a image; video clipping (clip_start_ms/clip_duration_ms) is only valid for video sources

…even though images show no trim control in the builder.

## Root cause

The builder serializes **every** slide with `clip_start_ms: 0` / `clip_duration_ms: null` (the legacy whole-asset default that keeps untouched decks byte-identical). The save validator used `clip_start_ms is not None`, and `0 is not None` is `True` — so the no-op clip looked like a real clip:

- IMAGE slides hit the *video-only* 400.
- A latent sibling bug: an untrimmed VIDEO saved **before** the transcoder probed `duration_seconds` entered the same block and was wrongly rejected as *still being processed*.

## Fix

Ignore a no-op clip for all asset types:

`has_clip = bool(s.clip_start_ms) or s.clip_duration_ms is not None`

A real clip (`start > 0` or a fixed duration) still engages the video-only + bound checks, unchanged.

## Tests

- `test_allows_noop_clip_on_image` — image + no-op clip → 201
- `test_rejects_real_clip_on_image` — image + `clip_start_ms:5000` → 400 (real guard preserved)
- `test_allows_noop_clip_on_unprobed_video` — video w/ `duration_seconds=None` + no-op clip → 201 (latent fix)

84/84 `test_slideshow_assets.py` green locally.
