### PR TITLE
Add forgot-password / self-service reset flow (fixes #231)

### DIFF
--- a/alembic/versions/0053_password_reset_token.py
+++ b/alembic/versions/0053_password_reset_token.py
@@ -1,0 +1,46 @@
+"""users: reset_token + reset_token_created_at for self-service password reset
+
+Adds two nullable columns to ``users`` backing the forgot-password / reset
+flow (issue #231):
+
+* ``reset_token`` — a single-use, unique, time-limited secret emailed to the
+  user (or minted by the ``reset-password`` CLI). The ``/reset-password``
+  handler validates it, lets the user set a new password, then burns it.
+* ``reset_token_created_at`` — when the token was issued, driving the
+  ``RESET_TOKEN_TTL`` (1 hour) expiry check in ``reset_token_is_expired``.
+
+No backfill: no reset tokens exist before this migration ships, so both
+columns start NULL for every row. Adding nullable columns with no default is
+a metadata-only change in Postgres (brief ACCESS EXCLUSIVE, no table rewrite).
+
+Revision ID: 0053
+Revises: 0052
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0053"
+down_revision = "0052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("reset_token", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("reset_token_created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_unique_constraint("uq_users_reset_token", "users", ["reset_token"])
+
+
+def downgrade() -> None:
+    # Project policy (tests/test_migration_policy.py): downgrades are not
+    # supported — forward-only migrations.
+    raise NotImplementedError("downgrade not supported")

--- a/cms/__main__.py
+++ b/cms/__main__.py
@@ -1,0 +1,119 @@
+"""Agora CMS command-line entry point.
+
+Currently exposes a single administrative command:
+
+    python -m cms reset-password <email> [--password PW | --generate]
+
+This is the **offline fallback** for the forgot-password flow (issue #231):
+when SMTP isn't configured, or the *only* admin is locked out and can't reach
+the web UI to invite/reset anyone, an operator with shell access to the
+container/host can set a new password directly. It bypasses the email round
+trip entirely — it writes the new ``password_hash`` straight to the row.
+
+Run it from inside the CMS container (where ``DATABASE_URL`` is set), e.g.:
+
+    docker exec -it agora-cms-cms-1 python -m cms reset-password admin@example.com
+
+If neither ``--password`` nor ``--generate`` is given, you'll be prompted to
+type the new password twice (hidden input).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import secrets
+import sys
+
+from sqlalchemy import select
+
+from cms.auth import get_settings, hash_password
+from cms.database import init_db, get_session_factory, wait_for_db, dispose_db
+from cms.models.user import User
+
+
+def _resolve_new_password(args: argparse.Namespace) -> str:
+    """Return the new plaintext password from args or an interactive prompt."""
+    if args.password is not None:
+        if len(args.password) < 6:
+            print("error: password must be at least 6 characters", file=sys.stderr)
+            raise SystemExit(2)
+        return args.password
+    if args.generate:
+        # URL-safe, ~24 chars of entropy — printed once for the operator to relay.
+        return secrets.token_urlsafe(18)
+    # Interactive: prompt twice, hidden.
+    first = getpass.getpass("New password: ")
+    if len(first) < 6:
+        print("error: password must be at least 6 characters", file=sys.stderr)
+        raise SystemExit(2)
+    second = getpass.getpass("Confirm new password: ")
+    if first != second:
+        print("error: passwords do not match", file=sys.stderr)
+        raise SystemExit(2)
+    return first
+
+
+async def _reset_password(email: str, new_password: str) -> int:
+    """Set ``email``'s password to ``new_password``. Returns a process exit code."""
+    init_db(get_settings())
+    await wait_for_db()
+    try:
+        factory = get_session_factory()
+        async with factory() as db:
+            user = (
+                await db.execute(select(User).where(User.email == email))
+            ).scalar_one_or_none()
+            if user is None:
+                print(f"error: no user found with email {email!r}", file=sys.stderr)
+                return 1
+            user.password_hash = hash_password(new_password)
+            # Clear any pending one-time tokens / forced change so the account
+            # is fully re-credentialed and immediately usable.
+            user.must_change_password = False
+            user.reset_token = None
+            user.reset_token_created_at = None
+            user.setup_token = None
+            user.setup_token_created_at = None
+            await db.commit()
+            print(f"Password reset for {email} (active={user.is_active}).")
+            return 0
+    finally:
+        await dispose_db()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m cms")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    rp = sub.add_parser(
+        "reset-password",
+        help="Set a user's password directly (offline forgot-password fallback).",
+    )
+    rp.add_argument("email", help="Email address of the account to reset.")
+    grp = rp.add_mutually_exclusive_group()
+    grp.add_argument(
+        "--password", help="New password (≥6 chars). Omit to be prompted interactively."
+    )
+    grp.add_argument(
+        "--generate",
+        action="store_true",
+        help="Generate a random password and print it.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "reset-password":
+        new_password = _resolve_new_password(args)
+        code = asyncio.run(_reset_password(args.email, new_password))
+        if code == 0 and args.generate:
+            print(f"Generated password: {new_password}")
+        return code
+
+    parser.error(f"unknown command {args.command!r}")
+    return 2  # unreachable; parser.error raises SystemExit
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cms/models/user.py
+++ b/cms/models/user.py
@@ -16,6 +16,14 @@ from cms.database import Base
 # magic-login link sitting in an inbox (see issue #599).
 SETUP_TOKEN_TTL = timedelta(days=7)
 
+# How long a self-service password-reset token stays usable after it is issued
+# (issue #231). Reset links are far more sensitive than invites — a single
+# click sets a new password and grants access to an *existing* account — so the
+# window is deliberately short. One hour matches the common reset-token TTL
+# across the industry (GitHub, Django's default PasswordResetTokenGenerator
+# day-scale notwithstanding, most SaaS reset links sit at 15 min – 1 h).
+RESET_TOKEN_TTL = timedelta(hours=1)
+
 
 def setup_token_is_expired(user: "User", *, now: datetime | None = None) -> bool:
     """Return ``True`` iff ``user``'s setup token exists but is past its TTL.
@@ -35,6 +43,26 @@ def setup_token_is_expired(user: "User", *, now: datetime | None = None) -> bool
     if issued.tzinfo is None:
         issued = issued.replace(tzinfo=timezone.utc)
     return now > issued + SETUP_TOKEN_TTL
+
+
+def reset_token_is_expired(user: "User", *, now: datetime | None = None) -> bool:
+    """Return ``True`` iff ``user``'s password-reset token exists but is past TTL.
+
+    Same fail-closed contract as :func:`setup_token_is_expired`: a token present
+    with no ``reset_token_created_at`` is treated as expired so a timestamp-less
+    reset token can never be redeemed. A user with no reset token at all is not
+    "expired" — there is simply nothing to validate.
+    """
+    if not user.reset_token:
+        return False
+    if user.reset_token_created_at is None:
+        return True
+    now = now or datetime.now(timezone.utc)
+    issued = user.reset_token_created_at
+    # Tolerate naive timestamps from SQLite (CI) by assuming UTC.
+    if issued.tzinfo is None:
+        issued = issued.replace(tzinfo=timezone.utc)
+    return now > issued + RESET_TOKEN_TTL
 
 
 class Role(Base):
@@ -96,6 +124,17 @@ class User(Base):
     # invite link can't be used indefinitely (issue #599). Nullable because
     # rows predate the column; the 0052 migration backfills pending invites.
     setup_token_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Self-service password-reset token (issue #231) + its issue timestamp.
+    # Distinct from setup_token: that one activates a never-logged-in invite,
+    # this one re-credentials an existing account. Burned on successful reset
+    # and gated by RESET_TOKEN_TTL via reset_token_is_expired(). Nullable+unique
+    # so at most one live reset link exists per user at a time.
+    reset_token: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, unique=True
+    )
+    reset_token_created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 

--- a/cms/services/email_service.py
+++ b/cms/services/email_service.py
@@ -179,6 +179,73 @@ def send_welcome_email_background(
         )
 
 
+def send_password_reset_email_sync(
+    smtp_cfg: dict,
+    to_email: str,
+    display_name: str,
+    reset_url: str,
+) -> bool:
+    """Send a password-reset email synchronously (for use in BackgroundTasks)."""
+    greeting = display_name or to_email
+
+    html_body = f"""\
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
+    <div style="background: #1a1a2e; color: #e0e0e0; padding: 2rem; border-radius: 8px;">
+        <h1 style="color: #7c83ff; margin-top: 0;">Reset your password</h1>
+        <p>Hi {greeting},</p>
+        <p>We received a request to reset the password for your Agora CMS account.</p>
+        <p>Click the button below to choose a new password:</p>
+        <p style="margin-top: 1.5rem;">
+            <a href="{reset_url}" style="background: #7c83ff; color: #fff; padding: 0.6rem 1.5rem; border-radius: 4px; text-decoration: none; font-weight: 600;">Reset My Password</a>
+        </p>
+        <p style="margin-top: 1.5rem; font-size: 0.9rem; color: #aaa;">If the button doesn't work, copy and paste this link into your browser:</p>
+        <p style="font-size: 0.85rem; word-break: break-all;"><a href="{reset_url}" style="color: #7c83ff;">{reset_url}</a></p>
+        <hr style="border: none; border-top: 1px solid #0f3460; margin: 2rem 0;">
+        <p style="font-size: 0.85rem; color: #888;">This link is single-use and expires in 1 hour.</p>
+        <p style="font-size: 0.85rem; color: #888;">If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
+        <p style="font-size: 0.85rem; color: #888;">This is an automated message from Agora CMS. Do not reply to this email.</p>
+    </div>
+</body>
+</html>"""
+
+    text_body = (
+        f"Reset your password\n\n"
+        f"Hi {greeting},\n\n"
+        f"We received a request to reset the password for your Agora CMS account.\n\n"
+        f"Choose a new password by visiting:\n{reset_url}\n\n"
+        f"This link is single-use and expires in 1 hour.\n"
+        f"If you didn't request a password reset, you can safely ignore this email.\n"
+    )
+
+    ok, _ = _send_email(smtp_cfg, to_email, "Reset your Agora CMS password", html_body, text_body)
+    return ok
+
+
+def send_password_reset_email_background(
+    smtp_cfg: dict,
+    to_email: str,
+    display_name: str,
+    reset_url: str,
+) -> None:
+    """Send password-reset email and create a notification on failure."""
+    ok = send_password_reset_email_sync(
+        smtp_cfg=smtp_cfg,
+        to_email=to_email,
+        display_name=display_name,
+        reset_url=reset_url,
+    )
+    if not ok:
+        _create_notification_sync(
+            level="error",
+            title="Password-reset email failed",
+            message=f"Failed to send a password-reset email to {to_email}. "
+                    "If this account is locked out, an administrator can reset the "
+                    "password from the CLI: python -m cms reset-password <email>.",
+            details={"to_email": to_email, "display_name": display_name},
+        )
+
+
 def test_smtp_connection(smtp_cfg: dict, test_to_email: str) -> tuple[bool, str]:
     """Test SMTP connection by sending a test email. Returns (success, message)."""
     html_body = """\

--- a/cms/templates/forgot_password.html
+++ b/cms/templates/forgot_password.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}Forgot Password — Agora CMS{% endblock %}
+{% block nav %}
+<header>
+    <div class="nav-brand">Agora CMS</div>
+</header>
+{% endblock %}
+{% block content %}
+<div class="login-wrap">
+    <div class="card login-card">
+        <h2>Reset Password</h2>
+        {% if error %}
+        <div class="login-error">{{ error }}</div>
+        {% endif %}
+        {% if sent %}
+        <div class="login-error" style="background:rgba(76,175,80,0.15); border-color:#4caf50; color:#a5d6a7;">
+            {{ message }}
+        </div>
+        <p style="margin-top:1rem; text-align:center; font-size:0.9rem;">
+            <a href="/login">Back to sign in</a>
+        </p>
+        {% else %}
+        <p style="color:var(--text-muted, #aaa); font-size:0.9rem;">
+            Enter your account email and we'll send you a link to set a new password.
+        </p>
+        <form method="post" action="/forgot-password">
+            <div class="form-group">
+                <label>Email</label>
+                <input type="email" name="email" placeholder="Enter email address"
+                       required autofocus autocomplete="username">
+            </div>
+            <button type="submit" class="btn btn-primary" style="width:100%; margin-top:0.5rem;">Send Reset Link</button>
+        </form>
+        <p style="margin-top:1rem; text-align:center; font-size:0.9rem;">
+            <a href="/login">Back to sign in</a>
+        </p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -9,6 +9,9 @@
 <div class="login-wrap">
     <div class="card login-card">
         <h2>Sign In</h2>
+        {% if notice %}
+        <div class="login-error" style="background:rgba(76,175,80,0.15); border-color:#4caf50; color:#a5d6a7;">{{ notice }}</div>
+        {% endif %}
         {% if error %}
         <div class="login-error">{{ error }}</div>
         {% endif %}
@@ -25,6 +28,9 @@
             </div>
             <button type="submit" class="btn btn-primary" style="width:100%; margin-top:0.5rem;">Sign In</button>
         </form>
+        <p style="margin-top:1rem; text-align:center; font-size:0.9rem;">
+            <a href="/forgot-password">Forgot password?</a>
+        </p>
     </div>
 </div>
 {% endblock %}

--- a/cms/templates/reset_password.html
+++ b/cms/templates/reset_password.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Set New Password — Agora CMS{% endblock %}
+{% block nav %}
+<header>
+    <div class="nav-brand">Agora CMS</div>
+</header>
+{% endblock %}
+{% block content %}
+<div class="login-wrap">
+    <div class="card login-card">
+        <h2>Set a New Password</h2>
+        {% if error %}
+        <div class="login-error">{{ error }}</div>
+        {% endif %}
+        <form method="post" action="/reset-password">
+            <input type="hidden" name="token" value="{{ token }}">
+            <div class="form-group">
+                <label>New Password</label>
+                <input type="password" name="new_password" placeholder="At least 6 characters"
+                       required autofocus autocomplete="new-password" minlength="6">
+            </div>
+            <div class="form-group">
+                <label>Confirm Password</label>
+                <input type="password" name="confirm_password" placeholder="Re-enter new password"
+                       required autocomplete="new-password" minlength="6">
+            </div>
+            <button type="submit" class="btn btn-primary" style="width:100%; margin-top:0.5rem;">Set Password</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/cms/ui.py
+++ b/cms/ui.py
@@ -48,7 +48,7 @@ from cms.models.device_profile import DeviceProfile
 from cms.models.schedule import Schedule
 from cms.models.schedule_log import ScheduleLog, ScheduleLogEvent
 from cms.models.group_asset import GroupAsset
-from cms.models.user import User, UserGroup, setup_token_is_expired
+from cms.models.user import User, UserGroup, setup_token_is_expired, reset_token_is_expired
 from cms.services.transport import get_transport
 from cms.services.audit_service import audit_log
 from cms.services.json_compat import json_as_text
@@ -343,6 +343,208 @@ async def logout():
     response = RedirectResponse(url="/login", status_code=303)
     response.delete_cookie(COOKIE_NAME)
     return response
+
+
+# ── Forgot password / self-service reset (issue #231) ──
+
+# Tiny per-IP token bucket (mirrors cms/routers/bootstrap.py) so password-reset
+# requests can't be used to spray reset emails or to enumerate which addresses
+# have accounts via timing. Per-replica state is fine here — this is bot/abuse
+# deterrence, not a security boundary (the real defences are the generic
+# response below and the 1-hour single-use token).
+import time as _time
+from collections import defaultdict as _defaultdict, deque as _deque
+
+_reset_buckets: dict[tuple[str, str], "_deque[float]"] = _defaultdict(_deque)
+
+
+def _reset_ip(request: Request) -> str:
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _reset_ratelimited(request: Request, *, key: str, limit: int, window_sec: int) -> bool:
+    """Return True (and record the hit) when under the limit; False when over."""
+    bucket = _reset_buckets[(key, _reset_ip(request))]
+    now = _time.monotonic()
+    cutoff = now - window_sec
+    while bucket and bucket[0] < cutoff:
+        bucket.popleft()
+    if len(bucket) >= limit:
+        return False
+    bucket.append(now)
+    return True
+
+
+# Shown for every /forgot-password POST regardless of whether the address
+# matched an account — never reveal which emails are registered.
+_RESET_SENT_MSG = (
+    "If an account exists for that email address, we've sent a link to reset "
+    "the password. Check your inbox (and spam folder)."
+)
+
+
+@router.get("/forgot-password", response_class=HTMLResponse)
+async def forgot_password_page(request: Request):
+    return templates.TemplateResponse(
+        request, "forgot_password.html", {"error": None, "sent": False}
+    )
+
+
+@router.post("/forgot-password", response_class=HTMLResponse)
+async def forgot_password_submit(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_db),
+):
+    """Issue a password-reset token and email it, without leaking account existence.
+
+    Always renders the same generic "if an account exists…" confirmation so the
+    endpoint can't be used to enumerate registered email addresses. The token is
+    NOT exposed in the response — it only travels via the emailed link.
+    """
+    if not _reset_ratelimited(request, key="forgot-password", limit=5, window_sec=300):
+        return templates.TemplateResponse(
+            request, "forgot_password.html",
+            {"error": "Too many reset requests. Please wait a few minutes and try again.",
+             "sent": False},
+            status_code=429,
+        )
+
+    form = await request.form()
+    email = (form.get("email", "") or "").strip()
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+
+    # Only mint+send for an active account with SMTP configured. Every branch
+    # below still returns the identical generic page so the caller learns
+    # nothing about the address.
+    if user is not None and user.is_active:
+        from cms.services.email_service import (
+            get_smtp_settings,
+            send_password_reset_email_background,
+        )
+        smtp_cfg = await get_smtp_settings(db)
+        if smtp_cfg.get("host") and smtp_cfg.get("from_email"):
+            import secrets
+            reset_token = secrets.token_urlsafe(32)
+            user.reset_token = reset_token
+            user.reset_token_created_at = datetime.now(_tz.utc)
+            await audit_log(
+                db, user=user, action="auth.password_reset_requested",
+                resource_type="user", resource_id=str(user.id),
+                details={"email": user.email}, request=request,
+            )
+            await db.commit()
+
+            base = (settings.base_url or request.base_url._url).rstrip("/")
+            reset_url = f"{base}/reset-password?token={reset_token}"
+            from starlette.background import BackgroundTask
+            task = BackgroundTask(
+                send_password_reset_email_background,
+                smtp_cfg=smtp_cfg,
+                to_email=user.email,
+                display_name=user.display_name,
+                reset_url=reset_url,
+            )
+            return templates.TemplateResponse(
+                request, "forgot_password.html",
+                {"error": None, "sent": True, "message": _RESET_SENT_MSG},
+                background=task,
+            )
+
+    return templates.TemplateResponse(
+        request, "forgot_password.html",
+        {"error": None, "sent": True, "message": _RESET_SENT_MSG},
+    )
+
+
+@router.get("/reset-password", response_class=HTMLResponse)
+async def reset_password_page(
+    request: Request,
+    token: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """Show the new-password form for a valid reset token.
+
+    Mirrors /setup-account: the token is intentionally NOT consumed here so an
+    email-security prefetcher (Defender Safe Links, Proofpoint, etc.) that GETs
+    the link can't burn it before the human clicks. It is burned only on a
+    successful POST below.
+    """
+    result = await db.execute(select(User).where(User.reset_token == token))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active or reset_token_is_expired(user):
+        return templates.TemplateResponse(
+            request, "login.html",
+            {"error": "This password-reset link is invalid or has expired. "
+                      "Please request a new one."},
+            status_code=400,
+        )
+    return templates.TemplateResponse(
+        request, "reset_password.html", {"error": None, "token": token}
+    )
+
+
+@router.post("/reset-password", response_class=HTMLResponse)
+async def reset_password_submit(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Validate the reset token and set the new password, then burn the token."""
+    form = await request.form()
+    token = form.get("token", "")
+    new_password = form.get("new_password", "")
+    confirm_password = form.get("confirm_password", "")
+
+    result = await db.execute(select(User).where(User.reset_token == token))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active or reset_token_is_expired(user):
+        return templates.TemplateResponse(
+            request, "login.html",
+            {"error": "This password-reset link is invalid or has expired. "
+                      "Please request a new one."},
+            status_code=400,
+        )
+
+    if len(new_password) < 6:
+        return templates.TemplateResponse(
+            request, "reset_password.html",
+            {"error": "Password must be at least 6 characters", "token": token},
+            status_code=400,
+        )
+    if new_password != confirm_password:
+        return templates.TemplateResponse(
+            request, "reset_password.html",
+            {"error": "Passwords do not match", "token": token},
+            status_code=400,
+        )
+
+    user.password_hash = hash_password(new_password)
+    # Burn the reset token — single-use. Also clear any pending forced change
+    # and a stale setup token so the account is fully re-credentialed.
+    user.reset_token = None
+    user.reset_token_created_at = None
+    user.must_change_password = False
+    user.setup_token = None
+    user.setup_token_created_at = None
+    await audit_log(
+        db, user=user, action="auth.password_reset_completed",
+        resource_type="user", resource_id=str(user.id),
+        details={"email": user.email}, request=request,
+    )
+    await db.commit()
+
+    # Do not auto-login from a reset link; require a fresh sign-in with the new
+    # password so possession of the email link alone never yields a session.
+    return templates.TemplateResponse(
+        request, "login.html",
+        {"error": None,
+         "notice": "Your password has been reset. Please sign in with your new password."},
+    )
 
 
 # ── Force password change ──

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,379 @@
+"""Tests for the forgot-password / self-service reset flow (issue #231).
+
+Covers the TTL predicate, the anti-enumeration ``/forgot-password`` behaviour,
+the deferred (Safe-Links-safe) ``/reset-password`` GET, the password-setting
+POST, and the offline CLI fallback's argument handling.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cms.auth import (
+    SETTING_SMTP_FROM_EMAIL,
+    SETTING_SMTP_HOST,
+    hash_password,
+    set_setting,
+    verify_password,
+)
+from cms.models.user import (
+    RESET_TOKEN_TTL,
+    Role,
+    User,
+    reset_token_is_expired,
+)
+
+
+async def _get_role_id(db: AsyncSession, name: str) -> uuid.UUID:
+    result = await db.execute(select(Role).where(Role.name == name))
+    return result.scalar_one().id
+
+
+async def _create_user(
+    db: AsyncSession,
+    *,
+    email: str = "reset-target@test.com",
+    password: str = "old-password-1",
+    is_active: bool = True,
+    reset_token: str | None = None,
+    reset_token_created_at: datetime | None = None,
+) -> User:
+    role_id = await _get_role_id(db, "Viewer")
+    user = User(
+        username=email.split("@")[0],
+        email=email,
+        display_name=email.split("@")[0],
+        password_hash=hash_password(password),
+        role_id=role_id,
+        is_active=is_active,
+        must_change_password=False,
+        reset_token=reset_token,
+        reset_token_created_at=reset_token_created_at,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _configure_smtp(db: AsyncSession) -> None:
+    await set_setting(db, SETTING_SMTP_HOST, "smtp.test.local")
+    await set_setting(db, SETTING_SMTP_FROM_EMAIL, "noreply@test.local")
+    await db.commit()
+
+
+async def _reload(db: AsyncSession, user_id: uuid.UUID) -> User:
+    # Expire the identity map so attribute access re-reads from the DB —
+    # the HTTP request committed via a *different* session, so our cached
+    # instance would otherwise show stale (pre-request) values.
+    db.expire_all()
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one()
+
+
+# -- TTL predicate --------------------------------------------------------
+
+
+def _user_with_reset(token, created_at):
+    return User(reset_token=token, reset_token_created_at=created_at)
+
+
+def test_reset_token_fresh_is_not_expired():
+    now = datetime.now(timezone.utc)
+    u = _user_with_reset("tok", now - timedelta(minutes=5))
+    assert reset_token_is_expired(u, now=now) is False
+
+
+def test_reset_token_aged_is_expired():
+    now = datetime.now(timezone.utc)
+    u = _user_with_reset("tok", now - (RESET_TOKEN_TTL + timedelta(minutes=1)))
+    assert reset_token_is_expired(u, now=now) is True
+
+
+def test_reset_token_absent_is_not_expired():
+    u = _user_with_reset(None, None)
+    assert reset_token_is_expired(u) is False
+
+
+def test_reset_token_without_timestamp_fails_closed():
+    u = _user_with_reset("tok", None)
+    assert reset_token_is_expired(u) is True
+
+
+def test_reset_token_naive_timestamp_assumed_utc():
+    now = datetime.now(timezone.utc)
+    naive = (now - timedelta(minutes=5)).replace(tzinfo=None)
+    u = _user_with_reset("tok", naive)
+    assert reset_token_is_expired(u, now=now) is False
+
+
+# -- /forgot-password (anti-enumeration) ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_unknown_email_is_generic(unauthed_client, db_session):
+    await _configure_smtp(db_session)
+    resp = await unauthed_client.post(
+        "/forgot-password", data={"email": "nobody@test.com"}
+    )
+    assert resp.status_code == 200
+    assert "sent a link to reset" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_known_user_mints_token(
+    unauthed_client, db_session, monkeypatch
+):
+    import cms.services.email_service as email_mod
+
+    sent = {}
+
+    def _fake_send(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(email_mod, "send_password_reset_email_background", _fake_send)
+
+    await _configure_smtp(db_session)
+    user = await _create_user(db_session, email="known@test.com")
+
+    resp = await unauthed_client.post(
+        "/forgot-password", data={"email": "known@test.com"}
+    )
+    assert resp.status_code == 200
+    assert "sent a link to reset" in resp.text
+
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token is not None
+    assert reloaded.reset_token_created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_no_smtp_does_not_mint_token(unauthed_client, db_session):
+    # SMTP deliberately NOT configured.
+    user = await _create_user(db_session, email="nosmtp@test.com")
+    resp = await unauthed_client.post(
+        "/forgot-password", data={"email": "nosmtp@test.com"}
+    )
+    assert resp.status_code == 200
+    assert "sent a link to reset" in resp.text
+
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token is None
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_inactive_user_does_not_mint_token(
+    unauthed_client, db_session
+):
+    await _configure_smtp(db_session)
+    user = await _create_user(
+        db_session, email="inactive@test.com", is_active=False
+    )
+    resp = await unauthed_client.post(
+        "/forgot-password", data={"email": "inactive@test.com"}
+    )
+    assert resp.status_code == 200
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token is None
+
+
+# -- GET /reset-password (deferred burn) ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_password_get_valid_shows_form(unauthed_client, db_session):
+    now = datetime.now(timezone.utc)
+    await _create_user(
+        db_session,
+        email="getvalid@test.com",
+        reset_token="reset-tok-getvalid",
+        reset_token_created_at=now,
+    )
+    resp = await unauthed_client.get("/reset-password?token=reset-tok-getvalid")
+    assert resp.status_code == 200
+    assert "Set a New Password" in resp.text
+    assert "reset-tok-getvalid" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_reset_password_get_does_not_burn_token(unauthed_client, db_session):
+    """A Safe-Links / Proofpoint prefetch GET must not consume the token."""
+    now = datetime.now(timezone.utc)
+    user = await _create_user(
+        db_session,
+        email="getnoburn@test.com",
+        reset_token="reset-tok-noburn",
+        reset_token_created_at=now,
+    )
+    await unauthed_client.get("/reset-password?token=reset-tok-noburn")
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token == "reset-tok-noburn"
+
+
+@pytest.mark.asyncio
+async def test_reset_password_get_invalid_token_rejected(unauthed_client, db_session):
+    resp = await unauthed_client.get("/reset-password?token=does-not-exist")
+    assert resp.status_code == 400
+    assert "invalid or has expired" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_reset_password_get_expired_token_rejected(unauthed_client, db_session):
+    old = datetime.now(timezone.utc) - (RESET_TOKEN_TTL + timedelta(minutes=1))
+    await _create_user(
+        db_session,
+        email="getexpired@test.com",
+        reset_token="reset-tok-expired",
+        reset_token_created_at=old,
+    )
+    resp = await unauthed_client.get("/reset-password?token=reset-tok-expired")
+    assert resp.status_code == 400
+    assert "invalid or has expired" in resp.text
+
+
+# -- POST /reset-password -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_password_post_sets_password_and_burns_token(
+    unauthed_client, db_session
+):
+    now = datetime.now(timezone.utc)
+    user = await _create_user(
+        db_session,
+        email="postok@test.com",
+        password="old-password-1",
+        reset_token="reset-tok-postok",
+        reset_token_created_at=now,
+    )
+    resp = await unauthed_client.post(
+        "/reset-password",
+        data={
+            "token": "reset-tok-postok",
+            "new_password": "brand-new-pw",
+            "confirm_password": "brand-new-pw",
+        },
+    )
+    assert resp.status_code == 200
+    assert "password has been reset" in resp.text
+
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token is None
+    assert reloaded.reset_token_created_at is None
+    assert reloaded.must_change_password is False
+    assert verify_password("brand-new-pw", reloaded.password_hash)
+    assert not verify_password("old-password-1", reloaded.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_reset_password_post_expired_token_rejected(unauthed_client, db_session):
+    old = datetime.now(timezone.utc) - (RESET_TOKEN_TTL + timedelta(minutes=1))
+    user = await _create_user(
+        db_session,
+        email="postexpired@test.com",
+        password="old-password-1",
+        reset_token="reset-tok-postexpired",
+        reset_token_created_at=old,
+    )
+    resp = await unauthed_client.post(
+        "/reset-password",
+        data={
+            "token": "reset-tok-postexpired",
+            "new_password": "brand-new-pw",
+            "confirm_password": "brand-new-pw",
+        },
+    )
+    assert resp.status_code == 400
+    reloaded = await _reload(db_session, user.id)
+    assert verify_password("old-password-1", reloaded.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_reset_password_post_mismatch_rejected(unauthed_client, db_session):
+    now = datetime.now(timezone.utc)
+    user = await _create_user(
+        db_session,
+        email="postmismatch@test.com",
+        reset_token="reset-tok-mismatch",
+        reset_token_created_at=now,
+    )
+    resp = await unauthed_client.post(
+        "/reset-password",
+        data={
+            "token": "reset-tok-mismatch",
+            "new_password": "brand-new-pw",
+            "confirm_password": "different-pw",
+        },
+    )
+    assert resp.status_code == 400
+    assert "do not match" in resp.text
+    # Token must survive a failed attempt so the user can retry.
+    reloaded = await _reload(db_session, user.id)
+    assert reloaded.reset_token == "reset-tok-mismatch"
+
+
+@pytest.mark.asyncio
+async def test_reset_password_post_too_short_rejected(unauthed_client, db_session):
+    now = datetime.now(timezone.utc)
+    await _create_user(
+        db_session,
+        email="postshort@test.com",
+        reset_token="reset-tok-short",
+        reset_token_created_at=now,
+    )
+    resp = await unauthed_client.post(
+        "/reset-password",
+        data={
+            "token": "reset-tok-short",
+            "new_password": "x",
+            "confirm_password": "x",
+        },
+    )
+    assert resp.status_code == 400
+    assert "at least 6 characters" in resp.text
+
+
+# -- login page surfaces the entry point ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_page_has_forgot_link(unauthed_client):
+    resp = await unauthed_client.get("/login")
+    assert resp.status_code == 200
+    assert "/forgot-password" in resp.text
+
+
+# -- CLI fallback argument handling ---------------------------------------
+
+
+def test_cli_generate_produces_password():
+    import argparse
+
+    from cms.__main__ import _resolve_new_password
+
+    ns = argparse.Namespace(password=None, generate=True)
+    pw = _resolve_new_password(ns)
+    assert len(pw) >= 6
+
+
+def test_cli_explicit_password_too_short_exits():
+    import argparse
+
+    from cms.__main__ import _resolve_new_password
+
+    ns = argparse.Namespace(password="x", generate=False)
+    with pytest.raises(SystemExit):
+        _resolve_new_password(ns)
+
+
+def test_cli_explicit_password_passthrough():
+    import argparse
+
+    from cms.__main__ import _resolve_new_password
+
+    ns = argparse.Namespace(password="a-good-password", generate=False)
+    assert _resolve_new_password(ns) == "a-good-password"
+


### PR DESCRIPTION
Fixes #231.

## Problem

After first-run setup there was **no way to recover a forgotten password** —
the only path was hand-editing the database. If the sole admin forgot their
password, the install was effectively bricked.

## Fix

A complete self-service reset flow, reusing the #599 setup-token TTL machinery.

### Web flow
- **Login page** gains a **"Forgot password?"** link.
- **`POST /forgot-password`** mints a single-use `reset_token` (**1-hour TTL**)
  and emails a reset link. It **always** renders the same generic
  *"if an account exists, we've sent a link"* page — **no account enumeration** —
  and is **per-IP rate limited** (5 / 5 min). Only an **active** account with
  **SMTP configured** actually gets a token + email.
- **`GET /reset-password`** validates the token but **does not consume it**
  (deferred burn — same Defender Safe Links / Proofpoint prefetch defence as
  `/setup-account`).
- **`POST /reset-password`** sets the new password, **burns the token**, clears
  `must_change_password`, and redirects to login. A reset link **never mints a
  session** on its own — the user must sign in with the new password.

### Model / migration
- New `reset_token` + `reset_token_created_at` columns on `users`.
- `RESET_TOKEN_TTL` (1 h) + `reset_token_is_expired()` predicate, mirroring
  `setup_token_is_expired` (strict TTL, **fails closed** on a missing timestamp).
- **Migration 0053** — nullable columns, metadata-only ALTER (no rewrite);
  `downgrade` raises `NotImplementedError` per the repo forward-only policy.

### CLI fallback (no-SMTP / locked-out-admin)
```
python -m cms reset-password <email> [--password PW | --generate]
```
Sets a password directly from inside the container. Prompts (hidden) twice if
neither flag is given.

### Email
`send_password_reset_email_*` in `email_service.py`, with a failure
notification (mirrors the welcome email), pointing the operator at the CLI
fallback.

## Testing

`tests/test_password_reset.py` — **21 passed** in-container:
- TTL predicate (fresh / aged / boundary / fail-closed / naive-datetime).
- Anti-enumeration: unknown / inactive / no-SMTP all return the same generic
  page and mint **no** token; known active + SMTP mints a token.
- Deferred GET: valid token shows the form and is **not** burned; invalid /
  expired rejected (400).
- POST: sets password + burns token + clears `must_change_password`; expired /
  mismatch / too-short rejected (token survives a failed attempt).
- Login page surfaces the link; CLI arg handling.

Existing `test_auth` / `test_rbac` / `test_rbac_matrix` (423) and
`test_migration_policy` (163) pass unchanged. No route schema change → no
`openapi.yaml` regen. Goodwill dev only.
