### PR TITLE
fix(devices): render table-wrap tooltips via body-level portal (un-clip group update pill)

### DIFF
--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -3016,3 +3016,87 @@ function _repositionAllOpenPopovers() {
 }
 window.addEventListener("scroll", _repositionAllOpenPopovers, true);
 window.addEventListener("resize", _repositionAllOpenPopovers);
+
+// ── Tooltip portal ────────────────────────────────────────────────────
+// Tooltips that live inside a horizontally-scrolling container
+// (`.table-wrap`, e.g. the grouped device table) are clipped at the
+// container's padding edge -- a scroll container clips BOTH axes and no
+// CSS (overflow-clip-margin is spec-ignored on scroll containers) lets a
+// child escape it. The canonical victim is the "Update available" pill on
+// the top device row, whose upward tooltip was cut off where the group
+// name sits. We hide the native CSS tooltip for any `.has-tooltip` inside
+// a `.table-wrap` (see style.css) and re-render it here in a single
+// body-level fixed element that escapes every clipping/stacking context.
+(function initTooltipPortal() {
+    let portal = null;
+    let activeTrigger = null;
+
+    function getPortal() {
+        if (!portal) {
+            portal = document.createElement("div");
+            portal.id = "tooltip-portal";
+            portal.setAttribute("role", "tooltip");
+            document.body.appendChild(portal);
+        }
+        return portal;
+    }
+
+    function hide() {
+        activeTrigger = null;
+        if (portal) portal.classList.remove("visible");
+    }
+
+    function show(trigger) {
+        const tip = trigger.querySelector(":scope > .tooltip");
+        if (!tip) return;
+        if (!tip.textContent.trim()) return;
+        activeTrigger = trigger;
+        const p = getPortal();
+        // Mirror the native tooltip's markup (already CMS-rendered and
+        // escaped) so multi-line `<div>` tooltips keep their structure.
+        p.innerHTML = tip.innerHTML;
+        // Lay out at the origin first so we can measure natural size.
+        p.style.left = "0px";
+        p.style.top = "0px";
+        p.classList.add("visible");
+        const PAD = 8, GAP = 10;
+        const r = trigger.getBoundingClientRect();
+        const pr = p.getBoundingClientRect();
+        let top = r.top - pr.height - GAP;          // prefer above
+        if (top < PAD) top = r.bottom + GAP;        // flip below if no room
+        let left = r.left + r.width / 2 - pr.width / 2;   // center on trigger
+        left = Math.max(PAD, Math.min(left, window.innerWidth - pr.width - PAD));
+        p.style.left = left + "px";
+        p.style.top = top + "px";
+    }
+
+    function candidate(target) {
+        if (!(target instanceof Element)) return null;
+        const trigger = target.closest(".has-tooltip");
+        if (!trigger) return null;
+        // Only portal tooltips that would otherwise be clipped by a
+        // scroll container; everything else keeps its native CSS tooltip.
+        if (!trigger.closest(".table-wrap")) return null;
+        return trigger;
+    }
+
+    document.addEventListener("pointerover", (e) => {
+        const trigger = candidate(e.target);
+        if (trigger && trigger !== activeTrigger) show(trigger);
+    });
+    document.addEventListener("pointerout", (e) => {
+        if (!activeTrigger) return;
+        const to = e.relatedTarget;
+        if (to instanceof Element && activeTrigger.contains(to)) return;
+        hide();
+    });
+    document.addEventListener("focusin", (e) => {
+        const trigger = candidate(e.target);
+        if (trigger) show(trigger);
+    });
+    document.addEventListener("focusout", hide);
+    // The portal is fixed-positioned off the trigger's rect; any scroll
+    // or resize invalidates it, so dismiss (re-shows on next hover).
+    window.addEventListener("scroll", hide, true);
+    window.addEventListener("resize", hide);
+})();

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1149,25 +1149,55 @@ tr.highlight-new td {
 .inline-label { font-size: 0.9rem; color: var(--text-muted); white-space: nowrap; }
 .group-body { padding: 0 1rem 0.75rem; }
 .group-body table { margin: 0; }
-/* Device-row badge tooltips (e.g. the "Update available" pill) point
-   upward; on the top row of a group panel they extend above the table,
-   into the group-name/header area. `.card .table-wrap` sets
-   `overflow-x: auto`, and per spec a non-`visible` value on one axis
-   forces the other axis to compute to `auto` too -- so `overflow-y`
-   silently became `auto` and clipped that tooltip at the table's top
-   edge (the top of the tooltip vanished right where the group name
-   sits). We can't make a single scroll container both scroll
-   horizontally and let the tooltip escape vertically, so keep the
-   horizontal scroll (the wide grouped device table must stay contained
-   -- see tests_e2e/test_layout_devices.py) and switch the vertical axis
-   to `clip` with an `overflow-clip-margin` large enough for the upward
-   tooltip. `overflow-clip-margin` extends the clip region outward
-   without changing layout or adding scrollbars; browsers without
-   support fall back to plain vertical clipping (today's behavior). */
+/* The wide grouped device table must stay horizontally contained
+   (see tests_e2e/test_layout_devices.py), so `.table-wrap` keeps
+   `overflow-x: auto`. Per the CSS overflow spec a non-`visible` value
+   on one axis forces the other axis to compute to `auto` as well, so
+   this element is unavoidably a scroll container that clips BOTH axes
+   at its padding edge -- there is no CSS way to let a child tooltip
+   escape it (`overflow-clip-margin` is spec-ignored on scroll
+   containers, so the earlier attempt was a no-op). Device-row badge
+   tooltips (e.g. the "Update available" pill) therefore can't render
+   inside the container without being clipped at the top edge, right
+   where the group name sits. Instead we suppress the native CSS
+   tooltip for any `.has-tooltip` inside a `.table-wrap` and render it
+   through a body-level fixed portal in app.js (see initTooltipPortal),
+   which escapes every clipping/stacking context. */
 .group-panel .group-body .table-wrap {
     overflow-x: auto;
-    overflow-y: clip;
-    overflow-clip-margin: 4rem;
+}
+/* Tooltips inside a scroll container are clipped at its padding edge;
+   the JS portal renders them at the document level instead. */
+.table-wrap .has-tooltip > .tooltip {
+    display: none;
+}
+
+/* Body-level tooltip portal (escapes scroll-container clipping). */
+#tooltip-portal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    max-width: 280px;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 0.6rem 0.85rem;
+    font-size: 0.8rem;
+    font-weight: 400;
+    line-height: 1.45;
+    white-space: normal;
+    box-shadow: 0 4px 20px rgba(233, 69, 96, 0.15), 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease;
+    z-index: 4000;
+    text-transform: none;
+}
+#tooltip-portal.visible {
+    opacity: 1;
+    visibility: visible;
 }
 .inline-edit-sm { font-size: 0.9rem; padding: 0.2rem 1.6rem 0.2rem 0.4rem; min-width: 11rem; }
 

