### PR TITLE
ci: fix nightly coverage thumbnail skip + e2e schedule date-rot

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -91,7 +91,12 @@ jobs:
 
       - name: Run full suite with coverage
         run: |
+          # `-m "not thumbnail"` matches the unit shards in tests.yml: the
+          # thumbnail-marked test needs Playwright + Chromium (not installed
+          # here) and is covered by the dedicated `composed-thumbnail-render`
+          # job. Without this the nightly fails on `No module named 'playwright'`.
           python -m pytest tests/ --ignore=tests/e2e \
+            -m "not thumbnail" \
             -n auto --dist=loadfile --tb=short -q -rs \
             --cov=cms --cov=shared --cov-report=xml --cov-report=term --cov-fail-under=50
 

--- a/tests_e2e/test_ui_schedules.py
+++ b/tests_e2e/test_ui_schedules.py
@@ -485,9 +485,15 @@ class TestScheduleEditWithDates:
         modal = page.locator(".modal-overlay")
         expect(modal).to_be_visible(timeout=3000)
 
-        # Set start and end dates
-        modal.locator("#edit-start-date").fill("2026-05-01")
-        modal.locator("#edit-end-date").fill("2026-05-31")
+        # Set start and end dates. Computed relative to today (not hardcoded)
+        # so the schedule stays active and its row remains in the main table
+        # instead of rotting into the "Expired Schedules" section once the
+        # dates pass -- see the date-rot fix in test_edit_all_fields below.
+        today = datetime.now(timezone.utc).date()
+        start_date = today.isoformat()
+        end_date = (today + timedelta(days=30)).isoformat()
+        modal.locator("#edit-start-date").fill(start_date)
+        modal.locator("#edit-end-date").fill(end_date)
 
         # Click Save
         modal.locator("#edit-save").click()
@@ -529,9 +535,16 @@ class TestScheduleEditWithDates:
         modal.locator("#edit-start-time").fill("14:00")
         modal.locator("#edit-end-time").fill("18:00")
 
-        # Set dates
-        modal.locator("#edit-start-date").fill("2026-06-01")
-        modal.locator("#edit-end-date").fill("2026-06-30")
+        # Set dates. Computed relative to today rather than hardcoded so the
+        # schedule stays active (end date in the future) and its row remains
+        # in the main schedules table. A hardcoded past end date (previously
+        # "2026-06-30") rots into the "Expired Schedules" section once it
+        # passes, breaking the `to_be_visible` assertion below.
+        today = datetime.now(timezone.utc).date()
+        start_date = today.isoformat()
+        end_date = (today + timedelta(days=60)).isoformat()
+        modal.locator("#edit-start-date").fill(start_date)
+        modal.locator("#edit-end-date").fill(end_date)
 
         # Change priority
         modal.locator("#edit-priority").fill("8")
@@ -547,8 +560,8 @@ class TestScheduleEditWithDates:
         schedules = api.get("/api/schedules").json()
         edited = next(s for s in schedules if s["name"] == "Fully Edited")
         assert edited["priority"] == 8
-        assert "2026-06-01" in edited["start_date"]
-        assert "2026-06-30" in edited["end_date"]
+        assert start_date in edited["start_date"]
+        assert end_date in edited["end_date"]
 
     def test_end_date_today_not_flagged_as_past(self, page: Page, api, ws_url):
         """Setting end date to today must NOT trigger the 'in the past' warning.


### PR DESCRIPTION
## Problem

The **Coverage (nightly)** workflow has failed every night since ~6/28 with a single failing test:

- `tests/test_composed_thumbnail_real_render.py::test_composed_thumbnail_real_render_produces_png`
- `ModuleNotFoundError: No module named 'playwright'`

Coverage itself is healthy (70.65%). The nightly job runs the full unit suite without Playwright/Chromium, but this test is marked `@pytest.mark.thumbnail` and needs a real browser to render.

## Fix

Add `-m "not thumbnail"` to the nightly coverage run, matching the sharded PR jobs in `tests.yml`. The thumbnail test is already exercised by the dedicated `composed-thumbnail-render` CI job which installs Playwright + Chromium.

The nightly workflow runs on PRs that modify it, so this PR self-validates.
