### PR TITLE
feat: searchable user-editable asset description

### DIFF
--- a/_commitmsg.txt
+++ b/_commitmsg.txt
@@ -1,0 +1,20 @@
+feat: searchable user-editable asset description
+
+Add a free-text ``description`` to library assets that users can edit
+inline from the expanded asset-detail row, and include it in the asset
+library's substring search so an asset is findable by notes the user
+has written rather than only by its filename.
+
+- model: new nullable ``Asset.description`` (Text) + trigram GIN index
+  ``idx_assets_description_trgm`` mirroring the existing name-field
+  search indexes (migration 0051; pg_trgm best-effort, skipped on
+  SQLite/unallow-listed PG exactly like 0030).
+- search: ``GET /api/assets/page`` ``q`` now also matches description.
+- edit: ``PATCH /api/assets/{id}`` accepts ``description`` (trimmed,
+  empty -> NULL, max 2000 chars); ``AssetOut`` returns it.
+- UI: inline multi-line editor in the asset-detail row (Enter/blur
+  saves, Shift+Enter newline, Escape reverts) reusing the existing
+  /api/assets/{id}/row server fragment so search results get it too.
+- docs/openapi.yaml regenerated.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

--- a/alembic/versions/0051_asset_description.py
+++ b/alembic/versions/0051_asset_description.py
@@ -1,0 +1,73 @@
+"""assets: user-editable description column + trigram search index
+
+Adds a nullable free-text ``description`` column to ``assets`` plus a
+trigram GIN index (Postgres only) mirroring the existing
+``display_name`` / ``filename`` search indexes from migration 0030.
+
+The asset library's ``q`` substring search (``GET /api/assets/page``)
+now matches against ``description`` in addition to the name fields, so
+users can find an asset by notes they've written about it.
+
+As in 0030, ``pg_trgm`` is enabled best-effort inside a savepoint: if
+the extension isn't allow-listed (typical on Azure PG Flex), the index
+is skipped and ``LIKE`` falls back to a sequential scan. SQLite (CI
+unit-test matrix) doesn't support GIN/pg_trgm so the index is skipped
+there too; the column itself is created on every dialect.
+
+Revision ID: 0051
+Revises: 0050
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0051"
+down_revision = "0050"
+branch_labels = None
+depends_on = None
+
+
+log = logging.getLogger("alembic.runtime.migration")
+
+
+def _try_enable_pg_trgm(bind) -> bool:
+    """Best-effort CREATE EXTENSION pg_trgm (see migration 0030)."""
+    sp = bind.begin_nested()
+    try:
+        bind.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        sp.commit()
+        return True
+    except Exception as exc:  # pragma: no cover -- exercised on Azure only
+        sp.rollback()
+        log.warning(
+            "pg_trgm extension unavailable (%s); skipping description "
+            "trigram index. Allow-list pg_trgm via azure.extensions and "
+            "create the index manually to enable accelerated LIKE search.",
+            exc,
+        )
+        return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    op.add_column(
+        "assets",
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+
+    if dialect == "postgresql":
+        if _try_enable_pg_trgm(bind):
+            op.execute(
+                "CREATE INDEX IF NOT EXISTS idx_assets_description_trgm "
+                "ON assets USING GIN (description gin_trgm_ops)"
+            )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade of 0051 is not supported")

--- a/cms/routers/assets.py
+++ b/cms/routers/assets.py
@@ -716,10 +716,11 @@ async def list_assets_paged(
     """Paginated + filtered asset listing for the asset library UI.
 
     All filters are AND-composed. ``q`` is a case-insensitive substring
-    match against ``display_name``, ``original_filename``, and
-    ``filename`` (Postgres-side this hits a trigram GIN index; SQLite
-    falls back to a sequential scan in tests). The caller's group ACL
-    is applied last and cannot be widened by URL parameters.
+    match against ``display_name``, ``original_filename``,
+    ``description``, and ``filename`` (Postgres-side this hits a trigram
+    GIN index; SQLite falls back to a sequential scan in tests). The
+    caller's group ACL is applied last and cannot be widened by URL
+    parameters.
     """
     # ── Parse + validate order ──
     descending = order.startswith("-")
@@ -763,6 +764,7 @@ async def list_assets_paged(
         filter_clauses.append(
             func.coalesce(Asset.display_name, "").ilike(like)
             | func.coalesce(Asset.original_filename, "").ilike(like)
+            | func.coalesce(Asset.description, "").ilike(like)
             | Asset.filename.ilike(like)
         )
 
@@ -2488,7 +2490,7 @@ async def update_asset(
     user: User = Depends(require_permission(ASSETS_WRITE)),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update asset properties (currently: display_name)."""
