### PR TITLE
Composed editor: move Description box below Name and groups

### DIFF
--- a/cms/templates/composed_editor.html
+++ b/cms/templates/composed_editor.html
@@ -20,13 +20,6 @@
                    style="width:100%; max-width:420px; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text);">
         </div>
 
-        <div class="form-group" style="margin-bottom:0;">
-            <label for="composed-description" style="display:block; font-weight:600;">Description</label>
-            <textarea id="composed-description" class="form-control" maxlength="2000" rows="2"
-                      placeholder="Optional. Searchable from the asset library."
-                      style="width:100%; max-width:420px; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); resize:vertical;">{{ asset_description }}</textarea>
-        </div>
-
         {% if user_groups | length > 0 %}
         <div class="form-group" style="margin-bottom:0;">
             <label style="display:block; font-weight:600;">Assign to groups</label>
@@ -48,6 +41,13 @@
             {% endif %}
         </div>
         {% endif %}
+
+        <div class="form-group" style="margin-bottom:0; grid-column:1 / -1;">
+            <label for="composed-description" style="display:block; font-weight:600;">Description</label>
+            <textarea id="composed-description" class="form-control" maxlength="2000" rows="2"
+                      placeholder="Optional. Searchable from the asset library."
+                      style="width:100%; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); resize:vertical;">{{ asset_description }}</textarea>
+        </div>
     </div>
 
     <div style="display:flex; align-items:baseline; gap:1rem; flex-wrap:wrap;">
@@ -555,7 +555,7 @@
     .settings .delete-btn:hover { background: var(--danger); color: #fff; }
     .composed-toolbar {
         display: grid;
-        grid-template-columns: 2fr 1fr 1fr;
+        grid-template-columns: 2fr 1fr;
         gap: 1rem;
         margin-bottom: 1rem;
         padding: 0.75rem;


### PR DESCRIPTION
## Move the composed Description box below Name + groups

Layout feedback follow-up to #854. The Description field now sits **full-width on its own row beneath** the Name input and the Assign-to-groups picker, instead of squeezed between them.

- `.composed-toolbar` grid drops from `2fr 1fr 1fr` to `2fr 1fr` (Name | Groups).
- The Description `form-group` is the last toolbar child and spans `grid-column: 1 / -1`, so it wraps to a new row at full width.

Template-only; no route/schema/openapi change. Jinja parse + existing composed route tests green.

Goodwill dev only.
