### PR TITLE
Render published composed-slide Ready badge server-side (no poll delay)

### DIFF
--- a/cms/templates/_macros.html
+++ b/cms/templates/_macros.html
@@ -218,6 +218,12 @@
                 <td data-live-variants="{{ a.id }}">
                     {% if a.asset_type.value == 'composed' and not a.checksum %}
                     <span class="has-tooltip"><span class="badge badge-failed">⚠ Unpublished</span><span class="tooltip">This composed slide has not been published — it will not appear on devices until you open it and click Publish.</span></span>
+                    {% elif a.asset_type.value == 'composed' %}
+                    {# Published composed slide. It has no transcode variants, so the
+                       generic variant_total branch below would fall through to a
+                       misleading "none" until the JS poll corrects it ~5s later. A
+                       published slide is ready to play on assigned devices. #}
+                    <span class="has-tooltip"><span class="badge badge-ready">Ready</span><span class="tooltip">Published — live on assigned devices.</span></span>
                     {% elif a.asset_type.value == 'webpage' or a.asset_type.value == 'stream' %}
                     —
                     {% elif a.asset_type.value == 'slideshow' %}

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -514,6 +514,78 @@ class TestAssetPreview:
 
 
 @pytest.mark.asyncio
+class TestComposedStatusBadge:
+    @staticmethod
+    def _status_cell(html: str, asset_id) -> str:
+        """Return the server-rendered status ``<td>`` for one asset.
+
+        The status cell is marked ``<td data-live-variants="<id>">``. We
+        scope assertions to it so we don't accidentally match the same
+        literal inside the inline status-poller JS (buildVariantBadge),
+        which also contains these badge strings.
+        """
+        marker = f'data-live-variants="{asset_id}"'
+        start = html.find(marker)
+        assert start >= 0, f"status cell for {asset_id} not found"
+        end = html.find("</td>", start)
+        return html[start:end]
+
+    async def test_published_composed_renders_ready_on_initial_load(
+        self, client, db_session
+    ):
+        """A published composed slide must show its "Ready" badge in the
+        server-rendered library table immediately — not fall through to a
+        muted "none" that only flips to Ready ~5s later when the JS status
+        poller runs.
+
+        Composed slides have no transcode variants (``variant_total == 0``),
+        so before this branch existed the status cell fell through every
+        ``elif`` to the ``none`` default. The poller's buildVariantBadge()
+        rendered "Ready", which is why the badge appeared a few seconds
+        after every reload.
+        """
+        from cms.models.asset import Asset, AssetType
+
+        published = Asset(
+            filename="composed_pub.html", asset_type=AssetType.COMPOSED,
+            size_bytes=1234, checksum="deadbeef",
+        )
+        db_session.add(published)
+        await db_session.commit()
+
+        resp = await client.get("/assets")
+        assert resp.status_code == 200
+        cell = self._status_cell(resp.text, published.id)
+
+        # Ready badge is rendered server-side up front — not a muted "none".
+        assert 'class="badge badge-ready">Ready' in cell
+        assert "none" not in cell
+
+    async def test_unpublished_composed_renders_unpublished_not_ready(
+        self, client, db_session
+    ):
+        """A composed slide that was never published (empty checksum) must
+        render the Unpublished warning in its status cell — never the
+        published "Ready" badge.
+        """
+        from cms.models.asset import Asset, AssetType
+
+        never_published = Asset(
+            filename="composed_unpub.html", asset_type=AssetType.COMPOSED,
+            size_bytes=0, checksum="",
+        )
+        db_session.add(never_published)
+        await db_session.commit()
+
+        resp = await client.get("/assets")
+        assert resp.status_code == 200
+        cell = self._status_cell(resp.text, never_published.id)
+
+        assert "⚠ Unpublished" in cell
+        assert 'class="badge badge-ready">Ready' not in cell
+
+
+@pytest.mark.asyncio
 class TestImageDuration:
     async def test_image_with_duration_shows_dash(self, client, db_session):
         """An image asset with duration_seconds set (e.g. HEIC) should show


### PR DESCRIPTION
## Symptom

A **published composed slide** showed no "Ready" status badge on the
library page right after a reload — the badge only appeared a few seconds
later.

## Cause

Composed slides have no transcode variants (`variant_total == 0`). In the
server-rendered status cell (`_macros.html` `asset_row`), a *published*
composed slide (`asset_type == 'composed'` **with** checksum) fell
through every `elif` and landed on the muted `none` default. The JS
status poller's `buildVariantBadge()` *does* have a published-composed
case, so it rendered "Ready" on the next ~5s poll — hence the flash-in.

## Fix

Add the published-composed branch to the server-side status cell,
mirroring the JS exactly, so the **Ready** badge renders on initial
paint. One-line behavioural change in `_macros.html`.

## Tests

`TestComposedStatusBadge` (in `test_assets.py`) renders `GET /assets`
and asserts the published slide's status cell shows Ready up front and
the never-published one shows ⚠ Unpublished. Assertions are scoped to
the asset's `data-live-variants` `<td>` because the badge strings also
appear in the inline poller JS (a whole-page substring check would match
the script, not the rendered cell).

- `tests/test_assets.py` + `tests/test_assets_table_layout.py`: 34 passed.