+    """Update asset properties (currently: display_name, description, url)."""
     result = await db.execute(select(Asset).where(Asset.id == asset_id, Asset.deleted_at.is_(None)))
     asset = result.scalar_one_or_none()
     if not asset:
@@ -2503,6 +2505,14 @@ async def update_asset(
         if name and len(name) > 255:
             raise HTTPException(status_code=400, detail="Name too long (max 255 characters)")
         incoming["display_name"] = name if name else None
+
+    if "description" in body:
+        desc = (body["description"] or "").strip()
+        if len(desc) > 2000:
+            raise HTTPException(
+                status_code=400, detail="Description too long (max 2000 characters)"
+            )
+        incoming["description"] = desc if desc else None
 
     if "url" in body:
         # URL editing is only supported for webpage assets. Stream URLs drive

--- a/cms/schemas/asset.py
+++ b/cms/schemas/asset.py
@@ -221,6 +221,7 @@ class AssetOut(BaseModel):
     filename: str
     original_filename: Optional[str] = None
     display_name: Optional[str] = None
+    description: Optional[str] = None
     asset_type: AssetType
     size_bytes: int
     checksum: str

--- a/cms/static/app.js
+++ b/cms/static/app.js
@@ -1710,6 +1710,75 @@ async function editAssetName(el) {
     });
 }
 
