### PR TITLE
fix(slideshow): honor per-slide visibility windows in CMS preview

### DIFF
--- a/cms/composed/render.py
+++ b/cms/composed/render.py
@@ -75,6 +75,7 @@ from cms.composed.slideshow_expand import (
 from cms.composed.validate import validate_layout
 from cms.models.asset import Asset, AssetType
 from cms.models.composed_slide import ComposedSlide
+from cms.services.slideshow_resolver import device_local_now
 
 # Widgets allowed to render a VIDEO asset. The ImageWidget only knows how
 # to emit an <img> from inline bytes, so routing a video to it would raise
@@ -331,6 +332,14 @@ async def _render_layout_to_html(
     sibling_asset_urls: dict[uuid.UUID, str] = {}
     slideshow_plans: dict[uuid.UUID, list[SlideshowSlidePlan]] = {}
 
+    # Preview/thumbnail render reflects what's live *right now*: any
+    # embedded-slideshow member whose per-slide visibility window is closed
+    # at the current CMS-local time is dropped, exactly like the device
+    # does.  No specific device here, so use the CMS global timezone.
+    # Computed lazily (only when an embedded slideshow is actually present)
+    # to avoid an extra timezone-setting read on the common no-slideshow path.
+    preview_now: datetime | None = None
+
     if declared_ids:
         storage_dir = settings.asset_storage_path
         rows = await db.execute(
@@ -411,11 +420,30 @@ async def _render_layout_to_html(
             if ref.asset_type == AssetType.SLIDESHOW:
                 # The render/preview path excludes deleted source assets
                 # (it reflects the live editor state, not a frozen device
-                # snapshot).
+                # snapshot).  It also drops members whose per-slide
+                # visibility window is closed at ``preview_now``, so the
+                # preview shows only what a device would currently play.
+                if preview_now is None:
+                    preview_now = await device_local_now(None, db)
                 members = await load_slideshow_members(
-                    db, aid, exclude_deleted=True
+                    db, aid, exclude_deleted=True, drop_closed_at=preview_now
                 )
                 if not members:
+                    # Disambiguate a structurally-empty slideshow from one
+                    # whose every member is simply outside its visibility
+                    # window right now (a transient, expected state).
+                    any_members = await load_slideshow_members(
+                        db, aid, exclude_deleted=True
+                    )
+                    if any_members:
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Slideshow {aid} has no slides scheduled to "
+                                "show right now (all per-slide visibility "
+                                "windows are currently closed)"
+                            ),
+                        )
                     raise HTTPException(
                         status_code=422,
                         detail=(

--- a/cms/composed/slideshow_expand.py
+++ b/cms/composed/slideshow_expand.py
@@ -23,6 +23,7 @@ routing and builds the
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,7 +31,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shared.models.asset import Asset
 from shared.models.slideshow_slide import SlideshowSlide
 from cms.schemas.asset import SLIDE_TRANSITIONS
-from cms.services.slideshow_resolver import expand_tag_members
+from cms.services.slideshow_resolver import (
+    _slide_window_open,
+    expand_tag_members,
+)
 
 
 def composed_cell_transition(transition: str) -> str:
@@ -58,6 +62,7 @@ async def load_slideshow_members(
     slideshow_asset_id: uuid.UUID,
     *,
     exclude_deleted: bool,
+    drop_closed_at: datetime | None = None,
 ) -> list[tuple[SlideshowSlide, Asset | None]]:
     """Return the slideshow's slides in ``position`` order with their sources.
 
@@ -78,6 +83,15 @@ async def load_slideshow_members(
     (the expansion filters them), so they never yield a ``None`` source.
     Returns an empty list when the slideshow has no slides (or expands to
     none, e.g. only empty tag blocks).
+
+    Per-slide visibility windows (manifest schema 1.5): when
+    ``drop_closed_at`` is supplied (a tz-aware local-now), any slide whose
+    visibility window is *closed* at that instant is dropped — so the
+    caller sees only the slides that are live right now.  This is the
+    device-faithful preview behaviour (the Pi drops closed slides too).
+    The default ``None`` means "show every slide" so the device-publish
+    path (which delegates window handling to the slideshow resolver) and
+    the structural pickability check in the editor are unaffected.
     """
     slide_rows = (
         await db.execute(
@@ -114,6 +128,11 @@ async def load_slideshow_members(
         src_rows = (await db.execute(src_q)).scalars().all()
         by_id = {a.id: a for a in src_rows}
 
-    return [
+    result = [
         (s, by_id.get(mid) if mid is not None else None) for s, mid in pairs
     ]
+    if drop_closed_at is not None:
+        result = [
+            pair for pair in result if _slide_window_open(pair[0], drop_closed_at)
+        ]
+    return result

--- a/cms/services/slideshow_resolver.py
+++ b/cms/services/slideshow_resolver.py
@@ -1072,13 +1072,15 @@ async def resolved_slideshow_checksum(
     )
 
 
-async def device_local_now(device: Device, db: AsyncSession) -> datetime:
+async def device_local_now(device: Device | None, db: AsyncSession) -> datetime:
     """Return the current time in ``device``'s effective local timezone.
 
     A per-device IANA tz override takes precedence over the CMS global
     ``timezone`` setting (mirroring the wire ``timezone`` the device
     applies locally); falls back to UTC when neither is set or the value
-    is invalid.  Drives per-slide visibility-window evaluation in
+    is invalid.  Passing ``device=None`` (e.g. the editor preview, which
+    has no specific device) skips the per-device override and uses the
+    CMS global ``timezone`` setting.  Drives per-slide visibility-window evaluation in
     :func:`build_fetch_for_slideshow` / :func:`resolved_slideshow_checksum`.
     """
     from cms.models.setting import CMSSetting  # lazy: avoid import cycle

--- a/tests/test_slideshow_preview.py
+++ b/tests/test_slideshow_preview.py
@@ -10,7 +10,7 @@ involved.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -46,7 +46,9 @@ class TestSlideshowPreview:
         await db_session.flush()
         return img
 
-    async def _make_slideshow(self, db_session, members, *, is_global=True):
+    async def _make_slideshow(
+        self, db_session, members, *, is_global=True, windows=None
+    ):
         ss = Asset(
             filename=f"show-{uuid.uuid4()}.slideshow",
             asset_type=AssetType.SLIDESHOW,
@@ -57,6 +59,7 @@ class TestSlideshowPreview:
         db_session.add(ss)
         await db_session.flush()
         for idx, src in enumerate(members):
+            window = (windows[idx] if windows else None) or {}
             db_session.add(
                 SlideshowSlide(
                     slideshow_asset_id=ss.id,
@@ -66,6 +69,7 @@ class TestSlideshowPreview:
                     play_to_end=False,
                     transition="fade",
                     transition_ms=600,
+                    **window,
                 )
             )
         await db_session.flush()
@@ -141,6 +145,70 @@ class TestSlideshowPreview:
         resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
         assert resp.status_code == 422, resp.text
         assert "can only cycle IMAGE and VIDEO" in resp.text
+
+    async def test_closed_window_slide_is_skipped_in_preview(
+        self, client, db_session, tmp_path
+    ):
+        # A per-slide visibility window in the past (valid_to long ago) is
+        # CLOSED right now, so the preview must drop that member and inline
+        # only the windowless (always-open) one -- matching what a device
+        # would currently play.
+        storage = _storage_dir(tmp_path)
+        open_img = await self._make_image(db_session, storage, "open.png")
+        closed_img = await self._make_image(db_session, storage, "closed.png")
+        ss = await self._make_slideshow(
+            db_session,
+            [open_img, closed_img],
+            windows=[None, {"valid_to": date(2000, 1, 1)}],
+        )
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.text
+        # Only the always-open member is inlined; the closed one is dropped.
+        assert body.count("data:image/png;base64,") == 1
+        assert "cw-ss-slide" in body
+
+    async def test_windowless_slide_always_kept_in_preview(
+        self, client, db_session, tmp_path
+    ):
+        # A slide with no window columns set is always open, so the preview
+        # is byte-for-byte the pre-feature behaviour (both members inlined).
+        storage = _storage_dir(tmp_path)
+        img1 = await self._make_image(db_session, storage, "w1.png")
+        img2 = await self._make_image(db_session, storage, "w2.png")
+        ss = await self._make_slideshow(
+            db_session, [img1, img2], windows=[None, None]
+        )
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 200, resp.text
+        assert resp.text.count("data:image/png;base64,") == 2
+
+    async def test_all_windows_closed_gives_friendly_422(
+        self, client, db_session, tmp_path
+    ):
+        # Every member's window is closed right now (all in the past): the
+        # preview must NOT 500 and must NOT report "has no slides" (the deck
+        # is structurally non-empty) -- it should surface the friendly
+        # "nothing scheduled right now" message.
+        storage = _storage_dir(tmp_path)
+        a = await self._make_image(db_session, storage, "pa.png")
+        b = await self._make_image(db_session, storage, "pb.png")
+        ss = await self._make_slideshow(
+            db_session,
+            [a, b],
+            windows=[
+                {"valid_to": date(2000, 1, 1)},
+                {"valid_to": date(1999, 6, 1)},
+            ],
+        )
+
+        resp = await client.get(f"/composed/slideshow/{ss.id}/preview")
+        assert resp.status_code == 422, resp.text
+        assert "scheduled to show right now" in resp.text
+        # Must not be confused with a structurally-empty slideshow.
+        assert "has no slides\"" not in resp.text
 
     async def test_csp_header_is_locked_down(self, client, db_session, tmp_path):
         storage = _storage_dir(tmp_path)


### PR DESCRIPTION
## Problem
After the device-side persist-drop fix (agora #268, 1.11.113), the **CMS Preview** still showed a slide that should be hidden by its per-slide visibility window (a slide set for 09:10-09:15 displayed at 09:08). Separate code path, separate bug.

## Root cause
`load_slideshow_members` — the shared expander behind preview, thumbnail, and composed-embed render — never evaluated the visibility-window predicate. The device-facing `slideshow_resolver` path was fine; only the browser-render paths leaked closed slides.

## Fix
- Gated `drop_closed_at: datetime | None` kwarg on `load_slideshow_members`. Default `None` leaves the device-publish (`publish.py`) and editor-pickability (`ui.py`) callers **unfiltered** — they must see every slide. When set, closed members are dropped via the existing `_slide_window_open` predicate.
- `_render_layout_to_html` computes preview "now" once (lazily, only when an embedded slideshow is present) via `device_local_now(None, db)` (CMS global timezone, no device) and passes it as `drop_closed_at`. Covers bare-slideshow preview + composed-embed/thumbnail.
- Relaxed `device_local_now` to `Device | None` (runtime already handled None).
- All-closed edge case: distinguishes a structurally-empty deck from one whose every member is merely out-of-window, surfacing a friendly *"no slides scheduled to show right now"* 422.

## Tests
Closed-window slide skipped, windowless slide always kept, all-windows-closed friendly 422. Deterministic (past date ranges → guaranteed closed regardless of wall-clock/tz). Targeted suites green locally: `test_slideshow_preview` (12), `test_composed_preview` (22), `test_slideshow_resolver` (48).

## Scope
Goodwill dev / test fleet. No device/publish behavior change.