--- a/tests_e2e/test_ui_devices.py
+++ b/tests_e2e/test_ui_devices.py
@@ -220,34 +220,42 @@ class TestPlaybackAssetTooltip:
             tooltip_trigger = detail.locator(".has-tooltip", has_text=asset_name).first
             expect(tooltip_trigger).to_be_visible(timeout=10_000)
 
-            # Hover to reveal the tooltip
+            # Hover to reveal the tooltip. Tooltips inside the device
+            # `.table-wrap` (a horizontal scroll container) are rendered
+            # through the body-level `#tooltip-portal` instead of their
+            # native `.tooltip` child, so they escape scroll-container
+            # clipping (see app.js initTooltipPortal / the "Update
+            # available" pill clipping bug).
             tooltip_trigger.hover()
 
-            # The .tooltip child should become visible and contain the full filename
-            tooltip = tooltip_trigger.locator(".tooltip")
-            expect(tooltip).to_be_visible(timeout=3000)
-            expect(tooltip).to_contain_text(asset_name)
+            # The native child stays hidden inside the scroll container...
+            native_tooltip = tooltip_trigger.locator(".tooltip")
+            expect(native_tooltip).to_be_hidden()
 
-            # Verify the tooltip is not clipped by overflow:hidden ancestors.
-            # A clipped tooltip would have a zero or near-zero visible height.
+            # ...and the portal becomes visible with the full filename.
+            portal = page.locator("#tooltip-portal")
+            expect(portal).to_be_visible(timeout=3000)
+            expect(portal).to_contain_text(asset_name)
+
+            # The portal is fixed-positioned at the document body, so it is
+            # never clipped by an overflow ancestor. Assert it isn't nested
+            # inside any clipping container and has real visible height.
             clip_info = page.evaluate("""(el) => {
                 const rect = el.getBoundingClientRect();
+                if (rect.height < 2) return { clipped: true, reason: 'zero-height' };
                 let ancestor = el.parentElement;
-                while (ancestor) {
+                while (ancestor && ancestor !== document.body) {
                     const style = window.getComputedStyle(ancestor);
-                    if (style.overflow === 'hidden' || style.overflowY === 'hidden') {
-                        const aRect = ancestor.getBoundingClientRect();
-                        // Check if tooltip extends outside the overflow container
-                        if (rect.top < aRect.top || rect.bottom > aRect.bottom) {
-                            return { clipped: true, tooltipTop: rect.top, ancestorTop: aRect.top };
-                        }
+                    if (style.overflow === 'hidden' || style.overflowY === 'hidden'
+                        || style.overflowX === 'auto' || style.overflowX === 'scroll') {
+                        return { clipped: true, reason: 'scroll-ancestor' };
                     }
                     ancestor = ancestor.parentElement;
                 }
                 return { clipped: false };
-            }""", tooltip.element_handle())
+            }""", portal.element_handle())
             assert not clip_info["clipped"], (
-                f"Tooltip is clipped by an overflow:hidden ancestor: {clip_info}"
+                f"Portal tooltip is clipped: {clip_info}"
             )
         finally:
             stop_event.set()


### PR DESCRIPTION
## Problem

The "Update available" pill tooltip on the **top device row of a group panel** is clipped at the top, where the group name sits. PR #835 attempted `overflow-y: clip; overflow-clip-margin: 4rem` but it was a **no-op**.

## Root cause

`.group-panel .group-body .table-wrap` must keep `overflow-x: auto` to horizontally contain the wide grouped device table (enforced by `tests_e2e/test_layout_devices.py`). Per the CSS overflow spec, a non-`visible` value on one axis forces the other axis to compute to `auto` — so the element is unavoidably a **scroll container that clips BOTH axes** at its padding edge. `overflow-clip-margin` is spec-ignored on scroll containers, so a child tooltip can never escape it via CSS.

## Fix

Suppress the native CSS tooltip for any `.has-tooltip` inside a `.table-wrap` and re-render it through a body-level `#tooltip-portal` (`position: fixed`, `z-index: 4000`) added in `app.js`:

- Mirrors the trigger's tooltip markup (preserves multi-line `<div>` tooltips).
- Positions above the trigger; flips below when there's no room; clamps horizontally to the viewport.
- Dismisses on scroll/resize (re-shows on next hover).
- Lives on `<body>` → escapes every clipping/stacking context, so **no `.table-wrap` tooltip can be clipped again** (applies site-wide: devices, asset library, etc.).

Tooltips outside `.table-wrap` keep their native CSS behavior untouched.

## Tests

Updated `tests_e2e/test_ui_devices.py::test_tooltip_shows_full_filename` to assert the portal shows the full filename (the native child is now hidden inside the scroll container) and that the portal is not clipped by a scroll ancestor.

Validated locally: `node --check app.js`, `py_compile` the test. Playwright e2e runs in CI.

Goodwill **dev** only.