+// Inline-edit an asset's free-text description from the expanded asset
+// detail row. Mirrors editAssetName but uses a multi-line <textarea>
+// (descriptions run longer than names) and PATCHes the same
+// /api/assets/{id} endpoint with {description}. Empty saves as null.
+// Blur or Enter commits; Shift+Enter inserts a newline; Escape reverts.
+async function editAssetDescription(el) {
+    const assetId = el.dataset.assetId;
+    const placeholder = el.dataset.placeholder || 'Add a description…';
+    const isPlaceholder = el.classList.contains('is-placeholder');
+    const currentText = isPlaceholder ? '' : el.textContent;
+
+    const input = document.createElement('textarea');
+    input.value = currentText;
+    input.placeholder = placeholder;
+    input.className = 'form-control';
+    input.rows = 3;
+    input.maxLength = 2000;
+    input.style.cssText = 'font-size:0.85rem; padding:0.25rem 0.4rem; width:100%; max-width:480px; resize:vertical;';
+
+    const parent = el.parentElement;
+    parent.replaceChild(input, el);
+    input.focus();
+
+    function render(text) {
+        if (text) {
+            el.textContent = text;
+            el.classList.remove('is-placeholder');
+        } else {
+            el.textContent = placeholder;
+            el.classList.add('is-placeholder');
+        }
+    }
+
+    function revert() {
+        render(currentText);
+        parent.replaceChild(el, input);
+    }
+
+    async function save() {
+        const newText = input.value.trim();
+        if (newText === currentText) { revert(); return; }
+        try {
+            const resp = await fetch(`/api/assets/${assetId}`, {
+                method: 'PATCH',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({description: newText || null}),
+            });
+            if (!resp.ok) {
+                const err = await resp.json().catch(() => ({}));
+                showToast(extractErrorMsg(err) || 'Update failed', true);
+                revert();
+                return;
+            }
+            render(newText);
+            parent.replaceChild(el, input);
+        } catch (e) {
+            showToast('Update failed: ' + e.message, true);
+            revert();
+        }
+    }
+
+    input.addEventListener('blur', save);
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); input.blur(); }
+        if (e.key === 'Escape') { e.preventDefault(); revert(); }
+    });
+    input.addEventListener('click', (e) => e.stopPropagation());
+}
+
 async function deleteAsset(assetId, filename) {
     if (!await showConfirm("Delete \"" + (filename || "this asset") + "\"?")) return;
     const resp = await apiCall("DELETE", `/api/assets/${assetId}`);

--- a/cms/static/style.css
+++ b/cms/static/style.css
@@ -1157,6 +1157,7 @@ tr.highlight-new td {
 .asset-filename-truncate { display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
 .editable-name { cursor: text; border-bottom: 1px dashed transparent; transition: border-color 0.2s; }
 .editable-name:hover { border-bottom-color: var(--text-muted); }
+.editable-name.is-placeholder { color: var(--text-muted); font-style: italic; }
 .col-filename { width: 40%; }
 .detail-item-wide { grid-column: 1 / -1; }
 .detail-value.monospace { font-family: monospace; font-size: 0.8rem; word-break: break-all; white-space: normal; }

--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -336,6 +336,22 @@
                             </span>
                         </div>
                         {% endif %}
+                        {% if 'assets:write' in user_perms %}
+                        <div class="detail-item detail-item-wide">
+                            <span class="detail-label">Description</span>
+                            <span class="detail-value editable-name{% if not a.description %} is-placeholder{% endif %}"
+                                  onclick="event.stopPropagation(); editAssetDescription(this)"
+                                  data-asset-id="{{ a.id }}"
+                                  data-placeholder="Add a description…"
+                                  title="Click to edit"
+                                  style="white-space:pre-wrap; word-break:break-word; cursor:text;">{{ a.description or 'Add a description…' }}</span>
+                        </div>
+                        {% elif a.description %}
+                        <div class="detail-item detail-item-wide">
+                            <span class="detail-label">Description</span>
+                            <span class="detail-value" style="white-space:pre-wrap; word-break:break-word;">{{ a.description }}</span>
+                        </div>
+                        {% endif %}
                         <div class="detail-item">
                             <span class="detail-label">Uploaded</span>
                             <span class="detail-value" data-utc="{{ a.uploaded_at.isoformat() }}">{{ a.uploaded_at.strftime('%b %d, %Y %I:%M %p') }}</span>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1090,10 +1090,11 @@ paths:
         Paginated + filtered asset listing for the asset library UI.
 
         All filters are AND-composed. ``q`` is a case-insensitive substring
-        match against ``display_name``, ``original_filename``, and
-        ``filename`` (Postgres-side this hits a trigram GIN index; SQLite
-        falls back to a sequential scan in tests). The caller's group ACL
-        is applied last and cannot be widened by URL parameters.
+        match against ``display_name``, ``original_filename``,
+        ``description``, and ``filename`` (Postgres-side this hits a trigram
+        GIN index; SQLite falls back to a sequential scan in tests). The
+        caller's group ACL is applied last and cannot be widened by URL
+        parameters.
       operationId: list_assets_paged_api_assets_page_get
       parameters:
       - name: q
@@ -1422,7 +1423,7 @@ paths:
   /api/assets/{asset_id}:
     patch:
       summary: Update Asset
-      description: 'Update asset properties (currently: display_name).'
+      description: 'Update asset properties (currently: display_name, description, url).'
       operationId: update_asset_api_assets__asset_id__patch
       parameters:
       - name: asset_id
@@ -4790,6 +4791,11 @@ components:
           - type: string
           - type: 'null'
           title: Display Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
         asset_type:
           $ref: '#/components/schemas/AssetType'
         size_bytes:

--- a/shared/models/asset.py
+++ b/shared/models/asset.py
@@ -36,6 +36,11 @@ class Asset(Base):
     filename: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     original_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)  # set when converted (e.g. HEIC→JPG)
     display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)  # user-editable friendly name
+    # User-editable free-text description. Included (alongside the name
+    # fields) in the case-insensitive substring search powering the asset
+    # library's ``q`` filter, so users can find assets by notes they've
+    # written rather than only by filename.
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
     asset_type: Mapped[AssetType] = mapped_column(Enum(AssetType), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, default=0)
     checksum: Mapped[str] = mapped_column(String(64), default="")  # SHA-256
@@ -126,6 +131,12 @@ class Asset(Base):
             "display_name",
             postgresql_using="gin",
             postgresql_ops={"display_name": "gin_trgm_ops"},
+        ),
+        Index(
+            "idx_assets_description_trgm",
+            "description",
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
         ),
         Index(
             "idx_assets_original_filename_trgm",

--- a/tests/test_assets_list.py
+++ b/tests/test_assets_list.py
@@ -90,6 +90,30 @@ class TestAssetsPage:
         assert len(items) == 1
         assert items[0]["filename"] == "holiday-promo-2026.mp4"
 
+    async def test_substring_search_matches_description(self, client, db_session):
+        """``q`` also matches the user-editable free-text description, so an
+        asset is findable by notes even when its name doesn't contain the
+        search term."""
+        from cms.models.asset import AssetType
+
+        created = await _seed_assets(
+            db_session,
+            [
+                ("clip-001.mp4", AssetType.VIDEO),
+                ("clip-002.mp4", AssetType.VIDEO),
+            ],
+        )
+        created[0].description = "Footage from the Seattle waterfront gala"
+        await db_session.commit()
+
+        # Term appears only in the description, not in any name field.
+        resp = await client.get("/api/assets/page", params={"q": "waterfront"})
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["filename"] == "clip-001.mp4"
+        assert items[0]["description"] == "Footage from the Seattle waterfront gala"
+
     async def test_type_filter_repeatable(self, client, db_session):
         from cms.models.asset import AssetType
 

--- a/tests/test_display_name.py
+++ b/tests/test_display_name.py
@@ -134,6 +134,73 @@ class TestPatchAssetDisplayName:
         assert resp.json()["display_name"] is None
 
 
+# ── PATCH /api/assets/{id} — description ──
+
+
+@pytest.mark.asyncio
+class TestPatchAssetDescription:
+    """Test the PATCH endpoint for setting/clearing the free-text description."""
+
+    async def test_set_description(self, client, db_session):
+        asset = await _create_asset(db_session)
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"description": "Lobby loop, shot 2026 Q1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "Lobby loop, shot 2026 Q1"
+
+    async def test_clear_description(self, client, db_session):
+        asset = await _create_asset(db_session)
+        asset.description = "old notes"
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"description": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] is None
+
+    async def test_description_strips_whitespace(self, client, db_session):
+        asset = await _create_asset(db_session)
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"description": "  padded notes  "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "padded notes"
+
+    async def test_description_too_long(self, client, db_session):
+        asset = await _create_asset(db_session)
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"description": "x" * 2001},
+        )
+        assert resp.status_code == 400
+        assert "too long" in resp.json()["detail"].lower()
+
+    async def test_description_independent_of_display_name(self, client, db_session):
+        """Patching description leaves display_name untouched and vice-versa."""
+        asset = await _create_asset(db_session, display_name="Keep Me")
+        await db_session.commit()
+
+        resp = await client.patch(
+            f"/api/assets/{asset.id}",
+            json={"description": "just a note"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["description"] == "just a note"
+        assert data["display_name"] == "Keep Me"
+
+
 # ── _asset_display_name() priority logic ──
 
 


### PR DESCRIPTION
Adds a **user-editable free-text description** to library assets, and — the key requirement — makes the asset library's search match against it, so an asset is findable by notes the user writes rather than only by filename.

## What's included
- **Model** (`shared/models/asset.py`): new nullable `Asset.description` (Text) + a trigram GIN index `idx_assets_description_trgm`, mirroring the existing `display_name`/`filename` search indexes.
- **Migration** (`0051_asset_description`): adds the column on every dialect; creates the GIN index on Postgres best-effort (skipped if `pg_trgm` isn't allow-listed, and on SQLite) — same pattern as `0030`.
- **Search** (`GET /api/assets/page`): the `q` substring filter now also matches `description`.
- **Edit** (`PATCH /api/assets/{id}`): accepts `description` (trimmed, empty → `NULL`, max 2000 chars). `AssetOut` returns it.
- **UI**: inline multi-line editor in the expanded asset-detail row — click to edit, Enter/blur saves, Shift+Enter for a newline, Escape reverts. It reuses the existing `/api/assets/{id}/row` server fragment, so search/paginated results render the editor too. Read-only fallback shown to users without `assets:write`.
- **docs/openapi.yaml** regenerated.

## Tests
- `tests/test_assets_list.py`: `test_substring_search_matches_description` (found via a term only in the description).
- `tests/test_display_name.py`: new `TestPatchAssetDescription` (set / clear / strip / too-long / independence from `display_name`).
- 30/30 targeted tests pass locally; `alembic upgrade head` + `alembic check` clean for `assets` on Postgres.

Goodwill dev only.
