### PR TITLE
feat(assistant): teach slideshow assistant per-slide visibility + trim

### DIFF
--- a/cms/services/assistant/prompts.py
+++ b/cms/services/assistant/prompts.py
@@ -185,6 +185,39 @@ Per-slide fields:
   (``"zoom out right down"`` is read as ``out_down_right``).  Default
   ``in``.
 
+Per-slide visibility window (when a slide is allowed to show):
+By default a slide always shows.  You can limit a slide to a date
+range, a time of day, and/or certain weekdays — outside its window the
+slide is silently skipped (the rest of the show plays normally).  All
+of these are optional and combine (a slide shows only when EVERY set
+condition is met).  They apply to BOTH asset slides and tag blocks.
+* ``valid_from`` / ``valid_to``: an inclusive calendar-date range as
+  ``"YYYY-MM-DD"`` strings (e.g. a Christmas slide ``valid_from``
+  ``"2026-12-01"`` ``valid_to`` ``"2026-12-26"``).  Either end may be
+  omitted for an open-ended range.  ``valid_to`` must be on or after
+  ``valid_from``.
+* ``active_start`` / ``active_end``: a time-of-day window as ``"HH:MM"``
+  (24-hour) — ``active_start`` inclusive, ``active_end`` exclusive.  A
+  window that wraps past midnight is allowed (set ``active_start`` later
+  than ``active_end``, e.g. ``"22:00"``–``"06:00"`` for overnight).
+* ``active_days``: a list of weekdays the slide may show, as integers
+  ``0``=Mon … ``6``=Sun (e.g. ``[0,1,2,3,4]`` for weekdays).  Omit or
+  use ``[]`` for every day.
+All windows are evaluated in the playing device's local time.  When the
+operator describes a window in words ("only show this in December",
+"weekday mornings", "weekends after 5pm"), translate it into these
+fields.  To clear a window, set the relevant fields back to null.
+
+Per-slide video trim (asset slides only, VIDEO sources only):
+A video slide can play just a sub-range of its source instead of the
+whole clip.
+* ``clip_start_ms``: the offset INTO the source video to start at, in
+  milliseconds (e.g. ``10000`` starts 10 seconds in).  Default 0.
+* ``clip_duration_ms``: how long to play from that start, in
+  milliseconds.  Omit / null to play to the natural end of the source.
+The trim must fit inside the source's real length; the source must have
+finished processing.  Trim is rejected on non-video and on tag blocks.
+
 Dynamic tag blocks:
 * A slide can instead be a **tag block** that auto-expands at play
   time to every asset carrying a given tag — great for "show all our

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -495,11 +495,16 @@ async def get_slideshow(asset_id: str) -> str:
     to every asset carrying a tag). Shared fields on every slide:
     ``{id, position, kind, duration_ms, play_to_end, transition,
     transition_ms, member_transition, member_transition_ms, fit,
-    effect, effect_direction}``.
+    effect, effect_direction, valid_from, valid_to, active_days,
+    active_start, active_end}``.  The last five are the per-slide
+    visibility window (all null = always shows; see
+    ``set_slideshow_slides`` for their meaning).
 
     ``asset`` slides also carry ``{source_asset_id, source_filename,
-    source_asset_type, source_duration_seconds, thumbnail_url}`` (the
-    tag fields are null). ``tag`` slides also carry ``{tag_id, tag_name,
+    source_asset_type, source_duration_seconds, thumbnail_url,
+    clip_start_ms, clip_duration_ms}`` (the tag fields are null;
+    ``clip_*`` are the per-slide video trim, both null = whole clip).
+    ``tag`` slides also carry ``{tag_id, tag_name,
     tag_order_by, member_count}`` (the source fields are null);
     ``member_count`` is how many assets currently match the tag.
 
@@ -535,7 +540,9 @@ async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
     slides.
 
     ASSET slides — ``{source_asset_id, duration_ms?, play_to_end?,
-    transition?, transition_ms?, fit?, effect?, effect_direction?}``:
+    transition?, transition_ms?, fit?, effect?, effect_direction?,
+    valid_from?, valid_to?, active_start?, active_end?, active_days?,
+    clip_start_ms?, clip_duration_ms?}``:
       - ``source_asset_id``: UUID of an IMAGE / VIDEO / COMPOSED asset
         (from ``list_assets`` or an existing slide's ``source_asset_id``).
       - ``duration_ms``: how long the slide shows, 500–3,600,000
@@ -562,6 +569,32 @@ async def set_slideshow_slides(asset_id: str, slides: list[dict]) -> str:
         bottom-right). Word order and separators DON'T matter —
         ``"zoom out right down"`` and ``"out-right-down"`` are both
         accepted and normalized to ``out_down_right``. Defaults to ``in``.
