### PR TITLE
feat(slideshow): quick-fill Now/Today chips for per-slide visibility window

### DIFF
--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -391,6 +391,24 @@
     letter-spacing: 0.04em;
     padding-left: 0.1rem;
 }
+/* Start input + quick-fill chip share one row; the input flexes, chip hugs. */
+.ssb-vis-inrow { display: flex; align-items: center; gap: 0.25rem; }
+.ssb-vis-inrow input[type=date],
+.ssb-vis-inrow input[type=time] { flex: 1 1 auto; width: auto; }
+.ssb-vis-nowbtn {
+    flex: 0 0 auto;
+    background: #2a2a2a;
+    color: #8fd9c9;
+    border: 1px solid #3a6f64;
+    border-radius: 4px;
+    padding: 0.16rem 0.4rem;
+    font-size: 0.62rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.ssb-vis-nowbtn:hover { background: #1abc9c; color: #10241f; border-color: #1abc9c; }
 .ssb-vis-days { display: flex; gap: 3px; flex-wrap: wrap; }
 .ssb-vis-day {
     width: 26px;
@@ -1713,7 +1731,10 @@ function visibilityCtlHtml(s, i) {
                     <fieldset class="ssb-vis-fs">
                         <legend>Date range</legend>
                         <div class="ssb-vis-pair">
-                            <input type="date" class="ssb-vis-valid-from" value="${escapeHtml(s.valid_from || '')}" aria-label="Start date">
+                            <div class="ssb-vis-inrow">
+                                <input type="date" class="ssb-vis-valid-from" value="${escapeHtml(s.valid_from || '')}" aria-label="Start date">
+                                <button type="button" class="ssb-vis-nowbtn ssb-vis-today-btn" title="Set start date to today">📅 Today</button>
+                            </div>
                             <span class="ssb-vis-to">to</span>
                             <input type="date" class="ssb-vis-valid-to" value="${escapeHtml(s.valid_to || '')}" aria-label="End date">
                         </div>
@@ -1721,7 +1742,10 @@ function visibilityCtlHtml(s, i) {
                     <fieldset class="ssb-vis-fs">
                         <legend>Time of day</legend>
                         <div class="ssb-vis-pair">
-                            <input type="time" class="ssb-vis-active-start" value="${escapeHtml(visTimeInputVal(s.active_start))}" aria-label="Start time">
+                            <div class="ssb-vis-inrow">
+                                <input type="time" class="ssb-vis-active-start" value="${escapeHtml(visTimeInputVal(s.active_start))}" aria-label="Start time">
+                                <button type="button" class="ssb-vis-nowbtn ssb-vis-now-btn" title="Set start time to now (fills End +1h if empty)">⏱ Now</button>
+                            </div>
                             <span class="ssb-vis-to">to</span>
                             <input type="time" class="ssb-vis-active-end" value="${escapeHtml(visTimeInputVal(s.active_end))}" aria-label="End time">
                         </div>
@@ -1756,6 +1780,10 @@ function wireVisibilityCtls(slot, i) {
     bind('.ssb-vis-valid-to', 'valid_to');
     bind('.ssb-vis-active-start', 'active_start');
     bind('.ssb-vis-active-end', 'active_end');
+    const nowBtn = slot.querySelector('.ssb-vis-now-btn');
+    if (nowBtn) nowBtn.addEventListener('click', () => setSlideVisNow(i));
+    const todayBtn = slot.querySelector('.ssb-vis-today-btn');
+    if (todayBtn) todayBtn.addEventListener('click', () => setSlideVisToday(i));
     slot.querySelectorAll('.ssb-vis-day').forEach((chip) => {
         const d = Number(chip.dataset.day);
         chip.addEventListener('click', () => toggleSlideVisDay(i, d));
@@ -1789,6 +1817,43 @@ function setSlideVisMode(i, mode) {
         s._visLimit = true;
         s._visOpen = true;
     }
+    markDirty();
+    renderTimeline();
+}
+
+// "Set to now" quick-fill for the Time of day window. Fills Start with the
+// current wall-clock time (browser local). End is seeded to Start+1h ONLY
+// when End is empty, so typing Start by hand still leaves an open-ended
+// (until-midnight) window untouched. A start near midnight wraps the End
+// past 00:00 — a legitimate overnight window the resolver supports.
+function setSlideVisNow(i) {
+    const s = slides[i];
+    if (!s) return;
+    const now = new Date();
+    const startMins = now.getHours() * 60 + now.getMinutes();
+    s.active_start = String(now.getHours()).padStart(2, '0') + ':' +
+                     String(now.getMinutes()).padStart(2, '0');
+    if (!s.active_end) {
+        const endMins = (startMins + 60) % 1440;
+        s.active_end = String(Math.floor(endMins / 60)).padStart(2, '0') + ':' +
+                       String(endMins % 60).padStart(2, '0');
+    }
+    s._visLimit = true;
+    markDirty();
+    renderTimeline();
+}
+
+// "Set to today" quick-fill for the Date range window. Fills the Start date
+// with today's local calendar date and leaves the End date open ("from today
+// onward"), unless an existing End is now in the past, which would make an
+// impossible range — in that case it's pulled up to today.
+function setSlideVisToday(i) {
+    const s = slides[i];
+    if (!s) return;
+    const today = new Date().toLocaleDateString('en-CA');  // YYYY-MM-DD, browser local
+    s.valid_from = today;
+    if (s.valid_to && s.valid_to < today) s.valid_to = today;
+    s._visLimit = true;
     markDirty();
     renderTimeline();
 }

--- a/tests/test_slideshow_builder_ui.py
+++ b/tests/test_slideshow_builder_ui.py
@@ -99,6 +99,22 @@ class TestSlideshowBuilderRoutes:
             block = resp.text[start:start + 400]
             assert "z-index: 2" in block, f"{cls} missing z-index above blur fg"
 
+    async def test_visibility_block_has_quick_fill_chips(self, client):
+        """The per-slide Visibility block offers scheduler-style quick-fill
+        chips: a "Now" chip for the time-of-day Start and a "Today" chip for
+        the date-range Start, each wired to a handler."""
+        resp = await client.get("/assets/new/slideshow")
+        assert resp.status_code == 200, resp.text
+        # Chip buttons in visibilityCtlHtml.
+        assert "ssb-vis-now-btn" in resp.text
+        assert "ssb-vis-today-btn" in resp.text
+        # Click handlers wired in wireVisibilityCtls.
+        assert "setSlideVisNow(i)" in resp.text
+        assert "setSlideVisToday(i)" in resp.text
+        # "Set to now" seeds End +1h ONLY when End is empty (open-ended
+        # windows typed by hand stay open).
+        assert "if (!s.active_end)" in resp.text
+
     async def test_create_mode_preview_btn_hidden_until_mint(self, client):
         """Bug: AI-assistant slideshow create left the page in create-mode
         chrome — Create button never flipped to Save and no Preview button


### PR DESCRIPTION
## What

Adds scheduler-style **quick-fill chips** to the per-slide **Visibility** block in the slideshow builder, matching the convenience features the schedule edit modal already has.

- **⏱ Now** chip beside the *Time of day* Start input → fills it with the current browser-local time. End is auto-seeded to **Start + 1h _only when End is empty_**, so a hand-typed open-ended (until-midnight) window is preserved. A start near midnight wraps End past 00:00 — a valid overnight window the resolver already honors.
- **📅 Today** chip beside the *Date range* Start input → fills it with today's local date, leaving End open (`from today onward`); End is pulled up to today only if it would otherwise be an impossible past range.

## Why

User asked to bring the scheduler modal's "set time to now / set date to today / auto-advance end" helpers into the slideshow visibility editor.

## Timezone note

The visibility block has no timezone selector — windows are evaluated in **device-local** time server-side (unchanged). The chips use the **author's browser clock** purely as a convenience for entering a value; they don't change how the window is interpreted.

## Scope

Template + CSS only (`cms/templates/slideshow_builder.html`). No server, schema, or window-resolver changes. Default render of an untouched slide is unchanged.

## Tests

- New `test_visibility_block_has_quick_fill_chips` pins the chip markup + `setSlideVisNow` / `setSlideVisToday` handlers + the "seed End only when empty" guard.
- `tests/test_slideshow_builder_ui.py` — **30 passed** locally.

Goodwill dev only.
