### PR TITLE
Expire welcome/invite setup tokens after 7 days (fixes #599)

### DIFF
--- a/alembic/versions/0052_setup_token_expiry.py
+++ b/alembic/versions/0052_setup_token_expiry.py
@@ -1,0 +1,51 @@
+"""users: setup_token_created_at column for invite-token expiry
+
+Adds a nullable ``setup_token_created_at`` timestamp to ``users`` so the
+welcome/invite magic-login token can carry a TTL (see issue #599 —
+"Setup-email tokens never expire"). The application stamps this column
+whenever it issues a token (create-user / resend-invite) and the
+``/setup-account`` handler rejects tokens older than
+``SETUP_TOKEN_TTL`` (7 days).
+
+Backfill: every existing row that still has an outstanding
+``setup_token`` (i.e. a pending invitee who never completed setup) is
+stamped with the account's own ``created_at``. This makes the TTL apply
+*retroactively* from when the account was created — so an invite emailed
+weeks ago is treated as already-expired on deploy (exactly the hole #599
+describes), while a freshly-created pending invite still works until its
+7-day window elapses.
+
+Adding a nullable column with no default is a metadata-only change in
+Postgres (brief ACCESS EXCLUSIVE, no table rewrite), and the backfill
+UPDATE only touches the handful of rows with a non-null setup_token.
+
+Revision ID: 0052
+Revises: 0051
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0052"
+down_revision = "0051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("setup_token_created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Retroactively date outstanding invite tokens from the account's creation
+    # so months-old links expire immediately under the new TTL check.
+    op.execute(
+        "UPDATE users SET setup_token_created_at = created_at "
+        "WHERE setup_token IS NOT NULL AND setup_token_created_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "setup_token_created_at")

--- a/alembic/versions/0052_setup_token_expiry.py
+++ b/alembic/versions/0052_setup_token_expiry.py
@@ -48,4 +48,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("users", "setup_token_created_at")
+    # Project policy (tests/test_migration_policy.py): downgrades are not
+    # supported — forward-only migrations.
+    raise NotImplementedError("downgrade not supported")

--- a/cms/models/user.py
+++ b/cms/models/user.py
@@ -1,13 +1,40 @@
 """User, Role, and UserGroup ORM models for RBAC."""
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from cms.database import Base
+
+# How long a welcome/invite setup token stays usable after it is issued.
+# Invitation tokens cluster between 24 h and 7 d across the industry (GitHub,
+# GitLab, Google Workspace invites are all 7 d); 7 d gives a new user time to
+# acquire their device while bounding the credential-exposure window of a
+# magic-login link sitting in an inbox (see issue #599).
+SETUP_TOKEN_TTL = timedelta(days=7)
+
+
+def setup_token_is_expired(user: "User", *, now: datetime | None = None) -> bool:
+    """Return ``True`` iff ``user``'s setup token exists but is past its TTL.
+
+    Fails closed: a token with no ``setup_token_created_at`` issue timestamp
+    (e.g. a legacy row the backfill somehow missed) is treated as expired so a
+    timestamp-less token can never grant indefinite access. A user with no
+    token at all is *not* "expired" — there is simply nothing to validate.
+    """
+    if not user.setup_token:
+        return False
+    if user.setup_token_created_at is None:
+        return True
+    now = now or datetime.now(timezone.utc)
+    issued = user.setup_token_created_at
+    # Tolerate naive timestamps from SQLite (CI) by assuming UTC.
+    if issued.tzinfo is None:
+        issued = issued.replace(tzinfo=timezone.utc)
+    return now > issued + SETUP_TOKEN_TTL
 
 
 class Role(Base):
@@ -63,6 +90,13 @@ class User(Base):
     )
     setup_token: Mapped[str | None] = mapped_column(
         String(128), nullable=True, unique=True
+    )
+    # When ``setup_token`` was issued (create-user / resend-invite). Drives the
+    # SETUP_TOKEN_TTL expiry check in ``setup_token_is_expired`` so an old
+    # invite link can't be used indefinitely (issue #599). Nullable because
+    # rows predate the column; the 0052 migration backfills pending invites.
+    setup_token_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
     role: Mapped[Role] = relationship(back_populates="users")

--- a/cms/routers/users.py
+++ b/cms/routers/users.py
@@ -2,6 +2,7 @@
 
 import secrets
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy import select
@@ -89,6 +90,7 @@ async def change_my_password(
     # that the human actually completed setup. See cms/ui.py::setup_account
     # for why we defer this from the GET handler.
     current_user.setup_token = None
+    current_user.setup_token_created_at = None
     if was_setup_completion:
         # This call was the user finishing first-time setup, so it doubles
         # as their first real authentication. Stamp last_login_at to match
@@ -191,6 +193,7 @@ async def create_user(
         is_active=True,
         must_change_password=True,
         setup_token=setup_token,
+        setup_token_created_at=datetime.now(timezone.utc),
     )
     db.add(user)
     await db.flush()
@@ -351,9 +354,10 @@ async def resend_invite(
             detail="SMTP is not configured. Set up email in Settings → SMTP first.",
         )
 
-    # Regenerate setup token (invalidates old link)
+    # Regenerate setup token (invalidates old link) and restart its TTL clock.
     new_token = secrets.token_urlsafe(32)
     user.setup_token = new_token
+    user.setup_token_created_at = datetime.now(timezone.utc)
     await db.commit()
 
     base = (get_settings().base_url or request.base_url._url).rstrip("/")

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -48,7 +48,7 @@ from cms.models.device_profile import DeviceProfile
 from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.group_asset import GroupAsset
-from cms.models.user import User, UserGroup
+from cms.models.user import User, UserGroup, setup_token_is_expired
 from cms.services.transport import get_transport
 from cms.services.audit_service import audit_log
 from cms.services.json_compat import json_as_text
@@ -232,6 +232,16 @@ async def setup_account(
         select(User).where(User.setup_token == token, User.is_active.is_(True))
     )
     user = result.scalar_one_or_none()
+    if user and setup_token_is_expired(user):
+        # The token matched a real pending invite but its TTL has elapsed.
+        # Give a distinct, actionable message (vs. the generic invalid/used
+        # case below) so the user knows to ask for a fresh invitation.
+        return templates.TemplateResponse(
+            request, "login.html",
+            {"error": "This setup link has expired. Please ask an administrator "
+                      "to resend your invitation."},
+            status_code=400,
+        )
     if not user:
         return templates.TemplateResponse(
             request, "login.html",
@@ -397,6 +407,7 @@ async def force_password_change_submit(
     # that the human actually completed setup. See setup_account() for why
     # we defer this from the GET handler.
     user.setup_token = None
+    user.setup_token_created_at = None
     # First real authentication moment: stamp last_login_at here (was
     # previously stamped on every GET /setup-account, but that fires for
     # URL prefetchers before the user even clicks -- see setup_account()).

--- a/tests/test_setup_token_defer.py
+++ b/tests/test_setup_token_defer.py
@@ -23,6 +23,7 @@ endpoint specifically from the ``must_change_password`` redirect.
 """
 
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -30,7 +31,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cms.auth import hash_password
-from cms.models.user import Role, User
+from cms.models.user import SETUP_TOKEN_TTL, Role, User, setup_token_is_expired
 
 
 async def _get_role_id(db: AsyncSession, name: str) -> uuid.UUID:
@@ -44,8 +45,14 @@ async def _create_pending_user(
     email: str = "pending@test.com",
     setup_token: str = "test-setup-token-abc123",
     temp_password: str = "temp-password-1",
+    setup_token_created_at: datetime | None = ...,  # type: ignore[assignment]
 ) -> User:
     role_id = await _get_role_id(db, "Viewer")
+    # Default to a fresh issue timestamp so a just-created pending invite is
+    # within its TTL. Pass an explicit value (including None) to simulate aged
+    # or legacy tokens.
+    if setup_token_created_at is ...:
+        setup_token_created_at = datetime.now(timezone.utc)
     user = User(
         username=email.split("@")[0],
         email=email,
@@ -55,6 +62,7 @@ async def _create_pending_user(
         is_active=True,
         must_change_password=True,
         setup_token=setup_token,
+        setup_token_created_at=setup_token_created_at,
     )
     db.add(user)
     await db.commit()
@@ -448,3 +456,146 @@ async def test_password_change_with_wrong_current_password_does_not_burn_token(
 
     assert await _reload_setup_token(db_session, user_id) == "tok-burn-3"
     assert await _reload_must_change(db_session, user_id) is True
+
+
+async def _reload_setup_token_created_at(db: AsyncSession, user_id: uuid.UUID):
+    result = await db.execute(
+        select(User.setup_token_created_at).where(User.id == user_id)
+    )
+    return result.scalar_one()
+
+
+# -- setup-token TTL / expiry (issue #599) ---------------------------------
+
+
+def test_setup_token_is_expired_predicate():
+    """Unit-test the pure predicate: present-and-aged → expired; fresh →
+    not; missing timestamp → fail closed; no token → not expired."""
+    now = datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc)
+
+    fresh = User(setup_token="t", setup_token_created_at=now - timedelta(days=1))
+    assert setup_token_is_expired(fresh, now=now) is False
+
+    aged = User(
+        setup_token="t",
+        setup_token_created_at=now - (SETUP_TOKEN_TTL + timedelta(seconds=1)),
+    )
+    assert setup_token_is_expired(aged, now=now) is True
+
+    # Exactly at the TTL boundary is still valid (strict ``>``).
+    boundary = User(setup_token="t", setup_token_created_at=now - SETUP_TOKEN_TTL)
+    assert setup_token_is_expired(boundary, now=now) is False
+
+    # Token present but no issue timestamp → treated as expired (fail closed).
+    no_ts = User(setup_token="t", setup_token_created_at=None)
+    assert setup_token_is_expired(no_ts, now=now) is True
+
+    # No token at all → nothing to validate, not "expired".
+    none = User(setup_token=None, setup_token_created_at=None)
+    assert setup_token_is_expired(none, now=now) is False
+
+
+def test_setup_token_is_expired_tolerates_naive_timestamp():
+    """SQLite (the CI unit matrix) returns naive datetimes; the predicate
+    must assume UTC rather than raising on a naive/aware comparison."""
+    now = datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc)
+    naive_fresh = User(
+        setup_token="t",
+        setup_token_created_at=datetime(2026, 6, 24, 12, 0),  # naive, 1 day old
+    )
+    assert setup_token_is_expired(naive_fresh, now=now) is False
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_rejects_expired_token(
+    app, unauthed_client, db_session
+):
+    """GET /setup-account with a token past its TTL must NOT log the user in;
+    it returns the expired-link page (400) and leaves the token intact so the
+    distinct message can keep being shown until an admin resends."""
+    user = await _create_pending_user(
+        db_session,
+        email="expired1@test.com",
+        setup_token="tok-expired-1",
+        setup_token_created_at=datetime.now(timezone.utc)
+        - (SETUP_TOKEN_TTL + timedelta(days=1)),
+    )
+    user_id = user.id
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-expired-1", follow_redirects=False
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "expired" in resp.text.lower()
+    # No session cookie minted.
+    assert "set-cookie" not in {k.lower() for k in resp.headers}
+    # Token untouched (not burned) by the failed GET.
+    assert await _reload_setup_token(db_session, user_id) == "tok-expired-1"
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_accepts_token_within_ttl(
+    app, unauthed_client, db_session
+):
+    """A token issued just inside the TTL window still works."""
+    await _create_pending_user(
+        db_session,
+        email="fresh1@test.com",
+        setup_token="tok-fresh-1",
+        setup_token_created_at=datetime.now(timezone.utc)
+        - (SETUP_TOKEN_TTL - timedelta(hours=1)),
+    )
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-fresh-1", follow_redirects=False
+    )
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "/force-password-change"
+
+
+@pytest.mark.asyncio
+async def test_setup_account_get_rejects_tokenless_timestamp(
+    app, unauthed_client, db_session
+):
+    """A legacy row with a token but no issue timestamp fails closed (treated
+    as expired) so a timestamp-less token can't grant indefinite access."""
+    await _create_pending_user(
+        db_session,
+        email="legacy1@test.com",
+        setup_token="tok-legacy-1",
+        setup_token_created_at=None,
+    )
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-legacy-1", follow_redirects=False
+    )
+    assert resp.status_code == 400, resp.text
+    assert "expired" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_force_password_change_clears_setup_token_created_at(
+    app, unauthed_client, db_session
+):
+    """Completing setup burns the token AND clears its issue timestamp, so a
+    finished row carries no stale TTL state."""
+    user = await _create_pending_user(
+        db_session, email="clearts1@test.com", setup_token="tok-clearts-1"
+    )
+    user_id = user.id
+
+    resp = await unauthed_client.get(
+        "/setup-account?token=tok-clearts-1", follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    resp = await unauthed_client.post(
+        "/force-password-change",
+        data={"new_password": "brand-new-pw-1", "confirm_password": "brand-new-pw-1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+
+    assert await _reload_setup_token(db_session, user_id) is None
+    assert await _reload_setup_token_created_at(db_session, user_id) is None


### PR DESCRIPTION
Fixes #599.

## Problem

Welcome/invite **setup tokens never expired.** A user invited months ago
who never clicked the link still had a valid magic-login URL sitting in
their inbox — and in every forward, mailbox backup, archived ticket, or
breached email account. One click = full account takeover. Validation in
`setup_account()` was a **lookup only** — `WHERE setup_token == token AND
is_active`, with no time check anywhere in the flow.

(Note: this is distinct from the earlier "don't burn the token on GET
prefetch" fix — that prevented email scanners from *consuming* the link;
it did nothing about *lifetime*.)

## Fix

Bound the token lifetime to **`SETUP_TOKEN_TTL` = 7 days** (matching
GitHub / GitLab / Google Workspace invite norms; the issue surveys these).

- **`models/user.py`** — new nullable `setup_token_created_at` column +
  `SETUP_TOKEN_TTL` + `setup_token_is_expired()` predicate. Strict TTL (a
  window ending exactly at the boundary is still valid), **fails closed**
  on a missing timestamp, and tolerates SQLite's naive datetimes.
- **`0052` migration** — adds the column and **backfills outstanding
  invites with the account's `created_at`**, so the TTL applies
  *retroactively*: a weeks-old invite link is treated as expired on
  deploy (closing the exact hole #599 describes) while a freshly-created
  pending invite still works until its 7-day window elapses.
- **`routers/users.py`** — stamp `setup_token_created_at` on create-user
  and resend-invite (**resend restarts the clock**); clear it when the
  token is burned on setup completion.
- **`ui.py` `setup_account()`** — reject a TTL-expired token with a
  **distinct "link expired — ask an admin to resend"** page (vs. the
  generic invalid/used message) and mint **no** session.

## Testing

`tests/test_setup_token_defer.py` — **18 passed** in-container:
- TTL predicate unit tests (fresh / aged / boundary / missing-timestamp
  fail-closed / no-token / naive-datetime).
- GET-gate: expired token rejected (400, no cookie, token **not** burned),
  within-TTL accepted (303), timestamp-less fails closed, completion
  clears the stamp.
- Existing defer/last-login tests updated to stamp a fresh issue time.

`tests/test_invite_url_base_url.py` — 4 passed (exercises create + resend
stamping paths).

No route/schema-response change → no `openapi.yaml` regen. Adds a nullable
column with no default (metadata-only ALTER, no table rewrite). Goodwill
dev only.