+
+    Per-slide VISIBILITY WINDOW (optional; on asset AND tag slides) —
+    limit WHEN a slide is allowed to show.  A slide with no window always
+    shows; outside its window it is silently skipped.  The conditions
+    combine (the slide shows only when EVERY set one is met) and are
+    evaluated in the playing device's local time:
+      - ``valid_from`` / ``valid_to``: inclusive calendar-date range as
+        ``"YYYY-MM-DD"`` strings.  Either end may be omitted.
+        ``valid_to`` must be on or after ``valid_from``.
+      - ``active_start`` / ``active_end``: time-of-day window as
+        ``"HH:MM"`` (24-hour); start inclusive, end exclusive.  Set
+        start later than end for a window that wraps past midnight
+        (e.g. ``"22:00"``–``"06:00"``).
+      - ``active_days``: weekdays the slide may show, ints ``0``=Mon …
+        ``6``=Sun (e.g. ``[0,1,2,3,4]`` = weekdays).  Omit / ``[]`` =
+        every day.
+      Set any field to null to clear that part of the window.
+
+    Per-slide VIDEO TRIM (optional; asset slides with a VIDEO source
+    only) — play just a sub-range of the source clip:
+      - ``clip_start_ms``: offset INTO the source to start at, in ms
+        (default 0).
+      - ``clip_duration_ms``: how long to play from that start, in ms;
+        omit / null to play to the source's natural end.
+      The trim must fit inside the source's real length.  Rejected on
+      non-video sources and on tag slides.
 
     TAG slides (dynamic blocks) — set ``kind: "tag"`` and ``tag_id``
     instead of ``source_asset_id``. A tag block expands at play time to

--- a/tests/test_slideshow_editor_assistant.py
+++ b/tests/test_slideshow_editor_assistant.py
@@ -269,6 +269,41 @@ class TestBuildSystemPrompt:
         assert "create_tag" not in prompt
         assert "library" in prompt.lower()
 
+    def test_editor_prompt_documents_visibility_window(self):
+        """The per-slide visibility window (date range, time-of-day,
+        weekdays) must be advertised so the assistant can set/clear it."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        # All five window fields are named.
+        assert "valid_from" in prompt
+        assert "valid_to" in prompt
+        assert "active_start" in prompt
+        assert "active_end" in prompt
+        assert "active_days" in prompt
+        # The weekday encoding is spelled out so the assistant maps words
+        # like "weekdays" correctly.
+        assert "0" in prompt and "Mon" in prompt
+        # Evaluation is device-local.
+        assert "local time" in prompt.lower()
+
+    def test_editor_prompt_documents_video_trim(self):
+        """The per-slide video trim fields must be advertised so the
+        assistant can play a sub-range of a video source."""
+        from cms.services.assistant.prompts import build_system_prompt
+
+        aid = str(uuid.uuid4())
+        prompt = build_system_prompt(
+            self._user(), mode="slideshow_editor", composed_asset_id=aid
+        )
+        assert "clip_start_ms" in prompt
+        assert "clip_duration_ms" in prompt
+        # Trim is video-only.
+        assert "VIDEO" in prompt or "video" in prompt
+
     def test_slideshow_mode_without_id_falls_back_to_general(self):
         from cms.services.assistant.prompts import build_system_prompt
 


### PR DESCRIPTION
## What

Teaches the slideshow-editor AI assistant about two per-slide field groups it was previously blind to:

- **Visibility window** — `valid_from` / `valid_to` (date range), `active_start` / `active_end` (time of day), `active_days` (weekday mask).
- **Video trim** — `clip_start_ms` / `clip_duration_ms` (play a sub-range of a video source).

## Why

The CMS API (`set_slideshow_slides` / `get_slideshow`) already round-trips all of these fields, but the MCP tool docstrings and the slideshow-editor system prompt never mentioned them, so the assistant could not act on requests like *"only show this slide in December"* or *"start this clip 10 seconds in"*. This is a docs/prompt-only change — no route, schema, or behavior change.

## Changes

- `cms/services/assistant/prompts.py`: document the visibility window + video-trim fields in the per-slide section of `SLIDESHOW_EDITOR_PROMPT_TEMPLATE`.
- `mcp/server.py`: extend the `set_slideshow_slides` and `get_slideshow` docstrings (the tool schema the model sees) with the same fields.
- `tests/test_slideshow_editor_assistant.py`: assert the prompt advertises the visibility + trim fields.

## Testing

`pytest tests/test_slideshow_editor_assistant.py` — 19 passed.
