### PR TITLE
feat: hybrid light theme (Auto/Light/Dark)

### DIFF
--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1,20 +1,114 @@
+/* ──────────────────────────────────────────────────────────────────────
+   Theme tokens.
+
+   :root holds the DARK theme (the historical default — values are
+   unchanged). The light palette lives in two places that share the same
+   token values:
+     • :root[data-theme="light"]  — user explicitly chose Light.
+     • @media (prefers-color-scheme: light) on :root:not([data-theme="dark"])
+       — user is on "Auto" (no explicit choice / data-theme="auto") and
+       their OS prefers light.
+   An explicit data-theme="dark" always wins over the OS preference.
+
+   When adding a themeable colour, add a token here AND a light override in
+   BOTH light blocks below. Brand colours that read well on any background
+   (--accent, --primary used as a chip background, --text-on-accent) are
+   intentionally theme-invariant.
+   ────────────────────────────────────────────────────────────────────── */
 :root {
     --bg: #1a1a2e;
     --surface: #16213e;
+    --surface-alt: #1e2d50;
+    --surface-2: rgba(0,0,0,0.06);
+    --card-bg: var(--surface);
     --primary: #0f3460;
     --accent: #e94560;
     --accent-hover: #d63050;
     --text: #eee;
     --text-muted: #999;
-    --surface-alt: #1e2d50;
+    --text-on-accent: #fff;
     --success: #2ecc71;
     --warning: #f39c12;
     --danger: #e74c3c;
     --radius: 8px;
     --border: #0f3460;
     --select-bg: var(--bg);
-    --select-border: var(--primary);
+    --select-border: var(--border);
+    --color-scheme: dark;
+    /* Translucent overlays (lighten-on-hover, subtle tints, raised borders).
+       Dark theme layers white at low alpha; light theme layers black. */
+    --overlay-hover: rgba(255,255,255,0.08);
+    --overlay-subtle: rgba(255,255,255,0.04);
+    --overlay-faint: rgba(255,255,255,0.03);
+    --overlay-faintest: rgba(255,255,255,0.02);
+    --overlay-border: rgba(255,255,255,0.05);
+    --overlay-strong: rgba(255,255,255,0.25);
+    --overlay-row: rgba(255,255,255,0.05);
+    --overlay-row-hover: rgba(255,255,255,0.09);
+    --overlay-img-border: rgba(255,255,255,0.18);
+    /* Neutral elevation shadows. */
+    --shadow-sm: 0 4px 16px rgba(0,0,0,0.3);
+    --shadow-md: 0 8px 24px rgba(0,0,0,0.4);
+    --shadow-lg: 0 8px 32px rgba(0,0,0,0.4);
 }
