### PR TITLE
Fix composed thumbnail transcode: No module named fastapi on worker

### DIFF
--- a/cms/services/asset_readiness.py
+++ b/cms/services/asset_readiness.py
@@ -13,7 +13,25 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import HTTPException
+try:  # fastapi is a CMS-only dep; the worker image does not install it.
+    from fastapi import HTTPException
+except ModuleNotFoundError:  # pragma: no cover - exercised only in the worker image
+
+    class HTTPException(Exception):  # type: ignore[no-redef]
+        """Minimal stand-in for ``fastapi.HTTPException``.
+
+        The worker imports this module transitively (composed thumbnail
+        render → ``slideshow_expand`` → ``slideshow_resolver`` → here) but
+        only ever calls ``composed_unpublished_reason``, which never raises
+        ``HTTPException``. The HTTP-raising assignment gate below runs only
+        in the CMS, where the real ``fastapi.HTTPException`` is imported.
+        """
+
+        def __init__(self, status_code: int = 500, detail: object = None) -> None:
+            self.status_code = status_code
+            self.detail = detail
+            super().__init__(detail)
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload

--- a/tests/test_worker_render_no_fastapi.py
+++ b/tests/test_worker_render_no_fastapi.py
@@ -1,0 +1,60 @@
+"""Regression guard: the worker thumbnail-render import chain must NOT
+require ``fastapi``.
+
+``fastapi`` is a CMS-only dependency and is intentionally absent from the
+worker image (``Dockerfile.worker`` / ``worker/requirements.txt``). The
+worker renders composed-slide thumbnails by importing
+``cms.composed.render.build_composed_html`` and ``worker.composed_render``.
+
+This has regressed twice: first via ``cms.composed.render`` itself
+(fixed in PR #728 with a guarded import), then via
+``cms.services.asset_readiness`` after the slideshow-in-composed feature
+added ``render -> slideshow_expand -> slideshow_resolver -> asset_readiness``
+to the chain. Both surfaced in production as
+``No module named 'fastapi'`` thumbnail-transcode failures.
+
+This test runs in a subprocess with ``fastapi`` blocked from import so a
+new unguarded top-level ``from fastapi import ...`` anywhere on the worker
+render chain fails CI instead of silently breaking every composed
+thumbnail in the field.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_worker_render_chain_imports_without_fastapi() -> None:
+    script = textwrap.dedent(
+        """
+        import builtins, sys
+        _real = builtins.__import__
+        def _blocked(name, *a, **k):
+            if name.split('.')[0] == 'fastapi':
+                raise ModuleNotFoundError("No module named 'fastapi'")
+            return _real(name, *a, **k)
+        builtins.__import__ = _blocked
+        for m in list(sys.modules):
+            if m.split('.')[0] == 'fastapi':
+                del sys.modules[m]
+
+        # The exact symbols the worker imports to render thumbnails.
+        from cms.composed.render import build_composed_html  # noqa: F401
+        from worker.composed_render import render_composed_to_png  # noqa: F401
+        print("OK")
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        "Worker render import chain pulled in fastapi (CMS-only dep, not in "
+        "the worker image). A module on the chain has an unguarded "
+        "`from fastapi import ...`.\n\nSTDOUT:\n"
+        f"{proc.stdout}\n\nSTDERR:\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout


### PR DESCRIPTION
## Fix: composed thumbnail transcode fails with `No module named 'fastapi'`

### Root cause
Composed-slide thumbnails are rendered in the **worker** image, which intentionally has no `fastapi` (CMS-only dependency). The worker imports `cms.composed.render.build_composed_html`, whose import chain now reaches `cms.services.asset_readiness` via:

`render -> slideshow_expand -> slideshow_resolver -> asset_readiness`

`asset_readiness.py` had an **unguarded** top-level `from fastapi import HTTPException`, so **every** composed-slide thumbnail transcode failed with `No module named 'fastapi'` (affects all composed slides, not just animated ones).

PR #728 fixed the same class of bug in `render.py`; the later slideshow-in-composed feature added this new fastapi import onto the worker chain, reintroducing the failure.

### Fix
- Guard the import in `asset_readiness.py` with the same API-compatible `HTTPException` fallback `render.py` already uses. The CMS keeps real FastAPI 404/422 translation; the worker only ever calls `composed_unpublished_reason` (which never raises), so behaviour is unchanged on both sides.
- New `tests/test_worker_render_no_fastapi.py`: a subprocess regression guard that imports the worker render chain with `fastapi` blocked, so any future unguarded fastapi import fails CI instead of silently breaking every composed thumbnail in the field.

Goodwill dev only.