+
+/* Light palette — keep these two blocks in sync. */
+:root[data-theme="light"] {
+    --bg: #f4f5f8;
+    --surface: #ffffff;
+    --surface-alt: #eceef3;
+    --surface-2: rgba(0,0,0,0.05);
+    --text: #1b2333;
+    --text-muted: #5b6472;
+    --success: #1e9e57;
+    --warning: #b9770e;
+    --danger: #c0392b;
+    --border: #d6dae2;
+    --select-bg: #ffffff;
+    --color-scheme: light;
+    --overlay-hover: rgba(0,0,0,0.06);
+    --overlay-subtle: rgba(0,0,0,0.04);
+    --overlay-faint: rgba(0,0,0,0.03);
+    --overlay-faintest: rgba(0,0,0,0.02);
+    --overlay-border: rgba(0,0,0,0.08);
+    --overlay-strong: rgba(0,0,0,0.12);
+    --overlay-row: rgba(0,0,0,0.03);
+    --overlay-row-hover: rgba(0,0,0,0.06);
+    --overlay-img-border: rgba(0,0,0,0.15);
+    --shadow-sm: 0 4px 16px rgba(0,0,0,0.10);
+    --shadow-md: 0 8px 24px rgba(0,0,0,0.12);
+    --shadow-lg: 0 8px 32px rgba(0,0,0,0.14);
+}
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]):not([data-theme="light"]) {
+        --bg: #f4f5f8;
+        --surface: #ffffff;
+        --surface-alt: #eceef3;
+        --surface-2: rgba(0,0,0,0.05);
+        --text: #1b2333;
+        --text-muted: #5b6472;
+        --success: #1e9e57;
+        --warning: #b9770e;
+        --danger: #c0392b;
+        --border: #d6dae2;
+        --select-bg: #ffffff;
+        --color-scheme: light;
+        --overlay-hover: rgba(0,0,0,0.06);
+        --overlay-subtle: rgba(0,0,0,0.04);
+        --overlay-faint: rgba(0,0,0,0.03);
+        --overlay-faintest: rgba(0,0,0,0.02);
+        --overlay-border: rgba(0,0,0,0.08);
+        --overlay-strong: rgba(0,0,0,0.12);
+        --overlay-row: rgba(0,0,0,0.03);
+        --overlay-row-hover: rgba(0,0,0,0.06);
+        --overlay-img-border: rgba(0,0,0,0.15);
+        --shadow-sm: 0 4px 16px rgba(0,0,0,0.10);
+        --shadow-md: 0 8px 24px rgba(0,0,0,0.12);
+        --shadow-lg: 0 8px 32px rgba(0,0,0,0.14);
+    }
+}
+
+html { color-scheme: var(--color-scheme); }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -27,7 +121,7 @@ select {
     padding: 0.4rem 1.8rem 0.4rem 0.5rem;
     font-size: 0.9rem;
     cursor: pointer;
-    color-scheme: dark;
+    color-scheme: var(--color-scheme);
     -webkit-appearance: none;
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
@@ -52,7 +146,7 @@ body {
 /* Navigation */
 header {
     background: var(--surface);
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
     padding: 1rem 1.5rem;
     display: flex;
     justify-content: space-between;
@@ -138,8 +232,14 @@ header {
 }
 .header-icon:hover {
     color: var(--text);
-    background: rgba(255,255,255,0.08);
+    background: var(--overlay-hover);
 }
+
+/* Theme toggle: show only the icon for the current mode. */
+#theme-toggle .ti { display: none; }
+#theme-toggle[data-mode="auto"] .ti-auto { display: block; }
+#theme-toggle[data-mode="light"] .ti-light { display: block; }
+#theme-toggle[data-mode="dark"] .ti-dark { display: block; }
 
 /* ── Notification bell ── */
 .notification-bell-wrapper {
@@ -169,9 +269,9 @@ header {
     width: 380px;
     max-height: 450px;
     background: var(--surface);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: var(--radius);
-    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    box-shadow: var(--shadow-md);
     z-index: 1000;
     overflow: hidden;
 }
@@ -180,7 +280,7 @@ header {
     justify-content: space-between;
     align-items: center;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
 }
 .notification-panel-actions { display: flex; gap: 0.4rem; }
 .btn-danger-subtle { color: var(--danger); border-color: var(--danger); }
@@ -191,12 +291,12 @@ header {
 }
 .notification-item {
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid rgba(255,255,255,0.05);
+    border-bottom: 1px solid var(--overlay-row);
     cursor: pointer;
     transition: background 0.15s;
     position: relative;
 }
-.notification-item:hover { background: rgba(255,255,255,0.04); }
+.notification-item:hover { background: var(--overlay-subtle); }
 .notification-item.unread { border-left: 3px solid var(--accent); }
 .notification-item.notif-error .notif-title { color: var(--danger); }
 .notification-item.notif-warning .notif-title { color: var(--warning); }
@@ -216,7 +316,7 @@ header {
 
 nav {
     background: var(--surface);
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
     padding: 0 1.5rem;
     display: flex;
     align-items: center;
@@ -250,7 +350,7 @@ nav {
     display: flex;
     gap: 0.25rem;
     margin-bottom: 1.5rem;
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
 }
 .sub-tab {
     padding: 0.5rem 1rem;
@@ -285,8 +385,8 @@ h2 { font-size: 1.2rem; margin-bottom: 1rem; }
     overflow: visible;
 }
 .card-highlight {
-    border: 1px solid rgba(255,255,255,0.25);
-    background: linear-gradient(135deg, var(--surface) 0%, rgba(255,255,255,0.04) 100%);
+    border: 1px solid var(--overlay-strong);
+    background: linear-gradient(135deg, var(--surface) 0%, var(--overlay-subtle) 100%);
 }
 .card-playing {
     border: 1px solid var(--success);
@@ -337,7 +437,7 @@ table {
 th, td {
     text-align: left;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
     white-space: nowrap;
 }
 td.wrap { white-space: normal; word-break: break-word; }
@@ -347,7 +447,7 @@ th {
     color: var(--text-muted);
     font-weight: 600;
 }
-tr:hover td { background: rgba(255,255,255,0.02); }
+tr:hover td { background: var(--overlay-faintest); }
 
 /* Status badges */
 .badge {
@@ -364,14 +464,14 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .badge-offline { background: #7f8c8d; color: #fff; }
 .badge-online { background: var(--success); color: #000; }
 .badge-splash { background: #f39c12; color: #000; }
-.badge-video { background: var(--primary); color: var(--text); }
-.badge-image { background: #8e44ad; color: var(--text); }
-.badge-webpage { background: #2980b9; color: var(--text); }
-.badge-stream { background: #e67e22; color: var(--text); }
-.badge-saved_stream { background: #d35400; color: var(--text); }
-.badge-slideshow { background: #16a085; color: var(--text); }
-.badge-composed { background: #6366f1; color: var(--text); }
-.badge-builtin { background: var(--primary); color: var(--text); font-size: 0.65rem; margin-left: 0.3rem; vertical-align: middle; }
+.badge-video { background: var(--primary); color: var(--text-on-accent); }
+.badge-image { background: #8e44ad; color: var(--text-on-accent); }
+.badge-webpage { background: #2980b9; color: var(--text-on-accent); }
+.badge-stream { background: #e67e22; color: var(--text-on-accent); }
+.badge-saved_stream { background: #d35400; color: var(--text-on-accent); }
+.badge-slideshow { background: #16a085; color: var(--text-on-accent); }
+.badge-composed { background: #6366f1; color: var(--text-on-accent); }
+.badge-builtin { background: var(--primary); color: var(--text-on-accent); font-size: 0.65rem; margin-left: 0.3rem; vertical-align: middle; }
 .badge-processing { background: #3498db; color: #fff; margin-left: 0.4rem; }
 /* Progress-fill badge: darker "filled" region on the left grows to the
  * right as --pct advances, while the right side stays the base blue.
@@ -475,7 +575,7 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .btn-success { background: var(--success); color: #000; }
 .btn-danger { background: var(--danger); color: #fff; }
 .btn-warn { background: var(--warning); color: #000; }
-.btn-secondary { background: var(--primary); color: var(--text); }
+.btn-secondary { background: var(--primary); color: var(--text-on-accent); }
 .btn-sm { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
 .btn:disabled, .btn[disabled] { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 .inline-edit { background-color: var(--select-bg); border: 1px solid var(--select-border); color: var(--text); padding: 0.2rem 0.4rem; border-radius: var(--radius); width: 100%; font-size: 0.9rem; min-width: 8rem; }
@@ -483,7 +583,7 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .inline-edit:focus { border-color: var(--accent); outline: none; }
 select.inline-edit { width: 100%; min-width: 8rem; }
 select.inline-edit:hover { border-color: var(--accent); }
-.btn-small { padding: 0.25rem 0.5rem; font-size: 0.75rem; border: none; border-radius: var(--radius); cursor: pointer; background: var(--primary); color: var(--text); }
+.btn-small { padding: 0.25rem 0.5rem; font-size: 0.75rem; border: none; border-radius: var(--radius); cursor: pointer; background: var(--primary); color: var(--text-on-accent); }
 .btn-small:hover { opacity: 0.85; }
 .btn-small.btn-warn { background: var(--warning); color: #000; }
 .btn-small.btn-danger { background: var(--danger); color: #fff; }
@@ -517,7 +617,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     border: 1px solid var(--select-border);
     border-radius: var(--radius);
     font-size: 0.9rem;
-    color-scheme: dark;
+    color-scheme: var(--color-scheme);
 }
 .form-group select {
     padding-right: 1.8rem;
@@ -530,7 +630,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     border: 1px solid var(--select-border);
     border-radius: var(--radius);
     font-size: 0.9rem;
-    color-scheme: dark;
+    color-scheme: var(--color-scheme);
 }
 .form-group input[type="time"],
 .form-group input[type="number"] {
@@ -635,7 +735,7 @@ select.inline-edit:hover { border-color: var(--accent); }
 
 /* Upload */
 .upload-area {
-    border: 2px dashed var(--primary);
+    border: 2px dashed var(--border);
     border-radius: var(--radius);
     padding: 2rem;
     text-align: center;
@@ -701,12 +801,12 @@ select.inline-edit:hover { border-color: var(--accent); }
 
 .modal-box {
     background: var(--surface);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: var(--radius);
     padding: 1.5rem;
     min-width: 320px;
     max-width: 440px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--shadow-lg);
 }
 
 .modal-box p {
@@ -719,7 +819,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     padding: 0.5rem 0.75rem;
     margin-bottom: 1.25rem;
     background: var(--bg);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
     font-size: 0.95rem;
@@ -753,7 +853,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     justify-content: space-between;
     align-items: center;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
     font-size: 0.9rem;
     color: var(--text-muted);
 }
@@ -808,7 +908,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     width: calc(100% - 8px) !important;
     height: calc(100% - 8px) !important;
     object-fit: cover;
-    border: 1px solid rgba(255, 255, 255, 0.18);
+    border: 1px solid var(--overlay-img-border);
     border-radius: 3px;
     box-shadow: 4px 4px 0 0 #2c2c2c, 8px 8px 0 0 #1c1c1c;
 }
@@ -833,7 +933,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     min-width: 280px;
     max-width: 480px;
     background: var(--surface);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: var(--radius);
     padding: 0.85rem 1rem 0.85rem 1rem;
     color: var(--text);
@@ -841,7 +941,7 @@ select.inline-edit:hover { border-color: var(--accent); }
     display: flex;
     align-items: center;
     gap: 0.65rem;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--shadow-sm);
     z-index: 1001;
     animation: slideUp 0.2s ease, fadeOut 0.3s ease 2.7s forwards;
 }
@@ -964,13 +1064,13 @@ tr.highlight-new td {
 
 /* Expandable device rows */
 .device-row { cursor: pointer; }
-.device-row:hover td { background: rgba(255,255,255,0.04); }
+.device-row:hover td { background: var(--overlay-subtle); }
 
 /* Expandable asset rows */
 .asset-row { cursor: pointer; }
-.asset-row:hover td { background: rgba(255,255,255,0.04); }
+.asset-row:hover td { background: var(--overlay-subtle); }
 .asset-row.expanded .expand-toggle { transform: rotate(90deg); display: inline-block; }
-.asset-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
+.asset-detail td { border-bottom: 1px solid var(--border); padding: 0 1rem 1rem; }
 .asset-detail td:first-child { padding: 0; }
 .variants-table { width: 100%; border-collapse: collapse; }
 .variants-table th { text-align: left; font-size: 0.75rem; text-transform: uppercase; color: var(--text-muted); font-weight: 600; padding: 0.35rem 0.5rem; border-bottom: 1px solid var(--border); }
@@ -984,10 +1084,10 @@ tr.highlight-new td {
     user-select: none;
 }
 .device-row.expanded .expand-toggle { transform: rotate(90deg); display: inline-block; }
-.device-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
+.device-detail td { border-bottom: 1px solid var(--border); padding: 0 1rem 1rem; }
 .device-detail td:first-child { padding: 0; }
 .audit-row { cursor: pointer; }
-.audit-row:hover td { background: rgba(255,255,255,0.04); }
+.audit-row:hover td { background: var(--overlay-subtle); }
 .audit-row.expanded .expand-toggle { transform: rotate(90deg); display: inline-block; }
 /* Description cell: ellipsise long text; full text shown via title= and
    in the expanded row's Description detail-item. */
@@ -997,11 +1097,11 @@ tr.highlight-new td {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-.audit-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
+.audit-detail td { border-bottom: 1px solid var(--border); padding: 0 1rem 1rem; }
 .audit-detail td:first-child { padding: 0; }
 /* Event log table — same expand/detail pattern as audit log. */
 .event-row { cursor: pointer; }
-.event-row:hover td { background: rgba(255,255,255,0.04); }
+.event-row:hover td { background: var(--overlay-subtle); }
 .event-row.expanded .expand-toggle { transform: rotate(90deg); display: inline-block; }
 .event-description { overflow: hidden; }
 .event-description > div {
@@ -1009,7 +1109,7 @@ tr.highlight-new td {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-.event-detail td { border-bottom: 1px solid var(--primary); padding: 0 1rem 1rem; }
+.event-detail td { border-bottom: 1px solid var(--border); padding: 0 1rem 1rem; }
 .event-detail td:first-child { padding: 0; }
 /* Diff table inside the expand panel — field | from → to */
 .audit-changes {
@@ -1029,7 +1129,7 @@ tr.highlight-new td {
 .audit-changes .diff-old { color: var(--text-muted); text-decoration: line-through; }
 .audit-changes .diff-new { color: var(--text); font-weight: 500; }
 .audit-json {
-    background: var(--bg-dark, #1a1a2e);
+    background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.75rem 1rem;
@@ -1083,11 +1183,11 @@ tr.highlight-new td {
        a translucent white overlay. Matches the standard light-border
        contrast pattern (see .card-highlight). */
     background:
-        linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.08)),
+        linear-gradient(var(--overlay-hover), var(--overlay-hover)),
         var(--surface);
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    border: 1px solid var(--overlay-strong);
     border-radius: 0.5rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+    box-shadow: var(--shadow-md);
     display: none;
     flex-direction: column;
     min-width: 10rem;
@@ -1097,14 +1197,14 @@ tr.highlight-new td {
 }
 .group-popup[popover]:popover-open { display: flex; }
 .group-popup-item { background: none; border: none; color: var(--text); cursor: pointer; padding: 0.4rem 0.75rem; text-align: left; font-size: 0.85rem; white-space: nowrap; }
-.group-popup-item:hover { background: var(--primary); color: #fff; }
+.group-popup-item:hover { background: var(--primary); color: var(--text-on-accent); }
 .detail-toolbar { padding: 0.75rem 0 0; margin-top: 0.25rem; display: flex; align-items: center; gap: 0.75rem; }
 
 /* Group panels */
-.group-panel { border: 1px solid var(--primary); border-radius: var(--radius); margin-bottom: 0.75rem; overflow: visible; transition: border-color 0.2s; }
+.group-panel { border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 0.75rem; overflow: visible; transition: border-color 0.2s; }
 .group-panel.drag-over { border-color: var(--accent); background: rgba(233,69,96,0.05); }
 .group-header { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; cursor: pointer; user-select: none; }
-.group-header:hover { background: rgba(255,255,255,0.03); }
+.group-header:hover { background: var(--overlay-faint); }
 .group-header .expand-toggle { font-size: 0.7rem; transition: transform 0.15s; }
 .group-panel.expanded .group-header .expand-toggle { transform: rotate(90deg); display: inline-block; }
 /* #569: more pronounced device-group child indent + faded chevron + row
@@ -1135,15 +1235,15 @@ tr.highlight-new td {
    relatively-positioned <tr>. Avoids the "darker stripe in the first
    2.5rem" double-tint that happens if both the chevron td and the
    adjacent in-flow td paint their own backgrounds at the same alpha. */
-.group-panel .device-row { background: rgba(255,255,255,0.05); }
-.group-panel .device-row:hover { background: rgba(255,255,255,0.09); }
+.group-panel .device-row { background: var(--overlay-row); }
+.group-panel .device-row:hover { background: var(--overlay-row-hover); }
 /* Neutralize the global `.device-row:hover td` rule (line ~895) inside
    group panels. Without this, in-flow tds would stack their own 0.04
    tint on top of the row's hover tint, producing a darker band on every
    cell except the absolutely-positioned chevron td (which isn't covered
    by the global rule). Row-level hover is sufficient here. */
 .group-panel .device-row:hover td { background: transparent; }
-.group-header .badge-count { font-size: 0.75rem; background: var(--primary); color: var(--text); padding: 0.15rem 0.5rem; border-radius: 10px; }
+.group-header .badge-count { font-size: 0.75rem; background: var(--primary); color: var(--text-on-accent); padding: 0.15rem 0.5rem; border-radius: 10px; }
 .group-actions { margin-left: auto; display: flex; align-items: center; gap: 0.5rem; }
 .group-actions .btn-sm { font-size: 0.9rem; }
 .inline-label { font-size: 0.9rem; color: var(--text-muted); white-space: nowrap; }
@@ -1294,7 +1394,7 @@ tr.highlight-new td {
 .sub-tab {
     padding: 0.5rem 1.2rem;
     background: var(--surface);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-bottom: none;
     color: var(--text-muted);
     cursor: pointer;
@@ -1305,7 +1405,7 @@ tr.highlight-new td {
 .sub-tab:last-child  { border-radius: 0 6px 0 0; }
 .sub-tab.active {
     background: var(--primary);
-    color: var(--text);
+    color: var(--text-on-accent);
     font-weight: 600;
 }
 .sub-tab:hover:not(.active) { background: rgba(15, 52, 96, 0.5); }
@@ -1374,12 +1474,12 @@ tr.highlight-new td {
 
 .permissions-table td {
     padding: 0.35rem 0.6rem;
-    border-bottom: 1px solid rgba(255,255,255,0.04);
+    border-bottom: 1px solid var(--overlay-subtle);
     vertical-align: middle;
 }
 
 .permissions-table tbody tr:hover {
-    background: rgba(255,255,255,0.03);
+    background: var(--overlay-faint);
 }
 
 .permissions-table input[type="checkbox"] {
@@ -1393,8 +1493,8 @@ tr.highlight-new td {
     font-size: 0.78rem;
     font-family: monospace;
     background: rgba(15, 52, 96, 0.6);
-    color: var(--text);
-    border: 1px solid var(--primary);
+    color: var(--text-on-accent);
+    border: 1px solid var(--border);
 }
 
 /* ── Collapsible permission groups ── */
@@ -1409,16 +1509,16 @@ tr.highlight-new td {
 .btn-xs {
     padding: 0.15rem 0.45rem;
     font-size: 0.72rem;
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: var(--radius);
     background: transparent;
     color: var(--text-muted);
     cursor: pointer;
 }
-.btn-xs:hover { background: var(--primary); color: var(--text); }
+.btn-xs:hover { background: var(--primary); color: var(--text-on-accent); }
 
 .perm-group {
-    border: 1px solid rgba(255,255,255,0.08);
+    border: 1px solid var(--overlay-hover);
     border-radius: 6px;
     margin-bottom: 0.35rem;
     background: rgba(22, 33, 62, 0.3);
@@ -1462,7 +1562,7 @@ tr.highlight-new td {
 .role-card {
     padding: 0.8rem;
     margin-bottom: 0.6rem;
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border);
     border-radius: 6px;
     background: rgba(22, 33, 62, 0.4);
 }
@@ -1584,7 +1684,7 @@ tr.highlight-new td {
     align-items: center;
     margin-bottom: 1rem;
     padding-bottom: 0.6rem;
-    border-bottom: 1px solid var(--primary);
+    border-bottom: 1px solid var(--border);
 }
 .modal-header h3 { margin: 0; }
 .modal-close {
@@ -1602,7 +1702,7 @@ tr.highlight-new td {
     gap: 0.5rem;
     margin-top: 1rem;
     padding-top: 0.8rem;
-    border-top: 1px solid var(--primary);
+    border-top: 1px solid var(--border);
 }
 
 
@@ -1667,11 +1767,11 @@ textarea:not(:-webkit-autofill) {
        --primary so would disappear against the page; use the standard
        light-contrast border token instead (matches .card-highlight). */
     background:
-        linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.08)),
+        linear-gradient(var(--overlay-hover), var(--overlay-hover)),
         var(--surface);
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    border: 1px solid var(--overlay-strong);
     border-radius: var(--radius);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    box-shadow: var(--shadow-md);
     padding: 0.25rem;
     display: flex;
     flex-direction: column;

--- a/cms/templates/_assistant_drawer.html
+++ b/cms/templates/_assistant_drawer.html
@@ -23,7 +23,7 @@
         width: min(380px, calc(100vw - 2rem));
         height: min(540px, calc(100vh - 6rem));
         display: flex; flex-direction: column;
-        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        border: 1px solid var(--border, var(--overlay-img-border));
         border-radius: 12px; overflow: hidden;
         background: var(--surface, #1a1a2e); color: var(--text, #e6e6e6);
         box-shadow: 0 10px 34px rgba(0,0,0,0.45);
@@ -32,7 +32,7 @@
     #cw-ai-head {
         display: flex; align-items: center; justify-content: space-between;
         padding: 0.6rem 0.85rem;
-        border-bottom: 1px solid var(--border, rgba(255,255,255,0.18));
+        border-bottom: 1px solid var(--border, var(--overlay-img-border));
         background: var(--surface-alt, #16213e);
     }
     #cw-ai-close {
@@ -46,7 +46,7 @@
     .cw-ai-hint { color: var(--text-muted, #b3b3c0); font-size: 0.82rem; }
     .cw-ai-msg { padding: 0.5rem 0.7rem; border-radius: 10px; max-width: 90%; white-space: pre-wrap; word-wrap: break-word; }
     .cw-ai-msg.user { align-self: flex-end; background: var(--primary, #2563eb); color: #fff; }
-    .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, rgba(255,255,255,0.18)); }
+    .cw-ai-msg.assistant { align-self: flex-start; background: var(--surface-alt, #16213e); border: 1px solid var(--border, var(--overlay-img-border)); }
     .cw-ai-msg.tool { align-self: flex-start; font-size: 0.78rem; color: var(--text-muted, #b3b3c0); font-style: italic; padding: 0.2rem 0.5rem; }
     .cw-ai-msg.error { align-self: flex-start; background: #fee2e2; color: #991b1b; }
     /* Rendered Markdown (assistant replies). Drop pre-wrap so marked's
@@ -59,15 +59,15 @@
     .cw-ai-msg.is-markdown ul, .cw-ai-msg.is-markdown ol { margin: 0 0 0.5rem 1.15rem; padding: 0; }
     .cw-ai-msg.is-markdown li { margin: 0.1rem 0; }
     .cw-ai-msg.is-markdown strong { font-weight: 700; }
-    .cw-ai-msg.is-markdown code { background: rgba(255,255,255,0.12); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
+    .cw-ai-msg.is-markdown code { background: var(--overlay-strong); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
     .cw-ai-msg.is-markdown a { color: var(--accent, #60a5fa); }
     #cw-ai-form {
         display: flex; gap: 0.5rem; padding: 0.6rem;
-        border-top: 1px solid var(--border, rgba(255,255,255,0.18));
+        border-top: 1px solid var(--border, var(--overlay-img-border));
     }
     #cw-ai-input {
         flex: 1; resize: none; padding: 0.5rem; border-radius: 8px;
-        border: 1px solid var(--border, rgba(255,255,255,0.18));
+        border: 1px solid var(--border, var(--overlay-img-border));
         background: var(--bg, #0f0f1a); color: var(--text, #e6e6e6); font: inherit;
     }
     #cw-ai-send:disabled { opacity: 0.55; cursor: progress; }

--- a/cms/templates/_components/asset_filter_bar.html
+++ b/cms/templates/_components/asset_filter_bar.html
@@ -35,7 +35,7 @@
     is_admin=False,
     search_placeholder="Search name / filename…"
 ) %}
-<div id="{{ prefix }}-bar" class="asset-filter-bar" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; margin-top:0.75rem; padding:0.5rem; background:var(--bg-subtle, rgba(255,255,255,0.03)); border-radius:4px;">
+<div id="{{ prefix }}-bar" class="asset-filter-bar" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; margin-top:0.75rem; padding:0.5rem; background:var(--bg-subtle, var(--overlay-faint)); border-radius:4px;">
     <input type="search" id="{{ prefix }}-q" placeholder="{{ search_placeholder }}"
            style="flex:1 1 220px; min-width:180px; max-width:360px; padding:0.4rem 0.65rem; font-size:0.88rem;"
            autocomplete="off" spellcheck="false">

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -184,7 +184,7 @@
                     <button type="button" class="asset-add-tag-btn" data-asset-id="{{ a.id }}"
                             onclick="event.stopPropagation(); window._assetLibrary && window._assetLibrary.openRowAddTagPicker('{{ a.id }}', event)"
                             title="Add tag"
-                            style="margin-left:0.35rem; background:transparent; color:var(--text-muted, #999); border:1px dashed rgba(255,255,255,0.25); font-size:0.7rem; padding:0.02rem 0.4rem; border-radius:999px; cursor:pointer; line-height:1.4; vertical-align:middle;">+ tag</button>
+                            style="margin-left:0.35rem; background:transparent; color:var(--text-muted, #999); border:1px dashed var(--overlay-strong); font-size:0.7rem; padding:0.02rem 0.4rem; border-radius:999px; cursor:pointer; line-height:1.4; vertical-align:middle;">+ tag</button>
                     {% endif %}
                     {% if a.uploaded_by_user_id and uploader_map.get(a.uploaded_by_user_id | string) %}
                     <div class="text-muted" style="font-size:0.75rem; margin-top:0.15rem;">by {{ uploader_map[a.uploaded_by_user_id | string] }}</div>

--- a/cms/templates/assets.html
+++ b/cms/templates/assets.html
@@ -176,7 +176,7 @@
                     <div id="views-menu-list" style="max-height:280px; overflow-y:auto;">
                         <!-- populated by JS -->
                     </div>
-                    <div style="border-top:1px solid rgba(255,255,255,0.08); margin-top:0.35rem; padding-top:0.35rem;">
+                    <div style="border-top:1px solid var(--overlay-hover); margin-top:0.35rem; padding-top:0.35rem;">
                         <button type="button" class="btn btn-link btn-sm" style="width:100%; text-align:left; padding:0.4rem 0.75rem; background:none; border:0; color:var(--text); cursor:pointer;"
                                 onclick="window._assetLibrary && window._assetLibrary.openSaveViewModal()">&#x2795; Save current as view&hellip;</button>
                         <button type="button" class="btn btn-link btn-sm" id="views-manage-btn" style="display:none; width:100%; text-align:left; padding:0.4rem 0.75rem; background:none; border:0; color:var(--text); cursor:pointer;"
@@ -336,7 +336,7 @@
             <div id="tag-manager-list" style="max-height:360px; overflow-y:auto; margin-bottom:0.75rem;">
                 <!-- populated by JS -->
             </div>
-            <div style="border-top:1px solid rgba(255,255,255,0.08); padding-top:0.75rem;">
+            <div style="border-top:1px solid var(--overlay-hover); padding-top:0.75rem;">
                 <label style="display:block; margin-bottom:0.3rem; font-size:0.85rem; color:var(--text-muted);">Create new tag</label>
                 <div style="display:flex; gap:0.5rem; align-items:center;">
                     <input type="text" id="new-tag-name" placeholder="Tag name" maxlength="64"
@@ -1366,7 +1366,7 @@ function fallbackCopy(text, onSuccess) {
         const card = document.createElement('div');
         card.className = 'asset-grid-card';
         card.setAttribute('data-grid-card', a.id);
-        card.style.cssText = 'border:1px solid var(--border, #444); border-radius:6px; overflow:hidden; background:var(--bg-card, #1a1a1a); position:relative;';
+        card.style.cssText = 'border:1px solid var(--border); border-radius:6px; overflow:hidden; background:var(--surface); position:relative;';
         const name = a.display_name || a.original_filename || a.filename;
         const tags = Array.isArray(a.tags) ? a.tags : [];
         const tagChipsHtml = tags.length
@@ -1698,7 +1698,7 @@ function fallbackCopy(text, onSuccess) {
             const safeName = v.name.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
             return '<button type="button" class="views-menu-item" data-view-id="' + v.id + '"'
                 + ' style="display:flex; width:100%; align-items:center; padding:0.4rem 0.75rem; background:none; border:0; color:var(--text); cursor:pointer; text-align:left; font-size:0.9rem;"'
-                + ' onmouseover="this.style.background=\'rgba(255,255,255,0.06)\'" onmouseout="this.style.background=\'none\'"'
+                + ' onmouseover="this.style.background=\'var(--overlay-hover)\'" onmouseout="this.style.background=\'none\'"'
                 + ' onclick="window._assetLibrary && window._assetLibrary.applyView(\'' + v.id + '\')">'
                 + star + '<span style="flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">' + safeName + '</span></button>';
         }).join('');
@@ -1799,7 +1799,7 @@ function fallbackCopy(text, onSuccess) {
         }
         const rows = state.views.map(v => {
             const safeName = v.name.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            return '<div data-view-id="' + v.id + '" style="display:flex; align-items:center; gap:0.5rem; padding:0.5rem 0.25rem; border-bottom:1px solid rgba(255,255,255,0.06);">'
+            return '<div data-view-id="' + v.id + '" style="display:flex; align-items:center; gap:0.5rem; padding:0.5rem 0.25rem; border-bottom:1px solid var(--overlay-hover);">'
                 + '<input type="radio" name="default-view-radio" ' + (v.is_default ? 'checked' : '')
                 + ' onchange="window._assetLibrary && window._assetLibrary.setDefaultView(\'' + v.id + '\')" title="Set as default">'
                 + '<input type="text" class="manage-view-name" value="' + safeName.replace(/"/g, '&quot;') + '" maxlength="80"'
@@ -2204,7 +2204,7 @@ function fallbackCopy(text, onSuccess) {
             // JSON.stringify emits, otherwise inline onclick="..." breaks.
             const _attr = (s) => JSON.stringify(s).replace(/"/g, '&quot;');
             list.innerHTML = tags.map(t =>
-                '<div class="tag-mgr-row" style="display:flex; align-items:center; gap:0.4rem; padding:0.35rem 0.2rem; border-bottom:1px solid rgba(255,255,255,0.06);">' +
+                '<div class="tag-mgr-row" style="display:flex; align-items:center; gap:0.4rem; padding:0.35rem 0.2rem; border-bottom:1px solid var(--overlay-hover);">' +
                     '<input type="color" value="' + _escHtml(t.color) + '" title="Color" ' +
                         'onchange="window._assetLibrary && window._assetLibrary.recolorTag(\'' + _escHtml(t.id) + '\', this.value)" ' +
                         'style="width:1.8rem; height:1.6rem; padding:0; border:none; background:transparent; flex:0 0 auto; cursor:pointer;">' +

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -6,6 +6,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Agora CMS{% endblock %}</title>
+    {# Apply the saved theme before the stylesheet loads to avoid a flash of
+       the wrong theme. "auto" (or no saved value) falls back to the OS
+       preference via the prefers-color-scheme media query in style.css. #}
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('agora-theme');
+            document.documentElement.setAttribute(
+                'data-theme', (t === 'light' || t === 'dark') ? t : 'auto');
+        } catch (e) {
+            document.documentElement.setAttribute('data-theme', 'auto');
+        }
+    })();
+    </script>
     <link rel="stylesheet" href="/static/style.css?v={{ static_version }}">
 </head>
 <body>
@@ -38,6 +52,12 @@
             </span>
             {% endif %}
             {% endif %}
+            <button type="button" class="header-icon has-tooltip" id="theme-toggle" data-mode="auto" aria-label="Theme">
+                <svg class="ti ti-auto" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 3v18" fill="currentColor" stroke="none"/><path d="M12 3a9 9 0 0 0 0 18z" fill="currentColor" stroke="none"/></svg>
+                <svg class="ti ti-light" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4.5"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="ti ti-dark" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <span class="tooltip">Theme</span>
+            </button>
             <div class="notification-bell-wrapper" id="notification-bell-wrapper">
                 <button class="header-icon" id="notification-bell" aria-label="Notifications" onclick="toggleNotificationPanel()">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
@@ -120,6 +140,40 @@
     <script src="/static/asset_filter.js?v={{ static_version }}"></script>
     <script src="/static/app.js?v={{ static_version }}"></script>
     <script>
+    /* ── Theme toggle (Auto / Light / Dark) ── */
+    (function () {
+        var btn = document.getElementById('theme-toggle');
+        if (!btn) return;
+        var root = document.documentElement;
+        var order = ['auto', 'light', 'dark'];
+        var labels = {
+            auto: 'Theme: Auto (follows system)',
+            light: 'Theme: Light',
+            dark: 'Theme: Dark',
+        };
+        function current() {
+            var t = null;
+            try { t = localStorage.getItem('agora-theme'); } catch (e) { /* ignore */ }
+            return (t === 'light' || t === 'dark') ? t : 'auto';
+        }
+        function apply(mode) {
+            root.setAttribute('data-theme', mode);
+            btn.setAttribute('data-mode', mode);
+            var tip = btn.querySelector('.tooltip');
+            if (tip) tip.textContent = labels[mode];
+            btn.setAttribute('aria-label', labels[mode]);
+        }
+        apply(current());
+        btn.addEventListener('click', function () {
+            var next = order[(order.indexOf(current()) + 1) % order.length];
+            try {
+                if (next === 'auto') localStorage.removeItem('agora-theme');
+                else localStorage.setItem('agora-theme', next);
+            } catch (e) { /* ignore */ }
+            apply(next);
+        });
+    })();
+
     /* ── Notification bell ── */
     let _notifPanelOpen = false;
 

--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -169,7 +169,7 @@
     .palette-btn.active {
         border-color: var(--accent);
         background: var(--primary);
-        color: var(--text);
+        color: var(--text-on-accent);
     }
     #palette-search {
         display: block;
@@ -402,14 +402,15 @@
     .wx-results { display: flex; flex-direction: column; gap: 0.2rem; margin: 0.25rem 0; }
     .wx-result {
         text-align: left;
-        background: var(--bg-subtle, #f6f8fa);
-        border: 1px solid var(--border, #d0d7de);
+        background: var(--surface-alt);
+        color: var(--text);
+        border: 1px solid var(--border);
         border-radius: 5px;
         padding: 0.3rem 0.5rem;
         font-size: 0.8rem;
         cursor: pointer;
     }
-    .wx-result:hover { background: var(--bg-hover, #eaeef2); }
+    .wx-result:hover { background: var(--surface); }
     .cw-prev-media { width: 100%; height: 100%; position: relative; }
     .cw-prev-media img { width: 100%; height: 100%; display: block; }
     .cw-prev-media-badge {
@@ -3184,7 +3185,7 @@ function renderComposedGroupBadges() {
         const span = document.createElement("span");
         span.className = "group-badge";
         span.style.cssText =
-            "background:#444;color:#fff;padding:0.15rem 0.5rem;border-radius:0.5rem;font-size:0.8rem;cursor:pointer;";
+            "background:var(--surface-alt);color:var(--text);border:1px solid var(--border);padding:0.15rem 0.5rem;border-radius:0.5rem;font-size:0.8rem;cursor:pointer;";
         span.textContent = btn.dataset.groupName + " ✕";
         span.onclick = () => {
             window.composedSelectedGroupIds =

--- a/cms/templates/devices.html
+++ b/cms/templates/devices.html
@@ -55,7 +55,7 @@
     min-width: 1.5rem;
     padding: 0.05rem 0.45rem;
     border-radius: 999px;
-    background: rgba(255,255,255,0.10);
+    background: var(--overlay-hover);
     text-align: center;
     font-variant-numeric: tabular-nums;
     font-size: 0.78rem;

--- a/cms/templates/slideshow_builder.html
+++ b/cms/templates/slideshow_builder.html
@@ -1146,6 +1146,124 @@
     cursor: pointer;
 }
 .ssb-member-more:hover { background: rgba(26,188,156,0.2); }
+
+/* ──────────────────────────────────────────────────────────────────────
+   Light-theme chrome overrides for the slideshow builder.
+
+   The base styles above use neutral near-black greys appropriate for the
+   dark UI. In light mode we repaint only the editor *chrome* surfaces;
+   media letterboxes (#000/#111 thumbnails), saturated accent colours
+   (teal/purple/red) and slide-content colours are deliberately left as-is
+   so previews still match true device output. Two synced blocks: explicit
+   Light, and Auto (no explicit choice) + OS-light. Explicit Dark keeps the
+   original greys.
+   ────────────────────────────────────────────────────────────────────── */
+:root[data-theme="light"] .ssb-library { background:var(--surface-alt);border-color:var(--border); }
+:root[data-theme="light"] .ssb-decksource { background:var(--surface-alt);border-color:var(--border); }
+:root[data-theme="light"] .ssb-tagpanel { background:var(--surface-alt);border-color:var(--border); }
+:root[data-theme="light"] .ssb-tags-palette { background:var(--surface-alt);border-color:var(--border); }
+:root[data-theme="light"] .ssb-lib-meta { background:var(--surface-alt); }
+:root[data-theme="light"] .ssb-slot-meta { background:var(--surface-alt); }
+:root[data-theme="light"] .ssb-lib-tile { background:var(--surface);border-color:var(--border); }
+:root[data-theme="light"] .ssb-slot { background:var(--surface);border-color:var(--border); }
+:root[data-theme="light"] .ssb-tag-chip { background:var(--surface);border-color:var(--border); }
+:root[data-theme="light"] .ssb-member { background:var(--surface);border-color:var(--border); }
+:root[data-theme="light"] .ssb-seg { border-color:var(--border); }
+:root[data-theme="light"] .ssb-seg-btn { background:var(--surface);color:var(--text); }
+:root[data-theme="light"] .ssb-seg-btn + .ssb-seg-btn { border-left-color:var(--border); }
+:root[data-theme="light"] .ssb-slot-dur input[type=number] { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-slot-fx-item select { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-vis-pair input[type=date],
+:root[data-theme="light"] .ssb-vis-pair input[type=time] { background:var(--surface);color:var(--text);border-color:var(--border);color-scheme:light; }
+:root[data-theme="light"] .ssb-slot-kbbtn { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-kb-zoom button { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-kb-compass button { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-trans-dur-input { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-vis-day { background:var(--surface);color:var(--text-muted);border-color:var(--border); }
+:root[data-theme="light"] .ssb-gap-btn { background:var(--surface-alt);color:var(--text);border-color:var(--border); }
+:root[data-theme="light"] .ssb-trim-track { background:var(--surface-alt); }
+:root[data-theme="light"] .ssb-trans-menu { background:var(--surface);border-color:var(--border); }
+:root[data-theme="light"] .ssb-kb-menu { background:var(--surface);border-color:var(--border);color:var(--text); }
+:root[data-theme="light"] .ssb-trans-opt { color:var(--text); }
+:root[data-theme="light"] .ssb-vis-fs { border-color:var(--border); }
+:root[data-theme="light"] .ssb-slot-vis { border-top-color:var(--border); }
+:root[data-theme="light"] .ssb-slot-trim { border-top-color:var(--border); }
+:root[data-theme="light"] .ssb-trans-dur { border-top-color:var(--border);color:var(--text-muted); }
+:root[data-theme="light"] .ssb-end { border-color:var(--border);color:var(--text-muted); }
+:root[data-theme="light"] .ssb-append { border-color:var(--border);color:var(--text-muted); }
+:root[data-theme="light"] .ssb-slot-name { color:var(--text); }
+:root[data-theme="light"] .ssb-trim-start { color:var(--text); }
+:root[data-theme="light"] .ssb-trim-ctls { color:var(--text); }
+:root[data-theme="light"] .ssb-vis-radio { color:var(--text); }
+:root[data-theme="light"] .ssb-slot-pte { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-slot-fx-item { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-vis-head { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-trim-head { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-totals { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-active-mode { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-member-name { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-lib-type { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-lib-empty { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-empty-message { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-tags-empty { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-trans-opt-soon { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-trans-dur-unit { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-vis-to { color:var(--text-muted); }
+:root[data-theme="light"] .ssb-kb-preview-empty { color:var(--text-muted); }
+@media (prefers-color-scheme: light) {
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-library { background:var(--surface-alt);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-decksource { background:var(--surface-alt);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-tagpanel { background:var(--surface-alt);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-tags-palette { background:var(--surface-alt);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-lib-meta { background:var(--surface-alt); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-meta { background:var(--surface-alt); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-lib-tile { background:var(--surface);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot { background:var(--surface);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-tag-chip { background:var(--surface);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-member { background:var(--surface);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-seg { border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-seg-btn { background:var(--surface);color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-seg-btn + .ssb-seg-btn { border-left-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-dur input[type=number] { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-fx-item select { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-pair input[type=date],
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-pair input[type=time] { background:var(--surface);color:var(--text);border-color:var(--border);color-scheme:light; }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-kbbtn { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-kb-zoom button { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-kb-compass button { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-dur-input { background:var(--surface);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-day { background:var(--surface);color:var(--text-muted);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-gap-btn { background:var(--surface-alt);color:var(--text);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trim-track { background:var(--surface-alt); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-menu { background:var(--surface);border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-kb-menu { background:var(--surface);border-color:var(--border);color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-opt { color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-fs { border-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-vis { border-top-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-trim { border-top-color:var(--border); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-dur { border-top-color:var(--border);color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-end { border-color:var(--border);color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-append { border-color:var(--border);color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-name { color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trim-start { color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trim-ctls { color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-radio { color:var(--text); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-pte { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-slot-fx-item { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-head { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trim-head { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-totals { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-active-mode { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-member-name { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-lib-type { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-lib-empty { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-empty-message { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-tags-empty { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-opt-soon { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-trans-dur-unit { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-vis-to { color:var(--text-muted); }
+:root:not([data-theme="dark"]):not([data-theme="light"]) .ssb-kb-preview-empty { color:var(--text-muted); }
+}
 </style>
 
 <h1>{% if edit_mode %}Edit Slideshow{% else %}New Slideshow{% endif %}

--- a/tests/test_popover_contrast.py
+++ b/tests/test_popover_contrast.py
@@ -7,10 +7,21 @@ and/or `background: var(--surface-alt)` (a very slightly lighter navy),
 which made the popover edges nearly invisible against the page.
 
 The fix is the same pattern used by `.card-highlight`: paint the popover
-with the darker `--surface` and draw a neutral light border using
-`rgba(255, 255, 255, 0.25)`. These tests pin both declarations so a stray
-refactor of the dark-blue tokens can't silently re-introduce the
-low-contrast styling.
+with the darker `--surface` plus a translucent contrast overlay, and draw
+a neutral contrast border. Since the introduction of the light theme these
+are expressed with the theme-aware overlay tokens rather than raw white
+literals:
+
+    border:     1px solid var(--overlay-strong)
+    background: linear-gradient(var(--overlay-hover), var(--overlay-hover)),
+                var(--surface)
+
+In the dark theme ``--overlay-strong``/``--overlay-hover`` resolve to
+``rgba(255,255,255,0.25)``/``rgba(255,255,255,0.08)`` (the historical
+values); in the light theme they flip to black overlays so the border
+stays visible against a light page. These tests pin the token usage so a
+stray refactor can't silently re-introduce the low-contrast styling or
+hardcode a single-theme literal.
 """
 
 from pathlib import Path
@@ -39,36 +50,54 @@ def _rule_body(css: str, selector: str) -> str:
 
 def test_kebab_menu_uses_light_contrast_border(css: str) -> None:
     body = _rule_body(css, ".kebab-menu[popover]")
-    assert "rgba(255, 255, 255, 0.25)" in body, (
-        "Kebab popover border must use the standard light contrast color "
-        "(rgba(255, 255, 255, 0.25)) — the dark-blue --border token blends "
-        "into the page. Rule body was:\n" + body
+    assert "var(--overlay-strong)" in body, (
+        "Kebab popover border must use the theme-aware contrast token "
+        "var(--overlay-strong) — the dark-blue --border token blends into "
+        "the page, and a raw white literal would vanish on a light page. "
+        "Rule body was:\n" + body
     )
-    assert "rgba(255, 255, 255, 0.08)" in body and "var(--surface)" in body, (
-        "Kebab popover background must layer a translucent white overlay "
-        "(rgba(255, 255, 255, 0.08)) over var(--surface) so the menu reads "
-        "as lifted above surrounding cards."
+    assert "var(--border)" not in body and "var(--primary)" not in body, (
+        "Kebab popover border must not use the dark-blue --border/--primary "
+        "tokens (blue-on-blue, nearly invisible). Rule body was:\n" + body
     )
-    assert "rgba(255, 255, 255, 0.08)" in body, (
-        "Kebab popover overlay must be ~8% white over --surface so the menu "
-        "reads as lifted above surrounding cards without overpowering them."
+    assert "var(--overlay-hover)" in body and "var(--surface)" in body, (
+        "Kebab popover background must layer the translucent overlay token "
+        "var(--overlay-hover) over var(--surface) so the menu reads as "
+        "lifted above surrounding cards in both themes."
     )
 
 
 def test_group_popup_uses_light_contrast_border(css: str) -> None:
     body = _rule_body(css, ".group-popup[popover]")
-    assert "rgba(255, 255, 255, 0.25)" in body, (
-        "Group action popover border must use the standard light contrast "
-        "color (rgba(255, 255, 255, 0.25)). Rule body was:\n" + body
+    assert "var(--overlay-strong)" in body, (
+        "Group action popover border must use the theme-aware contrast token "
+        "var(--overlay-strong). Rule body was:\n" + body
     )
-    assert "rgba(255, 255, 255, 0.08)" in body and "var(--surface)" in body, (
-        "Group action popover background must layer a translucent white "
-        "overlay over var(--surface). --surface-alt alone is too close to "
-        "the --primary family and loses contrast against neighbouring cards."
+    assert "var(--border)" not in body and "var(--primary)" not in body, (
+        "Group action popover border must not use the dark-blue "
+        "--border/--primary tokens. Rule body was:\n" + body
     )
-    assert "rgba(255, 255, 255, 0.08)" in body, (
-        "Group action popover overlay must be at least 20% white so it "
-        "reads as distinctly lifted above the page."
+    assert "var(--overlay-hover)" in body and "var(--surface)" in body, (
+        "Group action popover background must layer var(--overlay-hover) "
+        "over var(--surface). --surface-alt alone is too close to the "
+        "--primary family and loses contrast against neighbouring cards."
+    )
+
+
+def test_overlay_tokens_match_legacy_dark_values(css: str) -> None:
+    """The overlay tokens used by the popovers must resolve to the historical
+    white-contrast literals in the dark (`:root`) theme, so the dark-mode
+    appearance is unchanged by the move from raw literals to tokens."""
+    root_idx = css.find(":root")
+    assert root_idx != -1
+    block = css[root_idx : css.find("}", root_idx)]
+    assert "--overlay-strong: rgba(255,255,255,0.25)" in block, (
+        "Dark --overlay-strong must stay rgba(255,255,255,0.25) so the "
+        "popover border matches its historical appearance."
+    )
+    assert "--overlay-hover: rgba(255,255,255,0.08)" in block, (
+        "Dark --overlay-hover must stay rgba(255,255,255,0.08) so the "
+        "popover background overlay matches its historical appearance."
     )
 
 


### PR DESCRIPTION
## Summary

Adds a **light theme** alongside the existing dark theme, using a **hybrid trigger**:

- Defaults to the browser/OS preference via prefers-color-scheme.
- An in-app **Auto / Light / Dark** toggle (header) overrides it, persisted in **localStorage** (no DB/account column, so no migration or OpenAPI regen).

Theme state lives on `<html data-theme="auto|light|dark">`; an early-paint `<head>` script sets it before the stylesheet loads to avoid FOUC. An explicit `data-theme="dark"` always wins over the OS preference.

## How it works

- `cms/static/style.css` `:root` holds the **dark** palette (historical default, values unchanged). The light palette is defined in two synced blocks: `:root[data-theme="light"]` (explicit) and `@media (prefers-color-scheme: light)` on `:root:not([data-theme="dark"]):not([data-theme="light"])` (Auto path).
- New semantic tokens (`--surface`/`--surface-alt`/`--surface-2`, `--text-on-accent`, `--overlay-*`, `--shadow-*`, `--color-scheme`) replace hardcoded literals across the shared chrome.
- Brand colours that read well on any background (`--accent`, `--primary` used as chip backgrounds, `--text-on-accent`) are intentionally theme-invariant.

## Editor chrome

The slideshow builder and composed editor mix UI chrome with **slide/canvas content** (which must render true device output regardless of admin theme). Chrome is themed; content is not:

- **slideshow_builder.html** — additive, light-only override block themes the image library, dynamic-tags panel, tag chips, timeline slots, inputs, popovers and member tray. Media letterboxes (`#000`/`#111` thumbnails) and saturated accents stay dark.
- **composed_editor.html** — fixed `.palette-btn.active` (was dark-on-navy), `.wx-result` rows (broken in dark too), and the `.group-badge` chip. The slide **canvas** is deliberately left as true device WYSIWYG output.

## Testing

- Verified all three states (dark unchanged, explicit light, Auto + OS-light) via Playwright screenshots during development.
- Reviewed live in Docker across the dashboard, asset pages, slideshow builder and composed editor.
- CSS braces balanced; all templates parse under Jinja.

No route or schema changes.
